### PR TITLE
Memoize achievement loaders

### DIFF
--- a/src/pages/Achievements.tsx
+++ b/src/pages/Achievements.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -42,14 +42,7 @@ const Achievements = () => {
   const [playerAchievements, setPlayerAchievements] = useState<PlayerAchievement[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (user) {
-      loadAchievements();
-      loadPlayerAchievements();
-    }
-  }, [user]);
-
-  const loadAchievements = async () => {
+  const loadAchievements = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('achievements')
@@ -65,9 +58,9 @@ const Achievements = () => {
     } catch (error: any) {
       console.error('Error loading achievements:', error);
     }
-  };
+  }, []);
 
-  const loadPlayerAchievements = async () => {
+  const loadPlayerAchievements = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -94,7 +87,14 @@ const Achievements = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      loadAchievements();
+      loadPlayerAchievements();
+    }
+  }, [user, loadAchievements, loadPlayerAchievements]);
 
   const getRarityColor = (rarity: string) => {
     switch (rarity) {


### PR DESCRIPTION
## Summary
- memoize the achievement loading helpers with `useCallback` so they keep stable identities when reused
- update the Achievements page effect dependencies to consume the memoized loaders safely

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e5e34c08832590c4a20f7072519b