### PR TITLE
Add mixing and mastering workflow to music studio

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -824,6 +824,9 @@ export type Database = {
           genre: string
           id: string
           lyrics: string | null
+          master_quality: number | null
+          mix_quality: number | null
+          production_cost: number | null
           quality_score: number
           release_date: string | null
           revenue: number
@@ -839,6 +842,9 @@ export type Database = {
           genre: string
           id?: string
           lyrics?: string | null
+          master_quality?: number | null
+          mix_quality?: number | null
+          production_cost?: number | null
           quality_score?: number
           release_date?: string | null
           revenue?: number
@@ -854,6 +860,9 @@ export type Database = {
           genre?: string
           id?: string
           lyrics?: string | null
+          master_quality?: number | null
+          mix_quality?: number | null
+          production_cost?: number | null
           quality_score?: number
           release_date?: string | null
           revenue?: number

--- a/supabase/migrations/20250916150000_update_song_production_pipeline.sql
+++ b/supabase/migrations/20250916150000_update_song_production_pipeline.sql
@@ -1,0 +1,5 @@
+-- Add mixing and mastering tracking to songs table
+ALTER TABLE public.songs
+ADD COLUMN IF NOT EXISTS mix_quality integer,
+ADD COLUMN IF NOT EXISTS master_quality integer,
+ADD COLUMN IF NOT EXISTS production_cost integer DEFAULT 0;


### PR DESCRIPTION
## Summary
- add mixing and mastering workflow with reusable helpers in the Music Studio, including mixing/mastering actions and production cost tracking
- update the Music Studio interface to surface the production pipeline with stage-specific progress and gating before release
- extend Supabase migrations and generated types to store mix/master quality and production cost data for songs

## Testing
- npm run lint *(fails: repository currently contains numerous pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c96c4e8d888325b94607607e2d49f2