### PR TITLE
Sanitize select option data with empty IDs

### DIFF
--- a/src/components/admin/SkillDefinitionsManager.tsx
+++ b/src/components/admin/SkillDefinitionsManager.tsx
@@ -179,7 +179,11 @@ const SkillDefinitionsManager: React.FC = () => {
       const skillRows = (skillsResponse.data ?? []) as SkillDefinitionRow[];
       const parentRows = (parentLinksResponse.data ?? []) as SkillParentLinkRow[];
 
-      const normalizedSkills = skillRows.map<SkillDefinitionWithParents>((row) => ({
+      const sanitizedSkillRows = skillRows.filter(
+        (row): row is SkillDefinitionRow => typeof row.id === 'string' && row.id.trim().length > 0,
+      );
+
+      const normalizedSkills = sanitizedSkillRows.map<SkillDefinitionWithParents>((row) => ({
         id: row.id,
         slug: row.slug,
         displayName: row.display_name,

--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -681,12 +681,21 @@ const Busking = () => {
           : fallbackModifiers;
       const fetchedHistory = (historyResponse.data as BuskingSessionWithRelations[]) ?? [];
 
-      setLocations(fetchedLocations);
-      setModifiers(fetchedModifiers);
+      const sanitizedLocations = fetchedLocations.filter(
+        (location): location is BuskingLocation =>
+          typeof location.id === "string" && location.id.trim().length > 0,
+      );
+      const sanitizedModifiers = fetchedModifiers.filter(
+        (modifier): modifier is BuskingModifier =>
+          typeof modifier.id === "string" && modifier.id.trim().length > 0,
+      );
+
+      setLocations(sanitizedLocations);
+      setModifiers(sanitizedModifiers);
       setHistory(fetchedHistory);
 
-      if (fetchedLocations.length > 0) {
-        setSelectedLocationId((current) => current || fetchedLocations[0].id);
+      if (sanitizedLocations.length > 0) {
+        setSelectedLocationId((current) => current || sanitizedLocations[0].id);
       } else {
         setSelectedLocationId("");
       }

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -411,7 +411,11 @@ const CharacterCreation = () => {
 
         if (error) throw error;
 
-        setCities((data as CityOption[] | null) ?? []);
+        const sanitizedCities = ((data as CityOption[] | null) ?? []).filter(
+          (city): city is CityOption => typeof city.id === "string" && city.id.trim().length > 0,
+        );
+
+        setCities(sanitizedCities);
       } catch (error) {
         console.error("Failed to load cities:", error);
         setCitiesError("We couldn't load cities right now. You can update this later in your profile.");

--- a/src/pages/GigBooking.tsx
+++ b/src/pages/GigBooking.tsx
@@ -212,7 +212,12 @@ const GigBooking = () => {
         .order('name', { ascending: true });
 
       if (error) throw error;
-      setCities((data ?? []) as CityRow[]);
+
+      const sanitizedCities = ((data ?? []) as CityRow[]).filter(
+        (city): city is CityRow => typeof city.id === 'string' && city.id.trim().length > 0,
+      );
+
+      setCities(sanitizedCities);
     } catch (error: unknown) {
       const fallbackMessage = "Failed to load cities";
       const errorMessage = error instanceof Error ? error.message : fallbackMessage;
@@ -243,7 +248,11 @@ const GigBooking = () => {
         .order('capacity', { ascending: true });
 
       if (error) throw error;
-      const venueRows = (data ?? []) as VenueRow[];
+
+      const venueRows = ((data ?? []) as VenueRow[]).filter(
+        (venue): venue is VenueRow => typeof venue.id === 'string' && venue.id.trim().length > 0,
+      );
+
       setVenues(venueRows.map(venue => ({
         id: venue.id,
         name: venue.name,

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -183,7 +183,11 @@ const Profile = () => {
 
         if (error) throw error;
 
-        setCityOptions((data as CityOption[] | null) ?? []);
+        const sanitizedCities = ((data as CityOption[] | null) ?? []).filter(
+          (city): city is CityOption => typeof city.id === "string" && city.id.trim().length > 0,
+        );
+
+        setCityOptions(sanitizedCities);
       } catch (error) {
         console.error("Error loading cities:", error);
         setCityError("We couldn't load cities right now. You can try again later.");

--- a/src/pages/StreamingPlatforms.tsx
+++ b/src/pages/StreamingPlatforms.tsx
@@ -561,7 +561,10 @@ const StreamingPlatforms = () => {
         }
       }
 
-      const songsData: SongRecord[] = finalSongs ?? [];
+      const songsDataRaw: SongRecord[] = finalSongs ?? [];
+      const songsData: SongRecord[] = songsDataRaw.filter(
+        (song): song is SongRecord => typeof song.id === 'string' && song.id.trim().length > 0,
+      );
 
       let streamingStatsData: StreamingStatsRecord[] = [];
       if (songsData.length > 0) {

--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -542,7 +542,12 @@ const TourManager = () => {
         .order('capacity', { ascending: true });
 
       if (error) throw error;
-      setVenues(data || []);
+
+      const sanitizedVenues = ((data ?? []) as VenueRow[]).filter(
+        (venue): venue is VenueRow => typeof venue.id === 'string' && venue.id.trim().length > 0,
+      );
+
+      setVenues(sanitizedVenues);
     } catch (error: unknown) {
       console.error('Error loading venues:', error);
     } finally {
@@ -560,7 +565,12 @@ const TourManager = () => {
         .order('name', { ascending: true });
 
       if (error) throw error;
-      setCities((data ?? []) as CityRow[]);
+
+      const sanitizedCities = ((data ?? []) as CityRow[]).filter(
+        (city): city is CityRow => typeof city.id === 'string' && city.id.trim().length > 0,
+      );
+
+      setCities(sanitizedCities);
     } catch (error: unknown) {
       const fallbackMessage = "Failed to load cities";
       const errorMessage = error instanceof Error ? error.message : fallbackMessage;


### PR DESCRIPTION
## Summary
- filter Supabase city and venue records to remove entries with blank IDs before exposing them to select components
- sanitize busking locations/modifiers, streaming songs, and skill definitions to avoid rendering select options with empty values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbcf6500388325bbfb95f6203d0132