### PR TITLE
Fix updateAttributes error handling

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -486,21 +486,25 @@ const useProvideGameData = (): GameDataContextValue => {
         updated_at: updates.updated_at ?? new Date().toISOString()
       };
 
-      const { data, error: updateError } = await supabase
-        .from("player_attributes")
-        .update(payload)
-        .eq("profile_id", selectedCharacterId)
-        .select()
-        .maybeSingle();
+      try {
+        const { data, error: updateError } = await supabase
+          .from("player_attributes")
+          .update(payload)
+          .eq("profile_id", selectedCharacterId)
+          .select()
+          .maybeSingle();
 
-      if (updateError) {
+        if (updateError) {
+          throw updateError;
+        }
+
+        const nextAttributes = data ?? (attributes ? { ...attributes, ...payload } : null);
+        setAttributes(nextAttributes);
+        return nextAttributes;
+      } catch (updateError) {
         console.error("Error updating attributes:", updateError);
         throw updateError;
       }
-
-      const nextAttributes = data ?? (attributes ? { ...attributes, ...payload } : null);
-      setAttributes(nextAttributes);
-      return nextAttributes ?? undefined;
     },
     [attributes, selectedCharacterId, user]
   );


### PR DESCRIPTION
## Summary
- wrap the Supabase update in `updateAttributes` with an explicit try/catch so the error handler is valid
- ensure `updateAttributes` updates state and returns the computed attributes map instead of the raw response

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb17a35c1c8325b4222542a7751fbb