### PR TITLE
Fix Select item values for city selections

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -154,6 +154,8 @@ const genderOptions: { value: ProfileGender; label: string }[] = [
   { value: "prefer_not_to_say", label: "Prefer not to say" },
 ];
 
+const NO_CITY_SELECTED_VALUE = "__no_city_selected__";
+
 const sanitizeHandle = (value: string) =>
   value
     .toLowerCase()
@@ -1043,8 +1045,10 @@ const CharacterCreation = () => {
                   City of Birth
                 </label>
                 <Select
-                  value={cityOfBirth ?? ""}
-                  onValueChange={(value) => setCityOfBirth(value || null)}
+                  value={cityOfBirth ?? NO_CITY_SELECTED_VALUE}
+                  onValueChange={(value) =>
+                    setCityOfBirth(value === NO_CITY_SELECTED_VALUE ? null : value)
+                  }
                   disabled={citiesLoading}
                 >
                   <SelectTrigger id="city-of-birth">
@@ -1053,7 +1057,7 @@ const CharacterCreation = () => {
                     />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">No listed city</SelectItem>
+                    <SelectItem value={NO_CITY_SELECTED_VALUE}>No listed city</SelectItem>
                     {cities.map((city) => (
                       <SelectItem key={city.id} value={city.id}>
                         {city.name ?? "Unnamed City"}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -83,6 +83,8 @@ const genderOptions: { value: ProfileGender; label: string }[] = [
   { value: "prefer_not_to_say", label: "Prefer not to say" },
 ];
 
+const NO_CITY_SELECTED_VALUE = "__no_city_selected__";
+
 const Profile = () => {
   const { toast } = useToast();
   const { user } = useAuth();
@@ -630,9 +632,12 @@ const Profile = () => {
                       <div className="space-y-2">
                         <Label htmlFor="city-of-birth">City of Birth</Label>
                         <Select
-                          value={formData.city_of_birth ?? ""}
+                          value={formData.city_of_birth ?? NO_CITY_SELECTED_VALUE}
                           onValueChange={(value) =>
-                            setFormData((prev) => ({ ...prev, city_of_birth: value || null }))
+                            setFormData((prev) => ({
+                              ...prev,
+                              city_of_birth: value === NO_CITY_SELECTED_VALUE ? null : value,
+                            }))
                           }
                           disabled={!isEditing || cityLoading}
                         >
@@ -645,7 +650,7 @@ const Profile = () => {
                             />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="">No listed city</SelectItem>
+                            <SelectItem value={NO_CITY_SELECTED_VALUE}>No listed city</SelectItem>
                             {cityOptions.map((city) => (
                               <SelectItem key={city.id} value={city.id}>
                                 {city.name ?? "Unnamed City"}


### PR DESCRIPTION
## Summary
- add explicit sentinel value for the optional city-of-birth select components
- translate the sentinel value back to `null` when storing the selected city so placeholder behaviour still works

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbce6a1aa08325ba39d6766b9f53c3