### PR TITLE
Fix band manager hook dependencies

### DIFF
--- a/src/pages/EnhancedBandManager.tsx
+++ b/src/pages/EnhancedBandManager.tsx
@@ -452,7 +452,7 @@ const EnhancedBandManager = () => {
     } catch (error) {
       console.error("Error fetching available members:", error);
     }
-  }, [fetchProfileSkillMap, skillDefinitions, user?.id]);
+  }, [user?.id]);
 
 
   const fetchBandDetails = useCallback(async () => {
@@ -540,9 +540,7 @@ const EnhancedBandManager = () => {
   }, [
     calculateBandStats,
     fetchAvailableMembers,
-    fetchProfileSkillMap,
     selectedBand,
-    skillDefinitions
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the stale fetchProfileSkillMap dependency from band manager callbacks
- trim unused dependency references from fetchBandDetails to match its implementation

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*
- npx eslint src/pages/EnhancedBandManager.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbcc5521088325ada109f24741b1b2