### PR TITLE
Implement Supabase-backed World Pulse charts

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -422,6 +422,45 @@ export type Database = {
         }
         Relationships: []
       }
+      genre_statistics: {
+        Row: {
+          avg_popularity: number
+          chart_date: string
+          chart_type: string
+          created_at: string
+          genre: string
+          growth: number
+          id: string
+          top_song: string | null
+          total_plays: number
+          total_songs: number
+        }
+        Insert: {
+          avg_popularity?: number
+          chart_date: string
+          chart_type?: string
+          created_at?: string
+          genre: string
+          growth?: number
+          id?: string
+          top_song?: string | null
+          total_plays?: number
+          total_songs?: number
+        }
+        Update: {
+          avg_popularity?: number
+          chart_date?: string
+          chart_type?: string
+          created_at?: string
+          genre?: string
+          growth?: number
+          id?: string
+          top_song?: string | null
+          total_plays?: number
+          total_songs?: number
+        }
+        Relationships: []
+      }
       gig_performances: {
         Row: {
           earnings: number | null
@@ -540,6 +579,68 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      }
+      global_charts: {
+        Row: {
+          artist_name: string | null
+          band_name: string | null
+          chart_date: string
+          chart_type: string
+          created_at: string
+          genre: string
+          id: string
+          plays: number
+          popularity: number
+          rank: number
+          song_id: string | null
+          song_title: string
+          trend: string
+          trend_change: number
+          weeks_on_chart: number
+        }
+        Insert: {
+          artist_name?: string | null
+          band_name?: string | null
+          chart_date: string
+          chart_type: string
+          created_at?: string
+          genre: string
+          id?: string
+          plays?: number
+          popularity?: number
+          rank: number
+          song_id?: string | null
+          song_title: string
+          trend?: string
+          trend_change?: number
+          weeks_on_chart?: number
+        }
+        Update: {
+          artist_name?: string | null
+          band_name?: string | null
+          chart_date?: string
+          chart_type?: string
+          created_at?: string
+          genre?: string
+          id?: string
+          plays?: number
+          popularity?: number
+          rank?: number
+          song_id?: string | null
+          song_title?: string
+          trend?: string
+          trend_change?: number
+          weeks_on_chart?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "global_charts_song_id_fkey"
+            columns: ["song_id"]
+            isOneToOne: false
+            referencedRelation: "songs"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       player_achievements: {
         Row: {

--- a/src/pages/WorldPulse.tsx
+++ b/src/pages/WorldPulse.tsx
@@ -1,20 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Progress } from "@/components/ui/progress";
-import { 
-  TrendingUp, 
-  Trophy, 
-  Music, 
-  Users, 
+import {
+  TrendingUp,
+  Trophy,
   Calendar,
   Star,
   Play,
   Crown,
   Award,
-  Zap
+  Zap,
+  Loader2
 } from "lucide-react";
 
 interface ChartEntry {
@@ -25,7 +27,7 @@ interface ChartEntry {
   genre: string;
   plays: number;
   popularity: number;
-  trend: 'up' | 'down' | 'same';
+  trend: "up" | "down" | "same";
   trendChange: number;
   weeksOnChart: number;
 }
@@ -39,233 +41,327 @@ interface GenreStats {
   growth: number;
 }
 
+type GlobalChartRow = Database["public"]["Tables"]["global_charts"]["Row"];
+type GenreStatisticRow = Database["public"]["Tables"]["genre_statistics"]["Row"];
+
+const parseNumeric = (value: number | string | null | undefined): number => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+};
+
+const clampPercentage = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(value)));
+};
+
+const toTrend = (value: string | null): ChartEntry["trend"] => {
+  if (value === "up" || value === "down" || value === "same") {
+    return value;
+  }
+  return "same";
+};
+
+const mapGlobalChartRow = (row: GlobalChartRow): ChartEntry => ({
+  rank: row.rank ?? 0,
+  title: row.song_title ?? "Unknown Track",
+  artist: row.artist_name ?? "Unknown Artist",
+  band: row.band_name ?? "—",
+  genre: row.genre ?? "Unknown",
+  plays: parseNumeric(row.plays),
+  popularity: clampPercentage(parseNumeric(row.popularity)),
+  trend: toTrend(row.trend ?? "same"),
+  trendChange: row.trend_change ?? 0,
+  weeksOnChart: row.weeks_on_chart ?? 0
+});
+
+const mapGenreStatisticRow = (row: GenreStatisticRow): GenreStats => ({
+  genre: row.genre,
+  totalPlays: parseNumeric(row.total_plays),
+  totalSongs: row.total_songs ?? 0,
+  avgPopularity: clampPercentage(parseNumeric(row.avg_popularity)),
+  topSong: row.top_song ?? "—",
+  growth: parseNumeric(row.growth)
+});
+
+const formatDateLabel = (value: string, prefix?: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return prefix ? `${prefix}${value}` : value;
+  }
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric"
+  }).format(date);
+  return prefix ? `${prefix}${formatted}` : formatted;
+};
+
+const getWeekLabel = (value: string | null) => {
+  if (!value) {
+    return "No weekly data";
+  }
+  return formatDateLabel(value, "Week of ");
+};
+
+const getDailyLabel = (value: string | null) => {
+  if (!value) {
+    return null;
+  }
+  return formatDateLabel(value);
+};
+
 const WorldPulse = () => {
   const [dailyChart, setDailyChart] = useState<ChartEntry[]>([]);
   const [weeklyChart, setWeeklyChart] = useState<ChartEntry[]>([]);
   const [genreStats, setGenreStats] = useState<GenreStats[]>([]);
-  const [currentWeek, setCurrentWeek] = useState("Week 23, 2024");
+  const [availableWeeks, setAvailableWeeks] = useState<string[]>([]);
+  const [selectedWeek, setSelectedWeek] = useState<string | null>(null);
+  const [latestDailyDate, setLatestDailyDate] = useState<string | null>(null);
+  const [isDailyLoading, setIsDailyLoading] = useState(false);
+  const [isWeeklyLoading, setIsWeeklyLoading] = useState(false);
+  const [isGenreLoading, setIsGenreLoading] = useState(false);
+  const [isWeeksLoading, setIsWeeksLoading] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
 
-  useEffect(() => {
-    loadChartData();
+  const loadLatestDailyChart = useCallback(async () => {
+    setIsDailyLoading(true);
+    try {
+      const { data: latestDateData, error: latestDateError } = await supabase
+        .from("global_charts")
+        .select("chart_date")
+        .eq("chart_type", "daily")
+        .order("chart_date", { ascending: false })
+        .limit(1);
+
+      if (latestDateError) {
+        throw latestDateError;
+      }
+
+      const latestDate = latestDateData?.[0]?.chart_date ?? null;
+      setLatestDailyDate(latestDate);
+
+      if (!latestDate) {
+        setDailyChart([]);
+        return;
+      }
+
+      const { data, error: dailyError } = await supabase
+        .from("global_charts")
+        .select("*")
+        .eq("chart_type", "daily")
+        .eq("chart_date", latestDate)
+        .order("rank", { ascending: true });
+
+      if (dailyError) {
+        throw dailyError;
+      }
+
+      const rows = (data ?? []) as GlobalChartRow[];
+      setDailyChart(rows.map(mapGlobalChartRow));
+    } catch (dailyLoadError) {
+      console.error("Failed to load daily chart:", dailyLoadError);
+      setError("Unable to load daily charts right now.");
+      setDailyChart([]);
+      setLatestDailyDate(null);
+    } finally {
+      setIsDailyLoading(false);
+    }
   }, []);
 
-  const loadChartData = async () => {
+  const loadAvailableWeeks = useCallback(async () => {
+    setIsWeeksLoading(true);
     try {
-      // Simulated chart data
-      const mockDailyChart: ChartEntry[] = [
-        {
-          rank: 1,
-          title: "Electric Storm",
-          artist: "Nova Thunder",
-          band: "Storm Riders",
-          genre: "Rock",
-          plays: 45789,
-          popularity: 95,
-          trend: "up",
-          trendChange: 3,
-          weeksOnChart: 2
-        },
-        {
-          rank: 2,
-          title: "Midnight Rebellion",
-          artist: "Shadow Phoenix",
-          band: "Dark Angels",
-          genre: "Metal",
-          plays: 42156,
-          popularity: 92,
-          trend: "down",
-          trendChange: -1,
-          weeksOnChart: 5
-        },
-        {
-          rank: 3,
-          title: "Digital Dreams",
-          artist: "Cyber Queen",
-          band: "Neon Knights",
-          genre: "Electronic",
-          plays: 38942,
-          popularity: 89,
-          trend: "up",
-          trendChange: 2,
-          weeksOnChart: 1
-        },
-        {
-          rank: 4,
-          title: "Broken Wings",
-          artist: "Angel Dust",
-          band: "Fallen Angels",
-          genre: "Alternative",
-          plays: 35678,
-          popularity: 85,
-          trend: "same",
-          trendChange: 0,
-          weeksOnChart: 3
-        },
-        {
-          rank: 5,
-          title: "Fire in the Sky",
-          artist: "Blaze",
-          band: "Phoenix Rising",
-          genre: "Punk",
-          plays: 32145,
-          popularity: 82,
-          trend: "up",
-          trendChange: 1,
-          weeksOnChart: 4
-        },
-        {
-          rank: 6,
-          title: "Whispers in the Dark",
-          artist: "Midnight",
-          band: "Shadow Band",
-          genre: "Gothic",
-          plays: 29876,
-          popularity: 78,
-          trend: "down",
-          trendChange: -2,
-          weeksOnChart: 6
-        },
-        {
-          rank: 7,
-          title: "Thunder Road",
-          artist: "Lightning",
-          band: "Storm Chasers",
-          genre: "Rock",
-          plays: 27543,
-          popularity: 75,
-          trend: "up",
-          trendChange: 4,
-          weeksOnChart: 1
-        },
-        {
-          rank: 8,
-          title: "Crystal Vision",
-          artist: "Mystic",
-          band: "Dream Weavers",
-          genre: "Progressive",
-          plays: 25421,
-          popularity: 72,
-          trend: "same",
-          trendChange: 0,
-          weeksOnChart: 8
-        },
-        {
-          rank: 9,
-          title: "Neon Nights",
-          artist: "Synthwave",
-          band: "Retro Future",
-          genre: "Electronic",
-          plays: 23198,
-          popularity: 69,
-          trend: "up",
-          trendChange: 2,
-          weeksOnChart: 2
-        },
-        {
-          rank: 10,
-          title: "Wild Heart",
-          artist: "Rebel",
-          band: "Free Spirits",
-          genre: "Folk Rock",
-          plays: 21087,
-          popularity: 66,
-          trend: "down",
-          trendChange: -3,
-          weeksOnChart: 7
-        }
-      ];
+      const { data, error: weeksError } = await supabase
+        .from("global_charts")
+        .select("chart_date")
+        .eq("chart_type", "weekly")
+        .order("chart_date", { ascending: false })
+        .limit(120);
 
-      const mockGenreStats: GenreStats[] = [
-        {
-          genre: "Rock",
-          totalPlays: 156789,
-          totalSongs: 45,
-          avgPopularity: 78,
-          topSong: "Electric Storm",
-          growth: 12.5
-        },
-        {
-          genre: "Metal",
-          totalPlays: 134567,
-          totalSongs: 38,
-          avgPopularity: 82,
-          topSong: "Midnight Rebellion",
-          growth: 8.3
-        },
-        {
-          genre: "Electronic",
-          totalPlays: 98432,
-          totalSongs: 52,
-          avgPopularity: 75,
-          topSong: "Digital Dreams",
-          growth: 15.7
-        },
-        {
-          genre: "Alternative",
-          totalPlays: 87654,
-          totalSongs: 41,
-          avgPopularity: 73,
-          topSong: "Broken Wings",
-          growth: 6.2
-        },
-        {
-          genre: "Punk",
-          totalPlays: 76543,
-          totalSongs: 35,
-          avgPopularity: 71,
-          topSong: "Fire in the Sky",
-          growth: 9.8
-        }
-      ];
+      if (weeksError) {
+        throw weeksError;
+      }
 
-      setDailyChart(mockDailyChart);
-      setWeeklyChart(mockDailyChart); // Using same data for demo
-      setGenreStats(mockGenreStats);
-    } catch (error) {
-      console.error("Failed to load chart data:", error);
+      const weekDates = Array.from(
+        new Set((data ?? []).map((row) => row.chart_date).filter((date): date is string => Boolean(date)))
+      );
+
+      setAvailableWeeks(weekDates);
+      setSelectedWeek((prev) => {
+        if (prev && weekDates.includes(prev)) {
+          return prev;
+        }
+        return weekDates[0] ?? null;
+      });
+    } catch (weeksLoadError) {
+      console.error("Failed to load available weeks:", weeksLoadError);
+      setError("Unable to load weekly chart periods.");
+      setAvailableWeeks([]);
+      setSelectedWeek(null);
+    } finally {
+      setIsWeeksLoading(false);
     }
-  };
+  }, []);
 
-  const getTrendIcon = (trend: string, change: number) => {
-    if (trend === 'up') return <TrendingUp className="h-4 w-4 text-success" />;
-    if (trend === 'down') return <TrendingUp className="h-4 w-4 text-destructive rotate-180" />;
+  const loadWeeklyChart = useCallback(async (week: string) => {
+    setIsWeeklyLoading(true);
+    try {
+      const { data, error: weeklyError } = await supabase
+        .from("global_charts")
+        .select("*")
+        .eq("chart_type", "weekly")
+        .eq("chart_date", week)
+        .order("rank", { ascending: true });
+
+      if (weeklyError) {
+        throw weeklyError;
+      }
+
+      const rows = (data ?? []) as GlobalChartRow[];
+      setWeeklyChart(rows.map(mapGlobalChartRow));
+    } catch (weeklyLoadError) {
+      console.error("Failed to load weekly chart:", weeklyLoadError);
+      setError("Unable to load weekly chart data.");
+      setWeeklyChart([]);
+    } finally {
+      setIsWeeklyLoading(false);
+    }
+  }, []);
+
+  const loadGenreStatistics = useCallback(async (week: string) => {
+    setIsGenreLoading(true);
+    try {
+      const { data, error: genreError } = await supabase
+        .from("genre_statistics")
+        .select("*")
+        .eq("chart_type", "weekly")
+        .eq("chart_date", week)
+        .order("total_plays", { ascending: false });
+
+      if (genreError) {
+        throw genreError;
+      }
+
+      const rows = (data ?? []) as GenreStatisticRow[];
+      setGenreStats(rows.map(mapGenreStatisticRow));
+    } catch (genreLoadError) {
+      console.error("Failed to load genre statistics:", genreLoadError);
+      setError("Unable to load genre statistics.");
+      setGenreStats([]);
+    } finally {
+      setIsGenreLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setError(null);
+    loadLatestDailyChart();
+    loadAvailableWeeks();
+  }, [loadLatestDailyChart, loadAvailableWeeks]);
+
+  useEffect(() => {
+    if (!selectedWeek) {
+      setWeeklyChart([]);
+      setGenreStats([]);
+      return;
+    }
+
+    loadWeeklyChart(selectedWeek);
+    loadGenreStatistics(selectedWeek);
+  }, [selectedWeek, refreshKey, loadWeeklyChart, loadGenreStatistics]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    setError(null);
+    try {
+      await Promise.all([loadLatestDailyChart(), loadAvailableWeeks()]);
+      setRefreshKey((prev) => prev + 1);
+    } catch (refreshError) {
+      console.error("Failed to refresh charts:", refreshError);
+      setError("Failed to refresh chart data. Please try again.");
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [loadLatestDailyChart, loadAvailableWeeks]);
+
+  const getTrendIcon = (trend: ChartEntry["trend"], change: number) => {
+    if (trend === "up") {
+      return <TrendingUp className="h-4 w-4 text-success" />;
+    }
+    if (trend === "down") {
+      return <TrendingUp className="h-4 w-4 text-destructive rotate-180" />;
+    }
     return <span className="h-4 w-4 text-muted-foreground">-</span>;
   };
 
-  const getTrendColor = (trend: string) => {
+  const getTrendColor = (trend: ChartEntry["trend"]) => {
     switch (trend) {
-      case 'up': return 'text-success';
-      case 'down': return 'text-destructive';
-      default: return 'text-muted-foreground';
+      case "up":
+        return "text-success";
+      case "down":
+        return "text-destructive";
+      default:
+        return "text-muted-foreground";
     }
   };
 
   const getRankBadge = (rank: number) => {
-    if (rank === 1) return <Crown className="h-4 w-4 text-yellow-500" />;
-    if (rank === 2) return <Award className="h-4 w-4 text-gray-400" />;
-    if (rank === 3) return <Award className="h-4 w-4 text-amber-600" />;
+    if (rank === 1) {
+      return <Crown className="h-4 w-4 text-yellow-500" />;
+    }
+    if (rank === 2) {
+      return <Award className="h-4 w-4 text-gray-400" />;
+    }
+    if (rank === 3) {
+      return <Award className="h-4 w-4 text-amber-600" />;
+    }
     return <span className="text-lg font-bold text-muted-foreground">#{rank}</span>;
   };
+
+  const weeklyDescription = selectedWeek
+    ? `Most popular songs for ${formatDateLabel(selectedWeek, "Week of ")}`
+    : "Select a week to view rankings";
+  const dailyDescription = getDailyLabel(latestDailyDate);
+  const currentWeekLabel = getWeekLabel(selectedWeek);
 
   return (
     <div className="min-h-screen bg-gradient-stage p-6">
       <div className="max-w-7xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div>
             <h1 className="text-3xl font-bold bg-gradient-primary bg-clip-text text-transparent">
               World Pulse Charts
             </h1>
             <p className="text-muted-foreground">Global music trends and rankings</p>
+            {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
           </div>
           <div className="flex items-center gap-2">
             <Badge variant="outline" className="border-primary/20">
               <Calendar className="h-3 w-3 mr-1" />
-              {currentWeek}
+              {currentWeekLabel}
             </Badge>
-            <Button variant="outline" className="border-primary/20 hover:bg-primary/10">
-              <Zap className="h-4 w-4 mr-2" />
-              Refresh Charts
+            <Button
+              variant="outline"
+              className="border-primary/20 hover:bg-primary/10"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Zap className="h-4 w-4 mr-2" />
+              )}
+              {isRefreshing ? "Refreshing..." : "Refresh Charts"}
             </Button>
           </div>
         </div>
@@ -284,170 +380,237 @@ const WorldPulse = () => {
                   <Trophy className="h-5 w-5 text-primary" />
                   Daily Chart - Top 10
                 </CardTitle>
-                <CardDescription>Most popular songs today</CardDescription>
+                <CardDescription>
+                  {dailyDescription
+                    ? `Most popular songs for ${dailyDescription}`
+                    : "Most popular songs from the latest update"}
+                </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-3">
-                  {dailyChart.map((entry) => (
-                    <div 
-                      key={entry.rank}
-                      className="flex items-center gap-4 p-4 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
-                    >
-                      <div className="flex items-center justify-center w-12">
-                        {getRankBadge(entry.rank)}
-                      </div>
-                      
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-semibold text-lg truncate">{entry.title}</h3>
-                          <Badge variant="outline" className="text-xs">
-                            {entry.genre}
-                          </Badge>
+                {isDailyLoading ? (
+                  <div className="py-6 text-center text-sm text-muted-foreground">Loading daily chart...</div>
+                ) : dailyChart.length === 0 ? (
+                  <div className="py-6 text-center text-sm text-muted-foreground">
+                    Daily chart data is not available yet.
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {dailyChart.map((entry) => (
+                      <div
+                        key={`${entry.rank}-${entry.title}`}
+                        className="flex items-center gap-4 p-4 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+                      >
+                        <div className="flex items-center justify-center w-12">
+                          {getRankBadge(entry.rank)}
                         </div>
-                        <p className="text-sm text-muted-foreground">
-                          {entry.artist} • {entry.band}
-                        </p>
-                      </div>
 
-                      <div className="text-right space-y-1">
-                        <div className="flex items-center gap-2">
-                          <Play className="h-3 w-3" />
-                          <span className="font-mono text-sm">{entry.plays.toLocaleString()}</span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h3 className="font-semibold text-lg truncate">{entry.title}</h3>
+                            <Badge variant="outline" className="text-xs">
+                              {entry.genre}
+                            </Badge>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {entry.artist}
+                            {entry.band && entry.band !== "—" ? ` • ${entry.band}` : ""}
+                          </p>
                         </div>
-                        <div className="flex items-center gap-2">
-                          {getTrendIcon(entry.trend, entry.trendChange)}
-                          <span className={`text-sm ${getTrendColor(entry.trend)}`}>
-                            {entry.trend === 'same' ? '—' : `${entry.trendChange > 0 ? '+' : ''}${entry.trendChange}`}
-                          </span>
+
+                        <div className="text-right space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Play className="h-3 w-3" />
+                            <span className="font-mono text-sm">{entry.plays.toLocaleString()}</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {getTrendIcon(entry.trend, entry.trendChange)}
+                            <span className={`text-sm ${getTrendColor(entry.trend)}`}>
+                              {entry.trend === "same"
+                                ? "—"
+                                : `${entry.trendChange > 0 ? "+" : ""}${entry.trendChange}`}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="w-24">
+                          <div className="text-xs text-muted-foreground mb-1">Popularity</div>
+                          <Progress value={entry.popularity} className="h-2" />
+                          <div className="text-xs text-right mt-1">{entry.popularity}%</div>
+                        </div>
+
+                        <div className="text-center text-xs text-muted-foreground">
+                          <div>{entry.weeksOnChart}</div>
+                          <div>weeks</div>
                         </div>
                       </div>
-
-                      <div className="w-24">
-                        <div className="text-xs text-muted-foreground mb-1">Popularity</div>
-                        <Progress value={entry.popularity} className="h-2" />
-                        <div className="text-xs text-right mt-1">{entry.popularity}%</div>
-                      </div>
-
-                      <div className="text-center text-xs text-muted-foreground">
-                        <div>{entry.weeksOnChart}</div>
-                        <div>weeks</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
           <TabsContent value="weekly">
             <Card className="bg-card/80 backdrop-blur-sm border-primary/20">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Star className="h-5 w-5 text-accent" />
-                  Weekly Chart - Top 10
-                </CardTitle>
-                <CardDescription>Most popular songs this week</CardDescription>
+              <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <CardTitle className="flex items-center gap-2">
+                    <Star className="h-5 w-5 text-accent" />
+                    Weekly Chart - Top 10
+                  </CardTitle>
+                  <CardDescription>{weeklyDescription}</CardDescription>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Select
+                    value={selectedWeek ?? undefined}
+                    onValueChange={(value) => {
+                      setSelectedWeek(value);
+                    }}
+                    disabled={isWeeksLoading || availableWeeks.length === 0}
+                  >
+                    <SelectTrigger className="w-[200px]">
+                      <SelectValue placeholder={isWeeksLoading ? "Loading weeks..." : "Select week"} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableWeeks.map((week) => (
+                        <SelectItem key={week} value={week}>
+                          {formatDateLabel(week, "Week of ")}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
               </CardHeader>
               <CardContent>
-                <div className="space-y-3">
-                  {weeklyChart.map((entry) => (
-                    <div 
-                      key={entry.rank}
-                      className="flex items-center gap-4 p-4 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
-                    >
-                      <div className="flex items-center justify-center w-12">
-                        {getRankBadge(entry.rank)}
-                      </div>
-                      
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-semibold text-lg truncate">{entry.title}</h3>
-                          <Badge variant="outline" className="text-xs">
-                            {entry.genre}
-                          </Badge>
+                {isWeeklyLoading ? (
+                  <div className="py-6 text-center text-sm text-muted-foreground">Loading weekly chart...</div>
+                ) : weeklyChart.length === 0 ? (
+                  <div className="py-6 text-center text-sm text-muted-foreground">
+                    {selectedWeek
+                      ? "No data available for the selected week yet."
+                      : "Select a week to view weekly rankings."}
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {weeklyChart.map((entry) => (
+                      <div
+                        key={`${entry.rank}-${entry.title}`}
+                        className="flex items-center gap-4 p-4 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+                      >
+                        <div className="flex items-center justify-center w-12">
+                          {getRankBadge(entry.rank)}
                         </div>
-                        <p className="text-sm text-muted-foreground">
-                          {entry.artist} • {entry.band}
-                        </p>
-                      </div>
 
-                      <div className="text-right space-y-1">
-                        <div className="flex items-center gap-2">
-                          <Play className="h-3 w-3" />
-                          <span className="font-mono text-sm">{entry.plays.toLocaleString()}</span>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h3 className="font-semibold text-lg truncate">{entry.title}</h3>
+                            <Badge variant="outline" className="text-xs">
+                              {entry.genre}
+                            </Badge>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {entry.artist}
+                            {entry.band && entry.band !== "—" ? ` • ${entry.band}` : ""}
+                          </p>
                         </div>
-                        <div className="flex items-center gap-2">
-                          {getTrendIcon(entry.trend, entry.trendChange)}
-                          <span className={`text-sm ${getTrendColor(entry.trend)}`}>
-                            {entry.trend === 'same' ? '—' : `${entry.trendChange > 0 ? '+' : ''}${entry.trendChange}`}
-                          </span>
+
+                        <div className="text-right space-y-1">
+                          <div className="flex items-center gap-2">
+                            <Play className="h-3 w-3" />
+                            <span className="font-mono text-sm">{entry.plays.toLocaleString()}</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {getTrendIcon(entry.trend, entry.trendChange)}
+                            <span className={`text-sm ${getTrendColor(entry.trend)}`}>
+                              {entry.trend === "same"
+                                ? "—"
+                                : `${entry.trendChange > 0 ? "+" : ""}${entry.trendChange}`}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="w-24">
+                          <div className="text-xs text-muted-foreground mb-1">Popularity</div>
+                          <Progress value={entry.popularity} className="h-2" />
+                          <div className="text-xs text-right mt-1">{entry.popularity}%</div>
+                        </div>
+
+                        <div className="text-center text-xs text-muted-foreground">
+                          <div>{entry.weeksOnChart}</div>
+                          <div>weeks</div>
                         </div>
                       </div>
-
-                      <div className="w-24">
-                        <div className="text-xs text-muted-foreground mb-1">Popularity</div>
-                        <Progress value={entry.popularity} className="h-2" />
-                        <div className="text-xs text-right mt-1">{entry.popularity}%</div>
-                      </div>
-
-                      <div className="text-center text-xs text-muted-foreground">
-                        <div>{entry.weeksOnChart}</div>
-                        <div>weeks</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
           <TabsContent value="genres">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {genreStats.map((genre) => (
-                <Card key={genre.genre} className="bg-card/80 backdrop-blur-sm border-primary/20">
-                  <CardHeader>
-                    <CardTitle className="flex items-center justify-between">
-                      <span>{genre.genre}</span>
-                      <Badge 
-                        variant={genre.growth > 10 ? "default" : "secondary"}
-                        className={genre.growth > 10 ? "bg-gradient-primary" : ""}
-                      >
-                        {genre.growth > 0 ? '+' : ''}{genre.growth.toFixed(1)}%
-                      </Badge>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="grid grid-cols-2 gap-4 text-center">
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {genre.totalPlays.toLocaleString()}
+            {isGenreLoading ? (
+              <Card className="bg-card/80 backdrop-blur-sm border-primary/20">
+                <CardContent>
+                  <div className="py-6 text-center text-sm text-muted-foreground">Loading genre statistics...</div>
+                </CardContent>
+              </Card>
+            ) : genreStats.length === 0 ? (
+              <Card className="bg-card/80 backdrop-blur-sm border-primary/20">
+                <CardContent>
+                  <div className="py-6 text-center text-sm text-muted-foreground">
+                    {selectedWeek
+                      ? "No genre analytics available for the selected week yet."
+                      : "Select a week to view genre performance."}
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {genreStats.map((genre) => (
+                  <Card key={genre.genre} className="bg-card/80 backdrop-blur-sm border-primary/20">
+                    <CardHeader>
+                      <CardTitle className="flex items-center justify-between">
+                        <span>{genre.genre}</span>
+                        <Badge
+                          variant={genre.growth > 10 ? "default" : "secondary"}
+                          className={genre.growth > 10 ? "bg-gradient-primary" : ""}
+                        >
+                          {genre.growth > 0 ? "+" : ""}
+                          {genre.growth.toFixed(1)}%
+                        </Badge>
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="grid grid-cols-2 gap-4 text-center">
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {Math.round(genre.totalPlays).toLocaleString()}
+                          </div>
+                          <div className="text-xs text-muted-foreground">Total Plays</div>
                         </div>
-                        <div className="text-xs text-muted-foreground">Total Plays</div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-accent">
-                          {genre.totalSongs}
+                        <div>
+                          <div className="text-2xl font-bold text-accent">{genre.totalSongs}</div>
+                          <div className="text-xs text-muted-foreground">Songs</div>
                         </div>
-                        <div className="text-xs text-muted-foreground">Songs</div>
                       </div>
-                    </div>
 
-                    <div>
-                      <div className="flex justify-between text-sm mb-2">
-                        <span>Avg Popularity</span>
-                        <span>{genre.avgPopularity}%</span>
+                      <div>
+                        <div className="flex justify-between text-sm mb-2">
+                          <span>Avg Popularity</span>
+                          <span>{genre.avgPopularity}%</span>
+                        </div>
+                        <Progress value={genre.avgPopularity} className="h-2" />
                       </div>
-                      <Progress value={genre.avgPopularity} className="h-2" />
-                    </div>
 
-                    <div className="pt-2 border-t border-border/50">
-                      <div className="text-xs text-muted-foreground mb-1">Top Song</div>
-                      <div className="font-medium text-sm">{genre.topSong}</div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
+                      <div className="pt-2 border-t border-border/50">
+                        <div className="text-xs text-muted-foreground mb-1">Top Song</div>
+                        <div className="font-medium text-sm">{genre.topSong}</div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
           </TabsContent>
         </Tabs>
       </div>

--- a/supabase/migrations/20250916103000_create_global_charts_tables.sql
+++ b/supabase/migrations/20250916103000_create_global_charts_tables.sql
@@ -1,0 +1,61 @@
+-- Create analytics tables for global chart tracking
+
+CREATE TABLE IF NOT EXISTS public.global_charts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  chart_date date NOT NULL,
+  chart_type text NOT NULL CHECK (chart_type IN ('daily', 'weekly')),
+  rank integer NOT NULL CHECK (rank > 0),
+  song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  song_title text NOT NULL,
+  artist_name text,
+  band_name text,
+  genre text NOT NULL,
+  plays numeric NOT NULL DEFAULT 0 CHECK (plays >= 0),
+  popularity numeric NOT NULL DEFAULT 0 CHECK (popularity >= 0 AND popularity <= 100),
+  trend text NOT NULL DEFAULT 'same' CHECK (trend IN ('up', 'down', 'same')),
+  trend_change integer NOT NULL DEFAULT 0,
+  weeks_on_chart integer NOT NULL DEFAULT 0 CHECK (weeks_on_chart >= 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_global_charts_unique_entry
+  ON public.global_charts(chart_date, chart_type, rank);
+
+CREATE INDEX IF NOT EXISTS idx_global_charts_chart_type_date
+  ON public.global_charts(chart_type, chart_date);
+
+CREATE INDEX IF NOT EXISTS idx_global_charts_song_id
+  ON public.global_charts(song_id);
+
+ALTER TABLE public.global_charts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Global charts are viewable by everyone"
+  ON public.global_charts
+  FOR SELECT
+  USING (true);
+
+CREATE TABLE IF NOT EXISTS public.genre_statistics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  chart_date date NOT NULL,
+  chart_type text NOT NULL DEFAULT 'weekly' CHECK (chart_type IN ('daily', 'weekly', 'monthly')),
+  genre text NOT NULL,
+  total_plays numeric NOT NULL DEFAULT 0 CHECK (total_plays >= 0),
+  total_songs integer NOT NULL DEFAULT 0 CHECK (total_songs >= 0),
+  avg_popularity numeric NOT NULL DEFAULT 0 CHECK (avg_popularity >= 0 AND avg_popularity <= 100),
+  top_song text,
+  growth numeric NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_genre_statistics_unique_period
+  ON public.genre_statistics(chart_date, chart_type, genre);
+
+CREATE INDEX IF NOT EXISTS idx_genre_statistics_chart_type_date
+  ON public.genre_statistics(chart_type, chart_date);
+
+ALTER TABLE public.genre_statistics ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Genre statistics are viewable by everyone"
+  ON public.genre_statistics
+  FOR SELECT
+  USING (true);


### PR DESCRIPTION
## Summary
- add a Supabase migration creating `global_charts` and `genre_statistics` analytics tables with supporting indexes and policies
- extend the generated Supabase TypeScript types to cover the new analytics tables
- update the World Pulse page to load data from Supabase, expose week selection, and drop the previous mock data

## Testing
- npm run lint *(fails: existing lint violations across unrelated files, including numerous `@typescript-eslint/no-explicit-any` and parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c9753846e48325882d7d313fabe89c