### PR TITLE
Memoize loadSongs in MusicStudio

### DIFF
--- a/src/pages/MusicStudio.tsx
+++ b/src/pages/MusicStudio.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -77,13 +77,7 @@ const MusicStudio = () => {
     "classical", "reggae", "country", "metal", "alternative", "indie"
   ];
 
-  useEffect(() => {
-    if (user) {
-      loadSongs();
-    }
-  }, [user]);
-
-  const loadSongs = async () => {
+  const loadSongs = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -108,7 +102,13 @@ const MusicStudio = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [toast, user]);
+
+  useEffect(() => {
+    if (user) {
+      loadSongs();
+    }
+  }, [loadSongs, user]);
 
   const calculateSongQuality = () => {
     if (!skills) return 50;


### PR DESCRIPTION
## Summary
- memoize the MusicStudio loadSongs helper with useCallback and proper dependencies
- update the related effect to rely on the memoized loader

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caaa2f0e6083258dac4f249e813271