### PR TITLE
Add automated song growth job and realtime updates

### DIFF
--- a/src/pages/SongManager.tsx
+++ b/src/pages/SongManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -31,6 +31,135 @@ interface Song {
   updated_at?: string;
 }
 
+interface SongGrowthRecord {
+  id: string;
+  song_id: string;
+  user_id: string;
+  streams_added: number;
+  revenue_added: number;
+  recorded_at: string;
+  songs?: {
+    title?: string | null;
+  } | null;
+}
+
+interface GrowthSummary {
+  totals: {
+    streams: number;
+    revenue: number;
+  };
+  bySong: {
+    songId: string;
+    title: string;
+    streams: number;
+    revenue: number;
+  }[];
+}
+
+const normalizeNumeric = (value: unknown): number => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const parsed = parseFloat(String(value));
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const normalizeInteger = (value: unknown): number => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+
+  if (typeof value === 'number') {
+    return Math.round(value);
+  }
+
+  const parsed = parseInt(String(value), 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const normalizeSongRecord = (record: any): Song => ({
+  id: record.id,
+  title: record.title,
+  genre: record.genre,
+  lyrics: record.lyrics ?? undefined,
+  quality_score: normalizeInteger(record.quality_score),
+  release_date: record.release_date ?? undefined,
+  chart_position:
+    record.chart_position === null || record.chart_position === undefined
+      ? undefined
+      : normalizeInteger(record.chart_position),
+  streams: normalizeInteger(record.streams),
+  revenue: Number(normalizeNumeric(record.revenue).toFixed(2)),
+  status: record.status as Song['status'],
+  created_at: record.created_at,
+  user_id: record.user_id,
+  updated_at: record.updated_at ?? undefined,
+});
+
+const normalizeGrowthRecord = (record: any): SongGrowthRecord => ({
+  id: record.id,
+  song_id: record.song_id,
+  user_id: record.user_id,
+  streams_added: normalizeInteger(record.streams_added),
+  revenue_added: Number(normalizeNumeric(record.revenue_added).toFixed(2)),
+  recorded_at: record.recorded_at,
+  songs: record.songs ?? undefined,
+});
+
+const summarizeGrowth = (
+  records: SongGrowthRecord[],
+  songs: Song[],
+  days: number
+): GrowthSummary => {
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  const totals = { streams: 0, revenue: 0 };
+  const perSong = new Map<
+    string,
+    { songId: string; title: string; streams: number; revenue: number }
+  >();
+
+  records.forEach((record) => {
+    const recordedTime = new Date(record.recorded_at).getTime();
+
+    if (Number.isNaN(recordedTime) || recordedTime < cutoff) {
+      return;
+    }
+
+    totals.streams += record.streams_added;
+    totals.revenue += record.revenue_added;
+
+    const fallbackTitle =
+      songs.find((song) => song.id === record.song_id)?.title || 'Unknown Song';
+    const title = record.songs?.title || fallbackTitle;
+
+    if (perSong.has(record.song_id)) {
+      const entry = perSong.get(record.song_id)!;
+      entry.streams += record.streams_added;
+      entry.revenue = Number((entry.revenue + record.revenue_added).toFixed(2));
+    } else {
+      perSong.set(record.song_id, {
+        songId: record.song_id,
+        title,
+        streams: record.streams_added,
+        revenue: Number(record.revenue_added.toFixed(2)),
+      });
+    }
+  });
+
+  return {
+    totals: {
+      streams: totals.streams,
+      revenue: Number(totals.revenue.toFixed(2)),
+    },
+    bySong: Array.from(perSong.values()).sort((a, b) => b.streams - a.streams),
+  };
+};
+
 const SongManager = () => {
   const { user } = useAuth();
   const { profile, skills, updateProfile } = useGameData();
@@ -44,28 +173,31 @@ const SongManager = () => {
   const [selectedSong, setSelectedSong] = useState<Song | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isRecordDialogOpen, setIsRecordDialogOpen] = useState(false);
+  const [growthHistory, setGrowthHistory] = useState<SongGrowthRecord[]>([]);
+
+  const POLL_INTERVAL = 30000;
 
   const genres = [
-    'Rock', 'Pop', 'Hip Hop', 'Jazz', 'Blues', 'Country', 
+    'Rock', 'Pop', 'Hip Hop', 'Jazz', 'Blues', 'Country',
     'Electronic', 'Folk', 'Reggae', 'Metal', 'Punk', 'Alternative'
   ];
 
-  useEffect(() => {
-    if (user) {
-      fetchSongs();
+  const fetchSongs = useCallback(async () => {
+    if (!user?.id) {
+      setSongs([]);
+      setLoading(false);
+      return;
     }
-  }, [user]);
 
-  const fetchSongs = async () => {
     try {
       const { data, error } = await supabase
         .from('songs')
         .select('*')
-        .eq('user_id', user?.id)
+        .eq('user_id', user.id)
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      setSongs(data || []);
+      setSongs((data || []).map(normalizeSongRecord));
     } catch (error: any) {
       console.error('Error fetching songs:', error);
       toast({
@@ -76,7 +208,161 @@ const SongManager = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.id, toast]);
+
+  const fetchGrowthHistory = useCallback(async () => {
+    if (!user?.id) {
+      setGrowthHistory([]);
+      return;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('song_stream_growth_history')
+        .select('id, song_id, user_id, streams_added, revenue_added, recorded_at, songs(title)')
+        .eq('user_id', user.id)
+        .order('recorded_at', { ascending: false })
+        .limit(200);
+
+      if (error) throw error;
+      setGrowthHistory((data || []).map(normalizeGrowthRecord));
+    } catch (error) {
+      console.error('Error fetching song growth:', error);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      setSongs([]);
+      setGrowthHistory([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    fetchSongs();
+    fetchGrowthHistory();
+  }, [user?.id, fetchSongs, fetchGrowthHistory]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      fetchSongs();
+      fetchGrowthHistory();
+    }, POLL_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, [user?.id, fetchSongs, fetchGrowthHistory]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    const channel = supabase
+      .channel(`songs-updates-${user.id}`)
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'songs',
+          filter: `user_id=eq.${user.id}`
+        },
+        (payload) => {
+          if (payload.eventType === 'INSERT' && payload.new) {
+            const normalized = normalizeSongRecord(payload.new);
+            setSongs((prev) => {
+              const exists = prev.some((song) => song.id === normalized.id);
+
+              if (exists) {
+                return prev.map((song) =>
+                  song.id === normalized.id ? { ...song, ...normalized } : song
+                );
+              }
+
+              return [normalized, ...prev].sort(
+                (a, b) =>
+                  new Date(b.created_at).getTime() -
+                  new Date(a.created_at).getTime()
+              );
+            });
+          }
+
+          if (payload.eventType === 'UPDATE' && payload.new) {
+            const normalized = normalizeSongRecord(payload.new);
+            setSongs((prev) =>
+              prev.map((song) =>
+                song.id === normalized.id ? { ...song, ...normalized } : song
+              )
+            );
+          }
+
+          if (payload.eventType === 'DELETE' && payload.old) {
+            const deletedId = (payload.old as { id?: string })?.id;
+            if (deletedId) {
+              setSongs((prev) => prev.filter((song) => song.id !== deletedId));
+            }
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    const channel = supabase
+      .channel(`song-growth-updates-${user.id}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'song_stream_growth_history',
+          filter: `user_id=eq.${user.id}`
+        },
+        (payload) => {
+          if (!payload.new) {
+            return;
+          }
+
+          const normalized = normalizeGrowthRecord(payload.new);
+          setGrowthHistory((prev) => {
+            if (prev.some((entry) => entry.id === normalized.id)) {
+              return prev;
+            }
+
+            const updated = [normalized, ...prev];
+            return updated.slice(0, 200);
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user?.id]);
+
+  const dailyGrowth = useMemo(
+    () => summarizeGrowth(growthHistory, songs, 1),
+    [growthHistory, songs]
+  );
+
+  const weeklyGrowth = useMemo(
+    () => summarizeGrowth(growthHistory, songs, 7),
+    [growthHistory, songs]
+  );
 
   const createSong = async () => {
     if (!user || !newSong.title || !newSong.genre) {
@@ -111,7 +397,7 @@ const SongManager = () => {
 
       if (error) throw error;
 
-      setSongs(prev => [data, ...prev]);
+      setSongs(prev => [normalizeSongRecord(data), ...prev]);
       setNewSong({ title: '', genre: '', lyrics: '' });
       setIsCreateDialogOpen(false);
       
@@ -190,6 +476,7 @@ const SongManager = () => {
     try {
       const initialStreams = Math.floor(song.quality_score * (profile?.fans || 0) / 100);
       const chartPosition = Math.max(1, 101 - Math.floor(song.quality_score * 0.8));
+      const initialRevenue = Number((initialStreams * 0.01).toFixed(2));
 
       const { error } = await supabase
         .from('songs')
@@ -198,16 +485,16 @@ const SongManager = () => {
           release_date: new Date().toISOString(),
           streams: initialStreams,
           chart_position: chartPosition,
-          revenue: initialStreams * 0.01
+          revenue: initialRevenue
         })
         .eq('id', song.id);
 
       if (error) throw error;
 
       const fameGain = Math.floor(song.quality_score / 2);
-      await updateProfile({ 
+      await updateProfile({
         fame: (profile?.fame || 0) + fameGain,
-        cash: (profile?.cash || 0) + (initialStreams * 0.01)
+        cash: (profile?.cash || 0) + initialRevenue
       });
 
       setSongs(prev => prev.map(s => 
@@ -218,7 +505,7 @@ const SongManager = () => {
               release_date: new Date().toISOString(),
               streams: initialStreams,
               chart_position: chartPosition,
-              revenue: initialStreams * 0.01
+              revenue: initialRevenue
             }
           : s
       ));
@@ -247,7 +534,8 @@ const SongManager = () => {
       if (error) throw error;
 
       setSongs(prev => prev.filter(s => s.id !== songId));
-      
+      setGrowthHistory(prev => prev.filter(record => record.song_id !== songId));
+
       toast({
         title: "Song Deleted",
         description: "Song has been removed from your collection"
@@ -269,6 +557,58 @@ const SongManager = () => {
       case 'released': return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100';
       default: return 'bg-muted text-muted-foreground';
     }
+  };
+
+  const renderGrowthPanel = (summary: GrowthSummary, windowLabel: string) => {
+    if (summary.totals.streams <= 0) {
+      return (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          No streaming activity recorded in the {windowLabel}.
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Stream growth captured over the {windowLabel}.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="rounded-lg bg-muted/60 p-4">
+            <p className="text-sm text-muted-foreground">Total Streams</p>
+            <p className="text-2xl font-bold">{summary.totals.streams.toLocaleString()}</p>
+          </div>
+          <div className="rounded-lg bg-muted/60 p-4">
+            <p className="text-sm text-muted-foreground">Streaming Revenue</p>
+            <p className="text-2xl font-bold">${summary.totals.revenue.toFixed(2)}</p>
+          </div>
+          <div className="rounded-lg bg-muted/60 p-4">
+            <p className="text-sm text-muted-foreground">Active Songs</p>
+            <p className="text-2xl font-bold">{summary.bySong.length}</p>
+          </div>
+        </div>
+        <div className="space-y-2">
+          {summary.bySong.slice(0, 5).map((entry, index) => (
+            <div
+              key={entry.songId}
+              className="flex items-center justify-between rounded-lg border bg-background/60 px-4 py-2"
+            >
+              <div className="flex items-center gap-3">
+                <Badge variant="outline" className="rounded-full px-3 py-1 text-xs">
+                  #{index + 1}
+                </Badge>
+                <div>
+                  <p className="font-semibold">{entry.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    +{entry.streams.toLocaleString()} streams · +${entry.revenue.toFixed(2)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   };
 
   const totalSongs = songs.length;
@@ -343,6 +683,33 @@ const SongManager = () => {
             </CardContent>
           </Card>
         </div>
+
+        {/* Streaming Growth */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Streaming Growth</CardTitle>
+            <CardDescription>
+              Automatic audience growth based on song quality and marketing skills
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Tabs defaultValue="daily" className="w-full">
+              <TabsList className="grid w-full gap-2 sm:w-auto sm:grid-cols-2">
+                <TabsTrigger value="daily">Daily</TabsTrigger>
+                <TabsTrigger value="weekly">Weekly</TabsTrigger>
+              </TabsList>
+              <TabsContent value="daily" className="mt-4">
+                {renderGrowthPanel(dailyGrowth, 'last 24 hours')}
+              </TabsContent>
+              <TabsContent value="weekly" className="mt-4">
+                {renderGrowthPanel(weeklyGrowth, 'last 7 days')}
+              </TabsContent>
+            </Tabs>
+            <p className="mt-4 text-xs text-muted-foreground">
+              Streaming metrics refresh automatically every 15 minutes.
+            </p>
+          </CardContent>
+        </Card>
 
         {/* Create Song Button */}
         <div className="flex justify-end">

--- a/supabase/migrations/20250916153000_song_stream_growth_job.sql
+++ b/supabase/migrations/20250916153000_song_stream_growth_job.sql
@@ -1,0 +1,81 @@
+-- Create table to track incremental streaming growth for released songs
+CREATE TABLE IF NOT EXISTS public.song_stream_growth_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  song_id UUID NOT NULL REFERENCES public.songs(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  streams_added INTEGER NOT NULL DEFAULT 0,
+  revenue_added NUMERIC(10,2) NOT NULL DEFAULT 0,
+  recorded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Ensure users can only see their own growth history
+ALTER TABLE public.song_stream_growth_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own song growth"
+ON public.song_stream_growth_history
+FOR SELECT
+USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS song_stream_growth_history_user_recorded_at_idx
+ON public.song_stream_growth_history (user_id, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS song_stream_growth_history_song_recorded_at_idx
+ON public.song_stream_growth_history (song_id, recorded_at DESC);
+
+-- Function to simulate organic growth for released songs based on quality and marketing
+CREATE OR REPLACE FUNCTION public.simulate_song_growth()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+BEGIN
+  WITH growth AS (
+    SELECT
+      s.id,
+      s.user_id,
+      GREATEST(
+        0,
+        FLOOR(
+          (s.quality_score::numeric * 0.6 + COALESCE(ps.marketing, 10) * 1.5)
+          * (0.85 + random() * 0.3)
+        )
+      )::int AS stream_increase
+    FROM public.songs s
+    LEFT JOIN public.player_skills ps ON ps.user_id = s.user_id
+    WHERE s.status = 'released'
+  ), updated AS (
+    UPDATE public.songs s
+    SET
+      streams = s.streams + g.stream_increase,
+      revenue = ROUND((s.revenue + (g.stream_increase * 0.01))::numeric, 2),
+      updated_at = now()
+    FROM growth g
+    WHERE s.id = g.id AND g.stream_increase > 0
+    RETURNING s.id, g.user_id, g.stream_increase,
+      ROUND((g.stream_increase * 0.01)::numeric, 2) AS revenue_added
+  )
+  INSERT INTO public.song_stream_growth_history (song_id, user_id, streams_added, revenue_added)
+  SELECT id, user_id, stream_increase, revenue_added
+  FROM updated
+  WHERE stream_increase > 0;
+END;
+$$;
+
+COMMENT ON FUNCTION public.simulate_song_growth IS 'Applies automated stream and revenue growth to released songs based on quality and marketing skills.';
+
+-- Ensure the pg_cron extension is available for scheduling
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- Schedule the growth function to run regularly (every 15 minutes)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'song_stream_growth_quarter_hour') THEN
+    PERFORM cron.schedule(
+      'song_stream_growth_quarter_hour',
+      '*/15 * * * *',
+      $$SELECT public.simulate_song_growth();$$
+    );
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add a `song_stream_growth_history` table, a `simulate_song_growth` function, and a pg_cron schedule to grow released songs automatically
- normalize Supabase song data, poll and subscribe for song and growth changes, and keep in-memory totals in sync
- surface daily and weekly streaming growth analytics in the Song Manager UI with automatic refresh messaging

## Testing
- npm run lint *(fails: project contains pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c96c4f950c8325803f085f99b87e98