### PR TITLE
Consolidate gameBalance imports in Busking page

### DIFF
--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -13,7 +13,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useToast } from "@/components/ui/use-toast";
 import { fetchWorldEnvironmentSnapshot, type WeatherCondition } from "@/utils/worldEnvironment";
-import { calculateFanGain, calculateGigPayment, type PerformanceAttributeBonuses } from "@/utils/gameBalance";
+import { calculateGigPayment, type PerformanceAttributeBonuses } from "@/utils/gameBalance";
 import { resolveAttributeValue } from "@/utils/attributeModifiers";
 import {
   AttributeFocus,


### PR DESCRIPTION
## Summary
- remove duplicate calculateFanGain named import in Busking page
- rely on existing grouped import for calculateFanGain while keeping other specifiers intact

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbbb25cce48325b8ffefad4a178d94