### PR TITLE
Fix character attributes upsert payload reference

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -701,7 +701,7 @@ const CharacterCreation = () => {
 
       const { error: attributesError } = await supabase
         .from("player_attributes")
-        .upsert(attributePayload, { onConflict: "user_id" });
+        .upsert(attributesPayload, { onConflict: "user_id" });
 
       if (attributesError) {
         throw attributesError;


### PR DESCRIPTION
## Summary
- fix the player attribute upsert to use the correctly named payload constructed earlier in the handler

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd3072cd88325a0fc92486612d5c2