### PR TITLE
Remove redundant skill score labels

### DIFF
--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -877,12 +877,6 @@ const BandManager = () => {
     return <Music className="h-4 w-4" />;
   };
 
-  const getSkillColor = (value: number) => {
-    if (value >= 80) return "text-success";
-    if (value >= 60) return "text-warning";
-    return "text-muted-foreground";
-  };
-
   const getEventTypeIcon = (type?: string | null) => {
     const normalized = type?.toLowerCase() ?? '';
 
@@ -1307,11 +1301,12 @@ const BandManager = () => {
                             const value = Number(skills?.[skillKey] ?? 0);
                             return (
                               <div key={skillKey} className="space-y-1">
-                                <div className="flex justify-between text-sm">
-                                  <span className="capitalize">{skillKey}</span>
-                                  <span className={getSkillColor(value)}>{value}/100</span>
-                                </div>
-                                <Progress value={value} className="h-1.5" />
+                                <span className="text-sm capitalize">{skillKey}</span>
+                                <Progress
+                                  value={value}
+                                  className="h-1.5"
+                                  aria-label={`${skillKey} skill level ${value} out of 100`}
+                                />
                               </div>
                             );
                           })}
@@ -1323,11 +1318,12 @@ const BandManager = () => {
                             const percent = Math.min(100, (value / 1000) * 100);
                             return (
                               <div key={attributeKey} className="space-y-1">
-                                <div className="flex justify-between text-sm">
-                                  <span className="capitalize">{attributeKey}</span>
-                                  <span className="text-primary font-semibold">{value}/1000</span>
-                                </div>
-                                <Progress value={percent} className="h-1.5" />
+                                <span className="text-sm capitalize">{attributeKey}</span>
+                                <Progress
+                                  value={percent}
+                                  className="h-1.5"
+                                  aria-label={`${attributeKey} attribute score ${value} out of 1000`}
+                                />
                               </div>
                             );
                           })}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -50,12 +50,6 @@ const Dashboard = () => {
     "technical"
   ];
 
-  const skillColor = (value: number) => {
-    if (value >= 80) return "text-success";
-    if (value >= 60) return "text-warning";
-    return "text-muted-foreground";
-  };
-
   const getActivityIcon = (type: string) => {
     switch (type) {
       case "gig": return <Play className="h-4 w-4" />;
@@ -275,11 +269,12 @@ const Dashboard = () => {
                 const value = Number(skills?.[skillKey] ?? 0);
                 return (
                   <div key={skillKey} className="space-y-2">
-                    <div className="flex justify-between text-sm">
-                      <span className="capitalize font-medium">{skillKey}</span>
-                      <span className={skillColor(value)}>{value}/100</span>
-                    </div>
-                    <Progress value={value} className="h-2" />
+                    <span className="capitalize font-medium text-sm">{skillKey}</span>
+                    <Progress
+                      value={value}
+                      className="h-2"
+                      aria-label={`${skillKey} skill level ${value} out of 100`}
+                    />
                   </div>
                 );
               })}
@@ -299,11 +294,12 @@ const Dashboard = () => {
                 const percent = Math.min(100, (value / 1000) * 100);
                 return (
                   <div key={attributeKey} className="space-y-2">
-                    <div className="flex justify-between text-sm">
-                      <span className="capitalize font-medium">{attributeKey}</span>
-                      <span className="text-primary font-semibold">{value}/1000</span>
-                    </div>
-                    <Progress value={percent} className="h-2" />
+                    <span className="capitalize font-medium text-sm">{attributeKey}</span>
+                    <Progress
+                      value={percent}
+                      className="h-2"
+                      aria-label={`${attributeKey} attribute score ${value} out of 1000`}
+                    />
                   </div>
                 );
               })}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -786,11 +786,12 @@ const Profile = () => {
                     const value = Number(skills?.[skillKey] ?? 0);
                     return (
                       <div key={skillKey} className="space-y-2">
-                        <div className="flex justify-between">
-                          <span className="text-sm font-medium capitalize">{skillKey}</span>
-                          <span className="text-sm font-bold text-primary">{value}/100</span>
-                        </div>
-                        <Progress value={value} className="h-2" />
+                        <span className="text-sm font-medium capitalize">{skillKey}</span>
+                        <Progress
+                          value={value}
+                          className="h-2"
+                          aria-label={`${skillKey} skill level ${value} out of 100`}
+                        />
                         <div className="text-xs text-muted-foreground">
                           {value >= 80
                             ? "Expert"
@@ -821,11 +822,12 @@ const Profile = () => {
                     const percent = Math.min(100, (value / 1000) * 100);
                     return (
                       <div key={attributeKey} className="space-y-2">
-                        <div className="flex justify-between">
-                          <span className="text-sm font-medium capitalize">{attributeKey}</span>
-                          <span className="text-sm font-bold text-primary">{value}/1000</span>
-                        </div>
-                        <Progress value={percent} className="h-2" />
+                        <span className="text-sm font-medium capitalize">{attributeKey}</span>
+                        <Progress
+                          value={percent}
+                          className="h-2"
+                          aria-label={`${attributeKey} attribute score ${value} out of 1000`}
+                        />
                         <div className="text-xs text-muted-foreground">
                           High values unlock greater opportunities and campaign performance.
                         </div>


### PR DESCRIPTION
## Summary
- drop redundant numeric labels from skill and attribute progress bars on the profile, dashboard, and band manager views
- add accessibility labels to progress indicators so screen readers still convey the underlying numeric values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb08c6720c8325bc81c937a4b2820f