### PR TITLE
Integrate Supabase competitions schema and wire competitive charts

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -200,6 +200,105 @@ export type Database = {
         }
         Relationships: []
       }
+      competition_participants: {
+        Row: {
+          awarded_at: string | null
+          competition_id: string
+          final_rank: number | null
+          id: string
+          joined_at: string | null
+          prize_amount: number
+          profile_id: string
+          score: number
+        }
+        Insert: {
+          awarded_at?: string | null
+          competition_id: string
+          final_rank?: number | null
+          id?: string
+          joined_at?: string | null
+          prize_amount?: number
+          profile_id: string
+          score?: number
+        }
+        Update: {
+          awarded_at?: string | null
+          competition_id?: string
+          final_rank?: number | null
+          id?: string
+          joined_at?: string | null
+          prize_amount?: number
+          profile_id?: string
+          score?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "competition_participants_competition_id_fkey"
+            columns: ["competition_id"]
+            isOneToOne: false
+            referencedRelation: "competitions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "competition_participants_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      competitions: {
+        Row: {
+          category: string
+          created_at: string
+          description: string | null
+          end_date: string
+          entry_fee: number
+          id: string
+          is_active: boolean
+          is_completed: boolean
+          max_participants: number
+          name: string
+          prize_pool: number
+          requirements: Json
+          start_date: string
+          updated_at: string
+        }
+        Insert: {
+          category?: string
+          created_at?: string
+          description?: string | null
+          end_date: string
+          entry_fee?: number
+          id?: string
+          is_active?: boolean
+          is_completed?: boolean
+          max_participants?: number
+          name: string
+          prize_pool?: number
+          requirements?: Json
+          start_date: string
+          updated_at?: string
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          description?: string | null
+          end_date?: string
+          entry_fee?: number
+          id?: string
+          is_active?: boolean
+          is_completed?: boolean
+          max_participants?: number
+          name?: string
+          prize_pool?: number
+          requirements?: Json
+          start_date?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       contracts: {
         Row: {
           advance_payment: number
@@ -576,6 +675,50 @@ export type Database = {
             columns: ["achievement_id"]
             isOneToOne: false
             referencedRelation: "achievements"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      player_rankings: {
+        Row: {
+          calculated_at: string
+          hit_songs: number
+          id: string
+          profile_id: string
+          rank: number
+          ranking_type: string
+          score: number
+          total_plays: number
+          trend: string
+        }
+        Insert: {
+          calculated_at?: string
+          hit_songs?: number
+          id?: string
+          profile_id: string
+          rank: number
+          ranking_type?: string
+          score?: number
+          total_plays?: number
+          trend?: string
+        }
+        Update: {
+          calculated_at?: string
+          hit_songs?: number
+          id?: string
+          profile_id?: string
+          rank?: number
+          ranking_type?: string
+          score?: number
+          total_plays?: number
+          trend?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "player_rankings_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20250916153000_create_competitions_tables.sql
+++ b/supabase/migrations/20250916153000_create_competitions_tables.sql
@@ -1,0 +1,77 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.competitions (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  start_date timestamptz not null,
+  end_date timestamptz not null,
+  prize_pool numeric not null default 0,
+  entry_fee numeric not null default 0,
+  max_participants integer not null default 0,
+  category text not null default 'general',
+  requirements jsonb not null default '{}'::jsonb,
+  is_active boolean not null default true,
+  is_completed boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint competitions_dates_check check (end_date > start_date)
+);
+
+create table if not exists public.competition_participants (
+  id uuid primary key default gen_random_uuid(),
+  competition_id uuid not null references public.competitions(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  score numeric not null default 0,
+  joined_at timestamptz not null default now(),
+  final_rank integer,
+  prize_amount numeric not null default 0,
+  awarded_at timestamptz
+);
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.competition_participants'::regclass
+      and conname = 'competition_participants_competition_id_profile_id_key'
+  ) then
+    alter table public.competition_participants
+      add constraint competition_participants_competition_id_profile_id_key unique (competition_id, profile_id);
+  end if;
+end
+$$;
+
+create table if not exists public.player_rankings (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  ranking_type text not null default 'global',
+  rank integer not null,
+  score numeric not null default 0,
+  total_plays numeric not null default 0,
+  hit_songs integer not null default 0,
+  trend text not null default 'same',
+  calculated_at timestamptz not null default now()
+);
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.player_rankings'::regclass
+      and conname = 'player_rankings_profile_id_ranking_type_key'
+  ) then
+    alter table public.player_rankings
+      add constraint player_rankings_profile_id_ranking_type_key unique (profile_id, ranking_type);
+  end if;
+end
+$$;
+
+create index if not exists competition_participants_competition_id_idx
+  on public.competition_participants (competition_id);
+
+create index if not exists competition_participants_profile_id_idx
+  on public.competition_participants (profile_id);
+
+create index if not exists player_rankings_ranking_type_rank_idx
+  on public.player_rankings (ranking_type, rank);


### PR DESCRIPTION
## Summary
- add migrations that provision competitions, competition_participants, and player_rankings tables with supporting constraints and indexes
- extend generated Supabase types to cover the new competition and ranking tables
- refactor the CompetitiveCharts page to read from the new tables, finalize competitions, and support join/leave actions with updated UI states

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c96c52bfe08325b51afe26efaabffd