### PR TITLE
Update Discord community link

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -573,7 +573,7 @@ const Auth = () => {
             Join thousands of musicians living their dream
           </p>
           <a
-            href="https://discord.gg/zkGYKYVu"
+            href="https://discord.gg/KB45k3XJuZ"
             target="_blank"
             rel="noopener noreferrer"
             className="text-xs font-oswald text-primary underline underline-offset-4 hover:text-primary/80"


### PR DESCRIPTION
## Summary
- update the Auth page footer to point to the new Discord invite link

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbc2e9f7448325aeb74b4fad74b97e