### PR TITLE
refactor: use type aliases for ui component props

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-type CommandDialogProps = DialogProps;
+export type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (


### PR DESCRIPTION
## Summary
- export the CommandDialogProps definition as a type alias of DialogProps
- ensure the textarea component continues to expose its props via a type alias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca97652da08325815b334a0597b446