### PR TITLE
Restrict direct access to character creator

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -25,8 +25,7 @@ import {
   X,
   MessageSquare,
   Globe,
-  Mic,
-  SparklesIcon
+  Mic
 } from "lucide-react";
 
 const Navigation = () => {
@@ -43,7 +42,6 @@ const Navigation = () => {
         { icon: User, label: "Profile", path: "/profile" },
         { icon: Calendar, label: "Schedule", path: "/schedule" },
         { icon: Trophy, label: "Achievements", path: "/achievements" },
-        { icon: SparklesIcon, label: "Character Creator", path: "/character-create" },
       ]
     },
     {

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { SparklesIcon, Wand2, CheckCircle2, AlertCircle, Palette, Gauge, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -103,6 +103,10 @@ type CityOption = {
   country: string | null;
 };
 
+type CharacterCreationLocationState = {
+  fromProfile?: boolean;
+};
+
 const genderOptions: { value: ProfileGender; label: string }[] = [
   { value: "female", label: "Female" },
   { value: "male", label: "Male" },
@@ -120,7 +124,11 @@ const sanitizeHandle = (value: string) =>
 const CharacterCreation = () => {
   const { user, loading } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const { toast } = useToast();
+
+  const locationState = location.state as CharacterCreationLocationState | null;
+  const fromProfileFlow = Boolean(locationState?.fromProfile);
 
   const [nameSuggestion, setNameSuggestion] = useState<string>(() => generateRandomName());
   const [displayName, setDisplayName] = useState<string>(nameSuggestion);
@@ -239,6 +247,12 @@ const CharacterCreation = () => {
       void fetchExistingData();
     }
   }, [user]);
+
+  useEffect(() => {
+    if (!loading && !isLoading && existingProfile && !fromProfileFlow) {
+      navigate("/profile", { replace: true });
+    }
+  }, [loading, isLoading, existingProfile, fromProfileFlow, navigate]);
 
   useEffect(() => {
     const fetchCities = async () => {


### PR DESCRIPTION
## Summary
- remove the Character Creator shortcut from the core navigation menu
- gate the CharacterCreation page so existing characters are redirected to the profile unless the flow originates from profile state

## Testing
- `npm run lint` *(fails: existing parsing error in src/pages/TourManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68caf258f5dc8325858ec41cc517c3b6