### PR TITLE
Declare optional applyScheduledPostEffects helper

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -81,6 +81,10 @@ type MessageFormState = {
   message: string;
 };
 
+declare const applyScheduledPostEffects:
+  | ((posts: SocialPost[], activityDescription: string) => Promise<void> | void)
+  | undefined;
+
 const PLATFORM_OPTIONS = [
   { value: "instagram", label: "Instagram" },
   { value: "twitter", label: "Twitter / X" },


### PR DESCRIPTION
## Summary
- declare an ambient type for the optional `applyScheduledPostEffects` helper used in the fan management page so TypeScript resolves the symbol

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cab6652b488325ae6411d3325afc50