### PR TITLE
Add React ComponentProps import for Toaster

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,7 +1,8 @@
+import type { ComponentProps } from "react";
 import { useTheme } from "next-themes";
 import { Toaster as Sonner } from "sonner";
 
-type ToasterProps = React.ComponentProps<typeof Sonner>;
+type ToasterProps = ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();


### PR DESCRIPTION
## Summary
- import the React ComponentProps type in the Sonner toaster wrapper
- use the imported alias when defining ToasterProps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba465f0bc83258bc1b6dac1e9e18a