### PR TITLE
Remove duplicate tour edit state declarations

### DIFF
--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -263,8 +263,6 @@ const TourManager = () => {
     end_date: ""
   });
   const [venueSchedules, setVenueSchedules] = useState<Record<string, VenueScheduleForm>>({});
-  const [editingTourId, setEditingTourId] = useState<string | null>(null);
-  const [editForms, setEditForms] = useState<Record<string, EditTourForm>>({});
 
   const supabaseClient = useMemo(() => supabase, []);
 


### PR DESCRIPTION
## Summary
- remove the duplicate useState declarations for `editingTourId` and `editForms` in `TourManager`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cab909590c832588bd13360786c66c