### PR TITLE
Memoize gig system data loading

### DIFF
--- a/src/pages/SimpleAdvancedGigSystem.tsx
+++ b/src/pages/SimpleAdvancedGigSystem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -16,11 +16,8 @@ export default function SimpleAdvancedGigSystem() {
   const [loading, setLoading] = useState(true);
   const [selectedVenue, setSelectedVenue] = useState<Venue | null>(null);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
+    setLoading(true);
     try {
       // Load venues
       const { data: venuesData } = await supabase
@@ -57,7 +54,11 @@ export default function SimpleAdvancedGigSystem() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user?.id]);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
 
   const bookGig = async (venue: Venue) => {
     if (!user?.id) {


### PR DESCRIPTION
## Summary
- wrap the SimpleAdvancedGigSystem loadData routine in useCallback keyed on the authenticated user
- call the memoized loader from useEffect and reset loading before each fetch so data refreshes when accounts change

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcc5992c48325bd4712ba98bfdd87