### PR TITLE
Fix profile upsert conflict for character save

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -720,7 +720,9 @@ const CharacterCreation = () => {
       while (!upsertedProfile) {
         const { data, error: profileError } = await supabase
           .from("profiles")
-          .upsert(attemptedProfilePayload as ProfileInsert)
+          .upsert(attemptedProfilePayload as ProfileInsert, {
+            onConflict: "user_id,slot_number",
+          })
           .select()
           .single();
 


### PR DESCRIPTION
## Summary
- ensure character profile upserts target the existing row by using the user and slot conflict key

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf82c888c83259e7b4f2a165ae602