### PR TITLE
Fix undefined slotNumber on character creation

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -620,9 +620,9 @@ const CharacterCreation = () => {
       gender,
       age: parsedAge,
       city_of_birth: cityOfBirth,
-      slot_number: slotNumber,
-      unlock_cost: unlockCost,
-      is_active: isActive,
+      slot_number: existingProfile?.slot_number ?? 1,
+      unlock_cost: existingProfile?.unlock_cost ?? 0,
+      is_active: existingProfile?.is_active ?? true,
     };
 
     try {


### PR DESCRIPTION
## Summary
- default the character creation payload's slot, unlock cost, and active state to existing profile values or sensible defaults
- prevent runtime ReferenceError when visiting the character creation page without pre-defined slot metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe0b6e9fc8325adf6b004861513a9