### PR TITLE
Lazy load Busking route to avoid duplicate identifier

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./hooks/useAuth";
 import { GameDataProvider } from "./hooks/useGameData";
-import Busking from "./pages/Busking";
 
 const Layout = lazy(() => import("./components/Layout"));
 const Index = lazy(() => import("./pages/Index"));
@@ -44,7 +43,7 @@ const WorldEnvironment = lazy(() => import("./pages/WorldEnvironment"));
 const SongManager = lazy(() => import("./pages/SongManager"));
 const InventoryManager = lazy(() => import("./pages/InventoryManager"));
 const PlayerStatistics = lazy(() => import("./pages/PlayerStatistics"));
-import Busking from "./pages/Busking";
+const Busking = lazy(() => import("./pages/Busking"));
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
## Summary
- replace the duplicate static Busking import with a single lazy-loaded definition in App.tsx to prevent redeclaration errors at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbdff493a0832599fae040359b21ee