### PR TITLE
refactor: extract skill system types

### DIFF
--- a/src/hooks/useSkillSystem.tsx
+++ b/src/hooks/useSkillSystem.tsx
@@ -10,56 +10,13 @@ import {
 
 import { supabase } from "@/integrations/supabase/client";
 import { type PlayerSkills, useGameData } from "./useGameData";
-
-export interface SkillDefinitionRecord {
-  id: string;
-  slug: string;
-  display_name?: string | null;
-  description?: string | null;
-  icon_slug?: string | null;
-  base_xp_gain?: number | null;
-  training_duration_minutes?: number | null;
-  metadata?: Record<string, unknown> | null;
-  is_trainable?: boolean | null;
-}
-
-export interface SkillRelationshipRecord {
-  id: string;
-  skill_slug: string;
-  required_skill_slug: string;
-  required_value: number;
-  metadata?: Record<string, unknown> | null;
-}
-
-export interface SkillProgressRecord {
-  id: string;
-  profile_id: string;
-  skill_slug: string;
-  current_value?: number | null;
-  total_xp?: number | null;
-  last_trained_at?: string | null;
-  unlocked_at?: string | null;
-  updated_at?: string | null;
-  metadata?: Record<string, unknown> | null;
-}
-
-export interface UpdateSkillProgressInput {
-  skillSlug: string;
-  newSkillValue: number;
-  xpGain: number;
-  timestamp?: string;
-  markUnlocked?: boolean;
-}
-
-interface SkillSystemContextValue {
-  definitions: SkillDefinitionRecord[];
-  relationships: SkillRelationshipRecord[];
-  progress: SkillProgressRecord[];
-  loading: boolean;
-  error: string | null;
-  refreshProgress: () => Promise<void>;
-  updateSkillProgress: (input: UpdateSkillProgressInput) => Promise<SkillProgressRecord | null>;
-}
+import {
+  type SkillDefinitionRecord,
+  type SkillProgressRecord,
+  type SkillRelationshipRecord,
+  type SkillSystemContextValue,
+  type UpdateSkillProgressInput
+} from "./useSkillSystem.types";
 
 const SkillSystemContext = createContext<SkillSystemContextValue | undefined>(undefined);
 

--- a/src/hooks/useSkillSystem.types.ts
+++ b/src/hooks/useSkillSystem.types.ts
@@ -1,0 +1,49 @@
+export interface SkillDefinitionRecord {
+  id: string;
+  slug: string;
+  display_name?: string | null;
+  description?: string | null;
+  icon_slug?: string | null;
+  base_xp_gain?: number | null;
+  training_duration_minutes?: number | null;
+  metadata?: Record<string, unknown> | null;
+  is_trainable?: boolean | null;
+}
+
+export interface SkillRelationshipRecord {
+  id: string;
+  skill_slug: string;
+  required_skill_slug: string;
+  required_value: number;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SkillProgressRecord {
+  id: string;
+  profile_id: string;
+  skill_slug: string;
+  current_value?: number | null;
+  total_xp?: number | null;
+  last_trained_at?: string | null;
+  unlocked_at?: string | null;
+  updated_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface UpdateSkillProgressInput {
+  skillSlug: string;
+  newSkillValue: number;
+  xpGain: number;
+  timestamp?: string;
+  markUnlocked?: boolean;
+}
+
+export interface SkillSystemContextValue {
+  definitions: SkillDefinitionRecord[];
+  relationships: SkillRelationshipRecord[];
+  progress: SkillProgressRecord[];
+  loading: boolean;
+  error: string | null;
+  refreshProgress: () => Promise<void>;
+  updateSkillProgress: (input: UpdateSkillProgressInput) => Promise<SkillProgressRecord | null>;
+}


### PR DESCRIPTION
## Summary
- move the skill system record and context interfaces into a dedicated types module
- update the skill system hook to consume the shared type exports

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cbcc5b42c88325b9049ec6af98ef19