### PR TITLE
Align GameData context value with interface

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -36,6 +36,7 @@ interface GameDataContextValue {
   activities: ActivityItem[];
   loading: boolean;
   error: string | null;
+  currentCity: Tables<'cities'> | null;
   hasCharacters: boolean;
   setActiveCharacter: (characterId: string) => Promise<void>;
   clearSelectedCharacter: () => void;
@@ -152,6 +153,10 @@ const useProvideGameData = (): GameDataContextValue => {
       setCharactersLoading(false);
     }
   }, [user, selectedCharacterId, updateSelectedCharacterId, clearSelectedCharacter]);
+
+  const refreshCharacters = useCallback(async () => {
+    return fetchCharacters();
+  }, [fetchCharacters]);
 
   const fetchGameData = useCallback(async () => {
     if (!user) {
@@ -541,11 +546,11 @@ const useProvideGameData = (): GameDataContextValue => {
     loading,
     error,
     currentCity,
+    hasCharacters,
+    setActiveCharacter,
+    clearSelectedCharacter,
     updateProfile,
     updateSkills,
-    updateLocation,
-    updateHealth,
-    updateCurrentCity,
     addActivity,
     createCharacter,
     refreshCharacters,


### PR DESCRIPTION
## Summary
- expose the current city and character management helpers through the GameData context so the return shape matches its interface
- add a concrete `refreshCharacters` implementation and drop unused update helpers from the provider value

## Testing
- npm run build *(fails: existing syntax error in src/pages/TourManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68caef1e2ce88325800fd44b1ea5ee90