### PR TITLE
Restrict profile access and expose public profiles view

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2093,6 +2093,17 @@ export type Database = {
         }
         Relationships: []
       },
+      public_profiles: {
+        Row: {
+          avatar_url: string | null
+          bio: string | null
+          display_name: string | null
+          id: string
+          user_id: string
+          username: string
+        }
+        Relationships: []
+      },
       player_achievement_summary: {
         Row: {
           earned_count: number

--- a/src/pages/BandChemistry.tsx
+++ b/src/pages/BandChemistry.tsx
@@ -310,8 +310,8 @@ const BandChemistry = () => {
           { data: skillsData, error: skillsError },
         ] = await Promise.all([
           supabase
-            .from("profiles")
-            .select("display_name, username, avatar_url, level")
+            .from("public_profiles")
+            .select("display_name, username, avatar_url")
             .eq("user_id", member.user_id)
             .maybeSingle(),
           supabase
@@ -336,7 +336,7 @@ const BandChemistry = () => {
           morale,
           chemistry,
           skill: calculateSkillAverage(skillsData),
-          loyalty: clampStat(40 + (profileData?.level ?? 1) * 10),
+          loyalty: clampStat(40 + Math.round(calculateSkillAverage(skillsData) / 5)),
           energy: clampStat(
             60 + Math.round(((skillsData?.performance ?? 50) + (skillsData?.songwriting ?? 50)) / 4)
           ),

--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -86,7 +86,7 @@ type GigRow = Database['public']['Tables']['gigs']['Row'] & {
   venue?: { name?: string | null; location?: string | null } | null;
 };
 type ScheduleEventRow = Database['public']['Tables']['schedule_events']['Row'];
-type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+type PublicProfileRow = Database['public']['Views']['public_profiles']['Row'];
 
 interface BandScheduleEvent {
   id: string;
@@ -155,13 +155,13 @@ const BandManager = () => {
         .map((member) => member.user_id)
         .filter((id): id is string => typeof id === 'string' && id.length > 0);
 
-      let profilesMap = new Map<string, Pick<ProfileRow, 'display_name' | 'avatar_url'>>();
+      let profilesMap = new Map<string, Pick<PublicProfileRow, 'display_name' | 'avatar_url'>>();
       let skillsMap = new Map<string, PlayerSkillsRow | null>();
 
       if (memberIds.length > 0) {
         const [profilesResponse, skillsResponse] = await Promise.all([
           supabase
-            .from('profiles')
+            .from('public_profiles')
             .select('user_id, display_name, avatar_url')
             .in('user_id', memberIds),
           supabase
@@ -174,7 +174,7 @@ const BandManager = () => {
         if (skillsResponse.error) throw skillsResponse.error;
 
         profilesMap = new Map(
-          ((profilesResponse.data as ProfileRow[]) ?? []).map((profile) => [profile.user_id, profile])
+          ((profilesResponse.data as PublicProfileRow[]) ?? []).map((profile) => [profile.user_id, profile])
         );
 
         skillsMap = new Map(

--- a/src/pages/EnhancedBandManager.tsx
+++ b/src/pages/EnhancedBandManager.tsx
@@ -36,8 +36,8 @@ interface BandMember {
   profiles: {
     username: string;
     display_name: string;
-    level: number;
-    avatar_url: string;
+    avatar_url: string | null;
+    levelEstimate: number;
   };
   player_skills: {
     guitar: number;
@@ -57,15 +57,16 @@ interface BandStats {
   gigsPerformed: number;
 }
 
-type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+type PublicProfileRow = Database["public"]["Views"]["public_profiles"]["Row"];
 type PlayerSkillsRow = Database["public"]["Tables"]["player_skills"]["Row"];
 type MemberSkillSet = Pick<
   PlayerSkillsRow,
   "guitar" | "vocals" | "drums" | "bass" | "performance" | "songwriting"
 >;
 
-interface AvailableMember extends ProfileRow {
+interface AvailableMember extends PublicProfileRow {
   player_skills: MemberSkillSet;
+  levelEstimate: number;
 }
 
 const defaultPlayerSkills: MemberSkillSet = {
@@ -75,6 +76,28 @@ const defaultPlayerSkills: MemberSkillSet = {
   bass: 20,
   performance: 20,
   songwriting: 20
+};
+
+const estimateSkillLevel = (skills?: MemberSkillSet | PlayerSkillsRow | null) => {
+  if (!skills) {
+    return 1;
+  }
+
+  const values = [
+    skills.guitar,
+    skills.vocals,
+    skills.drums,
+    skills.bass,
+    skills.performance,
+    skills.songwriting
+  ].filter((value): value is number => typeof value === "number");
+
+  if (values.length === 0) {
+    return 1;
+  }
+
+  const average = values.reduce((sum, value) => sum + value, 0) / values.length;
+  return Math.max(1, Math.round(average / 10));
 };
 
 const EnhancedBandManager = () => {
@@ -166,7 +189,7 @@ const EnhancedBandManager = () => {
   const fetchAvailableMembers = useCallback(async (currentMemberIds: string[]) => {
     try {
       const { data: profiles, error: profilesError } = await supabase
-        .from("profiles")
+        .from("public_profiles")
         .select("*")
         .neq("user_id", user?.id)
         .limit(20);
@@ -182,25 +205,19 @@ const EnhancedBandManager = () => {
             .eq("user_id", profile.user_id)
             .single();
 
-          const defaultSkills: MemberSkillSet = {
-            guitar: 20,
-            vocals: 20,
-            drums: 20,
-            bass: 20,
-            performance: 20,
-            songwriting: 20
+          const normalizedSkills: MemberSkillSet = {
+            guitar: skills?.guitar ?? defaultPlayerSkills.guitar,
+            vocals: skills?.vocals ?? defaultPlayerSkills.vocals,
+            drums: skills?.drums ?? defaultPlayerSkills.drums,
+            bass: skills?.bass ?? defaultPlayerSkills.bass,
+            performance: skills?.performance ?? defaultPlayerSkills.performance,
+            songwriting: skills?.songwriting ?? defaultPlayerSkills.songwriting
           };
 
           return {
             ...profile,
-            player_skills: {
-              guitar: skills?.guitar ?? defaultPlayerSkills.guitar,
-              vocals: skills?.vocals ?? defaultPlayerSkills.vocals,
-              drums: skills?.drums ?? defaultPlayerSkills.drums,
-              bass: skills?.bass ?? defaultPlayerSkills.bass,
-              performance: skills?.performance ?? defaultPlayerSkills.performance,
-              songwriting: skills?.songwriting ?? defaultPlayerSkills.songwriting
-            }
+            player_skills: normalizedSkills,
+            levelEstimate: estimateSkillLevel(normalizedSkills)
           };
         })
       );
@@ -229,14 +246,37 @@ const EnhancedBandManager = () => {
       const membersWithDetails = await Promise.all(
         (members || []).map(async (member) => {
           const [profileRes, skillsRes] = await Promise.all([
-            supabase.from("profiles").select("username, display_name, level, avatar_url").eq("user_id", member.user_id).single(),
-            supabase.from("player_skills").select("guitar, vocals, drums, bass, performance, songwriting").eq("user_id", member.user_id).single()
+            supabase
+              .from("public_profiles")
+              .select("username, display_name, avatar_url")
+              .eq("user_id", member.user_id)
+              .single(),
+            supabase
+              .from("player_skills")
+              .select("guitar, vocals, drums, bass, performance, songwriting")
+              .eq("user_id", member.user_id)
+              .single()
           ]);
+
+          const publicProfile = profileRes.data as PublicProfileRow | null;
+          const normalizedSkills: MemberSkillSet = {
+            guitar: skillsRes.data?.guitar ?? defaultPlayerSkills.guitar,
+            vocals: skillsRes.data?.vocals ?? defaultPlayerSkills.vocals,
+            drums: skillsRes.data?.drums ?? defaultPlayerSkills.drums,
+            bass: skillsRes.data?.bass ?? defaultPlayerSkills.bass,
+            performance: skillsRes.data?.performance ?? defaultPlayerSkills.performance,
+            songwriting: skillsRes.data?.songwriting ?? defaultPlayerSkills.songwriting
+          };
 
           return {
             ...member,
-            profiles: profileRes.data || { username: "", display_name: "", level: 1, avatar_url: "" },
-            player_skills: skillsRes.data || { guitar: 20, vocals: 20, drums: 20, bass: 20, performance: 20, songwriting: 20 }
+            profiles: {
+              username: publicProfile?.username ?? "",
+              display_name: publicProfile?.display_name ?? publicProfile?.username ?? "Band Member",
+              avatar_url: publicProfile?.avatar_url ?? null,
+              levelEstimate: estimateSkillLevel(normalizedSkills)
+            },
+            player_skills: normalizedSkills
           };
         })
       );
@@ -575,7 +615,7 @@ const EnhancedBandManager = () => {
                         </div>
                       </div>
                       <div className="flex items-center gap-2">
-                        <Badge variant="outline">Level {member.profiles.level}</Badge>
+                        <Badge variant="outline">Level {member.profiles.levelEstimate}</Badge>
                         {member.user_id === selectedBand.leader_id && (
                           <Crown className="h-4 w-4 text-yellow-400" />
                         )}
@@ -691,8 +731,8 @@ const EnhancedBandManager = () => {
                           <Users className="h-5 w-5 text-primary" />
                         </div>
                         <div>
-                          <CardTitle className="text-lg font-oswald">{member.display_name}</CardTitle>
-                          <CardDescription>@{member.username} • Level {member.level}</CardDescription>
+                          <CardTitle className="text-lg font-oswald">{member.display_name ?? member.username}</CardTitle>
+                          <CardDescription>@{member.username} • Level {member.levelEstimate}</CardDescription>
                         </div>
                       </div>
                     </CardHeader>

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -429,7 +429,7 @@ const SocialMedia = () => {
       }
 
       const { data, error } = await supabase
-        .from("profiles")
+        .from("public_profiles")
         .select("user_id, username, display_name, avatar_url")
         .eq("user_id", userId)
         .maybeSingle();
@@ -518,7 +518,7 @@ const SocialMedia = () => {
       const profileMap: Record<string, SocialProfile> = {};
       if (userIds.size > 0) {
         const { data: profileRows, error: profileError } = await supabase
-          .from("profiles")
+          .from("public_profiles")
           .select("user_id, username, display_name, avatar_url")
           .in("user_id", Array.from(userIds));
 

--- a/src/pages/WorldPulse.tsx
+++ b/src/pages/WorldPulse.tsx
@@ -46,7 +46,7 @@ interface GenreStats {
 
 type GlobalChartRow = Database["public"]["Tables"]["global_charts"]["Row"];
 type SongRow = Database["public"]["Tables"]["songs"]["Row"];
-type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+type PublicProfileRow = Database["public"]["Views"]["public_profiles"]["Row"];
 
 const formatDailyValue = (dateString: string) => {
   const parsed = new Date(dateString);
@@ -109,10 +109,10 @@ const WorldPulse = () => {
       )
     );
 
-    const profilesByUserId = new Map<string, ProfileRow>();
+    const profilesByUserId = new Map<string, PublicProfileRow>();
     if (userIds.length > 0) {
       const { data: profilesData, error: profilesError } = await supabase
-        .from("profiles")
+        .from("public_profiles")
         .select("user_id, display_name, username")
         .in("user_id", userIds);
 
@@ -121,7 +121,7 @@ const WorldPulse = () => {
       }
 
       (profilesData ?? []).forEach((profile) => {
-        profilesByUserId.set(profile.user_id, profile as ProfileRow);
+        profilesByUserId.set(profile.user_id, profile as PublicProfileRow);
       });
     }
 

--- a/supabase/migrations/20260220090000_create_public_profiles_view.sql
+++ b/supabase/migrations/20260220090000_create_public_profiles_view.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Restrict direct profile reads to the profile owner
+DROP POLICY IF EXISTS "Profiles are viewable by everyone" ON public.profiles;
+CREATE POLICY "Profile owners can view their data" ON public.profiles
+FOR SELECT
+USING (auth.uid() = user_id);
+
+-- Expose a sanitized view that omits financial/gameplay stats
+CREATE OR REPLACE VIEW public.public_profiles AS
+SELECT
+  id,
+  user_id,
+  username,
+  display_name,
+  avatar_url,
+  bio
+FROM public.profiles;
+
+GRANT SELECT ON public.public_profiles TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- tighten the profiles RLS policy to owner-only access and add a `public_profiles` view that exposes non-sensitive fields for authenticated readers
- extend the generated Supabase types with the new view definition
- switch non-owner profile lookups across the app (admin roster, band management, social feeds, world pulse) to the sanitized view and derive safe fallbacks such as skill-based level estimates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cad47493808325bee6832eedebb764