### PR TITLE
Add recorder ref initialization to MusicCreation

### DIFF
--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -212,6 +212,8 @@ const MusicCreation = () => {
     duration: 180
   });
 
+  const recorderRef = useRef<RecorderInstance | null>(null);
+
   const genres = [
     "Rock", "Pop", "Hip Hop", "Electronic", "Jazz", "Blues", "Country", 
     "Metal", "Punk", "Alternative", "Indie", "Classical", "Folk", "R&B"


### PR DESCRIPTION
## Summary
- initialize a `recorderRef` in `MusicCreation` to track the recorder instance
- keep deletion cleanup logic updating the recorder reference

## Testing
- `npm run build` *(fails: existing duplicate declaration of loadBandData in src/pages/BandManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cab92c9ab883258bddcb42446a9876