### PR TITLE
chore: remove duplicate supabase type import

### DIFF
--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -26,7 +26,6 @@ import {
 import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
-import type { Database } from "@/integrations/supabase/types";
 import { useToast } from "@/hooks/use-toast";
 import { calculateGigPayment, meetsRequirements } from "@/utils/gameBalance";
 import { applyEquipmentWear } from "@/utils/equipmentWear";


### PR DESCRIPTION
## Summary
- remove the duplicate Database type import in the tour manager page

## Testing
- npm run lint *(fails: existing lint errors in other files)*
- npm run build *(fails: existing syntax error in WorldPulse.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9f4c19f88325adb2134c6dedfe3b