### PR TITLE
Add scheduled song releases with marketing budgets

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1272,6 +1272,7 @@ export type Database = {
           production_cost: number | null
           quality_score: number
           release_date: string | null
+          marketing_budget: number | null
           revenue: number
           status: string
           streams: number
@@ -1290,6 +1291,7 @@ export type Database = {
           production_cost?: number | null
           quality_score?: number
           release_date?: string | null
+          marketing_budget?: number | null
           revenue?: number
           status?: string
           streams?: number
@@ -1308,6 +1310,7 @@ export type Database = {
           production_cost?: number | null
           quality_score?: number
           release_date?: string | null
+          marketing_budget?: number | null
           revenue?: number
           status?: string
           streams?: number

--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -187,7 +187,7 @@ const MusicCreation = () => {
       const [songUpdate, profileUpdate] = await Promise.all([
         supabase
           .from("songs")
-          .update({ status: "recorded", release_date: new Date().toISOString() })
+          .update({ status: "recorded" })
           .eq("id", song.id),
         supabase
           .from("profiles")


### PR DESCRIPTION
## Summary
- add marketing budget support and scheduling metadata to songs
- introduce release planning UI with automatic release handling
- prevent recording from setting release dates prematurely

## Testing
- `npm run build` *(fails: existing syntax error in StreamingPlatforms.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd4324408325b77a7375125867e6