### PR TITLE
refactor: import FormEvent in auth page

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -87,7 +87,7 @@ const Auth = () => {
     setError("");
   };
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleLogin = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError("");
@@ -129,7 +129,7 @@ const Auth = () => {
     }
   };
 
-  const handleSignup = async (e: React.FormEvent) => {
+  const handleSignup = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError("");
@@ -176,7 +176,7 @@ const Auth = () => {
     }
   };
 
-  const handleForgotPassword = async (e: React.FormEvent) => {
+  const handleForgotPassword = async (e: FormEvent) => {
     e.preventDefault();
     setResetLinkLoading(true);
     setError("");
@@ -206,7 +206,7 @@ const Auth = () => {
     }
   };
 
-  const handlePasswordUpdate = async (e: React.FormEvent) => {
+  const handlePasswordUpdate = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
     setStatus(null);


### PR DESCRIPTION
## Summary
- import the FormEvent type from React within the auth page
- reuse the imported FormEvent type for form handler definitions

## Testing
- npm run lint *(fails: existing lint error in src/pages/EnhancedBandManager.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cba46afd4c83259bf403b8001c9a08