### PR TITLE
Memoize fetchGameData callback in useGameData hook

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -39,13 +39,7 @@ export const useGameData = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (user) {
-      fetchGameData();
-    }
-  }, [user]);
-
-  const fetchGameData = async () => {
+  const fetchGameData = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -89,7 +83,13 @@ export const useGameData = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      fetchGameData();
+    }
+  }, [user, fetchGameData]);
 
   const updateProfile = async (updates: Partial<PlayerProfile>) => {
     if (!user || !profile) return;


### PR DESCRIPTION
## Summary
- memoize the fetchGameData function in useGameData with useCallback tied to the current user
- update the effect to depend on the memoized callback while continuing to load data when a user is present
- expose the memoized function as the refetch handler returned by the hook

## Testing
- npm run lint *(fails: existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e5ddbe4083258dcca2d29b7690b9