### PR TITLE
Fix audio meter cleanup reference

### DIFF
--- a/src/pages/RealtimeCommunication.tsx
+++ b/src/pages/RealtimeCommunication.tsx
@@ -193,8 +193,10 @@ const RealtimeCommunication: React.FC = () => {
   }, [currentMessage, user]);
 
   useEffect(() => {
+    const audioMeters = audioMetersRef.current;
+
     return () => {
-      Object.keys(audioMetersRef.current).forEach((participantId) => {
+      Object.keys(audioMeters).forEach((participantId) => {
         destroyAudioMeter(participantId);
       });
     };


### PR DESCRIPTION
## Summary
- cache the audio meters map before cleaning up the effect in RealtimeCommunication
- ensure cleanup iterates over the captured meters reference

## Testing
- npm run lint *(fails: existing parsing error in src/hooks/useGameData.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cafdb845308325a138858a3d99693e