### PR TITLE
Restrict profile select policy

### DIFF
--- a/supabase/migrations/20260301090000_restrict_profile_select.sql
+++ b/supabase/migrations/20260301090000_restrict_profile_select.sql
@@ -1,0 +1,8 @@
+DROP POLICY IF EXISTS "Profiles are viewable by everyone" ON public.profiles;
+
+CREATE POLICY "Users can view their own profile"
+ON public.profiles
+FOR SELECT
+USING (auth.uid() = user_id);
+
+GRANT SELECT ON public.profiles TO service_role;


### PR DESCRIPTION
## Summary
- drop the public profiles select policy that allowed universal reads
- add a self-access select policy and grant service role select rights

## Testing
- not run (supabase deployment requires external environment)


------
https://chatgpt.com/codex/tasks/task_e_68cad4731a3c8325ba8593ce4ef12940