### PR TITLE
Add achievement summary view and update player statistics

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1018,7 +1018,16 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      player_achievement_summary: {
+        Row: {
+          earned_count: number
+          last_unlocked_at: string | null
+          remaining_count: number
+          total_achievements: number
+          user_id: string
+        }
+        Relationships: []
+      }
     }
     Functions: {
       get_user_role: {

--- a/supabase/migrations/20250916130000_player_achievement_summary.sql
+++ b/supabase/migrations/20250916130000_player_achievement_summary.sql
@@ -1,0 +1,26 @@
+-- Create a summary view that tracks unlocked achievements per user
+DROP VIEW IF EXISTS public.player_achievement_summary;
+
+CREATE VIEW public.player_achievement_summary AS
+WITH total AS (
+  SELECT COUNT(*)::integer AS total_achievements
+  FROM public.achievements
+), player_counts AS (
+  SELECT
+    user_id,
+    COUNT(*)::integer AS earned_count,
+    MAX(unlocked_at) AS last_unlocked_at
+  FROM public.player_achievements
+  GROUP BY user_id
+)
+SELECT
+  p.user_id,
+  COALESCE(pc.earned_count, 0) AS earned_count,
+  t.total_achievements,
+  GREATEST(t.total_achievements - COALESCE(pc.earned_count, 0), 0) AS remaining_count,
+  pc.last_unlocked_at
+FROM public.profiles p
+CROSS JOIN total t
+LEFT JOIN player_counts pc ON pc.user_id = p.user_id;
+
+GRANT SELECT ON public.player_achievement_summary TO anon, authenticated;


### PR DESCRIPTION
## Summary
- create a Supabase view that aggregates unlocked achievements per user and expose it through the generated types
- update player statistics fetching to include achievement progress, real-time refreshes, and UI that shows earned versus remaining achievements

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c958a222d4832599236435bcab9e99