### PR TITLE
Reorder admin data effect

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -272,12 +272,6 @@ const AdminDashboard: React.FC = () => {
     }
   }, [fetchFeatureFlags, fetchSeasons, fetchUserActions]);
 
-  useEffect(() => {
-    if (user) {
-      loadAdminData();
-    }
-  }, [user, loadAdminData]);
-
   const toggleFeatureFlag = async (flagId: string, newValue: boolean) => {
     const previousFlags = featureFlags.map(flag => ({ ...flag }));
 
@@ -499,6 +493,12 @@ const AdminDashboard: React.FC = () => {
       default: return 'text-blue-600 bg-blue-100';
     }
   };
+
+  useEffect(() => {
+    if (user) {
+      loadAdminData();
+    }
+  }, [user, loadAdminData]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- relocate the admin dashboard effect so it runs after the `loadAdminData` callback is defined
- keep the `user` and `loadAdminData` dependencies intact to preserve the login-triggered data load

## Testing
- npm run build *(fails: existing duplicate state declarations in src/pages/TourManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cab2c45bd88325b08af02aa7f3497a