### PR TITLE
Add social post comments and repost features

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1215,6 +1215,51 @@ export type Database = {
         }
         Relationships: []
       }
+      social_comments: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          parent_comment_id: string | null
+          post_id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          parent_comment_id?: string | null
+          post_id: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          parent_comment_id?: string | null
+          post_id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_comments_parent_comment_id_fkey"
+            columns: ["parent_comment_id"]
+            isOneToOne: false
+            referencedRelation: "social_comments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "social_comments_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       social_posts: {
         Row: {
           comments: number | null
@@ -1259,6 +1304,38 @@ export type Database = {
           views?: number | null
         }
         Relationships: []
+      }
+      social_reposts: {
+        Row: {
+          created_at: string
+          id: string
+          message: string | null
+          post_id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          message?: string | null
+          post_id: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          message?: string | null
+          post_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "social_reposts_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "social_posts"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       songs: {
         Row: {

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -1,5 +1,4 @@
-
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,7 +10,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue
+  SelectValue,
 } from "@/components/ui/select";
 import {
   Dialog,
@@ -19,21 +18,52 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
 import { useAuth } from "@/hooks/useAuth";
-import { Heart, MessageCircle, Repeat2, Share, TrendingUp, Users, Eye, Loader2, Pencil, Plus } from "lucide-react";
-import type { Database } from "@/integrations/supabase/types";
+import {
+  Heart,
+  MessageCircle,
+  Repeat2,
+  Share,
+  TrendingUp,
+  Users,
+  Eye,
+  Loader2,
+  Pencil,
+  Plus,
+  Send,
+} from "lucide-react";
 
 type SocialPostRow = Database["public"]["Tables"]["social_posts"]["Row"];
-
 type SocialCampaignRow = Database["public"]["Tables"]["social_campaigns"]["Row"];
+type SocialCommentRow = Database["public"]["Tables"]["social_comments"]["Row"];
+type SocialRepostRow = Database["public"]["Tables"]["social_reposts"]["Row"];
+
+type CampaignStatus = "Active" | "Completed";
+
+interface SocialProfile {
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl?: string | null;
+}
+
+interface SocialComment extends SocialCommentRow {
+  replies: SocialComment[];
+  author?: SocialProfile;
+}
+
+interface SocialRepost extends SocialRepostRow {
+  author?: SocialProfile;
+}
 
 interface SocialPost {
   id: string;
+  userId: string;
   content: string;
   likes: number;
   comments: number;
@@ -41,6 +71,9 @@ interface SocialPost {
   views: number;
   timestamp: string;
   engagement: number;
+  author?: SocialProfile;
+  commentsTree: SocialComment[];
+  repostsList: SocialRepost[];
 }
 
 interface Campaign {
@@ -67,6 +100,229 @@ interface CampaignFormState {
 }
 
 const campaignStatusOptions: CampaignStatus[] = ["Active", "Completed"];
+
+const getDisplayName = (profile?: SocialProfile) => {
+  if (!profile) {
+    return "Fan";
+  }
+
+  return profile.displayName || profile.username || "Fan";
+};
+
+const calculateEngagement = (likes: number, comments: number, reposts: number, views: number) => {
+  if (!views || views <= 0) {
+    return 0;
+  }
+
+  const score = likes + comments * 1.5 + reposts * 2;
+  return Math.min(100, parseFloat(((score / views) * 100).toFixed(1)));
+};
+
+const getTimeValue = (value?: string | null) => {
+  if (!value) {
+    return 0;
+  }
+
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? 0 : time;
+};
+
+const formatRelativeTime = (timestamp?: string | null) => {
+  if (!timestamp) {
+    return "moments ago";
+  }
+
+  const target = new Date(timestamp);
+  if (Number.isNaN(target.getTime())) {
+    return "moments ago";
+  }
+
+  const diffSeconds = Math.floor((Date.now() - target.getTime()) / 1000);
+  if (diffSeconds < 0) {
+    return target.toLocaleString();
+  }
+
+  const intervals = [
+    { label: "year", seconds: 31536000 },
+    { label: "month", seconds: 2592000 },
+    { label: "week", seconds: 604800 },
+    { label: "day", seconds: 86400 },
+    { label: "hour", seconds: 3600 },
+    { label: "minute", seconds: 60 },
+  ];
+
+  for (const interval of intervals) {
+    const count = Math.floor(diffSeconds / interval.seconds);
+    if (count >= 1) {
+      return `${count} ${interval.label}${count > 1 ? "s" : ""} ago`;
+    }
+  }
+
+  return "just now";
+};
+
+const countComments = (comments: SocialComment[]): number =>
+  comments.reduce((total, comment) => total + 1 + countComments(comment.replies), 0);
+
+const sortCommentsByDate = (comments: SocialComment[]): SocialComment[] => {
+  comments.sort((a, b) => getTimeValue(a.created_at ?? a.updated_at) - getTimeValue(b.created_at ?? b.updated_at));
+  comments.forEach((comment) => {
+    if (comment.replies.length > 0) {
+      sortCommentsByDate(comment.replies);
+    }
+  });
+  return comments;
+};
+
+const buildCommentTree = (
+  commentRows: SocialCommentRow[],
+  profileMap: Record<string, SocialProfile>,
+): SocialComment[] => {
+  const commentMap = new Map<string, SocialComment>();
+
+  commentRows.forEach((row) => {
+    commentMap.set(row.id, {
+      ...row,
+      replies: [],
+      author: profileMap[row.user_id],
+    });
+  });
+
+  const roots: SocialComment[] = [];
+
+  commentRows.forEach((row) => {
+    const comment = commentMap.get(row.id);
+    if (!comment) {
+      return;
+    }
+
+    if (row.parent_comment_id && commentMap.has(row.parent_comment_id)) {
+      const parent = commentMap.get(row.parent_comment_id);
+      parent?.replies.push(comment);
+    } else {
+      roots.push(comment);
+    }
+  });
+
+  return sortCommentsByDate(roots);
+};
+
+const buildRepostList = (
+  rows: SocialRepostRow[],
+  profileMap: Record<string, SocialProfile>,
+): SocialRepost[] =>
+  rows
+    .map((row) => ({
+      ...row,
+      author: profileMap[row.user_id],
+    }))
+    .sort((a, b) => getTimeValue(b.created_at) - getTimeValue(a.created_at));
+
+const mapPostRow = (
+  row: SocialPostRow,
+  profileMap: Record<string, SocialProfile>,
+  commentTree: SocialComment[],
+  repostList: SocialRepost[],
+): SocialPost => {
+  const likes = row.likes ?? 0;
+  const comments = row.comments ?? countComments(commentTree);
+  const reposts = row.reposts ?? repostList.length;
+  const views = row.views ?? 0;
+  const timestamp = row.timestamp ?? row.created_at ?? new Date().toISOString();
+
+  return {
+    id: row.id,
+    userId: row.user_id,
+    content: row.content,
+    likes,
+    comments,
+    reposts,
+    views,
+    timestamp,
+    engagement: calculateEngagement(likes, comments, reposts, views),
+    author: profileMap[row.user_id],
+    commentsTree: commentTree,
+    repostsList: repostList,
+  };
+};
+
+const commentExists = (comments: SocialComment[], commentId: string): boolean =>
+  comments.some((comment) => comment.id === commentId || commentExists(comment.replies, commentId));
+
+const addCommentToTree = (comments: SocialComment[], newComment: SocialComment): SocialComment[] => {
+  if (!newComment.parent_comment_id) {
+    const updated = [...comments, { ...newComment, replies: newComment.replies ?? [] }];
+    return sortCommentsByDate(updated);
+  }
+
+  let inserted = false;
+  const updated = comments.map((comment) => {
+    if (comment.id === newComment.parent_comment_id) {
+      inserted = true;
+      const updatedReplies = [...comment.replies, { ...newComment, replies: newComment.replies ?? [] }];
+      sortCommentsByDate(updatedReplies);
+      return {
+        ...comment,
+        replies: updatedReplies,
+      };
+    }
+
+    if (comment.replies.length > 0) {
+      const nestedReplies = addCommentToTree(comment.replies, newComment);
+      if (nestedReplies !== comment.replies) {
+        inserted = true;
+        return {
+          ...comment,
+          replies: nestedReplies,
+        };
+      }
+    }
+
+    return comment;
+  });
+
+  return inserted ? updated : comments;
+};
+
+const removeCommentFromTree = (
+  comments: SocialComment[],
+  commentId: string,
+): { updated: SocialComment[]; removedCount: number } => {
+  let removedCount = 0;
+
+  const traverse = (list: SocialComment[]): SocialComment[] => {
+    let changed = false;
+    const result: SocialComment[] = [];
+
+    list.forEach((comment) => {
+      if (comment.id === commentId) {
+        removedCount += 1 + countComments(comment.replies);
+        changed = true;
+        return;
+      }
+
+      const updatedReplies = traverse(comment.replies);
+      if (updatedReplies !== comment.replies) {
+        changed = true;
+        result.push({
+          ...comment,
+          replies: updatedReplies,
+        });
+      } else {
+        result.push(comment);
+      }
+    });
+
+    return changed ? result : list;
+  };
+
+  const updated = traverse(comments);
+  if (removedCount === 0) {
+    return { updated: comments, removedCount: 0 };
+  }
+
+  return { updated, removedCount };
+};
 
 const mapStatusFromDb = (status: SocialCampaignRow["status"]): CampaignStatus => {
   switch (status) {
@@ -97,20 +353,20 @@ const mapRowToCampaign = (row: SocialCampaignRow): Campaign => ({
   engagement: Number(row.engagement ?? 0),
   status: mapStatusFromDb(row.status),
   startDate: row.start_date,
-  endDate: row.end_date
+  endDate: row.end_date,
 });
 
 const formatCampaignDate = (date: string | null) => {
-  if (!date) return "--";
+  if (!date) {
+    return "--";
+  }
 
-  const safeDateString = `${date}T00:00:00`;
-  const formattedDate = new Date(safeDateString).toLocaleDateString(undefined, {
+  const safeDate = `${date}T00:00:00`;
+  return new Date(safeDate).toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
-    year: "numeric"
+    year: "numeric",
   });
-
-  return formattedDate;
 };
 
 const createEmptyCampaignForm = (): CampaignFormState => ({
@@ -121,7 +377,7 @@ const createEmptyCampaignForm = (): CampaignFormState => ({
   engagement: "",
   status: "Active",
   startDate: "",
-  endDate: ""
+  endDate: "",
 });
 
 const mapCampaignToForm = (campaign: Campaign): CampaignFormState => ({
@@ -132,30 +388,239 @@ const mapCampaignToForm = (campaign: Campaign): CampaignFormState => ({
   engagement: Number.isFinite(campaign.engagement) ? campaign.engagement.toString() : "",
   status: campaign.status,
   startDate: campaign.startDate ?? "",
-  endDate: campaign.endDate ?? ""
+  endDate: campaign.endDate ?? "",
 });
 
 const SocialMedia = () => {
-  const { user } = useAuth();
-  const { toast } = useToast();
   const { user, loading: authLoading } = useAuth();
+  const { toast } = useToast();
+  const [followers, setFollowers] = useState<number | null>(null);
+  const [engagementRate, setEngagementRate] = useState<number | null>(null);
   const [newPost, setNewPost] = useState("");
-  const [followers] = useState(24500);
   const [posts, setPosts] = useState<SocialPost[]>([]);
   const [loadingPosts, setLoadingPosts] = useState(true);
   const [posting, setPosting] = useState(false);
-
-  const loadPosts = useCallback(async () => {
-    if (authLoading) {
-      return;
-    }
-  ]);
+  const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
+  const [activeReplyTargets, setActiveReplyTargets] = useState<Record<string, string | null>>({});
+  const [pendingComments, setPendingComments] = useState<Record<string, boolean>>({});
+  const [activeRepostPostId, setActiveRepostPostId] = useState<string | null>(null);
+  const [repostDrafts, setRepostDrafts] = useState<Record<string, string>>({});
+  const [pendingReposts, setPendingReposts] = useState<Record<string, boolean>>({});
+  const [profileLookup, setProfileLookup] = useState<Record<string, SocialProfile>>({});
+  const commentInputRefs = useRef<Record<string, HTMLTextAreaElement | null>>({});
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [campaignsLoading, setCampaignsLoading] = useState(false);
   const [campaignDialogOpen, setCampaignDialogOpen] = useState(false);
   const [campaignSaving, setCampaignSaving] = useState(false);
   const [campaignForm, setCampaignForm] = useState<CampaignFormState>(() => createEmptyCampaignForm());
   const [editingCampaign, setEditingCampaign] = useState<Campaign | null>(null);
+
+  const postIdsKey = useMemo(() => posts.map((post) => post.id).sort().join(","), [posts]);
+
+  const ensureProfile = useCallback(
+    async (userId: string) => {
+      if (!userId) {
+        return undefined;
+      }
+
+      const cached = profileLookup[userId];
+      if (cached) {
+        return cached;
+      }
+
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("user_id, username, display_name, avatar_url")
+        .eq("user_id", userId)
+        .maybeSingle();
+
+      if (error) {
+        console.error("Error fetching profile:", error);
+        return undefined;
+      }
+
+      if (!data) {
+        return undefined;
+      }
+
+      const profile: SocialProfile = {
+        userId: data.user_id,
+        username: data.username,
+        displayName: data.display_name ?? data.username,
+        avatarUrl: data.avatar_url,
+      };
+
+      setProfileLookup((previous) => ({ ...previous, [userId]: profile }));
+      return profile;
+    },
+    [profileLookup],
+  );
+
+  const loadPosts = useCallback(async () => {
+    if (!user) {
+      setPosts([]);
+      setProfileLookup({});
+      setLoadingPosts(false);
+      return;
+    }
+
+    setLoadingPosts(true);
+
+    try {
+      const { data: postRows, error: postError } = await supabase
+        .from("social_posts")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("timestamp", { ascending: false });
+
+      if (postError) {
+        throw postError;
+      }
+
+      const postsData = postRows ?? [];
+      const postIds = postsData.map((row) => row.id);
+
+      let commentRows: SocialCommentRow[] = [];
+      if (postIds.length > 0) {
+        const { data, error } = await supabase
+          .from("social_comments")
+          .select("*")
+          .in("post_id", postIds)
+          .order("created_at", { ascending: true });
+
+        if (error) {
+          throw error;
+        }
+
+        commentRows = data ?? [];
+      }
+
+      let repostRows: SocialRepostRow[] = [];
+      if (postIds.length > 0) {
+        const { data, error } = await supabase
+          .from("social_reposts")
+          .select("*")
+          .in("post_id", postIds)
+          .order("created_at", { ascending: false });
+
+        if (error) {
+          throw error;
+        }
+
+        repostRows = data ?? [];
+      }
+
+      const userIds = new Set<string>();
+      postsData.forEach((row) => userIds.add(row.user_id));
+      commentRows.forEach((row) => userIds.add(row.user_id));
+      repostRows.forEach((row) => userIds.add(row.user_id));
+
+      const profileMap: Record<string, SocialProfile> = {};
+      if (userIds.size > 0) {
+        const { data: profileRows, error: profileError } = await supabase
+          .from("profiles")
+          .select("user_id, username, display_name, avatar_url")
+          .in("user_id", Array.from(userIds));
+
+        if (profileError) {
+          throw profileError;
+        }
+
+        (profileRows ?? []).forEach((profile) => {
+          profileMap[profile.user_id] = {
+            userId: profile.user_id,
+            username: profile.username,
+            displayName: profile.display_name ?? profile.username,
+            avatarUrl: profile.avatar_url,
+          };
+        });
+
+        setProfileLookup((previous) => ({ ...previous, ...profileMap }));
+      }
+
+      const commentsByPost = new Map<string, SocialCommentRow[]>();
+      commentRows.forEach((comment) => {
+        const list = commentsByPost.get(comment.post_id) ?? [];
+        list.push(comment);
+        commentsByPost.set(comment.post_id, list);
+      });
+
+      const repostsByPost = new Map<string, SocialRepostRow[]>();
+      repostRows.forEach((repost) => {
+        const list = repostsByPost.get(repost.post_id) ?? [];
+        list.push(repost);
+        repostsByPost.set(repost.post_id, list);
+      });
+
+      const mappedPosts = postsData.map((row) => {
+        const commentTree = buildCommentTree(commentsByPost.get(row.id) ?? [], profileMap);
+        const repostList = buildRepostList(repostsByPost.get(row.id) ?? [], profileMap);
+        return mapPostRow(row, profileMap, commentTree, repostList);
+      });
+
+      setPosts(mappedPosts);
+    } catch (error) {
+      console.error("Error loading social posts:", error);
+      toast({
+        variant: "destructive",
+        title: "Unable to load posts",
+        description: "Please try again in a moment.",
+      });
+    } finally {
+      setLoadingPosts(false);
+    }
+  }, [toast, user]);
+
+  useEffect(() => {
+    if (!user) {
+      setFollowers(24500);
+      setEngagementRate(7.8);
+      return;
+    }
+
+    const fetchStats = async () => {
+      try {
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("user_id, followers, engagement_rate, username, display_name, avatar_url")
+          .eq("user_id", user.id)
+          .maybeSingle();
+
+        if (error) {
+          throw error;
+        }
+
+        if (data) {
+          setFollowers(data.followers ?? 0);
+          setEngagementRate(data.engagement_rate ?? 0);
+          setProfileLookup((previous) => ({
+            ...previous,
+            [data.user_id]: {
+              userId: data.user_id,
+              username: data.username,
+              displayName: data.display_name ?? data.username,
+              avatarUrl: data.avatar_url,
+            },
+          }));
+        } else {
+          setFollowers(0);
+          setEngagementRate(0);
+        }
+      } catch (error) {
+        console.error("Error fetching social metrics:", error);
+      }
+    };
+
+    void fetchStats();
+  }, [user]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+
+    void loadPosts();
+  }, [authLoading, loadPosts]);
 
   const loadCampaigns = useCallback(async () => {
     if (!user) {
@@ -173,7 +638,9 @@ const SocialMedia = () => {
         .eq("user_id", user.id)
         .order("created_at", { ascending: false });
 
-      if (error) throw error;
+      if (error) {
+        throw error;
+      }
 
       const mappedCampaigns = (data ?? []).map(mapRowToCampaign);
       setCampaigns(mappedCampaigns);
@@ -182,12 +649,20 @@ const SocialMedia = () => {
       toast({
         variant: "destructive",
         title: "Unable to load campaigns",
-        description: "Please try again in a moment."
+        description: "Please try again in a moment.",
       });
     } finally {
       setCampaignsLoading(false);
     }
   }, [toast, user]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+
+    void loadCampaigns();
+  }, [authLoading, loadCampaigns]);
 
   const createCampaign = useCallback(
     async (formState: CampaignFormState) => {
@@ -195,44 +670,36 @@ const SocialMedia = () => {
         toast({
           variant: "destructive",
           title: "Sign in to create campaigns",
-          description: "You need to be logged in to manage marketing campaigns."
+          description: "You need to be logged in to manage marketing campaigns.",
         });
         throw new Error("User not authenticated");
       }
 
-      try {
-        const { data, error } = await supabase
-          .from("social_campaigns")
-          .insert({
-            user_id: user.id,
-            name: formState.name.trim(),
-            platform: formState.platform.trim(),
-            budget: Number(formState.budget || 0),
-            reach: Number(formState.reach || 0),
-            engagement: Number(formState.engagement || 0),
-            status: mapStatusToDb(formState.status),
-            start_date: formState.startDate || null,
-            end_date: formState.endDate || null
-          })
-          .select()
-          .single();
+      const { data, error } = await supabase
+        .from("social_campaigns")
+        .insert({
+          user_id: user.id,
+          name: formState.name.trim(),
+          platform: formState.platform.trim(),
+          budget: Number(formState.budget || 0),
+          reach: Number(formState.reach || 0),
+          engagement: Number(formState.engagement || 0),
+          status: mapStatusToDb(formState.status),
+          start_date: formState.startDate || null,
+          end_date: formState.endDate || null,
+        })
+        .select("*")
+        .single();
 
-        if (error) throw error;
-
-        const newCampaign = mapRowToCampaign(data);
-        setCampaigns((previous) => [newCampaign, ...previous]);
-        return newCampaign;
-      } catch (error) {
-        console.error("Error creating campaign:", error);
-        toast({
-          variant: "destructive",
-          title: "Campaign not saved",
-          description: "We couldn't create the campaign. Please try again."
-        });
+      if (error) {
         throw error;
       }
+
+      const campaign = mapRowToCampaign(data);
+      setCampaigns((previous) => [campaign, ...previous]);
+      return campaign;
     },
-    [toast, user]
+    [toast, user],
   );
 
   const updateCampaign = useCallback(
@@ -241,13 +708,13 @@ const SocialMedia = () => {
         toast({
           variant: "destructive",
           title: "Sign in to update campaigns",
-          description: "You need to be logged in to update marketing campaigns."
+          description: "You need to be logged in to update marketing campaigns.",
         });
         throw new Error("User not authenticated");
       }
 
       const updatePayload: Record<string, unknown> = {
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       };
 
       if (updates.name !== undefined) updatePayload.name = updates.name.trim();
@@ -259,81 +726,52 @@ const SocialMedia = () => {
       if (updates.startDate !== undefined) updatePayload.start_date = updates.startDate;
       if (updates.endDate !== undefined) updatePayload.end_date = updates.endDate;
 
-      try {
-        const { data, error } = await supabase
-          .from("social_campaigns")
-          .update(updatePayload)
-          .eq("id", campaignId)
-          .eq("user_id", user.id)
-          .select()
-          .single();
+      const { data, error } = await supabase
+        .from("social_campaigns")
+        .update(updatePayload)
+        .eq("id", campaignId)
+        .eq("user_id", user.id)
+        .select("*")
+        .single();
 
-        if (error) throw error;
-
-        const updatedCampaign = mapRowToCampaign(data);
-        setCampaigns((previous) =>
-          previous.map((campaign) => (campaign.id === campaignId ? updatedCampaign : campaign))
-        );
-
-        return updatedCampaign;
-      } catch (error) {
-        console.error("Error updating campaign:", error);
-        toast({
-          variant: "destructive",
-          title: "Campaign update failed",
-          description: "We couldn't update the campaign. Please try again."
-        });
+      if (error) {
         throw error;
       }
+
+      const updatedCampaign = mapRowToCampaign(data);
+      setCampaigns((previous) =>
+        previous.map((campaign) => (campaign.id === campaignId ? updatedCampaign : campaign)),
+      );
+
+      return updatedCampaign;
     },
-    [toast, user]
+    [toast, user],
   );
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      if (!user) {
-        setFollowers(null);
-        setEngagementRate(null);
-        return;
-      }
+  const handleCampaignFieldChange = useCallback(
+    (field: keyof CampaignFormState, value: string | CampaignStatus) => {
+      setCampaignForm((previous) => ({
+        ...previous,
+        [field]: value,
+      }));
+    },
+    [],
+  );
 
-      try {
-        const { data, error } = await supabase
-          .from("profiles")
-          .select("followers, engagement_rate")
-          .eq("user_id", user.id)
-          .single();
-
-        if (error) throw error;
-
-        setFollowers(data?.followers ?? 0);
-        setEngagementRate(data?.engagement_rate ?? 0);
-      } catch (error) {
-        console.error("Error fetching social metrics:", error);
-      }
-    };
-
-    fetchStats();
-  }, [user]);
-
-  useEffect(() => {
-    void loadCampaigns();
-  }, [loadCampaigns]);
-
-  const handleCampaignDialogChange = (open: boolean) => {
+  const handleCampaignDialogChange = useCallback((open: boolean) => {
     setCampaignDialogOpen(open);
     if (!open) {
       setEditingCampaign(null);
       setCampaignForm(createEmptyCampaignForm());
     }
-  };
+  }, []);
 
-  const handleOpenCreateCampaign = () => {
+  const handleOpenCreateCampaign = useCallback(() => {
     if (!user) {
       toast({
         variant: "destructive",
         title: "Sign in to manage campaigns",
-        description: "Log in to create new marketing campaigns."
+        description: "Log in to create new marketing campaigns.",
       });
       return;
     }
@@ -341,132 +779,171 @@ const SocialMedia = () => {
     setEditingCampaign(null);
     setCampaignForm(createEmptyCampaignForm());
     setCampaignDialogOpen(true);
-  };
+  }, [toast, user]);
 
-  const handleEditCampaign = (campaign: Campaign) => {
+  const handleEditCampaign = useCallback((campaign: Campaign) => {
     setEditingCampaign(campaign);
     setCampaignForm(mapCampaignToForm(campaign));
     setCampaignDialogOpen(true);
-  };
+  }, []);
 
-  const handleCampaignFieldChange = (field: keyof CampaignFormState, value: string | CampaignStatus) => {
-    setCampaignForm((previous) => ({
-      ...previous,
-      [field]: value
-    }));
-  };
+  const handleCampaignSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
 
-  const handleCampaignSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+      const trimmedName = campaignForm.name.trim();
+      const trimmedPlatform = campaignForm.platform.trim();
 
-    const trimmedName = campaignForm.name.trim();
-    const trimmedPlatform = campaignForm.platform.trim();
-
-    if (!trimmedName || !trimmedPlatform) {
-      toast({
-        variant: "destructive",
-        title: "Add campaign details",
-        description: "Campaign name and platform are required."
-      });
-      return;
-    }
-
-    const numericBudget = Number(campaignForm.budget || 0);
-    const numericReach = Number(campaignForm.reach || 0);
-    const numericEngagement = Number(campaignForm.engagement || 0);
-
-    setCampaignSaving(true);
-
-    try {
-      if (editingCampaign) {
-        await updateCampaign(editingCampaign.id, {
-          name: trimmedName,
-          platform: trimmedPlatform,
-          budget: numericBudget,
-          reach: numericReach,
-          engagement: numericEngagement,
-          status: campaignForm.status,
-          startDate: campaignForm.startDate || null,
-          endDate: campaignForm.endDate || null
-        });
-
+      if (!trimmedName || !trimmedPlatform) {
         toast({
-          title: "Campaign updated",
-          description: "Your campaign changes have been saved."
+          variant: "destructive",
+          title: "Add campaign details",
+          description: "Campaign name and platform are required.",
         });
-      } else {
-        await createCampaign({
-          ...campaignForm,
-          name: trimmedName,
-          platform: trimmedPlatform,
-          budget: campaignForm.budget || numericBudget.toString(),
-          reach: campaignForm.reach || numericReach.toString(),
-          engagement: campaignForm.engagement || numericEngagement.toString()
-        });
-
-        toast({
-          title: "Campaign created",
-          description: "Your new marketing campaign is ready to launch."
-        });
+        return;
       }
 
-      handleCampaignDialogChange(false);
-    } catch (error) {
-      console.error("Error saving campaign:", error);
-    } finally {
-      setCampaignSaving(false);
-    }
-  };
+      const numericBudget = Number(campaignForm.budget || 0);
+      const numericReach = Number(campaignForm.reach || 0);
+      const numericEngagement = Number(campaignForm.engagement || 0);
 
-  const applySocialGrowth = async (followerGain: number, engagementBoost: number, message: string) => {
-    if (followerGain <= 0 && engagementBoost <= 0) return;
+      setCampaignSaving(true);
 
-    if (!user) {
+      try {
+        if (editingCampaign) {
+          await updateCampaign(editingCampaign.id, {
+            name: trimmedName,
+            platform: trimmedPlatform,
+            budget: numericBudget,
+            reach: numericReach,
+            engagement: numericEngagement,
+            status: campaignForm.status,
+            startDate: campaignForm.startDate || null,
+            endDate: campaignForm.endDate || null,
+          });
+
+          toast({
+            title: "Campaign updated",
+            description: "Your campaign changes have been saved.",
+          });
+        } else {
+          await createCampaign({
+            ...campaignForm,
+            name: trimmedName,
+            platform: trimmedPlatform,
+            budget: numericBudget.toString(),
+            reach: numericReach.toString(),
+            engagement: numericEngagement.toString(),
+          });
+
+          toast({
+            title: "Campaign created",
+            description: "Your new marketing campaign is ready to launch.",
+          });
+        }
+
+        handleCampaignDialogChange(false);
+      } catch (error) {
+        console.error("Error saving campaign:", error);
+      } finally {
+        setCampaignSaving(false);
+      }
+    },
+    [campaignForm, createCampaign, editingCampaign, handleCampaignDialogChange, toast, updateCampaign],
+  );
+
+  const applySocialGrowth = useCallback(
+    async (followerGain: number, engagementBoost: number, message: string) => {
+      if (followerGain <= 0 && engagementBoost <= 0) {
+        return;
+      }
+
+      if (!user) {
+        toast({
+          variant: "destructive",
+          title: "Log in to track growth",
+          description: "Sign in to sync social stats with your profile.",
+        });
+        return;
+      }
+
+      const currentFollowers = followers ?? 0;
+      const currentEngagement = engagementRate ?? 0;
+      const nextFollowers = Math.max(0, Math.round(currentFollowers + followerGain));
+      const nextEngagement = Math.max(0, Math.min(100, parseFloat((currentEngagement + engagementBoost).toFixed(2))));
+
+      setFollowers(nextFollowers);
+      setEngagementRate(nextEngagement);
+
+      const { error } = await supabase
+        .from("profiles")
+        .update({
+          followers: nextFollowers,
+          engagement_rate: nextEngagement,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("user_id", user.id);
+
+      if (error) {
+        console.error("Error updating social metrics:", error);
+        setFollowers(currentFollowers);
+        setEngagementRate(currentEngagement);
+        toast({
+          variant: "destructive",
+          title: "Couldn't update stats",
+          description: "Please try again after a moment.",
+        });
+        return;
+      }
+
       toast({
-        variant: "destructive",
-        title: "Log in to track growth",
-        description: "Sign in to sync social stats with your profile."
+        title: "Social stats updated",
+        description: message,
       });
+    },
+    [engagementRate, followers, toast, user],
+  );
+
+  const handleRunCampaign = useCallback(
+    async (campaignId: string) => {
+      const campaign = campaigns.find((item) => item.id === campaignId);
+      if (!campaign) {
+        return;
+      }
+
+      if (campaign.status === "Completed") {
+        toast({
+          variant: "destructive",
+          title: "Campaign already completed",
+          description: "Select another campaign to run.",
+        });
+        return;
+      }
+
+      const followerGain = Math.max(0, Math.round(campaign.reach * 0.05));
+      const engagementBoost = Math.max(0, parseFloat((campaign.engagement * 0.1).toFixed(2)));
+
+      await applySocialGrowth(
+        followerGain,
+        engagementBoost,
+        `${campaign.name} drove ${followerGain.toLocaleString()} new followers.`,
+      );
+
+      try {
+        await updateCampaign(campaignId, { status: "Completed" });
+      } catch (error) {
+        console.error("Error completing campaign:", error);
+      }
+    },
+    [applySocialGrowth, campaigns, toast, updateCampaign],
+  );
+
+  const handleCreatePost = useCallback(async () => {
+    const content = newPost.trim();
+    if (!content) {
       return;
     }
 
-    const currentFollowers = followers ?? 0;
-    const currentEngagement = engagementRate ?? 0;
-    const nextFollowers = Math.max(0, Math.round(currentFollowers + followerGain));
-    const nextEngagement = Math.max(0, Math.min(100, parseFloat((currentEngagement + engagementBoost).toFixed(2))));
-
-    setFollowers(nextFollowers);
-    setEngagementRate(nextEngagement);
-
-    const { error } = await supabase
-      .from("profiles")
-      .update({
-        followers: nextFollowers,
-        engagement_rate: nextEngagement,
-        updated_at: new Date().toISOString()
-      })
-      .eq("user_id", user.id);
-
-    if (error) {
-      console.error("Error updating social metrics:", error);
-      setFollowers(currentFollowers);
-      setEngagementRate(currentEngagement);
-      toast({
-        variant: "destructive",
-        title: "Couldn't update stats",
-        description: "Please try again after a moment."
-      });
-      return;
-    }
-
-    toast({
-      title: "Social stats updated",
-      description: message
-    });
-  };
-
-  const handleCreatePost = async () => {
-    if (!newPost.trim()) return;
     if (!user) {
       toast({
         variant: "destructive",
@@ -476,7 +953,6 @@ const SocialMedia = () => {
       return;
     }
 
-    const content = newPost.trim();
     setPosting(true);
 
     try {
@@ -498,15 +974,24 @@ const SocialMedia = () => {
         .select("*")
         .single();
 
-      if (error) throw error;
+      if (error) {
+        throw error;
+      }
 
       if (data) {
-        setPosts((prev) => [mapPost(data as SocialPostRow), ...prev]);
+        const profile = await ensureProfile(user.id);
+        const profileMap: Record<string, SocialProfile> = {};
+        if (profile) {
+          profileMap[user.id] = profile;
+        }
+
+        const mappedPost = mapPostRow(data as SocialPostRow, profileMap, [], []);
+        setPosts((previous) => [mappedPost, ...previous]);
       }
 
       setNewPost("");
       toast({
-        title: "Post Published!",
+        title: "Post published!",
         description: "Your post has been shared across all platforms.",
       });
     } catch (error) {
@@ -519,52 +1004,612 @@ const SocialMedia = () => {
     } finally {
       setPosting(false);
     }
-  };
+  }, [ensureProfile, newPost, toast, user]);
 
-  const handleRunCampaign = async (campaignId: string) => {
-    const campaign = campaigns.find((item) => item.id === campaignId);
-    if (!campaign) return;
+  const handleLike = useCallback(
+    async (postId: string) => {
+      if (!user) {
+        toast({
+          variant: "destructive",
+          title: "Sign in to like posts",
+          description: "Log in to engage with your social feed.",
+        });
+        return;
+      }
 
-    if (campaign.status === "Completed") {
-      toast({
-        variant: "destructive",
-        title: "Sign in required",
-        description: "You need to be signed in to like posts.",
-      });
+      const existingPost = posts.find((post) => post.id === postId);
+      if (!existingPost) {
+        return;
+      }
+
+      const optimisticLikes = existingPost.likes + 1;
+
+      setPosts((previous) =>
+        previous.map((post) =>
+          post.id === postId
+            ? {
+                ...post,
+                likes: optimisticLikes,
+                engagement: calculateEngagement(optimisticLikes, post.comments, post.reposts, post.views),
+              }
+            : post,
+        ),
+      );
+
+      const { data, error } = await supabase
+        .from("social_posts")
+        .update({ likes: optimisticLikes })
+        .eq("id", postId)
+        .select("likes, comments, reposts, views")
+        .single();
+
+      if (error) {
+        console.error("Error updating likes:", error);
+        setPosts((previous) =>
+          previous.map((post) => (post.id === postId ? existingPost : post)),
+        );
+        toast({
+          variant: "destructive",
+          title: "Unable to like post",
+          description: "Please try again later.",
+        });
+        return;
+      }
+
+      if (data) {
+        setPosts((previous) =>
+          previous.map((post) => {
+            if (post.id !== postId) {
+              return post;
+            }
+
+            const likes = data.likes ?? optimisticLikes;
+            const commentsCount = data.comments ?? post.comments;
+            const repostCount = data.reposts ?? post.reposts;
+            const views = data.views ?? post.views;
+
+            return {
+              ...post,
+              likes,
+              comments: commentsCount,
+              reposts: repostCount,
+              views,
+              engagement: calculateEngagement(likes, commentsCount, repostCount, views),
+            };
+          }),
+        );
+      }
+    },
+    [posts, toast, user],
+  );
+
+  const handleSubmitComment = useCallback(
+    async (postId: string, parentCommentId?: string) => {
+      if (!user) {
+        toast({
+          variant: "destructive",
+          title: "Sign in to comment",
+          description: "You need to sign in to participate in the conversation.",
+        });
+        return;
+      }
+
+      const key = parentCommentId ? `${postId}:${parentCommentId}` : postId;
+      const content = commentDrafts[key]?.trim();
+      if (!content) {
+        return;
+      }
+
+      setPendingComments((previous) => ({ ...previous, [key]: true }));
+
+      try {
+        const { data, error } = await supabase
+          .from("social_comments")
+          .insert({
+            post_id: postId,
+            user_id: user.id,
+            parent_comment_id: parentCommentId ?? null,
+            content,
+          })
+          .select("*")
+          .single();
+
+        if (error) {
+          throw error;
+        }
+
+        if (data) {
+          const profile = await ensureProfile(user.id);
+          const newComment: SocialComment = {
+            ...(data as SocialCommentRow),
+            replies: [],
+            author: profile,
+          };
+
+          setPosts((previous) =>
+            previous.map((post) => {
+              if (post.id !== postId) {
+                return post;
+              }
+
+              if (commentExists(post.commentsTree, newComment.id)) {
+                return post;
+              }
+
+              const updatedTree = addCommentToTree(post.commentsTree, newComment);
+              const nextComments = post.comments + 1;
+
+              return {
+                ...post,
+                commentsTree: updatedTree,
+                comments: nextComments,
+                engagement: calculateEngagement(post.likes, nextComments, post.reposts, post.views),
+              };
+            }),
+          );
+        }
+
+        setCommentDrafts((previous) => {
+          const next = { ...previous };
+          delete next[key];
+          return next;
+        });
+
+        if (parentCommentId) {
+          setActiveReplyTargets((previous) => ({ ...previous, [postId]: null }));
+        }
+
+        toast({
+          title: "Comment added",
+          description: "Your comment is live for fans to see.",
+        });
+      } catch (error) {
+        console.error("Error posting comment:", error);
+        toast({
+          variant: "destructive",
+          title: "Unable to post comment",
+          description: "Please try again in a moment.",
+        });
+      } finally {
+        setPendingComments((previous) => {
+          const next = { ...previous };
+          delete next[key];
+          return next;
+        });
+      }
+    },
+    [commentDrafts, ensureProfile, toast, user],
+  );
+
+  const handleToggleRepost = useCallback(
+    (postId: string) => {
+      if (!user) {
+        toast({
+          variant: "destructive",
+          title: "Sign in to repost",
+          description: "Log in to share posts with your followers.",
+        });
+        return;
+      }
+
+      setActiveRepostPostId((current) => (current === postId ? null : postId));
+    },
+    [toast, user],
+  );
+
+  const handleCancelRepost = useCallback((postId: string) => {
+    setActiveRepostPostId((current) => (current === postId ? null : current));
+    setRepostDrafts((previous) => {
+      if (!(postId in previous)) {
+        return previous;
+      }
+
+      const next = { ...previous };
+      delete next[postId];
+      return next;
+    });
+  }, []);
+
+  const handleSubmitRepost = useCallback(
+    async (postId: string) => {
+      if (!user) {
+        toast({
+          variant: "destructive",
+          title: "Sign in to repost",
+          description: "Log in to share posts with your followers.",
+        });
+        return;
+      }
+
+      setPendingReposts((previous) => ({ ...previous, [postId]: true }));
+      const message = repostDrafts[postId]?.trim() ?? "";
+
+      try {
+        const { data, error } = await supabase
+          .from("social_reposts")
+          .insert({
+            post_id: postId,
+            user_id: user.id,
+            message: message || null,
+          })
+          .select("*")
+          .single();
+
+        if (error) {
+          throw error;
+        }
+
+        if (data) {
+          const profile = await ensureProfile(user.id);
+          const repost: SocialRepost = {
+            ...(data as SocialRepostRow),
+            author: profile,
+          };
+
+          setPosts((previous) =>
+            previous.map((post) => {
+              if (post.id !== postId) {
+                return post;
+              }
+
+              const updatedList = [repost, ...post.repostsList].sort(
+                (a, b) => getTimeValue(b.created_at) - getTimeValue(a.created_at),
+              );
+              const nextReposts = post.reposts + 1;
+
+              return {
+                ...post,
+                repostsList: updatedList,
+                reposts: nextReposts,
+                engagement: calculateEngagement(post.likes, post.comments, nextReposts, post.views),
+              };
+            }),
+          );
+        }
+
+        setRepostDrafts((previous) => {
+          const next = { ...previous };
+          delete next[postId];
+          return next;
+        });
+        setActiveRepostPostId(null);
+
+        toast({
+          title: "Post reposted",
+          description: "Your repost is now visible to your fans.",
+        });
+      } catch (error) {
+        console.error("Error reposting:", error);
+        toast({
+          variant: "destructive",
+          title: "Unable to repost",
+          description: "Please try again later.",
+        });
+      } finally {
+        setPendingReposts((previous) => {
+          const next = { ...previous };
+          delete next[postId];
+          return next;
+        });
+      }
+    },
+    [ensureProfile, repostDrafts, toast, user],
+  );
+
+  const handleShare = useCallback(
+    (post: SocialPost) => {
+      const shareText = `${post.content}\n\nShared via Rockmundo Social Hub`;
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        navigator.clipboard
+          .writeText(shareText)
+          .then(() => {
+            toast({
+              title: "Post copied",
+              description: "The post content has been copied to your clipboard.",
+            });
+          })
+          .catch(() => {
+            toast({
+              title: "Post ready to share",
+              description: "Copy the post manually to share it with fans.",
+            });
+          });
+      } else {
+        toast({
+          title: "Post ready to share",
+          description: "Copy the post manually to share it with fans.",
+        });
+      }
+    },
+    [toast],
+  );
+
+  useEffect(() => {
+    if (!user) {
       return;
     }
 
-    const existingPost = posts.find((post) => post.id === postId);
-    if (!existingPost) return;
-
-    const updatedLikes = existingPost.likes + 1;
-    const optimisticPost: SocialPost = {
-      ...existingPost,
-      likes: updatedLikes,
-      engagement: calculateEngagement(updatedLikes, existingPost.comments, existingPost.reposts, existingPost.views),
-    };
-
-    try {
-      await updateCampaign(campaignId, { status: "Completed" });
-    } catch (error) {
-      console.error("Error completing campaign:", error);
+    if (!postIdsKey) {
+      return;
     }
-  };
+
+    const postIds = postIdsKey.split(",").filter(Boolean);
+    if (postIds.length === 0) {
+      return;
+    }
+
+    const formattedIds = postIds.map((id) => `"${id}"`).join(",");
+    const postsFilter = `id=in.(${formattedIds})`;
+    const relatedFilter = `post_id=in.(${formattedIds})`;
+
+    const channel = supabase.channel(`social-media-${user.id}`);
+
+    channel.on(
+      "postgres_changes",
+      { event: "UPDATE", schema: "public", table: "social_posts", filter: postsFilter },
+      (payload) => {
+        const updated = payload.new as SocialPostRow;
+        setPosts((previous) =>
+          previous.map((post) => {
+            if (post.id !== updated.id) {
+              return post;
+            }
+
+            const likes = updated.likes ?? post.likes;
+            const commentsCount = updated.comments ?? post.comments;
+            const repostCount = updated.reposts ?? post.reposts;
+            const views = updated.views ?? post.views;
+            const timestamp = updated.timestamp ?? post.timestamp;
+
+            return {
+              ...post,
+              likes,
+              comments: commentsCount,
+              reposts: repostCount,
+              views,
+              timestamp,
+              engagement: calculateEngagement(likes, commentsCount, repostCount, views),
+            };
+          }),
+        );
+      },
+    );
+
+    channel.on(
+      "postgres_changes",
+      { event: "INSERT", schema: "public", table: "social_comments", filter: relatedFilter },
+      (payload) => {
+        const newRow = payload.new as SocialCommentRow;
+        void (async () => {
+          const profile = await ensureProfile(newRow.user_id);
+          setPosts((previous) =>
+            previous.map((post) => {
+              if (post.id !== newRow.post_id) {
+                return post;
+              }
+
+              if (commentExists(post.commentsTree, newRow.id)) {
+                return post;
+              }
+
+              const comment: SocialComment = {
+                ...newRow,
+                replies: [],
+                author: profile,
+              };
+
+              const updatedTree = addCommentToTree(post.commentsTree, comment);
+              const nextComments = post.comments + 1;
+
+              return {
+                ...post,
+                commentsTree: updatedTree,
+                comments: nextComments,
+                engagement: calculateEngagement(post.likes, nextComments, post.reposts, post.views),
+              };
+            }),
+          );
+        })();
+      },
+    );
+
+    channel.on(
+      "postgres_changes",
+      { event: "DELETE", schema: "public", table: "social_comments", filter: relatedFilter },
+      (payload) => {
+        const oldRow = payload.old as SocialCommentRow;
+        setPosts((previous) =>
+          previous.map((post) => {
+            if (post.id !== oldRow.post_id) {
+              return post;
+            }
+
+            const { updated, removedCount } = removeCommentFromTree(post.commentsTree, oldRow.id);
+            if (removedCount === 0) {
+              return post;
+            }
+
+            const nextComments = Math.max(0, post.comments - removedCount);
+            return {
+              ...post,
+              commentsTree: updated,
+              comments: nextComments,
+              engagement: calculateEngagement(post.likes, nextComments, post.reposts, post.views),
+            };
+          }),
+        );
+      },
+    );
+
+    channel.on(
+      "postgres_changes",
+      { event: "INSERT", schema: "public", table: "social_reposts", filter: relatedFilter },
+      (payload) => {
+        const newRow = payload.new as SocialRepostRow;
+        void (async () => {
+          const profile = await ensureProfile(newRow.user_id);
+          setPosts((previous) =>
+            previous.map((post) => {
+              if (post.id !== newRow.post_id) {
+                return post;
+              }
+
+              if (post.repostsList.some((item) => item.id === newRow.id)) {
+                return post;
+              }
+
+              const repost: SocialRepost = {
+                ...newRow,
+                author: profile,
+              };
+
+              const updatedList = [repost, ...post.repostsList].sort(
+                (a, b) => getTimeValue(b.created_at) - getTimeValue(a.created_at),
+              );
+              const nextReposts = post.reposts + 1;
+
+              return {
+                ...post,
+                repostsList: updatedList,
+                reposts: nextReposts,
+                engagement: calculateEngagement(post.likes, post.comments, nextReposts, post.views),
+              };
+            }),
+          );
+        })();
+      },
+    );
+
+    channel.on(
+      "postgres_changes",
+      { event: "DELETE", schema: "public", table: "social_reposts", filter: relatedFilter },
+      (payload) => {
+        const oldRow = payload.old as SocialRepostRow;
+        setPosts((previous) =>
+          previous.map((post) => {
+            if (post.id !== oldRow.post_id) {
+              return post;
+            }
+
+            const filtered = post.repostsList.filter((repost) => repost.id !== oldRow.id);
+            if (filtered.length === post.repostsList.length) {
+              return post;
+            }
+
+            const nextReposts = Math.max(0, post.reposts - 1);
+            return {
+              ...post,
+              repostsList: filtered,
+              reposts: nextReposts,
+              engagement: calculateEngagement(post.likes, post.comments, nextReposts, post.views),
+            };
+          }),
+        );
+      },
+    );
+
+    channel.subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [ensureProfile, postIdsKey, user]);
+
+  const renderComments = (comments: SocialComment[], postId: string, depth = 0): JSX.Element[] =>
+    comments.map((comment) => {
+      const replyKey = `${postId}:${comment.id}`;
+      const isReplying = activeReplyTargets[postId] === comment.id;
+      const pendingReply = pendingComments[replyKey];
+
+      return (
+        <div
+          key={comment.id}
+          className={`space-y-3 ${depth > 0 ? "pl-4 border-l border-accent/20" : ""}`}
+        >
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs text-cream/60">
+              <span className="font-semibold text-cream">{getDisplayName(comment.author)}</span>
+              <span>{formatRelativeTime(comment.created_at ?? comment.updated_at)}</span>
+            </div>
+            <p className="text-sm text-cream/90 whitespace-pre-wrap">{comment.content}</p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-cream/60">
+            <button
+              type="button"
+              className="font-semibold uppercase tracking-wide hover:text-accent transition-colors"
+              onClick={() => setActiveReplyTargets((previous) => ({ ...previous, [postId]: comment.id }))}
+            >
+              Reply
+            </button>
+          </div>
+          {isReplying && (
+            <div className="space-y-2 rounded-lg border border-accent/30 bg-background/30 p-3">
+              <Textarea
+                value={commentDrafts[replyKey] ?? ""}
+                onChange={(event) =>
+                  setCommentDrafts((previous) => ({
+                    ...previous,
+                    [replyKey]: event.target.value,
+                  }))
+                }
+                placeholder={`Reply to ${getDisplayName(comment.author)}...`}
+                className="min-h-20 bg-background/40 border-accent/30 text-cream placeholder:text-cream/60"
+              />
+              <div className="flex gap-2 justify-end">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-cream/70 hover:text-cream"
+                  onClick={() => {
+                    setActiveReplyTargets((previous) => ({ ...previous, [postId]: null }));
+                    setCommentDrafts((previous) => {
+                      if (!(replyKey in previous)) {
+                        return previous;
+                      }
+
+                      const next = { ...previous };
+                      delete next[replyKey];
+                      return next;
+                    });
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="bg-accent hover:bg-accent/80 text-background"
+                  disabled={pendingReply || !(commentDrafts[replyKey]?.trim())}
+                  onClick={() => void handleSubmitComment(postId, comment.id)}
+                >
+                  {pendingReply ? (
+                    <>
+                      <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                      Replying...
+                    </>
+                  ) : (
+                    "Reply"
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+          {comment.replies.length > 0 && (
+            <div className="space-y-3">
+              {renderComments(comment.replies, postId, depth + 1)}
+            </div>
+          )}
+        </div>
+      );
+    });
 
   return (
     <div className="min-h-screen bg-gradient-primary p-6">
       <div className="max-w-7xl mx-auto space-y-6">
-        {/* Header */}
         <div className="text-center space-y-4">
-          <h1 className="text-5xl font-bebas text-cream tracking-wider">
-            SOCIAL MEDIA HUB
-          </h1>
-          <p className="text-xl text-cream/80 font-oswald">
-            Build your fanbase and create viral content
-          </p>
+          <h1 className="text-5xl font-bebas text-cream tracking-wider">SOCIAL MEDIA HUB</h1>
+          <p className="text-xl text-cream/80 font-oswald">Build your fanbase and create viral content</p>
         </div>
 
-        {/* Stats Overview */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           <Card className="bg-card/80 border-accent">
             <CardHeader className="pb-2">
@@ -618,7 +1663,6 @@ const SocialMedia = () => {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Create Post */}
           <div className="lg:col-span-2 space-y-6">
             <Card className="bg-card/80 border-accent">
               <CardHeader>
@@ -629,31 +1673,37 @@ const SocialMedia = () => {
                 <Textarea
                   placeholder="What's happening in the studio? Share your thoughts..."
                   value={newPost}
-                  onChange={(e) => setNewPost(e.target.value)}
+                  onChange={(event) => setNewPost(event.target.value)}
                   className="min-h-24 bg-background/50 border-accent text-cream placeholder:text-cream/60"
                 />
-                <div className="flex justify-between items-center">
-                  <div className="flex gap-2">
+                <div className="flex justify-between items-center flex-wrap gap-3">
+                  <div className="flex flex-wrap gap-2">
                     <Badge variant="outline">Instagram</Badge>
                     <Badge variant="outline">Twitter</Badge>
                     <Badge variant="outline">TikTok</Badge>
                     <Badge variant="outline">Facebook</Badge>
                   </div>
                   <Button
-                    onClick={handleCreatePost}
+                    onClick={() => void handleCreatePost()}
                     className="bg-accent hover:bg-accent/80 text-background font-bold"
                     disabled={!newPost.trim() || posting}
                   >
-                    {posting ? "Posting..." : "Post Now"}
+                    {posting ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Posting...
+                      </>
+                    ) : (
+                      "Post Now"
+                    )}
                   </Button>
                 </div>
               </CardContent>
             </Card>
 
-            {/* Posts Feed */}
             <div className="space-y-4">
               <h3 className="text-2xl font-bebas text-cream tracking-wide">Recent Posts</h3>
-              {(loadingPosts || authLoading) ? (
+              {loadingPosts || authLoading ? (
                 <Card className="bg-card/80 border-accent">
                   <CardContent className="py-8 text-center text-cream/70">
                     Fetching your latest posts...
@@ -671,43 +1721,161 @@ const SocialMedia = () => {
               ) : (
                 posts.map((post) => (
                   <Card key={post.id} className="bg-card/80 border-accent">
-                    <CardContent className="pt-6">
-                      <div className="space-y-4">
-                        <p className="text-cream leading-relaxed">{post.content}</p>
+                    <CardContent className="pt-6 space-y-5">
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between text-xs text-cream/60">
+                          <span className="font-semibold text-cream">{getDisplayName(post.author)}</span>
+                          <span>{formatRelativeTime(post.timestamp)}</span>
+                        </div>
+                        <p className="text-cream leading-relaxed whitespace-pre-wrap">{post.content}</p>
                         <div className="flex justify-between items-center text-cream/60 text-sm">
-                          <span>{formatPostTimestamp(post.timestamp)}</span>
-                          <div className="flex items-center gap-4">
-                            <span className="flex items-center gap-1">
-                              <Eye className="h-4 w-4" />
-                              {post.views.toLocaleString()}
-                            </span>
-                            <Badge variant="outline" className="text-xs">
-                              {post.engagement.toFixed(1)}% engagement
-                            </Badge>
+                          <span className="flex items-center gap-1">
+                            <Eye className="h-4 w-4" />
+                            {post.views.toLocaleString()}
+                          </span>
+                          <Badge variant="outline" className="text-xs">
+                            {post.engagement.toFixed(1)}% engagement
+                          </Badge>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center justify-between gap-4 border-t border-accent/20 pt-4">
+                        <div className="flex flex-wrap items-center gap-4">
+                          <button
+                            onClick={() => void handleLike(post.id)}
+                            className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors"
+                          >
+                            <Heart className="h-4 w-4" />
+                            <span>{post.likes.toLocaleString()}</span>
+                          </button>
+                          <button
+                            onClick={() => commentInputRefs.current[post.id]?.focus()}
+                            className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors"
+                          >
+                            <MessageCircle className="h-4 w-4" />
+                            <span>{post.comments.toLocaleString()}</span>
+                          </button>
+                          <button
+                            onClick={() => handleToggleRepost(post.id)}
+                            className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors"
+                          >
+                            <Repeat2 className="h-4 w-4" />
+                            <span>{post.reposts.toLocaleString()}</span>
+                          </button>
+                        </div>
+                        <button
+                          onClick={() => handleShare(post)}
+                          className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors"
+                        >
+                          <Share className="h-4 w-4" />
+                          Share
+                        </button>
+                      </div>
+
+                      {activeRepostPostId === post.id && (
+                        <div className="space-y-3 rounded-lg border border-accent/30 bg-background/30 p-4">
+                          <Textarea
+                            value={repostDrafts[post.id] ?? ""}
+                            onChange={(event) =>
+                              setRepostDrafts((previous) => ({
+                                ...previous,
+                                [post.id]: event.target.value,
+                              }))
+                            }
+                            placeholder="Add a message to your repost (optional)..."
+                            className="min-h-20 bg-background/40 border-accent/30 text-cream placeholder:text-cream/60"
+                          />
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-cream/70 hover:text-cream"
+                              onClick={() => handleCancelRepost(post.id)}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              size="sm"
+                              className="bg-accent hover:bg-accent/80 text-background"
+                              disabled={pendingReposts[post.id]}
+                              onClick={() => void handleSubmitRepost(post.id)}
+                            >
+                              {pendingReposts[post.id] ? (
+                                <>
+                                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                                  Sharing...
+                                </>
+                              ) : (
+                                "Repost"
+                              )}
+                            </Button>
                           </div>
                         </div>
-                        <div className="flex justify-between items-center pt-2 border-t border-accent/20">
-                          <div className="flex gap-6">
-                            <button
-                              onClick={() => handleLike(post.id)}
-                              className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors"
-                            >
-                              <Heart className="h-4 w-4" />
-                              <span>{post.likes.toLocaleString()}</span>
-                            </button>
-                            <button className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors">
-                              <MessageCircle className="h-4 w-4" />
-                              <span>{post.comments.toLocaleString()}</span>
-                            </button>
-                            <button className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors">
-                              <Repeat2 className="h-4 w-4" />
-                              <span>{post.reposts.toLocaleString()}</span>
-                            </button>
+                      )}
+
+                      {post.repostsList.length > 0 && (
+                        <div className="space-y-3 rounded-lg border border-accent/20 bg-background/20 p-4">
+                          <p className="text-xs uppercase tracking-wide text-cream/60">Recent reposts</p>
+                          <div className="space-y-3">
+                            {post.repostsList.map((repost) => (
+                              <div key={repost.id} className="space-y-1">
+                                <div className="flex items-center justify-between text-sm text-cream/80">
+                                  <span className="font-semibold text-cream">{getDisplayName(repost.author)}</span>
+                                  <span className="text-xs text-cream/60">{formatRelativeTime(repost.created_at)}</span>
+                                </div>
+                                {repost.message && (
+                                  <p className="text-sm text-cream/90 whitespace-pre-wrap">{repost.message}</p>
+                                )}
+                              </div>
+                            ))}
                           </div>
-                          <button className="flex items-center gap-2 text-cream/80 hover:text-accent transition-colors">
-                            <Share className="h-4 w-4" />
-                            Share
-                          </button>
+                        </div>
+                      )}
+
+                      <div className="space-y-4 rounded-lg border border-accent/20 bg-background/10 p-4">
+                        <div className="flex items-center justify-between">
+                          <h4 className="text-sm font-semibold text-cream">Comments</h4>
+                          <span className="text-xs text-cream/60">{post.comments.toLocaleString()} total</span>
+                        </div>
+                        {post.commentsTree.length === 0 ? (
+                          <p className="text-sm text-cream/60">Be the first to share your thoughts.</p>
+                        ) : (
+                          <div className="space-y-4">{renderComments(post.commentsTree, post.id)}</div>
+                        )}
+                        <div className="space-y-2">
+                          <Textarea
+                            ref={(element) => {
+                              commentInputRefs.current[post.id] = element;
+                            }}
+                            value={commentDrafts[post.id] ?? ""}
+                            onChange={(event) =>
+                              setCommentDrafts((previous) => ({
+                                ...previous,
+                                [post.id]: event.target.value,
+                              }))
+                            }
+                            placeholder="Share your thoughts..."
+                            className="min-h-20 bg-background/40 border-accent/30 text-cream placeholder:text-cream/60"
+                          />
+                          <div className="flex justify-end">
+                            <Button
+                              size="sm"
+                              className="bg-accent hover:bg-accent/80 text-background"
+                              disabled={pendingComments[post.id] || !(commentDrafts[post.id]?.trim())}
+                              onClick={() => void handleSubmitComment(post.id)}
+                            >
+                              {pendingComments[post.id] ? (
+                                <>
+                                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                                  Posting...
+                                </>
+                              ) : (
+                                <>
+                                  <Send className="mr-2 h-3.5 w-3.5" />
+                                  Comment
+                                </>
+                              )}
+                            </Button>
+                          </div>
                         </div>
                       </div>
                     </CardContent>
@@ -717,7 +1885,6 @@ const SocialMedia = () => {
             </div>
           </div>
 
-          {/* Campaigns Sidebar */}
           <div className="space-y-6">
             <Card className="bg-card/80 border-accent">
               <CardHeader>

--- a/supabase/migrations/20260201030000_create_social_comments_and_reposts.sql
+++ b/supabase/migrations/20260201030000_create_social_comments_and_reposts.sql
@@ -1,0 +1,147 @@
+-- Create social_comments and social_reposts tables to support engagement features
+CREATE TABLE IF NOT EXISTS public.social_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id uuid NOT NULL REFERENCES public.social_posts(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  parent_comment_id uuid REFERENCES public.social_comments(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS social_comments_post_id_idx ON public.social_comments (post_id);
+CREATE INDEX IF NOT EXISTS social_comments_parent_comment_id_idx ON public.social_comments (parent_comment_id);
+CREATE INDEX IF NOT EXISTS social_comments_user_id_idx ON public.social_comments (user_id);
+
+CREATE TABLE IF NOT EXISTS public.social_reposts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id uuid NOT NULL REFERENCES public.social_posts(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS social_reposts_post_id_idx ON public.social_reposts (post_id);
+CREATE INDEX IF NOT EXISTS social_reposts_user_id_idx ON public.social_reposts (user_id);
+
+ALTER TABLE public.social_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.social_reposts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone can view comments" ON public.social_comments;
+CREATE POLICY "Anyone can view comments"
+  ON public.social_comments
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Users can create comments" ON public.social_comments;
+CREATE POLICY "Users can create comments"
+  ON public.social_comments
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update their comments" ON public.social_comments;
+CREATE POLICY "Users can update their comments"
+  ON public.social_comments
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete their comments" ON public.social_comments;
+CREATE POLICY "Users can delete their comments"
+  ON public.social_comments
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Anyone can view reposts" ON public.social_reposts;
+CREATE POLICY "Anyone can view reposts"
+  ON public.social_reposts
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Users can create reposts" ON public.social_reposts;
+CREATE POLICY "Users can create reposts"
+  ON public.social_reposts
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete their reposts" ON public.social_reposts;
+CREATE POLICY "Users can delete their reposts"
+  ON public.social_reposts
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.update_social_comments_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_social_comments_updated_at ON public.social_comments;
+CREATE TRIGGER update_social_comments_updated_at
+  BEFORE UPDATE ON public.social_comments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_social_comments_updated_at();
+
+CREATE OR REPLACE FUNCTION public.sync_social_post_comment_count()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.social_posts
+    SET comments = COALESCE(comments, 0) + 1
+    WHERE id = NEW.post_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.social_posts
+    SET comments = GREATEST(COALESCE(comments, 0) - 1, 0)
+    WHERE id = OLD.post_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS sync_social_post_comment_count_insert ON public.social_comments;
+CREATE TRIGGER sync_social_post_comment_count_insert
+  AFTER INSERT ON public.social_comments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_social_post_comment_count();
+
+DROP TRIGGER IF EXISTS sync_social_post_comment_count_delete ON public.social_comments;
+CREATE TRIGGER sync_social_post_comment_count_delete
+  AFTER DELETE ON public.social_comments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_social_post_comment_count();
+
+CREATE OR REPLACE FUNCTION public.sync_social_post_repost_count()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.social_posts
+    SET reposts = COALESCE(reposts, 0) + 1
+    WHERE id = NEW.post_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.social_posts
+    SET reposts = GREATEST(COALESCE(reposts, 0) - 1, 0)
+    WHERE id = OLD.post_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS sync_social_post_repost_count_insert ON public.social_reposts;
+CREATE TRIGGER sync_social_post_repost_count_insert
+  AFTER INSERT ON public.social_reposts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_social_post_repost_count();
+
+DROP TRIGGER IF EXISTS sync_social_post_repost_count_delete ON public.social_reposts;
+CREATE TRIGGER sync_social_post_repost_count_delete
+  AFTER DELETE ON public.social_reposts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_social_post_repost_count();
+
+UPDATE public.social_posts
+SET comments = COALESCE((SELECT COUNT(*) FROM public.social_comments WHERE post_id = social_posts.id), 0),
+    reposts = COALESCE((SELECT COUNT(*) FROM public.social_reposts WHERE post_id = social_posts.id), 0);


### PR DESCRIPTION
## Summary
- create social_comments and social_reposts tables with row-level security and triggers to sync social_posts counts
- regenerate Supabase types to expose the new tables to the frontend
- rebuild the SocialMedia page with nested comments, repost attribution, and real-time updates for new interactions

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*
- `npx eslint src/pages/SocialMedia.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c9cd43798c83258521ef951cdbe827