### PR TITLE
Include owner display name in releaseSong dependencies

### DIFF
--- a/src/pages/SongManager.tsx
+++ b/src/pages/SongManager.tsx
@@ -1114,7 +1114,7 @@ const SongManager = () => {
     } finally {
       releasingSongsRef.current.delete(song.id);
     }
-  }, [createStreamingStatsRecord, enqueueStreamingSimulation, toast, updateProfile, user]);
+  }, [createStreamingStatsRecord, enqueueStreamingSimulation, ownerDisplayName, toast, updateProfile, user]);
 
   const openReleaseDialog = (song: Song) => {
     setSelectedSong(song);


### PR DESCRIPTION
## Summary
- include the owner display name in the `releaseSong` callback dependencies so toast copy reflects updated stage names

## Testing
- npm run lint *(fails: existing parsing error in src/hooks/useGameData.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cafdc0d5c08325994393673e4640df