### PR TITLE
Remove duplicate PromotionFunctionResponse definition

### DIFF
--- a/src/pages/StreamingPlatforms.tsx
+++ b/src/pages/StreamingPlatforms.tsx
@@ -47,21 +47,6 @@ interface PlatformBreakdown {
   revenue: number;
 }
 
-type PromotionCampaign = Database["public"]["Tables"]["promotion_campaigns"]["Row"] & {
-  platform?: string | null;
-};
-
-type PromotionFunctionResponse = {
-  success: boolean;
-  message: string;
-  campaign?: PromotionCampaign | null;
-  statsDelta?: {
-    streams: number;
-    revenue: number;
-    listeners: number;
-  } | null;
-};
-
 interface PlatformMetric extends StreamingPlatform {
   monthlyListeners: number;
   monthlyStreams: number;


### PR DESCRIPTION
## Summary
- remove the redundant PromotionFunctionResponse type alias so only the interface definition remains
- ensure the PromotionCampaign interface exposes the optional campaign fields consumed by the UI

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cac34807788325b86cf465294e8d1e