### PR TITLE
Include useRef import in realtime communication page

### DIFF
--- a/src/pages/RealtimeCommunication.tsx
+++ b/src/pages/RealtimeCommunication.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';


### PR DESCRIPTION
## Summary
- update the React import in RealtimeCommunication page to include useRef for the audio meter reference

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cac3469f848325baa17c449fa225e2