### PR TITLE
Add scheduling state flag for fan management posts

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -317,6 +317,7 @@ const FanManagement = () => {
       return sentimentMatch && platformMatch;
     });
   }, [fanMessages, sentimentFilter, platformFilter]);
+  const isScheduling = scheduledTime.trim().length > 0;
 
   const updateMessageForm = (field: keyof MessageFormState, value: string) => {
     setMessageForm((prev) => ({


### PR DESCRIPTION
## Summary
- derive an `isScheduling` flag from the scheduled time input in FanManagement
- continue to use the flag to toggle the post button label between scheduling and posting states

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cab664803c8325a539c067cadb0e71