### PR TITLE
Reorder admin data loading effect

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -136,12 +136,6 @@ const AdminDashboard: React.FC = () => {
     active: false
   });
 
-  useEffect(() => {
-    if (user) {
-      loadAdminData();
-    }
-  }, [user, loadAdminData]);
-
   const fetchFeatureFlags = useCallback(async () => {
     const { data, error } = await supabase
       .from('feature_flags')
@@ -277,6 +271,12 @@ const AdminDashboard: React.FC = () => {
       setLoading(false);
     }
   }, [fetchFeatureFlags, fetchSeasons, fetchUserActions]);
+
+  useEffect(() => {
+    if (user) {
+      loadAdminData();
+    }
+  }, [user, loadAdminData]);
 
   const toggleFeatureFlag = async (flagId: string, newValue: boolean) => {
     const previousFlags = featureFlags.map(flag => ({ ...flag }));


### PR DESCRIPTION
## Summary
- move the admin data loading effect below the callback so it is defined before use
- keep callback dependencies unchanged to avoid other hooks referencing undefined callbacks

## Testing
- npm run type-check *(fails: Missing script "type-check")*


------
https://chatgpt.com/codex/tasks/task_e_68caad7ca2b48325a7062ed7430db947