### PR TITLE
Memoize SkillTraining player data fetch

### DIFF
--- a/src/pages/SkillTraining.tsx
+++ b/src/pages/SkillTraining.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
@@ -110,17 +110,15 @@ const SkillTraining = () => {
     ? getRemainingCooldown(lastTrainingTime, trainingCooldown)
     : 0;
 
-  useEffect(() => {
-    if (user) {
-      fetchPlayerData();
+  const fetchPlayerData = useCallback(async () => {
+    if (!user?.id) {
+      return;
     }
-  }, [user]);
 
-  const fetchPlayerData = async () => {
     try {
       const [skillsResponse, profileResponse] = await Promise.all([
-        supabase.from("player_skills").select("*").eq("user_id", user?.id).single(),
-        supabase.from("profiles").select("*").eq("user_id", user?.id).single()
+        supabase.from("player_skills").select("*").eq("user_id", user.id).single(),
+        supabase.from("profiles").select("*").eq("user_id", user.id).single()
       ]);
 
       if (skillsResponse.data) setSkills(skillsResponse.data as PlayerSkills);
@@ -130,7 +128,13 @@ const SkillTraining = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      void fetchPlayerData();
+    }
+  }, [user, fetchPlayerData]);
 
   const handleTraining = async (session: TrainingSession) => {
     if (!skills || !profile) return;


### PR DESCRIPTION
## Summary
- memoize the SkillTraining player data fetcher with useCallback
- update the SkillTraining effect to depend on the memoized fetcher and guard on user presence

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68caaa32e45c8325b301ce110b2f3735