### PR TITLE
Import React HTMLAttributes for skeleton

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,6 +1,8 @@
+import type { HTMLAttributes } from "react";
+
 import { cn } from "@/lib/utils";
 
-function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
 }
 


### PR DESCRIPTION
## Summary
- import the HTMLAttributes type from React for the skeleton component
- update the Skeleton component signature to rely on the imported alias instead of the React namespace

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba45e8ed083258252aac661a67b6f