### PR TITLE
Refine database type definitions

### DIFF
--- a/src/hooks/useGameEvents.ts
+++ b/src/hooks/useGameEvents.ts
@@ -64,7 +64,7 @@ const parseRewardPayload = (rewards: unknown, profile: PlayerProfile | null): Re
     const baseValue = typeof currentValue === "number" ? currentValue : 0;
     const nextValue = baseValue + numericValue;
 
-    (updates as any)[field] = nextValue;
+    updates[field] = nextValue;
     messageDetails.push(`${formatKey(field as string)} ${numericValue > 0 ? "+" : ""}${numericValue}`);
 
     if (field === "cash") {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,5 +1,19 @@
 // Working database types to override the problematic generated types
 
+export type RequirementValue = number | string | boolean | null;
+
+export type RequirementRecord = Record<string, RequirementValue>;
+
+export type AchievementValue = number | string;
+
+export type AchievementRequirements = Record<string, AchievementValue>;
+
+export type AchievementRewards = Record<string, AchievementValue>;
+
+export type AchievementProgress = Record<string, AchievementValue>;
+
+export type EquipmentStatBoosts = Record<string, number>;
+
 export interface Profile {
   id: string;
   user_id: string;
@@ -46,7 +60,7 @@ export interface Venue {
   base_payment: number;
   venue_type: string | null;
   prestige_level: number;
-  requirements: any;
+  requirements: RequirementRecord;
   created_at: string;
 }
 
@@ -104,8 +118,8 @@ export interface Achievement {
   icon: string | null;
   category: string | null;
   rarity: string;
-  requirements: any;
-  rewards: any;
+  requirements: AchievementRequirements;
+  rewards: AchievementRewards;
   created_at: string;
 }
 
@@ -113,7 +127,7 @@ export interface PlayerAchievement {
   id: string;
   user_id: string;
   achievement_id: string;
-  progress: any;
+  progress: AchievementProgress;
   unlocked_at: string;
 }
 
@@ -132,7 +146,7 @@ export interface EquipmentItem {
   subcategory: string | null;
   price: number;
   rarity: string;
-  stat_boosts: any;
+  stat_boosts: EquipmentStatBoosts;
   image_url: string | null;
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- add dedicated record types for requirements, rewards, progress, and stat boosts in the database type overrides
- update game event reward handling to avoid explicit `any` usage while keeping numeric updates type-safe

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbcc54460c8325a42227159e52d7f3