### PR TITLE
Add Discord community link to Auth footer

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -572,6 +572,14 @@ const Auth = () => {
           <p className="text-xs text-muted-foreground/70 font-oswald">
             Join thousands of musicians living their dream
           </p>
+          <a
+            href="https://discord.gg/zkGYKYVu"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-oswald text-primary underline underline-offset-4 hover:text-primary/80"
+          >
+            Connect with the Rockmundo community on Discord
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Discord community link beneath the existing footer call-to-action on the auth page

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc0c4839c8325bd5ad6820357222d