### PR TITLE
Refine user role loading callback

### DIFF
--- a/src/hooks/useUserRole.tsx
+++ b/src/hooks/useUserRole.tsx
@@ -11,7 +11,13 @@ export const useUserRole = () => {
   const [loading, setLoading] = useState(true);
 
   const loadUserRole = useCallback(async () => {
-    if (!user) return;
+    if (!user) {
+      setUserRole(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
 
     try {
       const { data, error } = await supabase
@@ -29,13 +35,8 @@ export const useUserRole = () => {
   }, [user]);
 
   useEffect(() => {
-    if (user) {
-      loadUserRole();
-    } else {
-      setUserRole(null);
-      setLoading(false);
-    }
-  }, [loadUserRole, user]);
+    loadUserRole();
+  }, [loadUserRole]);
 
   const hasRole = (role: UserRole): boolean => {
     if (!userRole) return false;


### PR DESCRIPTION
## Summary
- memoize the user role loader to reset state when no authenticated user is present
- trigger the loader from the effect via the memoized callback while managing the loading flag around the fetch

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca976f6708832595d292f7e924dbd3