### PR TITLE
Simplify BandManager data loader effect

### DIFF
--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -539,15 +539,8 @@ const BandManager = () => {
   useEffect(() => {
     if (authLoading) return;
 
-    if (user) {
-      loadBandData();
-    } else {
-      setBand(null);
-      setMembers([]);
-      setPendingInvites([]);
-      setLoading(false);
-    }
-  }, [authLoading, user, loadBandData]);
+    loadBandData();
+  }, [authLoading, loadBandData]);
 
   const createBand = async () => {
     if (!user || !profile) return;


### PR DESCRIPTION
## Summary
- ensure BandManager relies on a single loadBandData helper by simplifying the effect hook
- let the helper handle all state resets when no authenticated user is present

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cad1665b8083259de1bf85d56c5b63