### PR TITLE
Handle missing Supabase ordering columns

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -41,6 +41,7 @@ import {
   type SkillUnlockUpsertInput,
 } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
+import { sortByOptionalKeys } from "@/utils/sorting";
 import { ensureDefaultWardrobe, parseClothingLoadout } from "@/utils/wardrobe";
 import type { Database, Tables, TablesInsert } from "@/integrations/supabase/types";
 import { useToast } from "@/components/ui/use-toast";
@@ -245,14 +246,19 @@ const CharacterCreation = () => {
       try {
         const { data, error } = await supabase
           .from("skill_definitions")
-          .select("*")
-          .order("sort_order", { ascending: true });
+          .select("*");
 
         if (error) {
           throw error;
         }
 
-        setSkillDefinitions((data as SkillDefinition[] | null) ?? []);
+        const sortedDefinitions = sortByOptionalKeys(
+          ((data as SkillDefinition[] | null) ?? []).filter(Boolean),
+          ["display_order", "sort_order", "order_index", "position"],
+          ["name", "slug"]
+        ) as SkillDefinition[];
+
+        setSkillDefinitions(sortedDefinitions);
       } catch (error) {
         console.error("Failed to load skill definitions:", error);
       }

--- a/src/utils/sorting.ts
+++ b/src/utils/sorting.ts
@@ -1,0 +1,83 @@
+export type SortableRecord = Record<string, unknown>;
+
+const normalizeNumber = (value: unknown) => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const normalizeString = (value: unknown) => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+};
+
+export const sortByOptionalKeys = <T extends SortableRecord>(
+  records: T[],
+  numericKeys: (keyof T | string)[] = [],
+  textKeys: (keyof T | string)[] = []
+): T[] => {
+  const sorted = [...records];
+
+  sorted.sort((aRecord, bRecord) => {
+    const a = aRecord as SortableRecord;
+    const b = bRecord as SortableRecord;
+
+    for (const key of numericKeys) {
+      const keyName = String(key);
+      const aValue = normalizeNumber(a[keyName]);
+      const bValue = normalizeNumber(b[keyName]);
+
+      const aHasValue = aValue !== null;
+      const bHasValue = bValue !== null;
+
+      if (aHasValue && bHasValue && aValue !== bValue) {
+        return (aValue as number) - (bValue as number);
+      }
+
+      if (aHasValue && !bHasValue) {
+        return -1;
+      }
+
+      if (!aHasValue && bHasValue) {
+        return 1;
+      }
+    }
+
+    for (const key of textKeys) {
+      const keyName = String(key);
+      const aValue = normalizeString(a[keyName]);
+      const bValue = normalizeString(b[keyName]);
+
+      const aHasValue = typeof aValue === "string";
+      const bHasValue = typeof bValue === "string";
+
+      if (aHasValue && bHasValue) {
+        const comparison = (aValue as string).localeCompare(bValue as string);
+        if (comparison !== 0) {
+          return comparison;
+        }
+      } else if (aHasValue) {
+        return -1;
+      } else if (bHasValue) {
+        return 1;
+      }
+    }
+
+    return 0;
+  });
+
+  return sorted;
+};


### PR DESCRIPTION
## Summary
- add a reusable sorting utility to order Supabase records without requiring optional columns
- update game data, character creation, and band manager fetches to sort client-side and prevent 400 responses when order columns are absent

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd444e054832580c36ffc9856fcab