### PR TITLE
Add detailed gig performance history tracking

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -629,27 +629,33 @@ export type Database = {
       }
       gig_performances: {
         Row: {
+          audience_reaction: Json | null
           earnings: number | null
           gig_id: string | null
           id: string
           performance_score: number | null
           performed_at: string
+          stage_results: Json | null
           user_id: string
         }
         Insert: {
+          audience_reaction?: Json | null
           earnings?: number | null
           gig_id?: string | null
           id?: string
           performance_score?: number | null
           performed_at?: string
+          stage_results?: Json | null
           user_id: string
         }
         Update: {
+          audience_reaction?: Json | null
           earnings?: number | null
           gig_id?: string | null
           id?: string
           performance_score?: number | null
           performed_at?: string
+          stage_results?: Json | null
           user_id?: string
         }
         Relationships: []

--- a/supabase/migrations/20260201020000_extend_gig_performances_with_results.sql
+++ b/supabase/migrations/20260201020000_extend_gig_performances_with_results.sql
@@ -1,0 +1,11 @@
+-- Extend gig_performances with detailed performance metadata
+ALTER TABLE public.gig_performances
+ADD COLUMN IF NOT EXISTS stage_results JSONB DEFAULT '[]'::jsonb,
+ADD COLUMN IF NOT EXISTS audience_reaction JSONB DEFAULT '{}'::jsonb;
+
+-- Backfill existing records with default values
+UPDATE public.gig_performances
+SET stage_results = COALESCE(stage_results, '[]'::jsonb);
+
+UPDATE public.gig_performances
+SET audience_reaction = COALESCE(audience_reaction, '{}'::jsonb);


### PR DESCRIPTION
## Summary
- add JSON columns to `gig_performances` and update generated Supabase types
- persist advanced gig stage results and crowd reaction snapshots when finishing gigs
- surface recent gig breakdowns inside the player statistics view

## Testing
- npm run lint *(fails: pre-existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cd1bb4688325909f4b8b205d6bdd