### PR TITLE
Add tour editing UI and cancellation logic

### DIFF
--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -61,6 +61,24 @@ interface TourVenue {
   };
 }
 
+interface EditTourForm {
+  start_date: string;
+  end_date: string;
+  status: string;
+  venues: Array<{
+    id: string;
+    venue_id: string;
+    date: string;
+    status: string | null;
+    ticket_price: number | null;
+  }>;
+  newVenue: {
+    venue_id: string;
+    date: string;
+    ticket_price: string;
+  };
+}
+
 const TourManager = () => {
   const { user } = useAuth();
   const { profile, skills } = useGameData();
@@ -69,12 +87,37 @@ const TourManager = () => {
   const [venues, setVenues] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [creatingTour, setCreatingTour] = useState(false);
+  const [editingTourId, setEditingTourId] = useState<string | null>(null);
+  const [editForms, setEditForms] = useState<Record<string, EditTourForm>>({});
   const [newTour, setNewTour] = useState({
     name: "",
     description: "",
     start_date: "",
     end_date: ""
   });
+
+  const normalizeDate = (date?: string | null) => (date ? date.split("T")[0] : "");
+
+  const initializeEditForm = (tour: Tour): EditTourForm => ({
+    start_date: normalizeDate(tour.start_date),
+    end_date: normalizeDate(tour.end_date),
+    status: tour.status || "planned",
+    venues: (tour.venues || []).map((venue) => ({
+      id: venue.id,
+      venue_id: venue.venue_id,
+      date: normalizeDate(venue.date),
+      status: venue.status || "scheduled",
+      ticket_price: venue.ticket_price
+    })),
+    newVenue: {
+      venue_id: "",
+      date: "",
+      ticket_price: ""
+    }
+  });
+
+  const tourStatusOptions = ['planned', 'active', 'completed', 'cancelled'];
+  const venueStatusOptions = ['scheduled', 'completed', 'cancelled'];
 
   useEffect(() => {
     if (user) {
@@ -83,8 +126,8 @@ const TourManager = () => {
     }
   }, [user]);
 
-  const loadTours = async () => {
-    if (!user) return;
+  const loadTours = async (): Promise<Tour[]> => {
+    if (!user) return [];
 
     try {
       const { data, error } = await supabase
@@ -100,13 +143,15 @@ const TourManager = () => {
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      setTours((data || []).map(tour => ({
+      const mappedTours = (data || []).map(tour => ({
         ...tour,
         venues: (tour.tour_venues || []).map(tv => ({
           ...tv,
           venue: tv.venues
         }))
-      })));
+      }));
+      setTours(mappedTours);
+      return mappedTours;
     } catch (error: any) {
       console.error('Error loading tours:', error);
       toast({
@@ -114,6 +159,7 @@ const TourManager = () => {
         title: "Error",
         description: "Failed to load tours"
       });
+      return [];
     }
   };
 
@@ -176,7 +222,7 @@ const TourManager = () => {
       });
 
       setNewTour({ name: "", description: "", start_date: "", end_date: "" });
-      loadTours();
+      await loadTours();
     } catch (error: any) {
       console.error('Error creating tour:', error);
       toast({
@@ -193,7 +239,7 @@ const TourManager = () => {
     if (!user) return;
 
     try {
-      const { data, error } = await supabase
+      const { error } = await supabase
         .from('tour_venues')
         .insert({
           tour_id: tourId,
@@ -212,13 +258,165 @@ const TourManager = () => {
         description: "Venue has been added to your tour"
       });
 
-      loadTours();
+      const updatedTours = await loadTours();
+      const updatedTour = updatedTours.find((t) => t.id === tourId);
+      if (updatedTour) {
+        setEditForms((prev) => ({
+          ...prev,
+          [tourId]: initializeEditForm(updatedTour)
+        }));
+      }
     } catch (error: any) {
       console.error('Error adding venue to tour:', error);
       toast({
         variant: "destructive",
         title: "Error",
         description: "Failed to add venue to tour"
+      });
+    }
+  };
+
+  const handleManageClick = (tour: Tour) => {
+    if (editingTourId === tour.id) {
+      setEditingTourId(null);
+      setEditForms((prev) => {
+        const { [tour.id]: _removed, ...rest } = prev;
+        return rest;
+      });
+      return;
+    }
+
+    setEditForms((prev) => ({
+      ...prev,
+      [tour.id]: initializeEditForm(tour)
+    }));
+    setEditingTourId(tour.id);
+  };
+
+  const handleCancelEditing = (tourId: string) => {
+    setEditingTourId(null);
+    setEditForms((prev) => {
+      const { [tourId]: _removed, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  const handleAddVenue = async (tourId: string) => {
+    const form = editForms[tourId];
+    if (!form) return;
+
+    const { venue_id, date, ticket_price } = form.newVenue;
+    const parsedPrice = parseFloat(ticket_price);
+
+    if (!venue_id || !date || Number.isNaN(parsedPrice)) {
+      toast({
+        variant: "destructive",
+        title: "Missing Information",
+        description: "Please select a venue, date, and ticket price"
+      });
+      return;
+    }
+
+    await addVenueToTour(tourId, venue_id, date, parsedPrice);
+    setEditForms((prev) => ({
+      ...prev,
+      [tourId]: {
+        ...prev[tourId],
+        newVenue: {
+          venue_id: "",
+          date: "",
+          ticket_price: ""
+        }
+      }
+    }));
+  };
+
+  const editTour = async (tourId: string) => {
+    if (!user) return;
+    const form = editForms[tourId];
+    if (!form) return;
+
+    try {
+      const { error: tourError } = await supabase
+        .from('tours')
+        .update({
+          start_date: form.start_date,
+          end_date: form.end_date,
+          status: form.status
+        })
+        .eq('id', tourId)
+        .eq('user_id', user.id);
+
+      if (tourError) throw tourError;
+
+      if (form.venues.length > 0) {
+        const venueResponses = await Promise.all(
+          form.venues.map((venue) =>
+            supabase
+              .from('tour_venues')
+              .update({
+                venue_id: venue.venue_id,
+                date: venue.date,
+                status: venue.status,
+                ticket_price: venue.ticket_price
+              })
+              .eq('id', venue.id)
+          )
+        );
+
+        const venueError = venueResponses.find((response) => response.error)?.error;
+        if (venueError) throw venueError;
+      }
+
+      toast({
+        title: "Tour Updated",
+        description: "Tour details have been updated"
+      });
+
+      await loadTours();
+      handleCancelEditing(tourId);
+    } catch (error: any) {
+      console.error('Error updating tour:', error);
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Failed to update tour"
+      });
+    }
+  };
+
+  const cancelTour = async (tourId: string) => {
+    if (!user) return;
+
+    try {
+      const { error: venueError } = await supabase
+        .from('tour_venues')
+        .delete()
+        .eq('tour_id', tourId);
+
+      if (venueError) throw venueError;
+
+      const { error: tourError } = await supabase
+        .from('tours')
+        .delete()
+        .eq('id', tourId)
+        .eq('user_id', user.id);
+
+      if (tourError) throw tourError;
+
+      toast({
+        title: "Tour Cancelled",
+        description: "The tour has been removed from your schedule"
+      });
+
+      await loadTours();
+      handleCancelEditing(tourId);
+    } catch (error: any) {
+      console.error('Error cancelling tour:', error);
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Failed to cancel tour"
       });
     }
   };
@@ -258,7 +456,7 @@ const TourManager = () => {
         description: `Great performance! Earned $${revenue} and ${fameGain} fame`
       });
 
-      loadTours();
+      await loadTours();
     } catch (error: any) {
       console.error('Error simulating tour show:', error);
       toast({
@@ -395,6 +593,7 @@ const TourManager = () => {
         <div className="space-y-4">
           {tours.length > 0 ? tours.map((tour) => {
             const stats = calculateTourStats(tour);
+            const editForm = editForms[tour.id];
             return (
               <Card key={tour.id} className="bg-card/80 backdrop-blur-sm border-primary/20">
                 <CardHeader>
@@ -406,8 +605,8 @@ const TourManager = () => {
                       </CardTitle>
                       <CardDescription>{tour.description}</CardDescription>
                     </div>
-                    <Badge variant="outline" className={getStatusColor(tour.status)}>
-                      {tour.status}
+                    <Badge variant="outline" className={getStatusColor(tour.status || 'planned')}>
+                      {tour.status || 'planned'}
                     </Badge>
                   </div>
                 </CardHeader>
@@ -432,40 +631,333 @@ const TourManager = () => {
                     </div>
                   </div>
 
+                  {editingTourId === tour.id && editForm && (
+                    <div className="rounded-lg border border-border/40 bg-secondary/20 p-4 space-y-4">
+                      <div className="grid gap-3 md:grid-cols-3">
+                        <div>
+                          <Label className="text-xs uppercase text-muted-foreground">Start Date</Label>
+                          <Input
+                            type="date"
+                            value={editForm.start_date}
+                            onChange={(e) =>
+                              setEditForms((prev) => ({
+                                ...prev,
+                                [tour.id]: {
+                                  ...prev[tour.id],
+                                  start_date: e.target.value
+                                }
+                              }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <Label className="text-xs uppercase text-muted-foreground">End Date</Label>
+                          <Input
+                            type="date"
+                            value={editForm.end_date}
+                            onChange={(e) =>
+                              setEditForms((prev) => ({
+                                ...prev,
+                                [tour.id]: {
+                                  ...prev[tour.id],
+                                  end_date: e.target.value
+                                }
+                              }))
+                            }
+                          />
+                        </div>
+                        <div>
+                          <Label className="text-xs uppercase text-muted-foreground">Status</Label>
+                          <select
+                            className="mt-1 w-full rounded-md border border-border bg-background/80 px-3 py-2 text-sm capitalize focus:outline-none focus:ring-2 focus:ring-primary"
+                            value={editForm.status}
+                            onChange={(e) =>
+                              setEditForms((prev) => ({
+                                ...prev,
+                                [tour.id]: {
+                                  ...prev[tour.id],
+                                  status: e.target.value
+                                }
+                              }))
+                            }
+                          >
+                            {tourStatusOptions.map((status) => (
+                              <option key={status} value={status}>
+                                {status.charAt(0).toUpperCase() + status.slice(1)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <h5 className="font-semibold text-sm">Add New Tour Stop</h5>
+                        <div className="grid gap-3 md:grid-cols-3">
+                          <div>
+                            <Label className="text-xs uppercase text-muted-foreground">Venue</Label>
+                            <select
+                              className="mt-1 w-full rounded-md border border-border bg-background/80 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                              value={editForm.newVenue.venue_id}
+                              onChange={(e) =>
+                                setEditForms((prev) => ({
+                                  ...prev,
+                                  [tour.id]: {
+                                    ...prev[tour.id],
+                                    newVenue: {
+                                      ...prev[tour.id].newVenue,
+                                      venue_id: e.target.value
+                                    }
+                                  }
+                                }))
+                              }
+                            >
+                              <option value="">Select venue</option>
+                              {venues.map((venueOption) => (
+                                <option key={venueOption.id} value={venueOption.id}>
+                                  {venueOption.name} • {venueOption.location}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <Label className="text-xs uppercase text-muted-foreground">Date</Label>
+                            <Input
+                              type="date"
+                              value={editForm.newVenue.date}
+                              onChange={(e) =>
+                                setEditForms((prev) => ({
+                                  ...prev,
+                                  [tour.id]: {
+                                    ...prev[tour.id],
+                                    newVenue: {
+                                      ...prev[tour.id].newVenue,
+                                      date: e.target.value
+                                    }
+                                  }
+                                }))
+                              }
+                            />
+                          </div>
+                          <div>
+                            <Label className="text-xs uppercase text-muted-foreground">Ticket Price</Label>
+                            <Input
+                              type="number"
+                              min="0"
+                              value={editForm.newVenue.ticket_price}
+                              onChange={(e) =>
+                                setEditForms((prev) => ({
+                                  ...prev,
+                                  [tour.id]: {
+                                    ...prev[tour.id],
+                                    newVenue: {
+                                      ...prev[tour.id].newVenue,
+                                      ticket_price: e.target.value
+                                    }
+                                  }
+                                }))
+                              }
+                            />
+                          </div>
+                        </div>
+                        <Button size="sm" onClick={() => handleAddVenue(tour.id)}>
+                          Add Venue
+                        </Button>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button onClick={() => editTour(tour.id)}>
+                          Save Changes
+                        </Button>
+                        <Button variant="outline" onClick={() => handleCancelEditing(tour.id)}>
+                          Cancel
+                        </Button>
+                        <Button variant="destructive" onClick={() => cancelTour(tour.id)}>
+                          Cancel Tour
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
                   {/* Tour Dates */}
                   <div>
                     <h4 className="font-semibold mb-2 flex items-center gap-2">
                       <Calendar className="h-4 w-4" />
                       Tour Dates ({tour.venues?.length || 0})
                     </h4>
-                    <div className="space-y-2 max-h-40 overflow-y-auto">
-                      {tour.venues?.map((venue) => (
-                        <div key={venue.id} className="flex items-center justify-between p-3 rounded-lg bg-secondary/30">
-                          <div className="flex-1">
-                            <p className="font-medium">{venue.venue.name}</p>
-                            <p className="text-sm text-muted-foreground flex items-center gap-1">
-                              <MapPin className="h-3 w-3" />
-                              {venue.venue.location} • {new Date(venue.date).toLocaleDateString()}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {venue.tickets_sold}/{venue.venue.capacity} tickets • ${venue.ticket_price} each
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline" className={getStatusColor(venue.status)}>
-                              {venue.status}
-                            </Badge>
-                            {venue.status === 'scheduled' && (
-                              <Button 
-                                size="sm"
-                                onClick={() => simulateTourShow(venue.id, venue.venue)}
-                              >
-                                Perform
-                              </Button>
-                            )}
-                          </div>
-                        </div>
-                      )) || (
+                    <div
+                      className={`space-y-2 ${editingTourId === tour.id ? 'overflow-visible' : 'max-h-40 overflow-y-auto'}`}
+                    >
+                      {tour.venues && tour.venues.length > 0 ? (
+                        tour.venues.map((venue) => {
+                          if (editingTourId === tour.id && editForm) {
+                            const editableVenue = editForm.venues.find((v) => v.id === venue.id);
+                            if (!editableVenue) {
+                              return (
+                                <div key={venue.id} className="flex items-center justify-between p-3 rounded-lg bg-secondary/30">
+                                  <div className="flex-1">
+                                    <p className="font-medium">{venue.venue.name}</p>
+                                    <p className="text-sm text-muted-foreground flex items-center gap-1">
+                                      <MapPin className="h-3 w-3" />
+                                      {venue.venue.location} • {new Date(venue.date).toLocaleDateString()}
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                      {venue.tickets_sold}/{venue.venue.capacity} tickets • ${venue.ticket_price} each
+                                    </p>
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    <Badge variant="outline" className={getStatusColor(venue.status || 'scheduled')}>
+                                      {venue.status || 'scheduled'}
+                                    </Badge>
+                                  </div>
+                                </div>
+                              );
+                            }
+
+                            const selectedVenueInfo =
+                              venues.find((option) => option.id === editableVenue.venue_id) || venue.venue;
+
+                            return (
+                              <div key={venue.id} className="space-y-3 rounded-lg bg-secondary/30 p-3">
+                                <div className="grid gap-3 md:grid-cols-2">
+                                  <div>
+                                    <Label className="text-xs uppercase text-muted-foreground">Venue</Label>
+                                    <select
+                                      className="mt-1 w-full rounded-md border border-border bg-background/80 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                                      value={editableVenue.venue_id}
+                                      onChange={(e) =>
+                                        setEditForms((prev) => ({
+                                          ...prev,
+                                          [tour.id]: {
+                                            ...prev[tour.id],
+                                            venues: prev[tour.id].venues.map((v) =>
+                                              v.id === venue.id ? { ...v, venue_id: e.target.value } : v
+                                            )
+                                          }
+                                        }))
+                                      }
+                                    >
+                                      <option value="">Select venue</option>
+                                      {venues.map((venueOption) => (
+                                        <option key={venueOption.id} value={venueOption.id}>
+                                          {venueOption.name} • {venueOption.location}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+                                  <div>
+                                    <Label className="text-xs uppercase text-muted-foreground">Date</Label>
+                                    <Input
+                                      type="date"
+                                      value={editableVenue.date}
+                                      onChange={(e) =>
+                                        setEditForms((prev) => ({
+                                          ...prev,
+                                          [tour.id]: {
+                                            ...prev[tour.id],
+                                            venues: prev[tour.id].venues.map((v) =>
+                                              v.id === venue.id ? { ...v, date: e.target.value } : v
+                                            )
+                                          }
+                                        }))
+                                      }
+                                    />
+                                  </div>
+                                </div>
+                                <div className="grid gap-3 md:grid-cols-2">
+                                  <div>
+                                    <Label className="text-xs uppercase text-muted-foreground">Ticket Price</Label>
+                                    <Input
+                                      type="number"
+                                      min="0"
+                                      value={editableVenue.ticket_price !== null ? editableVenue.ticket_price.toString() : ""}
+                                      onChange={(e) =>
+                                        setEditForms((prev) => {
+                                          const rawValue = e.target.value;
+                                          const parsedValue = rawValue === "" ? null : parseFloat(rawValue);
+                                          const safeValue =
+                                            parsedValue !== null && !Number.isNaN(parsedValue)
+                                              ? parsedValue
+                                              : null;
+                                          return {
+                                            ...prev,
+                                            [tour.id]: {
+                                              ...prev[tour.id],
+                                              venues: prev[tour.id].venues.map((v) =>
+                                                v.id === venue.id
+                                                  ? {
+                                                      ...v,
+                                                      ticket_price: safeValue
+                                                    }
+                                                  : v
+                                              )
+                                            }
+                                          };
+                                        })
+                                      }
+                                    />
+                                  </div>
+                                  <div>
+                                    <Label className="text-xs uppercase text-muted-foreground">Status</Label>
+                                    <select
+                                      className="mt-1 w-full rounded-md border border-border bg-background/80 px-3 py-2 text-sm capitalize focus:outline-none focus:ring-2 focus:ring-primary"
+                                      value={editableVenue.status || 'scheduled'}
+                                      onChange={(e) =>
+                                        setEditForms((prev) => ({
+                                          ...prev,
+                                          [tour.id]: {
+                                            ...prev[tour.id],
+                                            venues: prev[tour.id].venues.map((v) =>
+                                              v.id === venue.id ? { ...v, status: e.target.value } : v
+                                            )
+                                          }
+                                        }))
+                                      }
+                                    >
+                                      {venueStatusOptions.map((status) => (
+                                        <option key={status} value={status}>
+                                          {status.charAt(0).toUpperCase() + status.slice(1)}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </div>
+                                </div>
+                                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                                  <MapPin className="h-3 w-3" />
+                                  {selectedVenueInfo?.location} • Capacity {selectedVenueInfo?.capacity}
+                                </div>
+                              </div>
+                            );
+                          }
+
+                          return (
+                            <div key={venue.id} className="flex items-center justify-between p-3 rounded-lg bg-secondary/30">
+                              <div className="flex-1">
+                                <p className="font-medium">{venue.venue.name}</p>
+                                <p className="text-sm text-muted-foreground flex items-center gap-1">
+                                  <MapPin className="h-3 w-3" />
+                                  {venue.venue.location} • {new Date(venue.date).toLocaleDateString()}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {venue.tickets_sold}/{venue.venue.capacity} tickets • ${venue.ticket_price} each
+                                </p>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <Badge variant="outline" className={getStatusColor(venue.status || 'scheduled')}>
+                                  {venue.status || 'scheduled'}
+                                </Badge>
+                                {venue.status === 'scheduled' && (
+                                  <Button
+                                    size="sm"
+                                    onClick={() => simulateTourShow(venue.id, venue.venue)}
+                                  >
+                                    Perform
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })
+                      ) : (
                         <p className="text-center text-muted-foreground py-4">
                           No venues added to this tour yet
                         </p>
@@ -478,9 +970,13 @@ const TourManager = () => {
                     <div className="flex items-center gap-4 text-sm text-muted-foreground">
                       <span>{new Date(tour.start_date).toLocaleDateString()} - {new Date(tour.end_date).toLocaleDateString()}</span>
                     </div>
-                    <Button variant="outline" size="sm">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleManageClick(tour)}
+                    >
                       <Settings className="h-4 w-4 mr-2" />
-                      Manage
+                      {editingTourId === tour.id ? "Close" : "Manage"}
                     </Button>
                   </div>
                 </CardContent>


### PR DESCRIPTION
## Summary
- add editing state, helpers, and Supabase update logic for tours and tour venues
- implement tour cancellation that removes related tour_venues rows and refreshes the list
- expose inline controls to adjust tour dates, status, venues, and add new stops from the manager UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c96c4dfee883258495e0685f72934a