### PR TITLE
chore: type social post inserts

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
 import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 
@@ -51,6 +52,8 @@ interface SocialPost {
   media_type?: "image" | "video" | null;
   scheduled_for?: string | null;
 }
+
+type SocialPostInsert = Database['public']['Tables']['social_posts']['Insert'];
 
 interface FanDemographics {
   id: string;
@@ -448,28 +451,24 @@ const FanManagement = () => {
 
       // Create posts for multiple platforms
       const platforms = ['instagram', 'twitter', 'youtube'];
-      const postPromises = platforms.map(platform => {
-        const payload: Record<string, any> = {
+      const postPromises = platforms.map((platform) => {
+        const payload: SocialPostInsert = {
           user_id: user.id,
           platform,
           content: postContent,
           likes: Math.round(baseLikes * (0.8 + Math.random() * 0.4)),
           comments: Math.round(baseComments * (0.8 + Math.random() * 0.4)),
           shares: Math.round(baseShares * (0.8 + Math.random() * 0.4)),
-          fan_growth: Math.round(fanGrowth * (0.8 + Math.random() * 0.4))
+          fan_growth: Math.round(fanGrowth * (0.8 + Math.random() * 0.4)),
+          media_url: mediaUrl ?? null,
+          media_path: mediaUrl ? uploadedMediaPath ?? null : null,
+          media_type: mediaTypeValue,
+          scheduled_for: scheduledIso ?? undefined,
+          created_at: scheduledIso ?? undefined,
+          timestamp: scheduledIso ?? undefined,
+          reposts: null,
+          views: null
         };
-
-        if (mediaUrl) {
-          payload.media_url = mediaUrl;
-          payload.media_path = uploadedMediaPath;
-          payload.media_type = mediaTypeValue;
-        }
-
-        if (scheduledIso) {
-          payload.scheduled_for = scheduledIso;
-          payload.created_at = scheduledIso;
-          payload.timestamp = scheduledIso;
-        }
 
         return supabase.from('social_posts').insert(payload);
       });


### PR DESCRIPTION
## Summary
- import the generated Supabase Database type into the fan management page and expose a SocialPostInsert alias
- build social post payloads using the insert type, explicitly filling optional columns so no `any` casts are needed

## Testing
- npm run lint *(fails: existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68cab9117888832591463d3e2468e029