### PR TITLE
Rename character creation component constant to prevent redeclaration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import Dashboard from "./pages/Dashboard";
 import BandManager from "./pages/BandManager";
 import GigBooking from "./pages/GigBooking";
 import Profile from "./pages/Profile";
-import CharacterCreation from "./pages/CharacterCreation";
+import CharacterCreationPage from "./pages/CharacterCreation";
 import MusicStudio from "./pages/MusicStudio";
 import WorldPulse from "./pages/WorldPulse";
 import Schedule from "./pages/Schedule";
@@ -62,7 +62,7 @@ function App() {
                 <Route path="gigs/perform/:gigId" element={<PerformGig />} />
                 <Route path="busking" element={<Busking />} />
                 <Route path="profile" element={<Profile />} />
-                <Route path="character-create" element={<CharacterCreation />} />
+                <Route path="character-create" element={<CharacterCreationPage />} />
                 <Route path="music" element={<MusicStudio />} />
                 <Route path="charts" element={<WorldPulse />} />
                 <Route path="schedule" element={<Schedule />} />
@@ -89,7 +89,7 @@ function App() {
                 <Route path="songs" element={<SongManager />} />
                 <Route path="inventory" element={<InventoryManager />} />
                 <Route path="statistics" element={<PlayerStatistics />} />
-                <Route path="character/create" element={<CharacterCreation />} />
+                <Route path="character/create" element={<CharacterCreationPage />} />
               </Route>
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -90,7 +90,7 @@ const sanitizeHandle = (value: string) =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
 
-const CharacterCreation = () => {
+const CharacterCreationPage = () => {
   const { user, loading } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -597,4 +597,4 @@ const CharacterCreation = () => {
   );
 };
 
-export default CharacterCreation;
+export default CharacterCreationPage;


### PR DESCRIPTION
## Summary
- rename the character creation page component to `CharacterCreationPage`
- update routes to reference the renamed component to avoid duplicate identifier errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cadb9a82a88325af5a78f195aa2b07