### PR TITLE
Add audio recording song state

### DIFF
--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -204,6 +204,7 @@ const MusicCreation = () => {
   });
   const [updatingSong, setUpdatingSong] = useState(false);
   const [deletingSongId, setDeletingSongId] = useState<string | null>(null);
+  const [audioRecordingSongId, setAudioRecordingSongId] = useState<string | null>(null);
 
   const [newSong, setNewSong] = useState({
     title: "",


### PR DESCRIPTION
## Summary
- add local state to track the song being recorded

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68cab92940348325825bda21a604ea36