### PR TITLE
Add preview state management to music creation page

### DIFF
--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -194,6 +194,7 @@ const MusicCreation = () => {
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const [recording, setRecording] = useState(false);
+  const [previewSongId, setPreviewSongId] = useState<string | null>(null);
   const [editingSong, setEditingSong] = useState<Song | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [editSongForm, setEditSongForm] = useState({
@@ -469,6 +470,10 @@ const MusicCreation = () => {
     } finally {
       setUpdatingSong(false);
     }
+  };
+
+  const stopPreview = () => {
+    setPreviewSongId(null);
   };
 
   const deleteSong = async (songId: string) => {


### PR DESCRIPTION
## Summary
- add a previewSongId state hook to the music creation page
- provide a stopPreview helper that resets the preview state so deletion cleanup can call it safely

## Testing
- npm run lint *(fails: pre-existing lint errors in other pages)*

------
https://chatgpt.com/codex/tasks/task_e_68cab92a8e00832585d5ea68a37bf892