### PR TITLE
Fix CompetitiveCharts subscription dependencies

### DIFF
--- a/src/pages/CompetitiveCharts.tsx
+++ b/src/pages/CompetitiveCharts.tsx
@@ -495,7 +495,7 @@ const CompetitiveCharts: React.FC = () => {
       supabase.removeChannel(rankingChannel);
       supabase.removeChannel(competitionsChannel);
     };
-  }, [user, handleRankingRealtime, handleCompetitionRealtime]);
+  }, [userId, handleRankingRealtime, handleCompetitionRealtime]);
 
   const registerForCompetition = async (competitionId: string) => {
     if (!profile || !user) return;


### PR DESCRIPTION
## Summary
- ensure the Supabase subscription effect in CompetitiveCharts depends on the current user ID

## Testing
- npm run lint *(fails: existing parsing error in src/hooks/useGameData.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cafdb898dc8325953c7a2f2ba79634