### PR TITLE
Remove duplicate VenueRequirements type alias

### DIFF
--- a/src/pages/GigBooking.tsx
+++ b/src/pages/GigBooking.tsx
@@ -32,8 +32,6 @@ type VenueRequirements = JsonRequirementRecord & {
   min_popularity?: number | null;
 };
 
-type VenueRequirements = Record<string, number>;
-
 interface Venue {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- remove the redundant `VenueRequirements` alias that conflicted with the JSON-based definition in `GigBooking`

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cad16efb84832599c2580cf038e6b9