### PR TITLE
Define fan value constant for ROI calculations

### DIFF
--- a/src/pages/EnhancedFanManagement.tsx
+++ b/src/pages/EnhancedFanManagement.tsx
@@ -76,6 +76,8 @@ interface FanMessage {
   replied_at: string | null;
 }
 
+const FAN_VALUE_PER_FAN = 50;
+
 const sentimentDisplay: Record<string, { label: string; className: string }> = {
   positive: {
     label: "Positive",


### PR DESCRIPTION
## Summary
- add a FAN_VALUE_PER_FAN constant so ROI calculations reference a defined value

## Testing
- npm run build *(fails: "The symbol \"loadBandData\" has already been declared" in BandManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cab668e6088325b0132d8d21de4b8f