### PR TITLE
Rename recording state to recordingSession

### DIFF
--- a/src/pages/MusicCreation.tsx
+++ b/src/pages/MusicCreation.tsx
@@ -207,7 +207,7 @@ const MusicCreation = () => {
   const [profile, setProfile] = useState<ProfileInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
-  const [recording, setRecording] = useState(false);
+  const [recordingSession, setRecordingSession] = useState(false);
   const [localRecordings, setLocalRecordings] = useState<Record<string, LocalRecording[]>>({});
   const [editingSong, setEditingSong] = useState<Song | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);


### PR DESCRIPTION
## Summary
- rename the music creation recording boolean state to recordingSession
- update all usages to reference the new state name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cade7e856083258ede2f2f6432a4e0