### PR TITLE
Add global leaderboards data and UI

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1063,6 +1063,20 @@ export type Database = {
       }
     }
     Views: {
+      leaderboards: {
+        Row: {
+          avatar_url: string | null
+          display_name: string | null
+          experience: number
+          fame: number
+          total_achievements: number
+          total_gigs: number
+          total_revenue: number
+          user_id: string
+          username: string | null
+        }
+        Relationships: []
+      },
       player_achievement_summary: {
         Row: {
           earned_count: number

--- a/src/pages/PlayerStatistics.tsx
+++ b/src/pages/PlayerStatistics.tsx
@@ -1,13 +1,17 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAuth } from "@/hooks/useAuth";
 import { useGameData } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
-import { calculateLevel, getFameTitle, calculateEquipmentBonus } from "@/utils/gameBalance";
-import { 
+import type { Database } from "@/integrations/supabase/types";
+import { calculateLevel, getFameTitle } from "@/utils/gameBalance";
+import {
   User, 
   TrendingUp, 
   Star, 
@@ -19,7 +23,8 @@ import {
   Play,
   Target,
   BarChart3,
-  Crown
+  Crown,
+  type LucideIcon
 } from "lucide-react";
 
 interface AchievementProgress {
@@ -48,11 +53,53 @@ interface ExtendedStats {
   achievements: AchievementProgress;
 }
 
+type LeaderboardRow = Database["public"]["Views"]["leaderboards"]["Row"];
+
+type LeaderboardEntry = LeaderboardRow;
+
+type LeaderboardMetric = "fame" | "gigs" | "achievements";
+
+type LeaderboardField = "fame" | "total_gigs" | "total_achievements";
+
+const leaderboardMetricConfig: Record<LeaderboardMetric, {
+  label: string;
+  description: string;
+  field: LeaderboardField;
+  icon: LucideIcon;
+  format: (value: number) => string;
+}> = {
+  fame: {
+    label: "Fame",
+    description: "Overall celebrity status across Rockmundo.",
+    field: "fame",
+    icon: Crown,
+    format: (value: number) => value.toLocaleString(),
+  },
+  gigs: {
+    label: "Gigs Performed",
+    description: "Total gigs completed by each performer.",
+    field: "total_gigs",
+    icon: Calendar,
+    format: (value: number) => value.toLocaleString(),
+  },
+  achievements: {
+    label: "Achievements",
+    description: "Unlocked achievements by dedicated artists.",
+    field: "total_achievements",
+    icon: Trophy,
+    format: (value: number) => value.toLocaleString(),
+  },
+};
+
 const PlayerStatistics = () => {
   const { user } = useAuth();
   const { profile, skills } = useGameData();
   const [extendedStats, setExtendedStats] = useState<ExtendedStats | null>(null);
   const [loading, setLoading] = useState(true);
+  const [leaderboardEntries, setLeaderboardEntries] = useState<LeaderboardEntry[]>([]);
+  const [leaderboardLoading, setLeaderboardLoading] = useState(true);
+  const [leaderboardError, setLeaderboardError] = useState<string | null>(null);
+  const [selectedLeaderboardMetric, setSelectedLeaderboardMetric] = useState<LeaderboardMetric>("fame");
 
   const fetchExtendedStats = useCallback(async () => {
     if (!user) return;
@@ -193,11 +240,43 @@ const PlayerStatistics = () => {
     }
   }, [user, profile]);
 
+  const fetchLeaderboard = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      setLeaderboardLoading(true);
+      setLeaderboardError(null);
+
+      const { data, error } = await supabase
+        .from('leaderboards')
+        .select('*');
+
+      if (error) throw error;
+
+      const rows = ((data ?? []) as LeaderboardRow[]).map(row => ({
+        ...row,
+        total_revenue: Number(row.total_revenue ?? 0),
+      }));
+
+      setLeaderboardEntries(rows);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error('Error fetching leaderboard:', error.message);
+      } else {
+        console.error('Error fetching leaderboard:', error);
+      }
+      setLeaderboardError('Failed to load leaderboard data.');
+    } finally {
+      setLeaderboardLoading(false);
+    }
+  }, [user]);
+
   useEffect(() => {
     if (user) {
       fetchExtendedStats();
+      fetchLeaderboard();
     }
-  }, [user, fetchExtendedStats]);
+  }, [user, fetchExtendedStats, fetchLeaderboard]);
 
   useEffect(() => {
     if (!user) return;
@@ -214,6 +293,7 @@ const PlayerStatistics = () => {
         },
         () => {
           fetchExtendedStats();
+          fetchLeaderboard();
         }
       )
       .subscribe();
@@ -221,7 +301,25 @@ const PlayerStatistics = () => {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [user, fetchExtendedStats]);
+  }, [user, fetchExtendedStats, fetchLeaderboard]);
+
+  const metricConfig = leaderboardMetricConfig[selectedLeaderboardMetric];
+  const sortedLeaderboard = useMemo(() => {
+    const entries = [...leaderboardEntries];
+    return entries.sort((a, b) => b[metricConfig.field] - a[metricConfig.field]);
+  }, [leaderboardEntries, metricConfig.field]);
+  const topLeaderboardEntries = useMemo(() => sortedLeaderboard.slice(0, 5), [sortedLeaderboard]);
+  const playerRank = useMemo(() => {
+    if (!user) return null;
+    const index = sortedLeaderboard.findIndex(entry => entry.user_id === user.id);
+    return index === -1 ? null : index + 1;
+  }, [sortedLeaderboard, user]);
+  const playerMetricValue = useMemo(() => {
+    if (!user) return 0;
+    const entry = leaderboardEntries.find(item => item.user_id === user.id);
+    if (!entry) return 0;
+    return entry[metricConfig.field];
+  }, [leaderboardEntries, metricConfig.field, user]);
 
   if (loading || !profile || !skills) {
     return (
@@ -239,6 +337,8 @@ const PlayerStatistics = () => {
   const skillAverage = Math.round(
     (skills.performance + (skills.songwriting || 0) + (skills.guitar || 0) + (skills.vocals || 0) + (skills.drums || 0)) / 5
   );
+  const playerAvatarLabel = (profile.display_name || profile.username || 'P').slice(0, 2).toUpperCase();
+  const MetricIcon = metricConfig.icon;
 
   return (
     <div className="min-h-screen bg-gradient-stage p-6">
@@ -368,6 +468,134 @@ const PlayerStatistics = () => {
                     )}
                   </div>
                 )}
+              </CardContent>
+            </Card>
+
+            {/* Global Leaderboards */}
+            <Card>
+              <CardHeader>
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <BarChart3 className="h-5 w-5" />
+                      Global Leaderboards
+                    </CardTitle>
+                    <CardDescription>{metricConfig.description}</CardDescription>
+                  </div>
+                  <ToggleGroup
+                    type="single"
+                    value={selectedLeaderboardMetric}
+                    onValueChange={(value) => {
+                      if (value) {
+                        setSelectedLeaderboardMetric(value as LeaderboardMetric);
+                      }
+                    }}
+                    className="grid grid-cols-3 gap-2 md:inline-flex"
+                  >
+                    {Object.entries(leaderboardMetricConfig).map(([key, config]) => {
+                      const metricKey = key as LeaderboardMetric;
+                      const OptionIcon = config.icon;
+                      return (
+                        <ToggleGroupItem
+                          key={metricKey}
+                          value={metricKey}
+                          className="px-3 py-2 text-sm font-medium data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+                        >
+                          <span className="flex items-center gap-2">
+                            <OptionIcon className="h-4 w-4" />
+                            {config.label}
+                          </span>
+                        </ToggleGroupItem>
+                      );
+                    })}
+                  </ToggleGroup>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="rounded-lg border border-primary/30 bg-muted/40 p-4">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div className="flex items-center gap-3">
+                      <Avatar className="h-12 w-12">
+                        <AvatarImage
+                          src={profile.avatar_url || undefined}
+                          alt={profile.display_name || profile.username || 'Player avatar'}
+                        />
+                        <AvatarFallback>{playerAvatarLabel}</AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <p className="text-sm text-muted-foreground">Your Position</p>
+                        <p className="text-2xl font-bold text-primary">
+                          {playerRank ? `#${playerRank}` : "Unranked"}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-start gap-2 text-sm md:items-end">
+                      <div className="flex items-center gap-2 text-base font-semibold text-foreground">
+                        <MetricIcon className="h-4 w-4 text-primary" />
+                        <span>{metricConfig.format(playerMetricValue)}</span>
+                      </div>
+                      <span className="text-xs text-muted-foreground">{metricConfig.label}</span>
+                      {!playerRank && (
+                        <span className="text-xs text-muted-foreground">
+                          Complete more activities to enter the leaderboard.
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                {leaderboardError && (
+                  <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                    {leaderboardError}
+                  </div>
+                )}
+                <div className="space-y-3">
+                  {leaderboardLoading ? (
+                    <div className="space-y-2">
+                      {Array.from({ length: 5 }).map((_, index) => (
+                        <Skeleton key={index} className="h-14 w-full" />
+                      ))}
+                    </div>
+                  ) : topLeaderboardEntries.length > 0 ? (
+                    topLeaderboardEntries.map((entry, index) => {
+                      const displayName = entry.display_name || entry.username || 'Unknown Artist';
+                      const isCurrentUser = entry.user_id === user?.id;
+                      const metricValue = metricConfig.format(entry[metricConfig.field]);
+                      return (
+                        <div
+                          key={entry.user_id}
+                          className={`flex items-center justify-between rounded-lg border p-3 transition-colors ${
+                            isCurrentUser ? 'border-primary bg-primary/10' : 'border-border bg-card/40'
+                          }`}
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="text-lg font-bold text-muted-foreground">#{index + 1}</span>
+                            <Avatar className="h-10 w-10">
+                              <AvatarImage src={entry.avatar_url || undefined} alt={displayName} />
+                              <AvatarFallback>{displayName.slice(0, 2).toUpperCase()}</AvatarFallback>
+                            </Avatar>
+                            <div>
+                              <div className="font-semibold">{displayName}</div>
+                              {entry.username && (
+                                <div className="text-xs text-muted-foreground">@{entry.username}</div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="flex items-center justify-end gap-2 text-sm font-semibold">
+                              <MetricIcon className="h-4 w-4 text-primary" />
+                              <span>{metricValue}</span>
+                            </div>
+                            <div className="text-xs text-muted-foreground">{metricConfig.label}</div>
+                          </div>
+                        </div>
+                      );
+                    })
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      No leaderboard data available yet. Keep playing to be featured here.
+                    </p>
+                  )}
+                </div>
               </CardContent>
             </Card>
 

--- a/supabase/migrations/20250916153000_create_leaderboards_view.sql
+++ b/supabase/migrations/20250916153000_create_leaderboards_view.sql
@@ -1,0 +1,41 @@
+-- Create a leaderboard view that aggregates metrics across all players
+DROP VIEW IF EXISTS public.leaderboards;
+
+CREATE VIEW public.leaderboards AS
+WITH song_stats AS (
+  SELECT
+    user_id,
+    COALESCE(SUM(revenue), 0)::numeric AS total_song_revenue
+  FROM public.songs
+  GROUP BY user_id
+),
+gig_stats AS (
+  SELECT
+    user_id,
+    COALESCE(SUM(earnings), 0)::numeric AS total_gig_revenue,
+    COUNT(*)::integer AS total_gigs
+  FROM public.gig_performances
+  GROUP BY user_id
+),
+achievement_totals AS (
+  SELECT
+    user_id,
+    COALESCE(earned_count, 0)::integer AS total_achievements
+  FROM public.player_achievement_summary
+)
+SELECT
+  p.user_id,
+  p.username,
+  p.display_name,
+  p.avatar_url,
+  COALESCE(p.fame, 0) AS fame,
+  COALESCE(p.experience, 0) AS experience,
+  (COALESCE(ss.total_song_revenue, 0) + COALESCE(gs.total_gig_revenue, 0))::numeric AS total_revenue,
+  COALESCE(gs.total_gigs, 0) AS total_gigs,
+  COALESCE(at.total_achievements, 0) AS total_achievements
+FROM public.profiles p
+LEFT JOIN song_stats ss ON ss.user_id = p.user_id
+LEFT JOIN gig_stats gs ON gs.user_id = p.user_id
+LEFT JOIN achievement_totals at ON at.user_id = p.user_id;
+
+GRANT SELECT ON public.leaderboards TO anon, authenticated;


### PR DESCRIPTION
## Summary
- add a `leaderboards` database view to aggregate fame, revenue, experience, gigs, and achievement counts for every player
- extend the Supabase TypeScript definitions to expose the new view to the frontend
- load leaderboard data in the player statistics page and render a global leaderboard card with metric filters and player ranking details

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c96c55247c8325975220128b85b1e4