### PR TITLE
Prevent layout redirect loop between profile and creator

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -66,13 +66,10 @@ const Layout = () => {
   }, [user, loading, profileRefresh]);
 
   useEffect(() => {
-    if (
-      !loading &&
-      user &&
-      !checkingProfile &&
-      !hasProfile &&
-      location.pathname !== "/character-create"
-    ) {
+    const isOnCharacterCreation = location.pathname === "/character-create";
+    const isOnProfile = location.pathname === "/profile";
+
+    if (!loading && user && !checkingProfile && !hasProfile && !isOnCharacterCreation && !isOnProfile) {
       navigate("/character-create");
     }
   }, [loading, user, checkingProfile, hasProfile, location.pathname, navigate]);


### PR DESCRIPTION
## Summary
- update layout redirect guard to skip forcing profile users back into character creation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbecefaf5083258f64a1bcc838e4d2