### PR TITLE
feat: persist record label contracts

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -200,6 +200,51 @@ export type Database = {
         }
         Relationships: []
       }
+      contracts: {
+        Row: {
+          advance_payment: number
+          contract_type: string
+          created_at: string | null
+          duration_months: number
+          id: string
+          label_id: string | null
+          label_name: string
+          royalty_rate: number
+          signed_at: string
+          status: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          advance_payment?: number
+          contract_type: string
+          created_at?: string | null
+          duration_months: number
+          id?: string
+          label_id?: string | null
+          label_name: string
+          royalty_rate: number
+          signed_at?: string
+          status?: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          advance_payment?: number
+          contract_type?: string
+          created_at?: string | null
+          duration_months?: number
+          id?: string
+          label_id?: string | null
+          label_name?: string
+          royalty_rate?: number
+          signed_at?: string
+          status?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       equipment_items: {
         Row: {
           category: string

--- a/supabase/migrations/20250916140000_create_contracts_table.sql
+++ b/supabase/migrations/20250916140000_create_contracts_table.sql
@@ -1,0 +1,52 @@
+-- Create contracts table to track player agreements with labels
+CREATE TABLE IF NOT EXISTS public.contracts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  label_id TEXT,
+  label_name TEXT NOT NULL,
+  contract_type TEXT NOT NULL CHECK (contract_type IN ('demo', 'single', 'album', 'exclusive')),
+  duration_months INTEGER NOT NULL,
+  advance_payment INTEGER NOT NULL DEFAULT 0,
+  royalty_rate NUMERIC(6,4) NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('pending', 'active', 'completed', 'terminated')),
+  signed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS contracts_user_id_idx ON public.contracts (user_id);
+
+ALTER TABLE public.contracts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own contracts" ON public.contracts;
+CREATE POLICY "Users can view their own contracts"
+  ON public.contracts
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can create their own contracts" ON public.contracts;
+CREATE POLICY "Users can create their own contracts"
+  ON public.contracts
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update their own contracts" ON public.contracts;
+CREATE POLICY "Users can update their own contracts"
+  ON public.contracts
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.update_contracts_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_contracts_updated_at ON public.contracts;
+CREATE TRIGGER update_contracts_updated_at
+  BEFORE UPDATE ON public.contracts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_contracts_updated_at();


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates a contracts table with RLS policies
- extend generated Supabase types to cover the contracts table
- persist and load record label contracts through Supabase instead of mock data

## Testing
- npm run lint *(fails: repository already contains numerous unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c96064f1f88325b9569239daecc1ad