### PR TITLE
Add schedule event reminders and notification polling

### DIFF
--- a/supabase/migrations/20260201010000_add_reminders_to_schedule_events.sql
+++ b/supabase/migrations/20260201010000_add_reminders_to_schedule_events.sql
@@ -1,0 +1,12 @@
+-- Add reminder support to schedule events
+ALTER TABLE public.schedule_events
+  ADD COLUMN IF NOT EXISTS reminder_minutes INTEGER,
+  ADD COLUMN IF NOT EXISTS last_notified TIMESTAMP WITH TIME ZONE;
+
+-- Ensure reminder minutes are non-negative when provided
+ALTER TABLE public.schedule_events
+  DROP CONSTRAINT IF EXISTS schedule_events_reminder_minutes_check;
+
+ALTER TABLE public.schedule_events
+  ADD CONSTRAINT schedule_events_reminder_minutes_check
+    CHECK (reminder_minutes IS NULL OR reminder_minutes >= 0);


### PR DESCRIPTION
## Summary
- add reminder_minutes and last_notified columns to schedule_events via a new migration
- update the schedule management UI to capture reminder settings, persist them, and show reminder details on event cards
- add a periodic client-side reminder check that inserts notifications, surfaces toasts, and records last_notified timestamps

## Testing
- npm run lint *(fails: existing lint/type errors in unrelated files)*
- npm run build *(fails: existing syntax error in src/pages/WorldPulse.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c84e27a883258b6112e99c6e1fd7