### PR TITLE
Add admin management tabs for world data

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -11,9 +11,9 @@ import { useAuth } from '@/hooks/use-auth-context';
 import { toast } from '@/components/ui/sonner-toast';
 import {
   Users,
-  BarChart3, 
-  AlertTriangle, 
-  Shield, 
+  BarChart3,
+  AlertTriangle,
+  Shield,
   Database,
   Activity,
   Globe,
@@ -24,7 +24,11 @@ import {
   Flag,
   Ban,
   Eye,
-  RefreshCw
+  RefreshCw,
+  Building2,
+  MapPin,
+  ShoppingBag,
+  Sparkles
 } from 'lucide-react';
 
 interface SystemMetrics {
@@ -73,6 +77,80 @@ interface NewSeasonForm {
   active: boolean;
 }
 
+interface City {
+  id: string;
+  name: string;
+  country: string;
+  description: string | null;
+  bonuses: string | null;
+  unlocked: boolean;
+}
+
+interface CityFormData {
+  name: string;
+  country: string;
+  description: string;
+  bonuses: string;
+  unlocked: boolean;
+}
+
+interface Location {
+  id: string;
+  name: string;
+  city_id: string;
+  location_type: string | null;
+  description: string | null;
+  bonuses: string | null;
+  is_featured: boolean;
+}
+
+interface LocationFormData {
+  name: string;
+  city_id: string;
+  location_type: string;
+  description: string;
+  bonuses: string;
+  is_featured: boolean;
+}
+
+interface Shop {
+  id: string;
+  name: string;
+  city_id: string;
+  description: string | null;
+  inventory: string | null;
+  currency: string | null;
+  is_open: boolean;
+}
+
+interface ShopFormData {
+  name: string;
+  city_id: string;
+  description: string;
+  inventory: string;
+  currency: string;
+  is_open: boolean;
+}
+
+interface SpecialItem {
+  id: string;
+  name: string;
+  rarity: string | null;
+  effect: string | null;
+  description: string | null;
+  cost: number | null;
+  is_limited: boolean;
+}
+
+interface SpecialItemFormData {
+  name: string;
+  rarity: string;
+  effect: string;
+  description: string;
+  cost: string;
+  isLimited: boolean;
+}
+
 const USER_ACTIONS_PAGE_SIZE = 10;
 
 type FeatureFlagRecord = {
@@ -101,6 +179,45 @@ type UserActionRecord = {
   timestamp?: string | null;
   created_at?: string | null;
   severity?: string | null;
+};
+
+type CityRecord = {
+  id: string;
+  name?: string | null;
+  country?: string | null;
+  description?: string | null;
+  bonuses?: string | null;
+  unlocked?: boolean | null;
+};
+
+type LocationRecord = {
+  id: string;
+  name?: string | null;
+  city_id?: string | null;
+  location_type?: string | null;
+  description?: string | null;
+  bonuses?: string | null;
+  is_featured?: boolean | null;
+};
+
+type ShopRecord = {
+  id: string;
+  name?: string | null;
+  city_id?: string | null;
+  description?: string | null;
+  inventory?: string | null;
+  currency?: string | null;
+  is_open?: boolean | null;
+};
+
+type SpecialItemRecord = {
+  id: string;
+  name?: string | null;
+  rarity?: string | null;
+  effect?: string | null;
+  description?: string | null;
+  cost?: number | null;
+  is_limited?: boolean | null;
 };
 
 const AdminDashboard: React.FC = () => {
@@ -135,6 +252,57 @@ const AdminDashboard: React.FC = () => {
     multipliers: '',
     active: false
   });
+  const [cities, setCities] = useState<City[]>([]);
+  const [citiesLoading, setCitiesLoading] = useState(false);
+  const [cityForm, setCityForm] = useState<CityFormData>({
+    name: '',
+    country: '',
+    description: '',
+    bonuses: '',
+    unlocked: false
+  });
+  const [editingCityId, setEditingCityId] = useState<string | null>(null);
+  const [citySaving, setCitySaving] = useState(false);
+  const [deletingCityId, setDeletingCityId] = useState<string | null>(null);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [locationsLoading, setLocationsLoading] = useState(false);
+  const [locationForm, setLocationForm] = useState<LocationFormData>({
+    name: '',
+    city_id: '',
+    location_type: '',
+    description: '',
+    bonuses: '',
+    is_featured: false
+  });
+  const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
+  const [locationSaving, setLocationSaving] = useState(false);
+  const [deletingLocationId, setDeletingLocationId] = useState<string | null>(null);
+  const [shops, setShops] = useState<Shop[]>([]);
+  const [shopsLoading, setShopsLoading] = useState(false);
+  const [shopForm, setShopForm] = useState<ShopFormData>({
+    name: '',
+    city_id: '',
+    description: '',
+    inventory: '',
+    currency: '',
+    is_open: false
+  });
+  const [editingShopId, setEditingShopId] = useState<string | null>(null);
+  const [shopSaving, setShopSaving] = useState(false);
+  const [deletingShopId, setDeletingShopId] = useState<string | null>(null);
+  const [specialItems, setSpecialItems] = useState<SpecialItem[]>([]);
+  const [specialItemsLoading, setSpecialItemsLoading] = useState(false);
+  const [specialItemForm, setSpecialItemForm] = useState<SpecialItemFormData>({
+    name: '',
+    rarity: '',
+    effect: '',
+    description: '',
+    cost: '',
+    isLimited: false
+  });
+  const [editingSpecialItemId, setEditingSpecialItemId] = useState<string | null>(null);
+  const [specialItemSaving, setSpecialItemSaving] = useState(false);
+  const [deletingSpecialItemId, setDeletingSpecialItemId] = useState<string | null>(null);
 
   const fetchFeatureFlags = useCallback(async () => {
     const { data, error } = await supabase
@@ -230,6 +398,134 @@ const AdminDashboard: React.FC = () => {
     }
   }, []);
 
+  const fetchCities = useCallback(async () => {
+    setCitiesLoading(true);
+
+    try {
+      const { data, error } = await supabase
+        .from('cities')
+        .select('*')
+        .order('name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      const normalizedCities = (data ?? []).map((city: CityRecord) => ({
+        id: city.id,
+        name: city.name ?? '',
+        country: city.country ?? '',
+        description: city.description ?? null,
+        bonuses: city.bonuses ?? null,
+        unlocked: Boolean(city.unlocked)
+      })) as City[];
+
+      setCities(normalizedCities);
+    } catch (error) {
+      console.error('Error fetching cities:', error);
+      throw error;
+    } finally {
+      setCitiesLoading(false);
+    }
+  }, []);
+
+  const fetchLocations = useCallback(async () => {
+    setLocationsLoading(true);
+
+    try {
+      const { data, error } = await supabase
+        .from('locations')
+        .select('*')
+        .order('name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      const normalizedLocations = (data ?? []).map((location: LocationRecord) => ({
+        id: location.id,
+        name: location.name ?? '',
+        city_id: location.city_id ?? '',
+        location_type: location.location_type ?? null,
+        description: location.description ?? null,
+        bonuses: location.bonuses ?? null,
+        is_featured: Boolean(location.is_featured)
+      })) as Location[];
+
+      setLocations(normalizedLocations);
+    } catch (error) {
+      console.error('Error fetching locations:', error);
+      throw error;
+    } finally {
+      setLocationsLoading(false);
+    }
+  }, []);
+
+  const fetchShops = useCallback(async () => {
+    setShopsLoading(true);
+
+    try {
+      const { data, error } = await supabase
+        .from('shops')
+        .select('*')
+        .order('name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      const normalizedShops = (data ?? []).map((shop: ShopRecord) => ({
+        id: shop.id,
+        name: shop.name ?? '',
+        city_id: shop.city_id ?? '',
+        description: shop.description ?? null,
+        inventory: shop.inventory ?? null,
+        currency: shop.currency ?? null,
+        is_open: Boolean(shop.is_open)
+      })) as Shop[];
+
+      setShops(normalizedShops);
+    } catch (error) {
+      console.error('Error fetching shops:', error);
+      throw error;
+    } finally {
+      setShopsLoading(false);
+    }
+  }, []);
+
+  const fetchSpecialItems = useCallback(async () => {
+    setSpecialItemsLoading(true);
+
+    try {
+      const { data, error } = await supabase
+        .from('special_items')
+        .select('*')
+        .order('rarity', { ascending: true })
+        .order('name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      const normalizedItems = (data ?? []).map((item: SpecialItemRecord) => ({
+        id: item.id,
+        name: item.name ?? '',
+        rarity: item.rarity ?? null,
+        effect: item.effect ?? null,
+        description: item.description ?? null,
+        cost: typeof item.cost === 'number' ? item.cost : null,
+        is_limited: Boolean(item.is_limited)
+      })) as SpecialItem[];
+
+      setSpecialItems(normalizedItems);
+    } catch (error) {
+      console.error('Error fetching special items:', error);
+      throw error;
+    } finally {
+      setSpecialItemsLoading(false);
+    }
+  }, []);
+
   const loadAdminData = useCallback(async () => {
     try {
       setLoading(true);
@@ -249,7 +545,11 @@ const AdminDashboard: React.FC = () => {
       const tasks = [
         { name: 'feature flags', promise: fetchFeatureFlags() },
         { name: 'seasons', promise: fetchSeasons() },
-        { name: 'user actions', promise: fetchUserActions(0) }
+        { name: 'user actions', promise: fetchUserActions(0) },
+        { name: 'cities', promise: fetchCities() },
+        { name: 'locations', promise: fetchLocations() },
+        { name: 'shops', promise: fetchShops() },
+        { name: 'special items', promise: fetchSpecialItems() }
       ];
 
       const results = await Promise.allSettled(tasks.map(task => task.promise));
@@ -270,7 +570,15 @@ const AdminDashboard: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [fetchFeatureFlags, fetchSeasons, fetchUserActions]);
+  }, [
+    fetchFeatureFlags,
+    fetchSeasons,
+    fetchUserActions,
+    fetchCities,
+    fetchLocations,
+    fetchShops,
+    fetchSpecialItems
+  ]);
 
   const toggleFeatureFlag = async (flagId: string, newValue: boolean) => {
     const previousFlags = featureFlags.map(flag => ({ ...flag }));
@@ -436,6 +744,478 @@ const AdminDashboard: React.FC = () => {
     }
   };
 
+  const resetCityForm = () => {
+    setCityForm({
+      name: '',
+      country: '',
+      description: '',
+      bonuses: '',
+      unlocked: false
+    });
+    setEditingCityId(null);
+  };
+
+  const handleCitySubmit = async () => {
+    if (!cityForm.name.trim() || !cityForm.country.trim()) {
+      toast.error('City name and country are required');
+      return;
+    }
+
+    const payload = {
+      name: cityForm.name.trim(),
+      country: cityForm.country.trim(),
+      description: cityForm.description.trim() || null,
+      bonuses: cityForm.bonuses.trim() || null,
+      unlocked: cityForm.unlocked
+    };
+
+    setCitySaving(true);
+
+    try {
+      if (editingCityId) {
+        const { error } = await supabase
+          .from('cities')
+          .update(payload)
+          .eq('id', editingCityId);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('City updated successfully');
+      } else {
+        const { error } = await supabase.from('cities').insert([payload]);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('City created successfully');
+      }
+
+      resetCityForm();
+
+      try {
+        await fetchCities();
+      } catch (refreshError) {
+        console.error('Error refreshing cities:', refreshError);
+        toast.error('City saved, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error saving city:', error);
+      toast.error('Failed to save city');
+    } finally {
+      setCitySaving(false);
+    }
+  };
+
+  const handleCityEdit = (city: City) => {
+    setEditingCityId(city.id);
+    setCityForm({
+      name: city.name,
+      country: city.country,
+      description: city.description ?? '',
+      bonuses: city.bonuses ?? '',
+      unlocked: city.unlocked
+    });
+  };
+
+  const handleCityDelete = async (cityId: string) => {
+    setDeletingCityId(cityId);
+
+    try {
+      const { error } = await supabase
+        .from('cities')
+        .delete()
+        .eq('id', cityId);
+
+      if (error) {
+        throw error;
+      }
+
+      toast.success('City deleted successfully');
+
+      if (editingCityId === cityId) {
+        resetCityForm();
+      }
+
+      try {
+        await fetchCities();
+      } catch (refreshError) {
+        console.error('Error refreshing cities:', refreshError);
+        toast.error('City deleted, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error deleting city:', error);
+      toast.error('Failed to delete city');
+    } finally {
+      setDeletingCityId(null);
+    }
+  };
+
+  const resetLocationForm = () => {
+    setLocationForm({
+      name: '',
+      city_id: '',
+      location_type: '',
+      description: '',
+      bonuses: '',
+      is_featured: false
+    });
+    setEditingLocationId(null);
+  };
+
+  const handleLocationSubmit = async () => {
+    if (!locationForm.name.trim()) {
+      toast.error('Location name is required');
+      return;
+    }
+
+    if (!locationForm.city_id) {
+      toast.error('Please select a city for this location');
+      return;
+    }
+
+    const payload = {
+      name: locationForm.name.trim(),
+      city_id: locationForm.city_id,
+      location_type: locationForm.location_type.trim() || null,
+      description: locationForm.description.trim() || null,
+      bonuses: locationForm.bonuses.trim() || null,
+      is_featured: locationForm.is_featured
+    };
+
+    setLocationSaving(true);
+
+    try {
+      if (editingLocationId) {
+        const { error } = await supabase
+          .from('locations')
+          .update(payload)
+          .eq('id', editingLocationId);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Location updated successfully');
+      } else {
+        const { error } = await supabase.from('locations').insert([payload]);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Location created successfully');
+      }
+
+      resetLocationForm();
+
+      try {
+        await fetchLocations();
+      } catch (refreshError) {
+        console.error('Error refreshing locations:', refreshError);
+        toast.error('Location saved, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error saving location:', error);
+      toast.error('Failed to save location');
+    } finally {
+      setLocationSaving(false);
+    }
+  };
+
+  const handleLocationEdit = (location: Location) => {
+    setEditingLocationId(location.id);
+    setLocationForm({
+      name: location.name,
+      city_id: location.city_id,
+      location_type: location.location_type ?? '',
+      description: location.description ?? '',
+      bonuses: location.bonuses ?? '',
+      is_featured: location.is_featured
+    });
+  };
+
+  const handleLocationDelete = async (locationId: string) => {
+    setDeletingLocationId(locationId);
+
+    try {
+      const { error } = await supabase
+        .from('locations')
+        .delete()
+        .eq('id', locationId);
+
+      if (error) {
+        throw error;
+      }
+
+      toast.success('Location deleted successfully');
+
+      if (editingLocationId === locationId) {
+        resetLocationForm();
+      }
+
+      try {
+        await fetchLocations();
+      } catch (refreshError) {
+        console.error('Error refreshing locations:', refreshError);
+        toast.error('Location deleted, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error deleting location:', error);
+      toast.error('Failed to delete location');
+    } finally {
+      setDeletingLocationId(null);
+    }
+  };
+
+  const resetShopForm = () => {
+    setShopForm({
+      name: '',
+      city_id: '',
+      description: '',
+      inventory: '',
+      currency: '',
+      is_open: false
+    });
+    setEditingShopId(null);
+  };
+
+  const handleShopSubmit = async () => {
+    if (!shopForm.name.trim()) {
+      toast.error('Shop name is required');
+      return;
+    }
+
+    if (!shopForm.city_id) {
+      toast.error('Please select a city for this shop');
+      return;
+    }
+
+    const payload = {
+      name: shopForm.name.trim(),
+      city_id: shopForm.city_id,
+      description: shopForm.description.trim() || null,
+      inventory: shopForm.inventory.trim() || null,
+      currency: shopForm.currency.trim() || null,
+      is_open: shopForm.is_open
+    };
+
+    setShopSaving(true);
+
+    try {
+      if (editingShopId) {
+        const { error } = await supabase
+          .from('shops')
+          .update(payload)
+          .eq('id', editingShopId);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Shop updated successfully');
+      } else {
+        const { error } = await supabase.from('shops').insert([payload]);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Shop created successfully');
+      }
+
+      resetShopForm();
+
+      try {
+        await fetchShops();
+      } catch (refreshError) {
+        console.error('Error refreshing shops:', refreshError);
+        toast.error('Shop saved, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error saving shop:', error);
+      toast.error('Failed to save shop');
+    } finally {
+      setShopSaving(false);
+    }
+  };
+
+  const handleShopEdit = (shop: Shop) => {
+    setEditingShopId(shop.id);
+    setShopForm({
+      name: shop.name,
+      city_id: shop.city_id,
+      description: shop.description ?? '',
+      inventory: shop.inventory ?? '',
+      currency: shop.currency ?? '',
+      is_open: shop.is_open
+    });
+  };
+
+  const handleShopDelete = async (shopId: string) => {
+    setDeletingShopId(shopId);
+
+    try {
+      const { error } = await supabase
+        .from('shops')
+        .delete()
+        .eq('id', shopId);
+
+      if (error) {
+        throw error;
+      }
+
+      toast.success('Shop deleted successfully');
+
+      if (editingShopId === shopId) {
+        resetShopForm();
+      }
+
+      try {
+        await fetchShops();
+      } catch (refreshError) {
+        console.error('Error refreshing shops:', refreshError);
+        toast.error('Shop deleted, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error deleting shop:', error);
+      toast.error('Failed to delete shop');
+    } finally {
+      setDeletingShopId(null);
+    }
+  };
+
+  const resetSpecialItemForm = () => {
+    setSpecialItemForm({
+      name: '',
+      rarity: '',
+      effect: '',
+      description: '',
+      cost: '',
+      isLimited: false
+    });
+    setEditingSpecialItemId(null);
+  };
+
+  const handleSpecialItemSubmit = async () => {
+    if (!specialItemForm.name.trim()) {
+      toast.error('Special item name is required');
+      return;
+    }
+
+    if (!specialItemForm.rarity.trim()) {
+      toast.error('Please provide a rarity for the special item');
+      return;
+    }
+
+    if (!specialItemForm.effect.trim()) {
+      toast.error('Please describe the special item effect');
+      return;
+    }
+
+    const parsedCost = Number.parseFloat(specialItemForm.cost);
+
+    if (!Number.isFinite(parsedCost) || parsedCost < 0) {
+      toast.error('Cost must be a valid non-negative number');
+      return;
+    }
+
+    const payload = {
+      name: specialItemForm.name.trim(),
+      rarity: specialItemForm.rarity.trim(),
+      effect: specialItemForm.effect.trim(),
+      description: specialItemForm.description.trim() || null,
+      cost: parsedCost,
+      is_limited: specialItemForm.isLimited
+    };
+
+    setSpecialItemSaving(true);
+
+    try {
+      if (editingSpecialItemId) {
+        const { error } = await supabase
+          .from('special_items')
+          .update(payload)
+          .eq('id', editingSpecialItemId);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Special item updated successfully');
+      } else {
+        const { error } = await supabase.from('special_items').insert([payload]);
+
+        if (error) {
+          throw error;
+        }
+
+        toast.success('Special item created successfully');
+      }
+
+      resetSpecialItemForm();
+
+      try {
+        await fetchSpecialItems();
+      } catch (refreshError) {
+        console.error('Error refreshing special items:', refreshError);
+        toast.error('Special item saved, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error saving special item:', error);
+      toast.error('Failed to save special item');
+    } finally {
+      setSpecialItemSaving(false);
+    }
+  };
+
+  const handleSpecialItemEdit = (item: SpecialItem) => {
+    setEditingSpecialItemId(item.id);
+    setSpecialItemForm({
+      name: item.name,
+      rarity: item.rarity ?? '',
+      effect: item.effect ?? '',
+      description: item.description ?? '',
+      cost: item.cost !== null && item.cost !== undefined ? String(item.cost) : '',
+      isLimited: item.is_limited
+    });
+  };
+
+  const handleSpecialItemDelete = async (itemId: string) => {
+    setDeletingSpecialItemId(itemId);
+
+    try {
+      const { error } = await supabase
+        .from('special_items')
+        .delete()
+        .eq('id', itemId);
+
+      if (error) {
+        throw error;
+      }
+
+      toast.success('Special item deleted successfully');
+
+      if (editingSpecialItemId === itemId) {
+        resetSpecialItemForm();
+      }
+
+      try {
+        await fetchSpecialItems();
+      } catch (refreshError) {
+        console.error('Error refreshing special items:', refreshError);
+        toast.error('Special item deleted, but failed to refresh list');
+      }
+    } catch (error) {
+      console.error('Error deleting special item:', error);
+      toast.error('Failed to delete special item');
+    } finally {
+      setDeletingSpecialItemId(null);
+    }
+  };
+
   const handleUserActionsPageChange = async (direction: 'previous' | 'next') => {
     const totalPages = userActionsTotal > 0
       ? Math.ceil(userActionsTotal / USER_ACTIONS_PAGE_SIZE)
@@ -558,9 +1338,13 @@ const AdminDashboard: React.FC = () => {
       )}
 
       <Tabs defaultValue="monitoring" className="w-full">
-        <TabsList className="grid w-full grid-cols-6">
+        <TabsList className="grid w-full grid-cols-2 md:grid-cols-5 xl:grid-cols-10">
           <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
           <TabsTrigger value="features">Features</TabsTrigger>
+          <TabsTrigger value="cities">Cities</TabsTrigger>
+          <TabsTrigger value="locations">Locations</TabsTrigger>
+          <TabsTrigger value="shops">Shops</TabsTrigger>
+          <TabsTrigger value="special-items">Special Items</TabsTrigger>
           <TabsTrigger value="moderation">Moderation</TabsTrigger>
           <TabsTrigger value="events">Events</TabsTrigger>
           <TabsTrigger value="seasons">Seasons</TabsTrigger>
@@ -720,6 +1504,656 @@ const AdminDashboard: React.FC = () => {
                     />
                   </div>
                 ))}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="cities" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Building2 className="w-6 h-6" />
+                Cities
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold">Create or Update City</h3>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Name</label>
+                    <Input
+                      value={cityForm.name}
+                      onChange={(e) => setCityForm((prev) => ({ ...prev, name: e.target.value }))}
+                      placeholder="MegaCity Prime"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Country</label>
+                    <Input
+                      value={cityForm.country}
+                      onChange={(e) => setCityForm((prev) => ({ ...prev, country: e.target.value }))}
+                      placeholder="Neo Brazil"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Description</label>
+                    <Textarea
+                      value={cityForm.description}
+                      onChange={(e) => setCityForm((prev) => ({ ...prev, description: e.target.value }))}
+                      placeholder="A bustling hub for intergalactic rock fans"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Bonuses</label>
+                    <Textarea
+                      value={cityForm.bonuses}
+                      onChange={(e) => setCityForm((prev) => ({ ...prev, bonuses: e.target.value }))}
+                      placeholder="+10% merch sales, +5% fan loyalty"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between border rounded-lg px-3 py-2">
+                    <div>
+                      <div className="text-sm font-medium">Unlocked</div>
+                      <div className="text-xs text-muted-foreground">Available to players immediately</div>
+                    </div>
+                    <Switch
+                      checked={cityForm.unlocked}
+                      onCheckedChange={(checked) => setCityForm((prev) => ({ ...prev, unlocked: checked }))}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={handleCitySubmit} disabled={citySaving} className="flex-1">
+                      {citySaving
+                        ? editingCityId
+                          ? 'Updating...'
+                          : 'Creating...'
+                        : editingCityId
+                          ? 'Update City'
+                          : 'Create City'}
+                    </Button>
+                    {editingCityId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resetCityForm}
+                        disabled={citySaving}
+                        className="flex-1"
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <div className="lg:col-span-2 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold">Existing Cities</h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        try {
+                          await fetchCities();
+                        } catch (error) {
+                          console.error('Error refreshing cities:', error);
+                          toast.error('Failed to refresh cities');
+                        }
+                      }}
+                      disabled={citiesLoading}
+                    >
+                      <RefreshCw className="w-4 h-4 mr-2" />
+                      Refresh
+                    </Button>
+                  </div>
+                  {citiesLoading ? (
+                    <div className="flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+                    </div>
+                  ) : cities.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No cities configured yet.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {cities.map((city) => (
+                        <div key={city.id} className="p-4 border rounded-lg space-y-3">
+                          <div className="flex items-start justify-between gap-4">
+                            <div>
+                              <div className="font-semibold text-base">{city.name}</div>
+                              <div className="text-sm text-muted-foreground">{city.country}</div>
+                            </div>
+                            <Badge variant={city.unlocked ? 'default' : 'outline'}>
+                              {city.unlocked ? 'Unlocked' : 'Locked'}
+                            </Badge>
+                          </div>
+                          {city.description && (
+                            <p className="text-sm text-muted-foreground">{city.description}</p>
+                          )}
+                          {city.bonuses && (
+                            <p className="text-sm">
+                              <span className="font-medium">Bonuses:</span> {city.bonuses}
+                            </p>
+                          )}
+                          <div className="flex gap-2">
+                            <Button size="sm" variant="outline" onClick={() => handleCityEdit(city)}>
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => handleCityDelete(city.id)}
+                              disabled={deletingCityId === city.id}
+                            >
+                              {deletingCityId === city.id ? 'Deleting...' : 'Delete'}
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="locations" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MapPin className="w-6 h-6" />
+                Locations
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold">Create or Update Location</h3>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Name</label>
+                    <Input
+                      value={locationForm.name}
+                      onChange={(e) => setLocationForm((prev) => ({ ...prev, name: e.target.value }))}
+                      placeholder="Starport Amphitheater"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">City</label>
+                    <select
+                      className="w-full border rounded-md bg-background px-3 py-2 text-sm"
+                      value={locationForm.city_id}
+                      onChange={(e) => setLocationForm((prev) => ({ ...prev, city_id: e.target.value }))}
+                    >
+                      <option value="">Select a city</option>
+                      {cities.map((city) => (
+                        <option key={city.id} value={city.id}>
+                          {city.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Type</label>
+                    <Input
+                      value={locationForm.location_type}
+                      onChange={(e) => setLocationForm((prev) => ({ ...prev, location_type: e.target.value }))}
+                      placeholder="Arena, landmark, festival ground"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Description</label>
+                    <Textarea
+                      value={locationForm.description}
+                      onChange={(e) => setLocationForm((prev) => ({ ...prev, description: e.target.value }))}
+                      placeholder="Iconic venue orbiting the city core"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Bonuses</label>
+                    <Textarea
+                      value={locationForm.bonuses}
+                      onChange={(e) => setLocationForm((prev) => ({ ...prev, bonuses: e.target.value }))}
+                      placeholder="+15% ticket demand during cosmic events"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between border rounded-lg px-3 py-2">
+                    <div>
+                      <div className="text-sm font-medium">Featured Location</div>
+                      <div className="text-xs text-muted-foreground">Promote in seasonal rotations</div>
+                    </div>
+                    <Switch
+                      checked={locationForm.is_featured}
+                      onCheckedChange={(checked) => setLocationForm((prev) => ({ ...prev, is_featured: checked }))}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={handleLocationSubmit} disabled={locationSaving} className="flex-1">
+                      {locationSaving
+                        ? editingLocationId
+                          ? 'Updating...'
+                          : 'Creating...'
+                        : editingLocationId
+                          ? 'Update Location'
+                          : 'Create Location'}
+                    </Button>
+                    {editingLocationId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resetLocationForm}
+                        disabled={locationSaving}
+                        className="flex-1"
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <div className="lg:col-span-2 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold">Existing Locations</h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        try {
+                          await fetchLocations();
+                        } catch (error) {
+                          console.error('Error refreshing locations:', error);
+                          toast.error('Failed to refresh locations');
+                        }
+                      }}
+                      disabled={locationsLoading}
+                    >
+                      <RefreshCw className="w-4 h-4 mr-2" />
+                      Refresh
+                    </Button>
+                  </div>
+                  {locationsLoading ? (
+                    <div className="flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+                    </div>
+                  ) : locations.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No locations configured yet.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {locations.map((location) => {
+                        const cityName = cities.find((city) => city.id === location.city_id)?.name ?? 'Unknown City';
+                        return (
+                          <div key={location.id} className="p-4 border rounded-lg space-y-3">
+                            <div className="flex items-start justify-between gap-4">
+                              <div>
+                                <div className="font-semibold text-base">{location.name}</div>
+                                <div className="text-sm text-muted-foreground">{cityName}</div>
+                              </div>
+                              <Badge variant={location.is_featured ? 'default' : 'outline'}>
+                                {location.is_featured ? 'Featured' : 'Standard'}
+                              </Badge>
+                            </div>
+                            {location.location_type && (
+                              <p className="text-sm">
+                                <span className="font-medium">Type:</span> {location.location_type}
+                              </p>
+                            )}
+                            {location.description && (
+                              <p className="text-sm text-muted-foreground">{location.description}</p>
+                            )}
+                            {location.bonuses && (
+                              <p className="text-sm">
+                                <span className="font-medium">Bonuses:</span> {location.bonuses}
+                              </p>
+                            )}
+                            <div className="flex gap-2">
+                              <Button size="sm" variant="outline" onClick={() => handleLocationEdit(location)}>
+                                Edit
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="destructive"
+                                onClick={() => handleLocationDelete(location.id)}
+                                disabled={deletingLocationId === location.id}
+                              >
+                                {deletingLocationId === location.id ? 'Deleting...' : 'Delete'}
+                              </Button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="shops" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShoppingBag className="w-6 h-6" />
+                Shops
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold">Create or Update Shop</h3>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Name</label>
+                    <Input
+                      value={shopForm.name}
+                      onChange={(e) => setShopForm((prev) => ({ ...prev, name: e.target.value }))}
+                      placeholder="Galactic Gear Outfitters"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">City</label>
+                    <select
+                      className="w-full border rounded-md bg-background px-3 py-2 text-sm"
+                      value={shopForm.city_id}
+                      onChange={(e) => setShopForm((prev) => ({ ...prev, city_id: e.target.value }))}
+                    >
+                      <option value="">Select a city</option>
+                      {cities.map((city) => (
+                        <option key={city.id} value={city.id}>
+                          {city.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Description</label>
+                    <Textarea
+                      value={shopForm.description}
+                      onChange={(e) => setShopForm((prev) => ({ ...prev, description: e.target.value }))}
+                      placeholder="Specializes in rare guitar mods and stage outfits"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Inventory Notes</label>
+                    <Textarea
+                      value={shopForm.inventory}
+                      onChange={(e) => setShopForm((prev) => ({ ...prev, inventory: e.target.value }))}
+                      placeholder="List available items or JSON payload"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Currency</label>
+                    <Input
+                      value={shopForm.currency}
+                      onChange={(e) => setShopForm((prev) => ({ ...prev, currency: e.target.value }))}
+                      placeholder="Star Credits"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between border rounded-lg px-3 py-2">
+                    <div>
+                      <div className="text-sm font-medium">Shop Open</div>
+                      <div className="text-xs text-muted-foreground">Visible in-game marketplace</div>
+                    </div>
+                    <Switch
+                      checked={shopForm.is_open}
+                      onCheckedChange={(checked) => setShopForm((prev) => ({ ...prev, is_open: checked }))}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={handleShopSubmit} disabled={shopSaving} className="flex-1">
+                      {shopSaving
+                        ? editingShopId
+                          ? 'Updating...'
+                          : 'Creating...'
+                        : editingShopId
+                          ? 'Update Shop'
+                          : 'Create Shop'}
+                    </Button>
+                    {editingShopId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resetShopForm}
+                        disabled={shopSaving}
+                        className="flex-1"
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <div className="lg:col-span-2 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold">Existing Shops</h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        try {
+                          await fetchShops();
+                        } catch (error) {
+                          console.error('Error refreshing shops:', error);
+                          toast.error('Failed to refresh shops');
+                        }
+                      }}
+                      disabled={shopsLoading}
+                    >
+                      <RefreshCw className="w-4 h-4 mr-2" />
+                      Refresh
+                    </Button>
+                  </div>
+                  {shopsLoading ? (
+                    <div className="flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+                    </div>
+                  ) : shops.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No shops configured yet.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {shops.map((shop) => {
+                        const cityName = cities.find((city) => city.id === shop.city_id)?.name ?? 'Unknown City';
+                        return (
+                          <div key={shop.id} className="p-4 border rounded-lg space-y-3">
+                            <div className="flex items-start justify-between gap-4">
+                              <div>
+                                <div className="font-semibold text-base">{shop.name}</div>
+                                <div className="text-sm text-muted-foreground">{cityName}</div>
+                              </div>
+                              <Badge variant={shop.is_open ? 'default' : 'outline'}>
+                                {shop.is_open ? 'Open' : 'Closed'}
+                              </Badge>
+                            </div>
+                            {shop.currency && (
+                              <p className="text-sm">
+                                <span className="font-medium">Currency:</span> {shop.currency}
+                              </p>
+                            )}
+                            {shop.description && (
+                              <p className="text-sm text-muted-foreground">{shop.description}</p>
+                            )}
+                            {shop.inventory && (
+                              <p className="text-sm">
+                                <span className="font-medium">Inventory:</span> {shop.inventory}
+                              </p>
+                            )}
+                            <div className="flex gap-2">
+                              <Button size="sm" variant="outline" onClick={() => handleShopEdit(shop)}>
+                                Edit
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="destructive"
+                                onClick={() => handleShopDelete(shop.id)}
+                                disabled={deletingShopId === shop.id}
+                              >
+                                {deletingShopId === shop.id ? 'Deleting...' : 'Delete'}
+                              </Button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="special-items" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Sparkles className="w-6 h-6" />
+                Special Items
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold">Create or Update Special Item</h3>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Name</label>
+                    <Input
+                      value={specialItemForm.name}
+                      onChange={(e) => setSpecialItemForm((prev) => ({ ...prev, name: e.target.value }))}
+                      placeholder="Phoenix Feather Pick"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Rarity</label>
+                    <Input
+                      value={specialItemForm.rarity}
+                      onChange={(e) => setSpecialItemForm((prev) => ({ ...prev, rarity: e.target.value }))}
+                      placeholder="Legendary"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Effect</label>
+                    <Textarea
+                      value={specialItemForm.effect}
+                      onChange={(e) => setSpecialItemForm((prev) => ({ ...prev, effect: e.target.value }))}
+                      placeholder="Doubles solo performance power for one show"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Description</label>
+                    <Textarea
+                      value={specialItemForm.description}
+                      onChange={(e) => setSpecialItemForm((prev) => ({ ...prev, description: e.target.value }))}
+                      placeholder="Forged from supernova fragments by the ancients"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Cost</label>
+                    <Input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={specialItemForm.cost}
+                      onChange={(e) => setSpecialItemForm((prev) => ({ ...prev, cost: e.target.value }))}
+                      placeholder="5000"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between border rounded-lg px-3 py-2">
+                    <div>
+                      <div className="text-sm font-medium">Limited Availability</div>
+                      <div className="text-xs text-muted-foreground">Restrict stock to special events</div>
+                    </div>
+                    <Switch
+                      checked={specialItemForm.isLimited}
+                      onCheckedChange={(checked) => setSpecialItemForm((prev) => ({ ...prev, isLimited: checked }))}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={handleSpecialItemSubmit} disabled={specialItemSaving} className="flex-1">
+                      {specialItemSaving
+                        ? editingSpecialItemId
+                          ? 'Updating...'
+                          : 'Creating...'
+                        : editingSpecialItemId
+                          ? 'Update Item'
+                          : 'Create Item'}
+                    </Button>
+                    {editingSpecialItemId && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={resetSpecialItemForm}
+                        disabled={specialItemSaving}
+                        className="flex-1"
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <div className="lg:col-span-2 space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold">Existing Special Items</h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        try {
+                          await fetchSpecialItems();
+                        } catch (error) {
+                          console.error('Error refreshing special items:', error);
+                          toast.error('Failed to refresh special items');
+                        }
+                      }}
+                      disabled={specialItemsLoading}
+                    >
+                      <RefreshCw className="w-4 h-4 mr-2" />
+                      Refresh
+                    </Button>
+                  </div>
+                  {specialItemsLoading ? (
+                    <div className="flex justify-center py-8">
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
+                    </div>
+                  ) : specialItems.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No special items configured yet.</p>
+                  ) : (
+                    <div className="space-y-4">
+                      {specialItems.map((item) => (
+                        <div key={item.id} className="p-4 border rounded-lg space-y-3">
+                          <div className="flex items-start justify-between gap-4">
+                            <div>
+                              <div className="font-semibold text-base">{item.name}</div>
+                              <div className="text-sm text-muted-foreground">{item.rarity ?? 'Unspecified rarity'}</div>
+                            </div>
+                            <Badge variant={item.is_limited ? 'default' : 'outline'}>
+                              {item.is_limited ? 'Limited' : 'Unlimited'}
+                            </Badge>
+                          </div>
+                          {item.cost !== null && (
+                            <p className="text-sm">
+                              <span className="font-medium">Cost:</span> {item.cost}
+                            </p>
+                          )}
+                          {item.effect && (
+                            <p className="text-sm">
+                              <span className="font-medium">Effect:</span> {item.effect}
+                            </p>
+                          )}
+                          {item.description && (
+                            <p className="text-sm text-muted-foreground">{item.description}</p>
+                          )}
+                          <div className="flex gap-2">
+                            <Button size="sm" variant="outline" onClick={() => handleSpecialItemEdit(item)}>
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => handleSpecialItemDelete(item.id)}
+                              disabled={deletingSpecialItemId === item.id}
+                            >
+                              {deletingSpecialItemId === item.id ? 'Deleting...' : 'Delete'}
+                            </Button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- extend the admin dashboard tabs with dedicated Cities, Locations, Shops, and Special Items sections
- add Supabase-backed CRUD forms and lists for each new world-management entity with validation and toast feedback
- introduce TypeScript models and fetch helpers so the dashboard can load and refresh city, location, shop, and special item data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cad4dad0088325b05abb9e9d7a4ef4