### PR TITLE
Fix slotNumber reference in character creation

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -624,9 +624,9 @@ const CharacterCreation = () => {
       gender,
       age: parsedAge,
       city_of_birth: cityOfBirth,
-      slot_number: existingProfile?.slot_number ?? 1,
-      unlock_cost: existingProfile?.unlock_cost ?? 0,
-      is_active: existingProfile?.is_active ?? true,
+      slot_number: slotNumber,
+      unlock_cost: unlockCost,
+      is_active: isActive,
     };
 
     try {


### PR DESCRIPTION
## Summary
- reuse the computed `slotNumber`, `unlockCost`, and `isActive` values when composing the profile payload so the values are always defined during save
- prevents the `slotNumber` reference error that occurred while saving the character creation form

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe2a54c108325adb1057ef090c306