### PR TITLE
Fix default skills type annotation

### DIFF
--- a/src/pages/EnhancedBandManager.tsx
+++ b/src/pages/EnhancedBandManager.tsx
@@ -182,7 +182,7 @@ const EnhancedBandManager = () => {
             .eq("user_id", profile.user_id)
             .single();
 
-          const defaultSkills: PlayerSkillFields = {
+          const defaultSkills: MemberSkillSet = {
             guitar: 20,
             vocals: 20,
             drums: 20,


### PR DESCRIPTION
## Summary
- adjust default available member skills object to use the existing MemberSkillSet type

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cac3461f508325b3e1edc2ceff479c