### PR TITLE
refactor: use ComponentProps import in resizable

### DIFF
--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,9 +1,10 @@
 import { GripVertical } from "lucide-react";
+import type { ComponentProps } from "react";
 import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "@/lib/utils";
 
-const ResizablePanelGroup = ({ className, ...props }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+const ResizablePanelGroup = ({ className, ...props }: ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
   <ResizablePrimitive.PanelGroup
     className={cn("flex h-full w-full data-[panel-group-direction=vertical]:flex-col", className)}
     {...props}
@@ -16,7 +17,7 @@ const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
   withHandle?: boolean;
 }) => (
   <ResizablePrimitive.PanelResizeHandle


### PR DESCRIPTION
## Summary
- add a React ComponentProps type import to the resizable component
- replace fully-qualified React.ComponentProps usages with the imported alias

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cba460704483258f2c382007c26e87