### PR TITLE
fix: avoid blob usage in schedule export

### DIFF
--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1256,15 +1256,13 @@ const Schedule = () => {
 
     try {
       const icsContent = generateICS(events);
-      const blob = new Blob([icsContent], { type: "text/calendar;charset=utf-8" });
-      const url = URL.createObjectURL(blob);
+      const dataUrl = `data:text/calendar;charset=utf-8,${encodeURIComponent(icsContent)}`;
       const link = document.createElement("a");
-      link.href = url;
+      link.href = dataUrl;
       link.download = "rockmundo-schedule.ics";
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-      URL.revokeObjectURL(url);
 
       toast({
         title: "Calendar exported",


### PR DESCRIPTION
## Summary
- replace the Blob-based calendar export with a data URL to avoid environments that break on Blob.size
- keep the same download flow by programmatically clicking a temporary anchor element

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbcc776e3883258703ab5e40a89fc1