### PR TITLE
Add missing Supabase song fields

### DIFF
--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -59,6 +59,12 @@ type SupabaseSongRow = {
   streams?: number | null;
   duration?: number | null;
   created_at?: string | null;
+  updated_at?: string | null;
+  release_date?: string | null;
+  chart_position?: number | null;
+  revenue?: number | null;
+  artist_id?: string | null;
+  user_id?: string | null;
   audio_layers?: unknown;
 };
 


### PR DESCRIPTION
## Summary
- extend the SupabaseSongRow type in MusicCreation to cover chart position and other Supabase song columns
- ensure normalizeSong can safely access chart_position by reflecting the database schema

## Testing
- npm run build *(fails: existing duplicate `loadBandData` declaration in BandManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cab93b53508325944d31cae721e851