### PR TITLE
refactor: use type aliases for command dialog and textarea

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (


### PR DESCRIPTION
## Summary
- replace the `CommandDialogProps` interface with a direct alias to `DialogProps`
- update the `TextareaProps` export to a type alias while keeping the component signature unchanged

## Testing
- npm run lint *(fails: existing lint errors and warnings across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e5dcd2b88325a2530836b78de4f4