### PR TITLE
Add profile social metrics and dynamic SocialMedia stats

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -740,9 +740,11 @@ export type Database = {
           cash: number | null
           created_at: string | null
           display_name: string | null
+          engagement_rate: number | null
           experience: number | null
           fame: number | null
           fans: number | null
+          followers: number | null
           id: string
           level: number | null
           updated_at: string | null
@@ -755,9 +757,11 @@ export type Database = {
           cash?: number | null
           created_at?: string | null
           display_name?: string | null
+          engagement_rate?: number | null
           experience?: number | null
           fame?: number | null
           fans?: number | null
+          followers?: number | null
           id?: string
           level?: number | null
           updated_at?: string | null
@@ -770,9 +774,11 @@ export type Database = {
           cash?: number | null
           created_at?: string | null
           display_name?: string | null
+          engagement_rate?: number | null
           experience?: number | null
           fame?: number | null
           fans?: number | null
+          followers?: number | null
           id?: string
           level?: number | null
           updated_at?: string | null

--- a/supabase/migrations/20250916153000_add_social_metrics_to_profiles.sql
+++ b/supabase/migrations/20250916153000_add_social_metrics_to_profiles.sql
@@ -1,0 +1,10 @@
+-- Add followers and engagement rate tracking to player profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS followers bigint DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS engagement_rate numeric(5,2) DEFAULT 0;
+
+-- Ensure existing rows have non-null defaults for the new columns
+UPDATE public.profiles
+SET
+  followers = COALESCE(followers, 0),
+  engagement_rate = COALESCE(engagement_rate, 0);


### PR DESCRIPTION
## Summary
- add a migration that introduces followers and engagement rate columns on profiles
- update the Supabase generated types so the new profile fields are available to the client
- load social metrics for the logged-in user on the SocialMedia page and write changes back when posts or campaigns boost performance

## Testing
- npm run lint *(fails: repository currently contains pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c968c4bc5c83259bf1dc4c6d667b54