### PR TITLE
Add character reset flow and onboarding guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import WorldEnvironment from "./pages/WorldEnvironment";
 import SongManager from "./pages/SongManager";
 import InventoryManager from "./pages/InventoryManager";
 import PlayerStatistics from "./pages/PlayerStatistics";
+import CharacterCreation from "./pages/CharacterCreation";
 
 const queryClient = new QueryClient();
 
@@ -85,6 +86,7 @@ function App() {
                 <Route path="songs" element={<SongManager />} />
                 <Route path="inventory" element={<InventoryManager />} />
                 <Route path="statistics" element={<PlayerStatistics />} />
+                <Route path="character/create" element={<CharacterCreation />} />
               </Route>
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,17 +1,32 @@
 import { useEffect } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import Navigation from "@/components/ui/navigation";
 import { useAuth } from "@/hooks/use-auth-context";
 
 const Layout = () => {
   const navigate = useNavigate();
   const { user, loading } = useAuth();
+  const location = useLocation();
 
   useEffect(() => {
     if (!loading && !user) {
       navigate("/auth");
     }
   }, [user, loading, navigate]);
+
+  useEffect(() => {
+    if (loading || !user) {
+      return;
+    }
+
+    const needsOnboarding = typeof window !== 'undefined'
+      ? window.localStorage.getItem('rockmundo:needsOnboarding') === 'true'
+      : false;
+
+    if (needsOnboarding && location.pathname !== '/character/create') {
+      navigate('/character/create', { replace: true });
+    }
+  }, [loading, user, location.pathname, navigate]);
 
   if (loading) {
     return (

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2155,6 +2155,13 @@ export type Database = {
         }
         Returns: number
       }
+      reset_player_character: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          profile: Database["public"]["Tables"]["profiles"]["Row"]
+          skills: Database["public"]["Tables"]["player_skills"]["Row"]
+        }[]
+      }
     }
     Enums: {
       app_role: "admin" | "moderator" | "user"

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { useGameData } from "@/hooks/useGameData";
+import { Sparkles, User, Music } from "lucide-react";
+
+const CharacterCreation = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { profile, updateProfile, loading, refetch } = useGameData();
+
+  const [formData, setFormData] = useState({
+    display_name: "",
+    username: "",
+    bio: ""
+  });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (profile) {
+      setFormData({
+        display_name: profile.display_name || "",
+        username: profile.username || "",
+        bio: profile.bio || ""
+      });
+    }
+  }, [profile]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!profile) return;
+
+    setSaving(true);
+
+    try {
+      await updateProfile(formData);
+      await refetch();
+
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("rockmundo:needsOnboarding", "false");
+      }
+
+      toast({
+        title: "Character ready!",
+        description: "Your new persona is set. Let's take the stage.",
+      });
+
+      navigate("/dashboard", { replace: true });
+    } catch (error: unknown) {
+      const fallbackMessage = "Failed to save character details";
+      const errorMessage = error instanceof Error ? error.message : fallbackMessage;
+      console.error("Error completing character creation:", errorMessage, error);
+      toast({
+        variant: "destructive",
+        title: "Setup error",
+        description: errorMessage === fallbackMessage ? fallbackMessage : `${fallbackMessage}: ${errorMessage}`,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSkip = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("rockmundo:needsOnboarding", "false");
+    }
+
+    navigate("/dashboard", { replace: true });
+  };
+
+  if (loading || !profile) {
+    return (
+      <div className="min-h-screen bg-gradient-stage flex items-center justify-center p-6">
+        <div className="text-center space-y-4">
+          <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-primary mx-auto"></div>
+          <p className="text-lg font-oswald text-muted-foreground">Preparing your fresh start...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-stage p-6">
+      <div className="max-w-3xl mx-auto space-y-8">
+        <div className="text-center space-y-3">
+          <div className="flex items-center justify-center gap-2 text-primary text-sm font-semibold uppercase tracking-widest">
+            <Sparkles className="h-4 w-4" />
+            Character Creation
+          </div>
+          <h1 className="text-4xl font-bold bg-gradient-primary bg-clip-text text-transparent">
+            Craft Your New Musical Identity
+          </h1>
+          <p className="text-muted-foreground max-w-xl mx-auto">
+            Your previous progress has been archived. Set the tone for your comeback with a fresh name, look, and story before diving back into Rockmundo.
+          </p>
+        </div>
+
+        <Card className="bg-card/80 backdrop-blur border-primary/20">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5 text-primary" />
+              Player Details
+            </CardTitle>
+            <CardDescription>Introduce the world to your brand-new persona.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <Label htmlFor="displayName">Stage Name</Label>
+                <Input
+                  id="displayName"
+                  value={formData.display_name}
+                  onChange={(event) => setFormData((previous) => ({ ...previous, display_name: event.target.value }))}
+                  required
+                  placeholder="e.g. Aurora Blaze"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="username">Username</Label>
+                <Input
+                  id="username"
+                  value={formData.username}
+                  onChange={(event) => setFormData((previous) => ({ ...previous, username: event.target.value }))}
+                  required
+                  placeholder="Choose something unique"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="bio">Backstory</Label>
+                <Textarea
+                  id="bio"
+                  value={formData.bio}
+                  onChange={(event) => setFormData((previous) => ({ ...previous, bio: event.target.value }))}
+                  rows={5}
+                  placeholder="Share your origins, influences, or ambitions."
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm text-muted-foreground flex items-center gap-2">
+                  <Music className="h-4 w-4 text-primary" />
+                  We'll reopen the full game once your persona is saved.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button type="button" variant="outline" onClick={handleSkip} disabled={saving}>
+                    Skip for now
+                  </Button>
+                  <Button type="submit" className="bg-gradient-primary" disabled={saving}>
+                    {saving ? "Saving..." : "Launch New Career"}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default CharacterCreation;

--- a/supabase/migrations/20260215090000_create_reset_player_character_function.sql
+++ b/supabase/migrations/20260215090000_create_reset_player_character_function.sql
@@ -1,0 +1,84 @@
+-- Create function to fully reset a player's character state
+CREATE OR REPLACE FUNCTION public.reset_player_character()
+RETURNS TABLE (
+  profile public.profiles,
+  skills public.player_skills
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  generated_username text;
+  new_profile public.profiles%ROWTYPE;
+  new_skills public.player_skills%ROWTYPE;
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to reset character' USING ERRCODE = '42501';
+  END IF;
+
+  generated_username := 'Player' || substr(current_user_id::text, 1, 8);
+
+  -- Remove dependent records that belong to the current character
+  DELETE FROM public.social_comments WHERE user_id = current_user_id;
+  DELETE FROM public.social_reposts WHERE user_id = current_user_id;
+  DELETE FROM public.social_posts WHERE user_id = current_user_id;
+  DELETE FROM public.promotion_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.social_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.streaming_stats WHERE user_id = current_user_id;
+  DELETE FROM public.player_equipment WHERE user_id = current_user_id;
+  DELETE FROM public.player_streaming_accounts WHERE user_id = current_user_id;
+  DELETE FROM public.player_achievements WHERE user_id = current_user_id;
+  DELETE FROM public.contracts WHERE user_id = current_user_id;
+  DELETE FROM public.gig_performances WHERE user_id = current_user_id;
+  DELETE FROM public.tours WHERE user_id = current_user_id;
+  DELETE FROM public.venue_bookings WHERE user_id = current_user_id;
+  DELETE FROM public.venue_relationships WHERE user_id = current_user_id;
+  DELETE FROM public.user_actions WHERE user_id = current_user_id;
+  DELETE FROM public.global_chat WHERE user_id = current_user_id;
+  DELETE FROM public.activity_feed WHERE user_id = current_user_id;
+  DELETE FROM public.fan_demographics WHERE user_id = current_user_id;
+  DELETE FROM public.band_members WHERE user_id = current_user_id;
+
+  -- Remove bands the player owns and any related conflicts
+  DELETE FROM public.band_conflicts
+    WHERE band_id IN (
+      SELECT id FROM public.bands WHERE leader_id = current_user_id
+    );
+  DELETE FROM public.bands WHERE leader_id = current_user_id;
+
+  -- Remove songs and related stats after associated campaign data is cleared
+  DELETE FROM public.songs WHERE user_id = current_user_id;
+
+  -- Reset core profile & skills data
+  DELETE FROM public.player_skills WHERE user_id = current_user_id;
+  DELETE FROM public.profiles WHERE user_id = current_user_id;
+
+  INSERT INTO public.profiles (user_id, username, display_name)
+  VALUES (
+    current_user_id,
+    generated_username,
+    'New Player'
+  )
+  RETURNING * INTO new_profile;
+
+  INSERT INTO public.player_skills (user_id)
+  VALUES (current_user_id)
+  RETURNING * INTO new_skills;
+
+  INSERT INTO public.fan_demographics (user_id)
+  VALUES (current_user_id);
+
+  INSERT INTO public.activity_feed (user_id, activity_type, message)
+  VALUES (
+    current_user_id,
+    'reset',
+    'Your journey has been reset. Time to create a new legend!'
+  );
+
+  RETURN QUERY SELECT new_profile, new_skills;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.reset_player_character() TO authenticated;


### PR DESCRIPTION
## Summary
- add a Supabase `reset_player_character` routine that clears per-character tables and re-seeds defaults
- expose a `resetCharacter` helper in `useGameData` and surface a reset confirmation flow on the profile page
- add a character creation onboarding page with routing/guard logic to funnel players back through setup after a reset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cad679dfa48325ab21f9499a0ca1ab