### PR TITLE
Fix undefined slot metadata in character creation

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -227,6 +227,10 @@ const CharacterCreation = () => {
   const [citiesLoading, setCitiesLoading] = useState<boolean>(false);
   const [citiesError, setCitiesError] = useState<string | null>(null);
 
+  const slotNumber = existingProfile?.slot_number ?? 1;
+  const unlockCost = existingProfile?.unlock_cost ?? 0;
+  const isActive = existingProfile?.is_active ?? true;
+
   const selectedStyleDefinition = useMemo(
     () => avatarStyles.find((style) => style.id === selectedAvatarStyle) ?? avatarStyles[0],
     [selectedAvatarStyle],


### PR DESCRIPTION
## Summary
- provide default values for slot metadata when editing or creating a character so payload construction no longer references undefined variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe0661f508325ac2be1face09fd6f