### PR TITLE
Handle Supabase schema cache column mismatches

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -705,17 +705,15 @@ const CharacterCreation = () => {
           break;
         }
 
-        if (profileError.code === "42703") {
-          const missingColumn = extractMissingColumn(profileError);
-          if (
-            missingColumn &&
-            !skippedProfileColumns.has(missingColumn) &&
-            missingColumn in attemptedProfilePayload
-          ) {
-            skippedProfileColumns.add(missingColumn);
-            attemptedProfilePayload = omitFromRecord(attemptedProfilePayload, missingColumn);
-            continue;
-          }
+        const missingColumn = extractMissingColumn(profileError);
+        if (
+          missingColumn &&
+          !skippedProfileColumns.has(missingColumn) &&
+          missingColumn in attemptedProfilePayload
+        ) {
+          skippedProfileColumns.add(missingColumn);
+          attemptedProfilePayload = omitFromRecord(attemptedProfilePayload, missingColumn);
+          continue;
         }
 
         throw profileError;
@@ -803,17 +801,15 @@ const CharacterCreation = () => {
           break;
         }
 
-        if (attributesError.code === "42703") {
-          const missingColumn = extractMissingColumn(attributesError);
-          if (
-            missingColumn &&
-            !skippedAttributeColumns.has(missingColumn) &&
-            missingColumn in attemptedAttributesPayload
-          ) {
-            skippedAttributeColumns.add(missingColumn);
-            attemptedAttributesPayload = omitFromRecord(attemptedAttributesPayload, missingColumn);
-            continue;
-          }
+        const missingColumn = extractMissingColumn(attributesError);
+        if (
+          missingColumn &&
+          !skippedAttributeColumns.has(missingColumn) &&
+          missingColumn in attemptedAttributesPayload
+        ) {
+          skippedAttributeColumns.add(missingColumn);
+          attemptedAttributesPayload = omitFromRecord(attemptedAttributesPayload, missingColumn);
+          continue;
         }
 
         throw attributesError;


### PR DESCRIPTION
## Summary
- update Supabase error helpers to detect schema cache column misses and omit unsupported fields
- allow character creation to skip unavailable profile and attribute columns instead of failing
- harden social media metrics updates to fall back when profile columns are absent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbe88d3ac08325bce6de35e1e68a13