### PR TITLE
Add state flag for character creator redirect

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -70,7 +70,7 @@ const Layout = () => {
     const isOnProfile = location.pathname === "/profile";
 
     if (!loading && user && !checkingProfile && !hasProfile && !isOnCharacterCreation && !isOnProfile) {
-      navigate("/character-create");
+      navigate("/character-create", { state: { fromProfile: true } });
     }
   }, [loading, user, checkingProfile, hasProfile, location.pathname, navigate]);
 


### PR DESCRIPTION
## Summary
- include navigation state when Layout routes incomplete profiles to the character creator
- leverage the existing CharacterCreation guard to avoid redirect loops for incomplete profiles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf2a111688325b6b97c60aa22d0e9