### PR TITLE
Fix band member loading query

### DIFF
--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -159,6 +159,14 @@ const BandManager = () => {
     try {
       let topEntry: Record<string, unknown> | undefined;
 
+      const chartsTable = "global_charts";
+      const chartColumns = [
+        "band_id",
+        "rank",
+        "trend_change",
+        "weeks_on_chart",
+      ];
+
       for (const column of chartColumns) {
         const response = await supabase
           .from(chartsTable)
@@ -187,6 +195,30 @@ const BandManager = () => {
         } else {
           console.error('Fallback chart query failed:', fallbackResponse.error);
         }
+      }
+
+      const { data, error } = await supabase
+        .from('band_members')
+        .select(`
+          *,
+          profile:profiles (
+            display_name,
+            avatar_url
+          ),
+          skills:player_skills (
+            vocals,
+            guitar,
+            bass,
+            drums,
+            songwriting,
+            performance
+          )
+        `)
+        .eq('band_id', bandId);
+
+      if (error) {
+        console.error('Error fetching band members:', error);
+        return;
       }
 
       const memberRows = (data ?? []) as BandMemberRow[];


### PR DESCRIPTION
## Summary
- define the chart metadata constants before iterating in `loadBandMembers`
- load band members from Supabase with their profile and skill data and handle query errors

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9f4a0c8c83259e3c4d26c0968304