### PR TITLE
Fix undefined upcoming bookings count reference

### DIFF
--- a/src/pages/VenueManagement.tsx
+++ b/src/pages/VenueManagement.tsx
@@ -638,7 +638,8 @@ const VenueManagement = () => {
 
   const isLoadingVenues = loadingVenues || loadingRelationships;
   const hasVenues = venuesWithDetails.length > 0;
-  const hasUpcomingBookings = upcomingBookings.length > 0;
+  const upcomingBookingsCount = upcomingBookings.length;
+  const hasUpcomingBookings = upcomingBookingsCount > 0;
 
   return (
     <div className="min-h-screen bg-gradient-primary p-6">


### PR DESCRIPTION
## Summary
- derive the upcoming bookings count from the existing bookings array
- reuse the derived value for both the count display and presence checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf4af955c83258baa9ad7fe727861