### PR TITLE
Enhance tour logistics calculations

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1400,6 +1400,8 @@ export type Database = {
           travel_cost: number | null
           lodging_cost: number | null
           misc_cost: number | null
+          travel_time: number | null
+          rest_days: number | null
           venue_id: string
         }
         Insert: {
@@ -1413,6 +1415,8 @@ export type Database = {
           travel_cost?: number | null
           lodging_cost?: number | null
           misc_cost?: number | null
+          travel_time?: number | null
+          rest_days?: number | null
           venue_id: string
         }
         Update: {
@@ -1426,6 +1430,8 @@ export type Database = {
           travel_cost?: number | null
           lodging_cost?: number | null
           misc_cost?: number | null
+          travel_time?: number | null
+          rest_days?: number | null
           venue_id?: string
         }
         Relationships: [

--- a/supabase/migrations/20260201020000_add_travel_time_and_rest_days_to_tour_venues.sql
+++ b/supabase/migrations/20260201020000_add_travel_time_and_rest_days_to_tour_venues.sql
@@ -1,0 +1,10 @@
+-- Add travel logistics tracking to tour_venues
+ALTER TABLE public.tour_venues
+  ADD COLUMN travel_time numeric DEFAULT 0,
+  ADD COLUMN rest_days integer DEFAULT 1;
+
+-- Ensure existing rows use the defaults
+UPDATE public.tour_venues
+SET
+  travel_time = COALESCE(travel_time, 0),
+  rest_days = COALESCE(rest_days, 1);


### PR DESCRIPTION
## Summary
- add travel_time and rest_days columns to tour_venues with a migration and regenerate Supabase typings
- calculate travel logistics, block scheduling conflicts, and auto-adjust costs when adding tour stops in TourManager
- expose travel stats and an optimal route suggestion in the tour management UI

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd4c3e248325aea8f63560269613