### PR TITLE
Remove duplicate PromotionCampaign type alias

### DIFF
--- a/src/pages/StreamingPlatforms.tsx
+++ b/src/pages/StreamingPlatforms.tsx
@@ -47,21 +47,6 @@ interface PlatformBreakdown {
   revenue: number;
 }
 
-type PromotionCampaign = Database["public"]["Tables"]["promotion_campaigns"]["Row"] & {
-  platform?: string | null;
-};
-
-type PromotionFunctionResponse = {
-  success: boolean;
-  message: string;
-  campaign?: PromotionCampaign | null;
-  statsDelta?: {
-    streams: number;
-    revenue: number;
-    listeners: number;
-  } | null;
-};
-
 interface PlatformMetric extends StreamingPlatform {
   monthlyListeners: number;
   monthlyStreams: number;


### PR DESCRIPTION
## Summary
- remove the redundant `PromotionCampaign` type alias so the interface definition is the single source of truth
- rely on the existing `PromotionCampaign`/`PromotionFunctionResponse` interfaces to avoid duplicate identifier conflicts

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cac3473eb48325adc8c4dcf310ebcb