### PR TITLE
Remove toast from fetchSongs dependencies

### DIFF
--- a/src/pages/SongManager.tsx
+++ b/src/pages/SongManager.tsx
@@ -706,7 +706,7 @@ const SongManager = () => {
     } finally {
       setLoading(false);
     }
-  }, [user?.id, toast]);
+  }, [user?.id]);
 
   const fetchGrowthHistory = useCallback(async () => {
     if (!user?.id) {


### PR DESCRIPTION
## Summary
- remove the toast instance from the `fetchSongs` callback dependencies so the hook only depends on reactive values

## Testing
- npm run lint *(fails: existing parsing error in src/hooks/useGameData.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cafdbf7bbc8325b34d84ba44fd0b17