### PR TITLE
Fix attribute insert block closure in createCharacter

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -627,14 +627,16 @@ const useProvideGameData = (): GameDataContextValue => {
           setSkillUnlocks([]);
         }
 
-        const { error: attributesInsertError } = await supabase
-          .from("player_attributes")
-          .insert({
-            user_id: user.id,
-            profile_id: newProfile.id
-          });
+        if (attributeDefinitions.length > 0) {
+          const { error: attributeInsertError } = await supabase
+            .from("player_attributes")
+            .insert({
+              user_id: user.id,
+              profile_id: newProfile.id
+            });
 
-        if (attributesInsertError) throw attributesInsertError;
+          if (attributeInsertError) throw attributeInsertError;
+        }
 
         setCharacters(prev => [...prev, newProfile]);
 


### PR DESCRIPTION
## Summary
- wrap the player attribute insert in an `attributeDefinitions.length > 0` guard
- rename the insert error variable and close the block before continuing with the rest of the flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb17a24f388325b8247706a7f13100