### PR TITLE
Add Supabase types for admin dashboard tables

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -744,6 +744,36 @@ export type Database = {
         }
         Relationships: []
       }
+      feature_flags: {
+        Row: {
+          id: string
+          name: string
+          description: string | null
+          enabled: boolean
+          category: string | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          description?: string | null
+          enabled?: boolean
+          category?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          description?: string | null
+          enabled?: boolean
+          category?: string | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       game_events: {
         Row: {
           created_at: string | null
@@ -1403,6 +1433,39 @@ export type Database = {
         }
         Relationships: []
       }
+      seasons: {
+        Row: {
+          id: string
+          name: string
+          start_date: string
+          end_date: string
+          multipliers: Json | null
+          active: boolean
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          start_date: string
+          end_date: string
+          multipliers?: Json | null
+          active?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          start_date?: string
+          end_date?: string
+          multipliers?: Json | null
+          active?: boolean
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       social_campaigns: {
         Row: {
           budget: number
@@ -1845,6 +1908,39 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      user_actions: {
+        Row: {
+          id: string
+          user_id: string | null
+          username: string | null
+          action: string
+          details: string | null
+          timestamp: string | null
+          created_at: string | null
+          severity: string | null
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          username?: string | null
+          action: string
+          details?: string | null
+          timestamp?: string | null
+          created_at?: string | null
+          severity?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          username?: string | null
+          action?: string
+          details?: string | null
+          timestamp?: string | null
+          created_at?: string | null
+          severity?: string | null
+        }
+        Relationships: []
       }
       user_roles: {
         Row: {


### PR DESCRIPTION
## Summary
- add type definitions for the feature_flags table in the generated Supabase typings
- define seasons metadata types including JSON multiplier payloads
- expose user_actions rows and mutations so admin dashboard queries type-check

## Testing
- npx tsc --noEmit
- npm run build *(fails: existing duplicate state variable declarations in src/pages/TourManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68caad7da6f0832595d5b4215960ec72