### PR TITLE
Fix missing Sparkles icon import in navigation

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -25,7 +25,8 @@ import {
   X,
   MessageSquare,
   Globe,
-  Mic
+  Mic,
+  Sparkles
 } from "lucide-react";
 
 const Navigation = () => {


### PR DESCRIPTION
## Summary
- import the Sparkles icon from lucide-react so the navigation can render the Character Creator link without runtime errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cadbb155b48325aa3fd90bad677aa4