### PR TITLE
Add fan campaign tracking and analytics

### DIFF
--- a/src/pages/EnhancedFanManagement.tsx
+++ b/src/pages/EnhancedFanManagement.tsx
@@ -60,6 +60,31 @@ interface EngagementCampaign {
   targetDemographic: string;
 }
 
+interface CampaignResults {
+  summary?: string;
+  actual_growth?: number;
+  expected_growth?: number;
+  estimated_revenue?: number;
+  roi?: number;
+  notes?: string;
+}
+
+interface FanCampaignRecord {
+  id: string;
+  title: string;
+  cost: number;
+  duration: number;
+  expected_growth: number;
+  actual_growth: number | null;
+  target_demo: string;
+  roi: number | null;
+  results: CampaignResults | null;
+  launched_at: string;
+  completed_at: string | null;
+}
+
+const FAN_VALUE_PER_FAN = 4;
+
 const EnhancedFanManagement = () => {
   const { user } = useAuth();
   const { toast } = useToast();
@@ -69,6 +94,7 @@ const EnhancedFanManagement = () => {
   const [loading, setLoading] = useState(true);
   const [posting, setPosting] = useState(false);
   const [campaigning, setCampaigning] = useState(false);
+  const [campaignHistory, setCampaignHistory] = useState<FanCampaignRecord[]>([]);
 
   const [newPost, setNewPost] = useState({
     platform: "",
@@ -129,15 +155,35 @@ const EnhancedFanManagement = () => {
 
   const fetchData = async () => {
     try {
-      const [fanResponse, postsResponse, profileResponse] = await Promise.all([
+      const [fanResponse, postsResponse, profileResponse, campaignsResponse] = await Promise.all([
         supabase.from("fan_demographics").select("*").eq("user_id", user?.id).single(),
         supabase.from("social_posts").select("*").eq("user_id", user?.id).order("created_at", { ascending: false }).limit(10),
-        supabase.from("profiles").select("*").eq("user_id", user?.id).single()
+        supabase.from("profiles").select("*").eq("user_id", user?.id).single(),
+        supabase
+          .from("fan_campaigns")
+          .select("*")
+          .eq("user_id", user?.id)
+          .order("launched_at", { ascending: false })
+          .limit(10)
       ]);
 
       if (fanResponse.data) setFanData(fanResponse.data);
       if (postsResponse.data) setSocialPosts(postsResponse.data);
       if (profileResponse.data) setProfile(profileResponse.data);
+      if (campaignsResponse.data) {
+        const normalizedCampaigns: FanCampaignRecord[] = campaignsResponse.data.map((campaign: any) => ({
+          ...campaign,
+          cost: typeof campaign.cost === "string" ? parseFloat(campaign.cost) : campaign.cost,
+          roi:
+            campaign.roi !== null
+              ? typeof campaign.roi === "string"
+                ? parseFloat(campaign.roi)
+                : campaign.roi
+              : null,
+          results: campaign.results as CampaignResults | null
+        }));
+        setCampaignHistory(normalizedCampaigns);
+      }
     } catch (error) {
       console.error("Error fetching data:", error);
     } finally {
@@ -232,6 +278,8 @@ const EnhancedFanManagement = () => {
   };
 
   const launchCampaign = async (campaign: EngagementCampaign) => {
+    if (!user) return;
+
     if ((profile?.cash || 0) < campaign.cost) {
       toast({
         variant: "destructive",
@@ -244,29 +292,39 @@ const EnhancedFanManagement = () => {
     setCampaigning(true);
 
     try {
-      // Update profile cash
       const newCash = (profile?.cash || 0) - campaign.cost;
+      const performanceMultiplier = 0.75 + Math.random() * 0.5;
+      const actualGrowth = Math.max(0, Math.round(campaign.expectedGrowth * performanceMultiplier));
+      const estimatedRevenue = actualGrowth * FAN_VALUE_PER_FAN;
+      const roiValue = campaign.cost > 0
+        ? Number((((estimatedRevenue - campaign.cost) / campaign.cost) * 100).toFixed(1))
+        : 0;
+      const performanceSummary =
+        actualGrowth > campaign.expectedGrowth
+          ? "Exceeded expectations"
+          : actualGrowth === campaign.expectedGrowth
+            ? "Met expectations"
+            : "Underperformed expectations";
+
       await supabase
         .from("profiles")
         .update({ cash: newCash })
         .eq("user_id", user?.id);
 
-      // Update fan demographics based on campaign
       if (fanData) {
         let updates: Partial<FanDemographics> = {
-          total_fans: fanData.total_fans + campaign.expectedGrowth,
-          weekly_growth: fanData.weekly_growth + campaign.expectedGrowth
+          total_fans: fanData.total_fans + actualGrowth,
+          weekly_growth: fanData.weekly_growth + actualGrowth
         };
 
-        // Apply specific demographic targeting
         if (campaign.targetDemographic === "age_18_25") {
-          updates.age_18_25 = fanData.age_18_25 + Math.round(campaign.expectedGrowth * 0.8);
+          updates.age_18_25 = fanData.age_18_25 + Math.round(actualGrowth * 0.8);
         } else if (campaign.targetDemographic === "age_36_45") {
-          updates.age_36_45 = fanData.age_36_45 + Math.round(campaign.expectedGrowth * 0.8);
+          updates.age_36_45 = fanData.age_36_45 + Math.round(actualGrowth * 0.8);
         } else if (campaign.targetDemographic === "platform_tiktok") {
-          updates.platform_tiktok = fanData.platform_tiktok + Math.round(campaign.expectedGrowth * 0.9);
+          updates.platform_tiktok = fanData.platform_tiktok + Math.round(actualGrowth * 0.9);
         } else if (campaign.targetDemographic === "all_platforms") {
-          const growthPerPlatform = Math.round(campaign.expectedGrowth / 4);
+          const growthPerPlatform = Math.round(actualGrowth / 4);
           updates.platform_instagram = fanData.platform_instagram + growthPerPlatform;
           updates.platform_twitter = fanData.platform_twitter + growthPerPlatform;
           updates.platform_youtube = fanData.platform_youtube + growthPerPlatform;
@@ -278,24 +336,65 @@ const EnhancedFanManagement = () => {
           .update(updates)
           .eq("user_id", user?.id);
 
-        setFanData(prev => prev ? { ...prev, ...updates } : null);
+        setFanData(prev => (prev ? { ...prev, ...updates } : prev));
       }
 
-      // Add activity
+      const formattedTarget = formatTargetDemo(campaign.targetDemographic);
+
+      const { data: insertedCampaign, error: campaignError } = await supabase
+        .from("fan_campaigns")
+        .insert({
+          user_id: user?.id,
+          title: campaign.title,
+          cost: campaign.cost,
+          duration: campaign.duration,
+          expected_growth: campaign.expectedGrowth,
+          target_demo: campaign.targetDemographic,
+          actual_growth: actualGrowth,
+          roi: roiValue,
+          results: {
+            summary: performanceSummary,
+            actual_growth: actualGrowth,
+            expected_growth: campaign.expectedGrowth,
+            estimated_revenue: estimatedRevenue,
+            roi: roiValue,
+            notes: `Targeted ${formattedTarget} audience.`
+          }
+        })
+        .select()
+        .single();
+
+      if (campaignError) throw campaignError;
+
       await supabase
         .from("activity_feed")
         .insert({
           user_id: user?.id,
           activity_type: "campaign",
-          message: `Launched "${campaign.title}" campaign (+${campaign.expectedGrowth} fans)`,
-          earnings: -campaign.cost
+          message: `"${campaign.title}" campaign gained ${actualGrowth} fans (${roiValue.toFixed(1)}% ROI)`,
+          earnings: estimatedRevenue - campaign.cost
         });
 
-      setProfile(prev => prev ? { ...prev, cash: newCash } : null);
+      setProfile(prev => (prev ? { ...prev, cash: newCash } : prev));
+
+      if (insertedCampaign) {
+        const normalizedCampaign: FanCampaignRecord = {
+          ...insertedCampaign,
+          cost: typeof insertedCampaign.cost === "string" ? parseFloat(insertedCampaign.cost) : insertedCampaign.cost,
+          roi:
+            insertedCampaign.roi !== null
+              ? typeof insertedCampaign.roi === "string"
+                ? parseFloat(insertedCampaign.roi)
+                : insertedCampaign.roi
+              : null,
+          results: insertedCampaign.results as CampaignResults | null
+        };
+        setCampaignHistory(prev => [normalizedCampaign, ...prev]);
+      }
 
       toast({
-        title: "Campaign Launched!",
-        description: `"${campaign.title}" is now running and will gain you ${campaign.expectedGrowth} fans over ${campaign.duration} days!`
+        title: "Campaign Completed!",
+        description: `"${campaign.title}" brought in ${actualGrowth} new fans with a ${roiValue.toFixed(1)}% ROI.`
       });
 
     } catch (error) {
@@ -329,6 +428,47 @@ const EnhancedFanManagement = () => {
     const platformData = platforms.find(p => p.id === platform);
     return platformData ? platformData.color : "text-gray-500";
   };
+
+  const formatTargetDemo = (target: string) =>
+    target
+      .split("_")
+      .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(" ");
+
+  const formatCurrency = (value: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: value % 1 === 0 ? 0 : 2
+    }).format(value);
+
+  const formatPercentage = (value: number) => `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+
+  const getCampaignRoi = (campaign: FanCampaignRecord) =>
+    campaign.roi ?? campaign.results?.roi ?? 0;
+
+  const getActualGrowth = (campaign: FanCampaignRecord) =>
+    campaign.actual_growth ?? campaign.results?.actual_growth ?? 0;
+
+  const totalCampaignSpend = campaignHistory.reduce(
+    (sum, campaign) => sum + (typeof campaign.cost === "number" ? campaign.cost : 0),
+    0
+  );
+  const totalCampaignGrowth = campaignHistory.reduce(
+    (sum, campaign) => sum + getActualGrowth(campaign),
+    0
+  );
+  const averageCampaignRoi =
+    campaignHistory.length > 0
+      ? campaignHistory.reduce((sum, campaign) => sum + getCampaignRoi(campaign), 0) / campaignHistory.length
+      : 0;
+  const bestCampaign = campaignHistory.reduce<FanCampaignRecord | null>((best, campaign) => {
+    if (!best) return campaign;
+    return getCampaignRoi(campaign) > getCampaignRoi(best) ? campaign : best;
+  }, null);
+  const bestCampaignRoi = bestCampaign ? getCampaignRoi(bestCampaign) : 0;
+  const bestCampaignGrowth = bestCampaign ? getActualGrowth(bestCampaign) : 0;
+  const bestCampaignSpend = bestCampaign ? (typeof bestCampaign.cost === "number" ? bestCampaign.cost : 0) : 0;
 
   if (loading) {
     return (
@@ -640,6 +780,123 @@ const EnhancedFanManagement = () => {
               </Card>
             ))}
           </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="font-bebas">CAMPAIGN ANALYTICS</CardTitle>
+              <CardDescription>Track performance, ROI, and audience impact from your launches</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {campaignHistory.length > 0 ? (
+                <>
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+                    <div className="rounded-lg bg-muted p-4 text-center">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Campaigns Run</p>
+                      <p className="text-2xl font-bold">{campaignHistory.length}</p>
+                    </div>
+                    <div className="rounded-lg bg-muted p-4 text-center">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Fans Gained</p>
+                      <p className="text-2xl font-bold text-green-500">+{totalCampaignGrowth.toLocaleString()}</p>
+                    </div>
+                    <div className="rounded-lg bg-muted p-4 text-center">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total Spend</p>
+                      <p className="text-2xl font-bold">{formatCurrency(totalCampaignSpend)}</p>
+                    </div>
+                    <div className="rounded-lg bg-muted p-4 text-center">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Average ROI</p>
+                      <p
+                        className={`text-2xl font-bold ${averageCampaignRoi >= 0 ? "text-green-500" : "text-red-500"}`}
+                      >
+                        {formatPercentage(averageCampaignRoi)}
+                      </p>
+                    </div>
+                  </div>
+
+                  {bestCampaign && (
+                    <div className="rounded-lg border bg-muted/40 p-4">
+                      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                            Top Performing Campaign
+                          </p>
+                          <p className="font-medium">{bestCampaign.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            +{bestCampaignGrowth.toLocaleString()} fans • {formatCurrency(bestCampaignSpend)} spend • Target: {formatTargetDemo(bestCampaign.target_demo)}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={bestCampaignRoi >= 0 ? "secondary" : "destructive"}
+                          className="w-fit"
+                        >
+                          ROI {formatPercentage(bestCampaignRoi)}
+                        </Badge>
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="space-y-4">
+                    {campaignHistory.map(campaign => {
+                      const actualGrowth = getActualGrowth(campaign);
+                      const roiValue = getCampaignRoi(campaign);
+                      const roiPositive = roiValue >= 0;
+
+                      return (
+                        <div key={campaign.id} className="space-y-3 rounded-lg border p-4">
+                          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                            <div>
+                              <p className="font-semibold">{campaign.title}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {new Date(campaign.completed_at ?? campaign.launched_at).toLocaleDateString()} • Target: {formatTargetDemo(campaign.target_demo)}
+                              </p>
+                            </div>
+                            <Badge variant={roiPositive ? "secondary" : "destructive"} className="w-fit">
+                              ROI {formatPercentage(roiValue)}
+                            </Badge>
+                          </div>
+
+                          {campaign.results?.summary && (
+                            <p className="text-sm text-muted-foreground">{campaign.results.summary}</p>
+                          )}
+
+                          <div className="grid grid-cols-1 gap-3 text-sm text-muted-foreground md:grid-cols-4">
+                            <div className="flex items-center gap-2">
+                              <Users className="h-4 w-4 text-green-500" />
+                              <span>
+                                +{actualGrowth.toLocaleString()} fans
+                                <span className="ml-1 text-xs text-muted-foreground">
+                                  ({campaign.expected_growth.toLocaleString()} expected)
+                                </span>
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <TrendingDown className="h-4 w-4 text-red-500" />
+                              <span>{formatCurrency(typeof campaign.cost === "number" ? campaign.cost : 0)}</span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Calendar className="h-4 w-4 text-blue-500" />
+                              <span>{campaign.duration} days</span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Target className="h-4 w-4 text-purple-500" />
+                              <span>{formatTargetDemo(campaign.target_demo)}</span>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </>
+              ) : (
+                <div className="space-y-3 py-8 text-center text-muted-foreground">
+                  <TrendingUp className="mx-auto h-10 w-10" />
+                  <p className="font-medium text-foreground">No campaigns launched yet</p>
+                  <p className="text-sm">
+                    Launch a campaign to see detailed performance analytics and ROI insights.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </TabsContent>
       </Tabs>
     </div>

--- a/supabase/migrations/20260201020000_create_fan_campaigns_table.sql
+++ b/supabase/migrations/20260201020000_create_fan_campaigns_table.sql
@@ -1,0 +1,44 @@
+-- Create fan_campaigns table to track engagement campaign performance
+CREATE TABLE IF NOT EXISTS public.fan_campaigns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  title TEXT NOT NULL,
+  cost NUMERIC(12,2) NOT NULL CHECK (cost >= 0),
+  duration INTEGER NOT NULL CHECK (duration > 0),
+  expected_growth INTEGER NOT NULL CHECK (expected_growth >= 0),
+  target_demo TEXT NOT NULL,
+  actual_growth INTEGER CHECK (actual_growth >= 0),
+  roi NUMERIC(6,2),
+  results JSONB,
+  launched_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  completed_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS fan_campaigns_user_id_idx ON public.fan_campaigns (user_id);
+
+ALTER TABLE public.fan_campaigns ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their fan campaigns" ON public.fan_campaigns;
+CREATE POLICY "Users can view their fan campaigns"
+  ON public.fan_campaigns
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can insert their fan campaigns" ON public.fan_campaigns;
+CREATE POLICY "Users can insert their fan campaigns"
+  ON public.fan_campaigns
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update their fan campaigns" ON public.fan_campaigns;
+CREATE POLICY "Users can update their fan campaigns"
+  ON public.fan_campaigns
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete their fan campaigns" ON public.fan_campaigns;
+CREATE POLICY "Users can delete their fan campaigns"
+  ON public.fan_campaigns
+  FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add a Supabase migration that introduces a fan_campaigns table with ROI and results tracking
- persist launched fan campaigns from the enhanced fan management page and calculate actual growth with ROI feedback
- surface a Campaign Analytics dashboard that summarizes campaign performance, spend, and historical details

## Testing
- npm run lint *(fails: existing lint violations throughout repo unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd1a40008325878829aa1c6758c3