### PR TITLE
Add live event hook and automated status refresh

### DIFF
--- a/src/hooks/useGameEvents.ts
+++ b/src/hooks/useGameEvents.ts
@@ -1,0 +1,354 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/hooks/use-auth-context";
+import type { Tables } from "@/integrations/supabase/types";
+import type { PlayerProfile, ActivityItem } from "@/hooks/useGameData";
+
+export type GameEvent = Tables<'game_events'>;
+export type EventParticipant = Tables<'event_participants'>;
+
+export type GameEventWithStatus = GameEvent & {
+  participants: EventParticipant[];
+  participantCount: number;
+  isUserParticipant: boolean;
+  isUserRewardClaimed: boolean;
+  availableSlots: number | null;
+};
+
+type UseGameEventsOptions = {
+  profile: PlayerProfile | null;
+  updateProfile: (updates: Partial<PlayerProfile>) => Promise<PlayerProfile | null | undefined>;
+  addActivity: (activityType: string, message: string, earnings?: number) => Promise<ActivityItem | null | undefined>;
+};
+
+type RewardSummary = {
+  updates: Partial<PlayerProfile>;
+  messageDetails: string[];
+  cashDelta: number;
+};
+
+type RawRecord = Record<string, unknown>;
+
+const rewardableFields: (keyof PlayerProfile)[] = [
+  "cash",
+  "experience",
+  "fame",
+  "fans",
+  "followers",
+  "engagement_rate",
+  "health"
+];
+
+const formatKey = (key: string) => key.replace(/_/g, " ");
+
+const parseRewardPayload = (rewards: unknown, profile: PlayerProfile | null): RewardSummary => {
+  const updates: Partial<PlayerProfile> = {};
+  const messageDetails: string[] = [];
+  let cashDelta = 0;
+
+  if (!rewards || typeof rewards !== "object" || Array.isArray(rewards)) {
+    return { updates, messageDetails, cashDelta };
+  }
+
+  const rewardsRecord = rewards as RawRecord;
+
+  rewardableFields.forEach(field => {
+    const value = rewardsRecord[field as string];
+    const numericValue = typeof value === "number" ? value : Number(value);
+
+    if (!Number.isFinite(numericValue) || numericValue === 0) {
+      return;
+    }
+
+    const currentValue = profile?.[field];
+    const baseValue = typeof currentValue === "number" ? currentValue : 0;
+    const nextValue = baseValue + numericValue;
+
+    updates[field] = nextValue as PlayerProfile[typeof field];
+    messageDetails.push(`${formatKey(field as string)} ${numericValue > 0 ? "+" : ""}${numericValue}`);
+
+    if (field === "cash") {
+      cashDelta += numericValue;
+    }
+  });
+
+  return { updates, messageDetails, cashDelta };
+};
+
+const meetsRequirements = (requirements: unknown, profile: PlayerProfile | null) => {
+  if (!requirements || typeof requirements !== "object" || Array.isArray(requirements)) {
+    return true;
+  }
+
+  if (!profile) {
+    return false;
+  }
+
+  const requirementEntries = Object.entries(requirements as RawRecord);
+  const profileRecord = profile as unknown as RawRecord;
+
+  return requirementEntries.every(([key, value]) => {
+    const numericValue = typeof value === "number" ? value : Number(value);
+
+    if (!Number.isFinite(numericValue)) {
+      return true;
+    }
+
+    const current = profileRecord[key];
+
+    if (typeof current === "number") {
+      return current >= numericValue;
+    }
+
+    return true;
+  });
+};
+
+const mapEventResponse = (
+  events: (GameEvent & { event_participants: EventParticipant[] | null })[],
+  userId: string | undefined
+): GameEventWithStatus[] =>
+  events.map(event => {
+    const participants = event.event_participants ?? [];
+    const participantCount = participants.length;
+    const participant = userId
+      ? participants.find(entry => entry.user_id === userId)
+      : undefined;
+
+    const availableSlots = typeof event.max_participants === "number"
+      ? Math.max(event.max_participants - participantCount, 0)
+      : null;
+
+    return {
+      ...event,
+      participants,
+      participantCount,
+      isUserParticipant: Boolean(participant),
+      isUserRewardClaimed: Boolean(participant?.rewards_claimed),
+      availableSlots
+    };
+  });
+
+export const useGameEvents = (options?: Partial<UseGameEventsOptions>) => {
+  const { user } = useAuth();
+  const [events, setEvents] = useState<GameEventWithStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [joiningEventId, setJoiningEventId] = useState<string | null>(null);
+  const [completingEventId, setCompletingEventId] = useState<string | null>(null);
+
+  const fetchEvents = useCallback(
+    async (showInitialLoader: boolean = false) => {
+      try {
+        if (showInitialLoader) {
+          setLoading(true);
+        } else {
+          setRefreshing(true);
+        }
+
+        const { data, error: fetchError } = await supabase
+          .from('game_events')
+          .select('*, event_participants(*)')
+          .order('start_date', { ascending: true });
+
+        if (fetchError) {
+          throw fetchError;
+        }
+
+        const mapped = mapEventResponse((data ?? []) as (GameEvent & { event_participants: EventParticipant[] | null })[], user?.id);
+        setEvents(mapped);
+        setError(null);
+      } catch (err: unknown) {
+        console.error('Error loading game events:', err);
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('Failed to load game events.');
+        }
+      } finally {
+        if (showInitialLoader) {
+          setLoading(false);
+        } else {
+          setRefreshing(false);
+        }
+      }
+    },
+    [user?.id]
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void fetchEvents(true);
+
+    const channel = supabase.channel('game-events-feed');
+
+    channel.on('postgres_changes', { schema: 'public', table: 'game_events' }, () => {
+      if (!isMounted) {
+        return;
+      }
+      void fetchEvents();
+    });
+
+    channel.on('postgres_changes', { schema: 'public', table: 'event_participants' }, () => {
+      if (!isMounted) {
+        return;
+      }
+      void fetchEvents();
+    });
+
+    void channel.subscribe();
+
+    return () => {
+      isMounted = false;
+      void channel.unsubscribe();
+    };
+  }, [fetchEvents]);
+
+  const syncParticipantCount = useCallback(async (eventId: string) => {
+    const { count, error: countError } = await supabase
+      .from('event_participants')
+      .select('id', { count: 'exact', head: true })
+      .eq('event_id', eventId);
+
+    if (countError) {
+      throw countError;
+    }
+
+    const { error: updateError } = await supabase
+      .from('game_events')
+      .update({ current_participants: count ?? 0 })
+      .eq('id', eventId);
+
+    if (updateError) {
+      throw updateError;
+    }
+  }, []);
+
+  const joinEvent = useCallback(
+    async (eventId: string) => {
+      if (!user) {
+        throw new Error('You must be signed in to join an event.');
+      }
+
+      const targetEvent = events.find(event => event.id === eventId);
+
+      if (!targetEvent) {
+        throw new Error('Event not found.');
+      }
+
+      if (!targetEvent.is_active) {
+        throw new Error('This event is not currently active.');
+      }
+
+      if (targetEvent.isUserParticipant) {
+        throw new Error('You have already joined this event.');
+      }
+
+      if (typeof targetEvent.max_participants === 'number' && targetEvent.participantCount >= targetEvent.max_participants) {
+        throw new Error('This event has reached its participant limit.');
+      }
+
+      if (!meetsRequirements(targetEvent.requirements, options?.profile ?? null)) {
+        throw new Error('You do not meet the requirements for this event.');
+      }
+
+      try {
+        setJoiningEventId(eventId);
+
+        const { error: insertError } = await supabase
+          .from('event_participants')
+          .insert({
+            event_id: eventId,
+            user_id: user.id
+          });
+
+        if (insertError) {
+          if ('code' in insertError && insertError.code === '23505') {
+            throw new Error('You are already registered for this event.');
+          }
+          throw insertError;
+        }
+
+        await syncParticipantCount(eventId);
+        await fetchEvents();
+
+        if (options?.addActivity) {
+          await options.addActivity('event', `Joined event: ${targetEvent.title}`, 0);
+        }
+      } finally {
+        setJoiningEventId(null);
+      }
+    },
+    [events, fetchEvents, options, syncParticipantCount, user]
+  );
+
+  const completeEvent = useCallback(
+    async (eventId: string) => {
+      if (!user) {
+        throw new Error('You must be signed in to complete an event.');
+      }
+
+      const targetEvent = events.find(event => event.id === eventId);
+
+      if (!targetEvent) {
+        throw new Error('Event not found.');
+      }
+
+      const participant = targetEvent.participants.find(entry => entry.user_id === user.id);
+
+      if (!participant) {
+        throw new Error('You need to join the event before completing it.');
+      }
+
+      if (participant.rewards_claimed) {
+        throw new Error('You have already claimed rewards for this event.');
+      }
+
+      try {
+        setCompletingEventId(eventId);
+
+        const { error: updateError } = await supabase
+          .from('event_participants')
+          .update({ rewards_claimed: true })
+          .eq('id', participant.id);
+
+        if (updateError) {
+          throw updateError;
+        }
+
+        if (options?.updateProfile && options?.addActivity) {
+          const { updates, messageDetails, cashDelta } = parseRewardPayload(targetEvent.rewards, options.profile ?? null);
+
+          if (Object.keys(updates).length > 0) {
+            await options.updateProfile(updates);
+          }
+
+          const rewardMessage = messageDetails.length
+            ? `Completed event: ${targetEvent.title} - Rewards: ${messageDetails.join(', ')}`
+            : `Completed event: ${targetEvent.title}`;
+
+          await options.addActivity('event', rewardMessage, cashDelta);
+        }
+
+        await fetchEvents();
+      } finally {
+        setCompletingEventId(null);
+      }
+    },
+    [events, fetchEvents, options, user]
+  );
+
+  return {
+    events,
+    loading,
+    refreshing,
+    error,
+    joinEvent,
+    completeEvent,
+    refresh: fetchEvents,
+    joiningEventId,
+    completingEventId
+  };
+};

--- a/src/pages/WorldEnvironment.tsx
+++ b/src/pages/WorldEnvironment.tsx
@@ -4,8 +4,10 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useAuth } from '@/hooks/use-auth-context';
 import { useGameData } from '@/hooks/useGameData';
+import { useGameEvents, type GameEventWithStatus } from '@/hooks/useGameEvents';
 import { toast } from '@/components/ui/sonner-toast';
 import { supabase } from '@/integrations/supabase/client';
 import {
@@ -16,11 +18,11 @@ import {
   type RandomEvent,
 } from '@/utils/worldEnvironment';
 import { 
-  Cloud, 
-  Sun, 
-  CloudRain, 
-  CloudSnow, 
-  Zap, 
+  Cloud,
+  Sun,
+  CloudRain,
+  CloudSnow,
+  Zap,
   Wind,
   MapPin,
   Calendar,
@@ -33,7 +35,8 @@ import {
   TrendingUp,
   DollarSign,
   Music,
-  Thermometer
+  Thermometer,
+  Loader2
 } from 'lucide-react';
 
 const REFRESH_INTERVAL = 60_000;
@@ -49,12 +52,95 @@ const WorldEnvironment: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const isMountedRef = useRef(false);
 
+  const {
+    events: liveEvents,
+    loading: eventsLoading,
+    refreshing: eventsRefreshing,
+    error: eventsError,
+    joinEvent: joinGameEvent,
+    completeEvent: completeGameEvent,
+    refresh: refreshGameEvents,
+    joiningEventId,
+    completingEventId
+  } = useGameEvents({ profile, updateProfile, addActivity });
+
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };
   }, []);
+
+  const formatRewardEntries = useCallback((rewards: unknown) => {
+    if (!rewards || typeof rewards !== 'object' || Array.isArray(rewards)) {
+      return [] as { key: string; label: string; value: number }[];
+    }
+
+    return Object.entries(rewards as Record<string, unknown>)
+      .map(([key, value]) => {
+        const numericValue = typeof value === 'number' ? value : Number(value);
+        if (!Number.isFinite(numericValue) || numericValue === 0) {
+          return null;
+        }
+
+        return {
+          key,
+          label: key.replace(/_/g, ' '),
+          value: numericValue
+        };
+      })
+      .filter((entry): entry is { key: string; label: string; value: number } => entry !== null);
+  }, []);
+
+  const formatRequirementEntries = useCallback((requirements: unknown) => {
+    if (!requirements || typeof requirements !== 'object' || Array.isArray(requirements)) {
+      return [] as { key: string; label: string; value: number }[];
+    }
+
+    return Object.entries(requirements as Record<string, unknown>)
+      .map(([key, value]) => {
+        const numericValue = typeof value === 'number' ? value : Number(value);
+
+        if (!Number.isFinite(numericValue)) {
+          return null;
+        }
+
+        return {
+          key,
+          label: key.replace(/_/g, ' '),
+          value: numericValue
+        };
+      })
+      .filter((entry): entry is { key: string; label: string; value: number } => entry !== null);
+  }, []);
+
+  const handleJoinGameEvent = useCallback(
+    async (event: GameEventWithStatus) => {
+      try {
+        await joinGameEvent(event.id);
+        toast.success(`Joined ${event.title}`);
+      } catch (error: unknown) {
+        console.error('Error joining event:', error);
+        const message = error instanceof Error ? error.message : 'Failed to join event.';
+        toast.error(message);
+      }
+    },
+    [joinGameEvent]
+  );
+
+  const handleCompleteGameEvent = useCallback(
+    async (event: GameEventWithStatus) => {
+      try {
+        await completeGameEvent(event.id);
+        toast.success(`Rewards claimed for ${event.title}`);
+      } catch (error: unknown) {
+        console.error('Error completing event:', error);
+        const message = error instanceof Error ? error.message : 'Failed to complete event.';
+        toast.error(message);
+      }
+    },
+    [completeGameEvent]
+  );
 
   const loadWorldData = useCallback(async (showLoader: boolean = true) => {
     if (!user) {
@@ -598,6 +684,200 @@ const WorldEnvironment: React.FC = () => {
 
         <TabsContent value="events" className="space-y-6">
           <div className="space-y-4">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">Live Game Events</h2>
+                <p className="text-sm text-muted-foreground">
+                  Join limited-time challenges to earn rewards alongside the community.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void refreshGameEvents()}
+                disabled={eventsLoading || eventsRefreshing}
+              >
+                {eventsRefreshing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Refreshing
+                  </>
+                ) : (
+                  'Refresh'
+                )}
+              </Button>
+            </div>
+
+            {eventsError && (
+              <Alert variant="destructive">
+                <AlertTitle>Unable to load events</AlertTitle>
+                <AlertDescription>{eventsError}</AlertDescription>
+              </Alert>
+            )}
+
+            {eventsLoading ? (
+              <div className="flex items-center justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-primary" />
+              </div>
+            ) : liveEvents.length === 0 ? (
+              <Card>
+                <CardContent className="p-6 text-sm text-muted-foreground">
+                  No live events are active right now. Check back soon!
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {liveEvents.map((event) => {
+                  const rewardEntries = formatRewardEntries(event.rewards);
+                  const requirementEntries = formatRequirementEntries(event.requirements);
+                  const startDate = new Date(event.start_date);
+                  const endDate = new Date(event.end_date);
+                  const now = Date.now();
+                  const isExpired = endDate.getTime() < now;
+                  const statusLabel = event.is_active
+                    ? 'Active'
+                    : isExpired
+                      ? 'Completed'
+                      : 'Upcoming';
+                  const statusVariant = event.is_active
+                    ? 'default'
+                    : isExpired
+                      ? 'outline'
+                      : 'secondary';
+                  const participantProgress = typeof event.max_participants === 'number'
+                    ? Math.min(100, Math.round((event.participantCount / Math.max(event.max_participants, 1)) * 100))
+                    : null;
+                  const joinDisabled = !event.is_active || event.isUserParticipant || (event.availableSlots !== null && event.availableSlots <= 0);
+                  const completionDisabled = !event.isUserParticipant || event.isUserRewardClaimed;
+
+                  return (
+                    <Card key={event.id} className="border-primary/40">
+                      <CardContent className="space-y-4 p-6">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="space-y-1">
+                            <div className="flex items-center gap-2">
+                              <Music className="h-5 w-5 text-primary" />
+                              <h3 className="text-lg font-bold">{event.title}</h3>
+                            </div>
+                            {event.description && (
+                              <p className="text-sm text-muted-foreground">{event.description}</p>
+                            )}
+                          </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge variant={statusVariant} className="capitalize">
+                              {statusLabel}
+                            </Badge>
+                            {event.isUserParticipant && (
+                              <Badge variant={event.isUserRewardClaimed ? 'outline' : 'secondary'}>
+                                {event.isUserRewardClaimed ? 'Reward claimed' : 'Joined'}
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-3 text-sm text-muted-foreground sm:grid-cols-2">
+                          <div className="flex items-center gap-2">
+                            <Calendar className="h-4 w-4" />
+                            <span>
+                              {startDate.toLocaleString()} – {endDate.toLocaleString()}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Users className="h-4 w-4" />
+                            <span>
+                              {event.participantCount}
+                              {typeof event.max_participants === 'number'
+                                ? ` / ${event.max_participants} participants`
+                                : ' participants'}
+                            </span>
+                          </div>
+                        </div>
+
+                        {participantProgress !== null && (
+                          <div className="space-y-2">
+                            <Progress value={participantProgress} />
+                            <p className="text-xs text-muted-foreground">
+                              {event.availableSlots === 0
+                                ? 'Event is full'
+                                : `${event.availableSlots} slots remaining`}
+                            </p>
+                          </div>
+                        )}
+
+                        {requirementEntries.length > 0 && (
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold">Requirements</h4>
+                            <div className="flex flex-wrap gap-2 text-xs">
+                              {requirementEntries.map((requirement) => (
+                                <Badge key={`${event.id}-requirement-${requirement.key}`} variant="outline">
+                                  {requirement.label}: {requirement.value}+
+                                </Badge>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {rewardEntries.length > 0 && (
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-semibold">Rewards</h4>
+                            <div className="flex flex-wrap gap-2 text-xs">
+                              {rewardEntries.map((reward) => (
+                                <Badge key={`${event.id}-reward-${reward.key}`} variant="secondary">
+                                  {reward.label}: {reward.value > 0 ? '+' : ''}{reward.value}
+                                </Badge>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <Button
+                            size="sm"
+                            onClick={() => void handleJoinGameEvent(event)}
+                            disabled={joinDisabled || joiningEventId === event.id}
+                          >
+                            {joiningEventId === event.id ? (
+                              <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Joining...
+                              </>
+                            ) : (
+                              'Join Event'
+                            )}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void handleCompleteGameEvent(event)}
+                            disabled={completionDisabled || completingEventId === event.id}
+                          >
+                            {event.isUserRewardClaimed ? (
+                              'Rewards claimed'
+                            ) : completingEventId === event.id ? (
+                              <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Claiming...
+                              </>
+                            ) : (
+                              'Complete Event'
+                            )}
+                          </Button>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold">World Simulation Events</h2>
+              <p className="text-sm text-muted-foreground">
+                These global conditions influence demand, rewards, and tour planning across the world.
+              </p>
+            </div>
             {worldEvents.map((event) => (
               <Card key={event.id} className={event.is_active ? 'border-green-500' : 'border-gray-300'}>
                 <CardContent className="p-6">
@@ -650,7 +930,7 @@ const WorldEnvironment: React.FC = () => {
                   </div>
 
                   {event.is_active && event.participation_reward > 0 && (
-                    <Button onClick={() => participateInWorldEvent(event.id)} className="w-full">
+                    <Button onClick={() => void participateInWorldEvent(event.id)} className="w-full">
                       Participate in Event
                     </Button>
                   )}

--- a/supabase/migrations/20260301090000_manage_game_event_status.sql
+++ b/supabase/migrations/20260301090000_manage_game_event_status.sql
@@ -1,0 +1,53 @@
+-- Ensure pg_cron is available for scheduling automatic event updates
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- Function to activate or deactivate game events based on their schedule
+CREATE OR REPLACE FUNCTION public.refresh_game_event_statuses()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  current_utc timestamptz := timezone('utc', now());
+BEGIN
+  UPDATE public.game_events ge
+  SET is_active = true
+  WHERE ge.is_active IS DISTINCT FROM true
+    AND ge.start_date <= current_utc
+    AND ge.end_date > current_utc;
+
+  UPDATE public.game_events ge
+  SET is_active = false
+  WHERE ge.is_active IS DISTINCT FROM false
+    AND (ge.end_date <= current_utc OR ge.start_date > current_utc);
+END;
+$$;
+
+COMMENT ON FUNCTION public.refresh_game_event_statuses() IS 'Activates or deactivates game events when their scheduled window starts or ends.';
+
+GRANT EXECUTE ON FUNCTION public.refresh_game_event_statuses() TO service_role;
+
+-- Schedule the refresh to keep event state aligned with the calendar
+DO $$
+DECLARE
+  existing_job_id integer;
+BEGIN
+  SELECT jobid INTO existing_job_id
+  FROM cron.job
+  WHERE jobname = 'game_events_status_refresh_job';
+
+  IF existing_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(existing_job_id);
+  END IF;
+
+  PERFORM cron.schedule(
+    'game_events_status_refresh_job',
+    '*/5 * * * *',
+    $$SELECT public.refresh_game_event_statuses();$$
+  );
+END;
+$$;
+
+-- Run once so any existing events pick up the latest status immediately
+SELECT public.refresh_game_event_statuses();


### PR DESCRIPTION
## Summary
- create a dedicated `useGameEvents` hook to load and subscribe to game event data, enforce requirements, and grant rewards via profile/activity updates
- surface live events within the world environment screen with interactive join/complete controls, requirement and reward visuals, and manual refresh support
- add a pg_cron-backed migration that keeps `game_events.is_active` in sync with their scheduled window

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae240ac4c8325ae7d78f973180fe6