### PR TITLE
Import ChangeEvent and use alias in Profile avatar handler

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, type ChangeEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -316,7 +316,7 @@ const Profile = () => {
     }
   };
 
-  const handleAvatarUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleAvatarUpload = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file || !user) return;
 


### PR DESCRIPTION
## Summary
- import the `ChangeEvent` type from React in the profile page
- use the imported alias in the avatar upload handler signature

## Testing
- npm run lint *(fails: existing parsing error in src/pages/EnhancedBandManager.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cba46bb100832597700eb25cee700e