### PR TITLE
Fix duplicate Loader2 import in RealtimeCommunication

### DIFF
--- a/src/pages/RealtimeCommunication.tsx
+++ b/src/pages/RealtimeCommunication.tsx
@@ -26,7 +26,6 @@ import {
   Radio,
   Headphones,
   Heart,
-  Loader2,
   Lock,
   Crown,
   Loader2,


### PR DESCRIPTION
## Summary
- remove the duplicate Loader2 icon import from the RealtimeCommunication page

## Testing
- npm run lint *(fails: existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9a3a22948325ae1279d8c19c5309