### PR TITLE
Allow useGameData hook export with react-refresh lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,10 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true, allowExportNames: ["useGameData"] },
+      ],
       "@typescript-eslint/no-unused-vars": "off",
     },
   },


### PR DESCRIPTION
## Summary
- allow the useGameData hook to be exported alongside GameDataProvider by whitelisting it in the react-refresh/only-export-components rule

## Testing
- npm run lint *(fails: existing parsing error in src/hooks/useGameData.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cafdb6f8b0832588a2dbd9646ee3d3