### PR TITLE
Fix auth route chunk load failure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./hooks/useAuth";
 import { GameDataProvider } from "./hooks/useGameData";
+import Auth from "./pages/Auth";
 
 const Layout = lazy(() => import("./components/Layout"));
 const Index = lazy(() => import("./pages/Index"));
 const PerformGig = lazy(() => import("./pages/PerformGig"));
-const Auth = lazy(() => import("./pages/Auth"));
 const Dashboard = lazy(() => import("./pages/Dashboard"));
 const BandManager = lazy(() => import("./pages/BandManager"));
 const GigBooking = lazy(() => import("./pages/GigBooking"));


### PR DESCRIPTION
## Summary
- import the Auth page eagerly instead of lazily to prevent missing chunk fetches at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe5eda6f48325be080800b9a84ff6