### PR TITLE
Fix Sparkles icon imports to use SparklesIcon alias

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -26,7 +26,7 @@ import {
   MessageSquare,
   Globe,
   Mic,
-  Sparkles
+  SparklesIcon
 } from "lucide-react";
 
 const Navigation = () => {
@@ -43,7 +43,7 @@ const Navigation = () => {
         { icon: User, label: "Profile", path: "/profile" },
         { icon: Calendar, label: "Schedule", path: "/schedule" },
         { icon: Trophy, label: "Achievements", path: "/achievements" },
-        { icon: Sparkles, label: "Character Creator", path: "/character-create" },
+        { icon: SparklesIcon, label: "Character Creator", path: "/character-create" },
       ]
     },
     {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -28,7 +28,7 @@ import {
   Building2,
   MapPin,
   ShoppingBag,
-  Sparkles
+  SparklesIcon
 } from 'lucide-react';
 
 interface SystemMetrics {
@@ -2000,7 +2000,7 @@ const AdminDashboard: React.FC = () => {
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Sparkles className="w-6 h-6" />
+                <SparklesIcon className="w-6 h-6" />
                 Special Items
               </CardTitle>
             </CardHeader>

--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -23,7 +23,7 @@ import {
   MapPin,
   Mic,
   ShieldAlert,
-  Sparkles,
+  SparklesIcon,
   TrendingUp,
 } from "lucide-react";
 
@@ -654,7 +654,7 @@ const Busking = () => {
           <Card className="bg-card/80 backdrop-blur border-primary/20">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Fame</CardTitle>
-              <Sparkles className="h-4 w-4 text-warning" />
+              <SparklesIcon className="h-4 w-4 text-warning" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold text-warning">{profile.fame ?? 0}</div>
@@ -802,7 +802,7 @@ const Busking = () => {
                 <div className="p-4 bg-muted/30 rounded-lg">
                   <p className="text-xs uppercase text-muted-foreground tracking-wide">Projected Fame</p>
                   <div className="flex items-center gap-2 mt-2">
-                    <Sparkles className="h-5 w-5 text-warning" />
+                    <SparklesIcon className="h-5 w-5 text-warning" />
                     <span className="text-xl font-semibold">+{expectedFame}</span>
                   </div>
                   <p className="text-xs text-muted-foreground mt-1">More eyes on you mean more followers.</p>

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Sparkles, Wand2, CheckCircle2, AlertCircle, Palette, Gauge } from "lucide-react";
+import { SparklesIcon, Wand2, CheckCircle2, AlertCircle, Palette, Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -509,7 +509,7 @@ const CharacterCreationPage = () => {
         <Card className="border-primary/20 bg-background/80 shadow-lg backdrop-blur">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
-              <Sparkles className="h-5 w-5 text-primary" />
+              <SparklesIcon className="h-5 w-5 text-primary" />
               Backstory & Motivation
             </CardTitle>
             <CardDescription>

--- a/src/pages/MusicStudio.tsx
+++ b/src/pages/MusicStudio.tsx
@@ -25,7 +25,7 @@ import {
   Upload,
   AlertCircle,
   SlidersHorizontal,
-  Sparkles
+  SparklesIcon
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/use-auth-context";
@@ -908,7 +908,7 @@ const MusicStudio = () => {
                               <div className={`flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 rounded-lg border ${masteringComplete ? 'border-amber-500/40 bg-amber-500/10' : 'border-border/50 bg-muted/30'}`}>
                                 <div className="flex items-center gap-3">
                                   <div className={`rounded-full p-2 ${masteringComplete ? 'bg-amber-500/20 text-amber-600' : 'bg-muted text-muted-foreground'}`}>
-                                    <Sparkles className="h-5 w-5" />
+                                    <SparklesIcon className="h-5 w-5" />
                                   </div>
                                   <div>
                                     <p className="text-sm font-semibold">Mastering</p>
@@ -933,7 +933,7 @@ const MusicStudio = () => {
                                         size="sm"
                                         className="gap-2"
                                       >
-                                        <Sparkles className="h-4 w-4" />
+                                        <SparklesIcon className="h-4 w-4" />
                                         Master
                                       </Button>
                                     </>
@@ -1045,7 +1045,7 @@ const MusicStudio = () => {
                       <div className="animate-pulse">
                         {activeProcess === 'recording' && <Mic className="h-12 w-12 text-primary" />}
                         {activeProcess === 'mixing' && <SlidersHorizontal className="h-12 w-12 text-primary" />}
-                        {activeProcess === 'mastering' && <Sparkles className="h-12 w-12 text-primary" />}
+                        {activeProcess === 'mastering' && <SparklesIcon className="h-12 w-12 text-primary" />}
                       </div>
                     </div>
                   </div>

--- a/src/pages/WorldEnvironment.tsx
+++ b/src/pages/WorldEnvironment.tsx
@@ -25,7 +25,7 @@ import {
   MapPin,
   Calendar,
   AlertTriangle,
-  Sparkles,
+  SparklesIcon,
   Globe,
   Mountain,
   Building,
@@ -140,7 +140,7 @@ const WorldEnvironment: React.FC = () => {
       case 'competition': return <TrendingUp className="w-5 h-5 text-blue-500" />;
       case 'economic': return <DollarSign className="w-5 h-5 text-green-500" />;
       case 'disaster': return <AlertTriangle className="w-5 h-5 text-red-500" />;
-      case 'celebration': return <Sparkles className="w-5 h-5 text-yellow-500" />;
+      case 'celebration': return <SparklesIcon className="w-5 h-5 text-yellow-500" />;
       default: return <Globe className="w-5 h-5" />;
     }
   };


### PR DESCRIPTION
## Summary
- replace the unsupported Sparkles import with SparklesIcon in the navigation component
- align all other pages using Sparkles to import SparklesIcon from lucide-react
- ensure the Character Creator navigation entry and all Sparkles usages render via the supported icon component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cade8ea4108325a2b196fdb3626793