### PR TITLE
Update AuthProvider React imports

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode, type FC } from "react";
 import { User, Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
 import { AuthContext, type AuthContextType } from "./use-auth-context";
 
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- extend the React import in `useAuth` to include `ReactNode` and `FC`
- use the imported types for the AuthProvider signature

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba45ee4d88325ada43286974a958c