### PR TITLE
Link venues to cities and sync world view

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1130,6 +1130,7 @@ export type Database = {
         Row: {
           base_payment: number | null
           capacity: number | null
+          city_id: string | null
           created_at: string | null
           id: string
           location: string | null
@@ -1141,6 +1142,7 @@ export type Database = {
         Insert: {
           base_payment?: number | null
           capacity?: number | null
+          city_id?: string | null
           created_at?: string | null
           id?: string
           location?: string | null
@@ -1152,6 +1154,7 @@ export type Database = {
         Update: {
           base_payment?: number | null
           capacity?: number | null
+          city_id?: string | null
           created_at?: string | null
           id?: string
           location?: string | null
@@ -1160,7 +1163,15 @@ export type Database = {
           requirements?: Json | null
           venue_type?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "venues_city_id_fkey"
+            columns: ["city_id"]
+            isOneToOne: false
+            referencedRelation: "cities"
+            referencedColumns: ["id"]
+          }
+        ]
       }
     }
     Views: {

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -121,6 +121,7 @@ export interface Database {
           name: string
           location: string | null
           capacity: number | null
+          city_id: string | null
           base_payment: number
           venue_type: string | null
           prestige_level: number
@@ -132,6 +133,7 @@ export interface Database {
           name: string
           location?: string | null
           capacity?: number | null
+          city_id?: string | null
           base_payment?: number
           venue_type?: string | null
           prestige_level?: number
@@ -143,6 +145,7 @@ export interface Database {
           name?: string
           location?: string | null
           capacity?: number | null
+          city_id?: string | null
           base_payment?: number
           venue_type?: string | null
           prestige_level?: number


### PR DESCRIPTION
## Summary
- add city references to Supabase venue types so front-end can access linked city data
- load venue city metadata in Venue Management and surface the city location as a link to the world map
- synchronize the World Environment city selection with the `cityId` query string to honor incoming venue links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbcd7a9c4883259137e6a120565525