### PR TITLE
Refine current city resolver typing

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -24,6 +24,8 @@ export type ActivityItem = Tables<"activity_feed">;
 export type AttributeDefinition = Tables<"attribute_definitions">;
 export type ProfileAttribute = Tables<"profile_attributes">;
 
+type Nullable<T> = T | null;
+
 const CHARACTER_STORAGE_KEY = "rockmundo:selectedCharacterId";
 
 export interface CreateCharacterInput {
@@ -183,7 +185,7 @@ const useProvideGameData = (): GameDataContextValue => {
   }, [user, selectedCharacterId, clearGameState]);
 
   const resolveCurrentCity = useCallback(
-    async (cityId: string | null) => {
+    async (cityId: Nullable<string>) => {
       if (!cityId) {
         setCurrentCity(null);
         return;


### PR DESCRIPTION
## Summary
- add a local Nullable helper type in useGameData
- update resolveCurrentCity to accept null identifiers and keep Supabase status guard

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cb17a1457c8325960aea262ab7fd18