### PR TITLE
Add office, town center, and high street busking locations

### DIFF
--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -55,6 +55,48 @@ const fallbackTimestamp = "1970-01-01T00:00:00.000Z";
 
 const fallbackLocations: BuskingLocation[] = [
   {
+    id: "fallback-offices",
+    name: "Near Local Offices",
+    description: "Weekday lunch crowd of office workers eager for quick hits and covers.",
+    neighborhood: "Financial Commons",
+    recommended_skill: 50,
+    base_payout: 180,
+    fame_reward: 10,
+    experience_reward: 48,
+    risk_level: "medium",
+    ambiance: "Clockwork foot traffic surges at noon while security keeps an eye out.",
+    cooldown_minutes: 50,
+    created_at: fallbackTimestamp,
+  },
+  {
+    id: "fallback-town-center",
+    name: "Town Center",
+    description: "Central plaza with families, tourists, and street food all afternoon.",
+    neighborhood: "Civic Plaza",
+    recommended_skill: 65,
+    base_payout: 260,
+    fame_reward: 16,
+    experience_reward: 68,
+    risk_level: "medium",
+    ambiance: "Community events keep energy steady with occasional festival spikes.",
+    cooldown_minutes: 70,
+    created_at: fallbackTimestamp,
+  },
+  {
+    id: "fallback-high-street",
+    name: "High Street",
+    description: "Premier shopping strip packed with trendsetters and impulse tippers.",
+    neighborhood: "Retail Row",
+    recommended_skill: 75,
+    base_payout: 360,
+    fame_reward: 22,
+    experience_reward: 85,
+    risk_level: "high",
+    ambiance: "Boutique launches and brand pop-ups make for fierce competition.",
+    cooldown_minutes: 85,
+    created_at: fallbackTimestamp,
+  },
+  {
     id: "fallback-subway",
     name: "Subway Center Stage",
     description: "A bustling underground transit hub with great acoustics.",
@@ -125,6 +167,27 @@ const fallbackLocations: BuskingLocation[] = [
     created_at: fallbackTimestamp,
   },
 ];
+
+const locationAudienceHighlights: Record<
+  string,
+  {
+    label: string;
+    description: string;
+  }
+> = {
+  "Near Local Offices": {
+    label: "Workday Crowd",
+    description: "Lunch breaks surge from 11:30 to 2:00—arrive early to lock the spot.",
+  },
+  "Town Center": {
+    label: "Community Mix",
+    description: "Families and tourists linger for sing-alongs and upbeat covers.",
+  },
+  "High Street": {
+    label: "Retail Rush",
+    description: "Peak shoppers chase hype tracks and big hooks during evening hours.",
+  },
+};
 
 const fallbackModifiers: BuskingModifier[] = [
   {
@@ -679,7 +742,8 @@ const Busking = () => {
             <div>
               <h2 className="text-2xl font-bebas tracking-widest text-foreground">Choose Your Stage</h2>
               <p className="text-sm text-muted-foreground font-oswald">
-                Each location has its own risk profile, audience, and cooldown timer.
+                Tap into office lunch rushes, civic plaza hangouts, or the high street spotlight—each
+                location has its own risk profile, audience rhythms, and cooldown timer.
               </p>
             </div>
           </div>
@@ -692,6 +756,7 @@ const Busking = () => {
               const totalCooldownMs = (location.cooldown_minutes ?? 0) * 60 * 1000;
               const progressValue = totalCooldownMs > 0 ? Math.min(100, Math.max(0, ((totalCooldownMs - cooldownMs) / totalCooldownMs) * 100)) : 100;
               const rewardPercent = Math.round((location.base_payout / maxBasePayout) * 100);
+              const highlight = locationAudienceHighlights[location.name ?? ""];
 
               return (
                 <Card
@@ -718,6 +783,17 @@ const Busking = () => {
                       </Badge>
                     </div>
                     <p className="text-sm text-muted-foreground">{location.description}</p>
+                    {highlight && (
+                      <div className="flex items-start gap-2 rounded-md bg-muted/30 p-3">
+                        <History className="h-4 w-4 text-primary mt-0.5" />
+                        <div className="space-y-1">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                            {highlight.label}
+                          </p>
+                          <p className="text-xs text-muted-foreground">{highlight.description}</p>
+                        </div>
+                      </div>
+                    )}
                   </CardHeader>
                   <CardContent className="space-y-3">
                     <div className="flex items-center justify-between text-sm">

--- a/supabase/migrations/20260920120000_create_busking_tables.sql
+++ b/supabase/migrations/20260920120000_create_busking_tables.sql
@@ -67,6 +67,9 @@ create index if not exists busking_sessions_location_idx on public.busking_sessi
 -- Seed data to match the reference experience
 insert into public.busking_locations (name, description, neighborhood, recommended_skill, base_payout, fame_reward, experience_reward, risk_level, ambiance, cooldown_minutes)
 values
+    ('Near Local Offices', 'Weekday lunch crowd of office workers eager for quick hits and covers.', 'Financial Commons', 50, 180, 10, 48, 'medium', 'Clockwork foot traffic surges at noon while security keeps an eye out.', 50),
+    ('Town Center', 'Central plaza with families, tourists, and street food all afternoon.', 'Civic Plaza', 65, 260, 16, 68, 'medium', 'Community events keep energy steady with occasional festival spikes.', 70),
+    ('High Street', 'Premier shopping strip packed with trendsetters and impulse tippers.', 'Retail Row', 75, 360, 22, 85, 'high', 'Boutique launches and brand pop-ups make for fierce competition.', 85),
     ('Subway Center Stage', 'A bustling underground transit hub with great acoustics.', 'Downtown Transit Plaza', 45, 140, 8, 40, 'low', 'Echoing tunnels amplify your sound, commuters pass by quickly.', 45),
     ('Riverside Boardwalk', 'Open-air walkway beside the river, popular during sunsets.', 'Harbor District', 60, 220, 12, 55, 'medium', 'Tourists stroll slowly, perfect for ballads and duets.', 60),
     ('Night Market Spotlight', 'Energetic evening market with vibrant crowds.', 'Old Town Bazaar', 70, 320, 18, 75, 'high', 'Vendors cheer you on but noise levels spike unpredictably.', 75),


### PR DESCRIPTION
## Summary
- add fallback definitions for Near Local Offices, Town Center, and High Street with tailored risk, reward, and ambiance values
- surface audience highlight callouts in the busking location selector to spotlight the new crowd patterns
- sync Supabase busking_locations seed data so production mirrors the updated location catalog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae21f12488325ba4ec7d6282ea83d