### PR TITLE
Wrap app routes with game data provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,13 +49,14 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/auth" element={<Auth />} />
-              <Route path="/" element={<Layout />}>
+        <GameDataProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
+                <Route path="/auth" element={<Auth />} />
+                <Route path="/" element={<Layout />}>
                 <Route index element={<Index />} />
                 <Route path="dashboard" element={<Dashboard />} />
                 <Route path="band" element={<BandManager />} />
@@ -92,10 +93,11 @@ function App() {
                 <Route path="statistics" element={<PlayerStatistics />} />
                 <Route path="character/create" element={<CharacterCreation />} />
               </Route>
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </TooltipProvider>
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </TooltipProvider>
+        </GameDataProvider>
       </AuthProvider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
- wrap the router and layout hierarchy in the GameDataProvider so pages can access game data context

## Testing
- npm run lint *(fails: existing lint errors about no-explicit-any and hook deps in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbfef40848325bc9d904dc31ff289