### PR TITLE
Reset character baselines to zero

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -76,10 +76,10 @@ const backgrounds = [
   },
 ];
 
-const TOTAL_SKILL_POINTS = 13;
-const MIN_SKILL_VALUE = 1;
+const TOTAL_SKILL_POINTS = 0;
+const MIN_SKILL_VALUE = 0;
 const MAX_SKILL_VALUE = 10;
-const ATTRIBUTE_MIN_VALUE = 1;
+const ATTRIBUTE_MIN_VALUE = 0;
 const ATTRIBUTE_MAX_VALUE = 3;
 const ATTRIBUTE_SLIDER_STEP = 0.1;
 
@@ -176,13 +176,13 @@ const formatAttributeDisplay = (value: number): string => {
 };
 
 const defaultSkills = {
-  guitar: 1,
-  vocals: 1,
-  drums: 1,
-  bass: 1,
-  performance: 1,
-  songwriting: 1,
-  composition: 1,
+  guitar: 0,
+  vocals: 0,
+  drums: 0,
+  bass: 0,
+  performance: 0,
+  songwriting: 0,
+  composition: 0,
 };
 
 const ATTRIBUTE_KEYS = [
@@ -197,11 +197,11 @@ type SkillKey = keyof typeof defaultSkills;
 type AttributeKey = (typeof ATTRIBUTE_KEYS)[number];
 
 const defaultAttributes: Record<AttributeKey, number> = {
-  mental_focus: 1,
-  physical_endurance: 1,
-  stage_presence: 1,
-  crowd_engagement: 1,
-  social_reach: 1,
+  mental_focus: 0,
+  physical_endurance: 0,
+  stage_presence: 0,
+  crowd_engagement: 0,
+  social_reach: 0,
 };
 
 const buildSkillState = (
@@ -621,7 +621,10 @@ const CharacterCreation = () => {
     [totalSkillPoints]
   );
 
-  const allocationComplete = totalSkillPoints === TOTAL_SKILL_POINTS;
+  const allocationRequired = TOTAL_SKILL_POINTS > 0;
+  const allocationComplete = allocationRequired
+    ? totalSkillPoints === TOTAL_SKILL_POINTS
+    : overallocatedSkillPoints === 0;
   const allocationOver = overallocatedSkillPoints > 0;
 
   const handleSave = async () => {
@@ -648,11 +651,13 @@ const CharacterCreation = () => {
       return;
     }
 
-    if (!allocationComplete) {
+    if ((allocationRequired && !allocationComplete) || (!allocationRequired && allocationOver)) {
       toast({
         title: allocationOver ? "Skill allocation exceeded" : "Allocate remaining skill points",
         description: allocationOver
-          ? `Reduce your skills by ${overallocatedSkillPoints} point${overallocatedSkillPoints === 1 ? "" : "s"} to hit exactly ${TOTAL_SKILL_POINTS}.`
+          ? allocationRequired
+            ? `Reduce your skills by ${overallocatedSkillPoints} point${overallocatedSkillPoints === 1 ? "" : "s"} to hit exactly ${TOTAL_SKILL_POINTS}.`
+            : `Reduce your skills by ${overallocatedSkillPoints} point${overallocatedSkillPoints === 1 ? "" : "s"} to stay within your available budget.`
           : `You still have ${remainingSkillPoints} point${remainingSkillPoints === 1 ? "" : "s"} to assign before saving.`,
         variant: "destructive",
       });
@@ -1289,15 +1294,17 @@ const CharacterCreation = () => {
               Skill Distribution
             </CardTitle>
             <CardDescription>
-              Allocate your starting strengths. Every skill ranges from 1-10 and influences early gameplay systems.
+              Allocate your starting strengths. Every skill ranges from 0-10 and influences early gameplay systems.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-4 text-sm text-primary space-y-1">
               <div>
-                Total Skill Points:{" "}
+                Skill Points Assigned:{" "}
                 <span className="font-semibold">
-                  {totalSkillPoints} / {TOTAL_SKILL_POINTS}
+                  {allocationRequired
+                    ? `${totalSkillPoints} / ${TOTAL_SKILL_POINTS}`
+                    : totalSkillPoints}
                 </span>
               </div>
               {allocationOver ? (
@@ -1306,12 +1313,14 @@ const CharacterCreation = () => {
                   {overallocatedSkillPoints === 1 ? "" : "s"}. Adjust to continue.
                 </div>
               ) : (
-                <div className="text-xs text-primary/80">
-                  Remaining Points:{" "}
-                  <span className="font-semibold">{remainingSkillPoints}</span>
-                </div>
+                allocationRequired && (
+                  <div className="text-xs text-primary/80">
+                    Remaining Points:{" "}
+                    <span className="font-semibold">{remainingSkillPoints}</span>
+                  </div>
+                )
               )}
-              {!allocationComplete && !allocationOver && (
+              {allocationRequired && !allocationComplete && !allocationOver && (
                 <div className="text-xs text-destructive">
                   Spend all {TOTAL_SKILL_POINTS} points to continue.
                 </div>
@@ -1325,8 +1334,8 @@ const CharacterCreation = () => {
                     <span className="text-sm font-semibold text-primary">{skills[key]}</span>
                   </div>
                   <Slider
-                    min={1}
-                    max={10}
+                    min={MIN_SKILL_VALUE}
+                    max={MAX_SKILL_VALUE}
                     step={1}
                     value={[skills[key]]}
                     onValueChange={([value]) => handleSkillChange(key, value ?? skills[key])}

--- a/supabase/migrations/20261020100000_zero_skill_attribute_defaults.sql
+++ b/supabase/migrations/20261020100000_zero_skill_attribute_defaults.sql
@@ -1,0 +1,355 @@
+-- Align player skill and attribute baselines with zeroed defaults
+BEGIN;
+
+-- Ensure all player skill columns default to 0 and backfill existing data
+DO $$
+DECLARE
+  skill_columns constant text[] := ARRAY[
+    'guitar',
+    'vocals',
+    'drums',
+    'bass',
+    'performance',
+    'songwriting',
+    'composition',
+    'technical'
+  ];
+  present_skill_columns text[] := ARRAY[]::text[];
+  column_name text;
+  check_fragments text[] := ARRAY[]::text[];
+  check_sql text;
+BEGIN
+  FOREACH column_name IN ARRAY skill_columns LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns AS cols
+      WHERE cols.table_schema = 'public'
+        AND cols.table_name = 'player_skills'
+        AND cols.column_name = column_name
+    ) THEN
+      EXECUTE format('ALTER TABLE public.player_skills ALTER COLUMN %I SET DEFAULT 0', column_name);
+      EXECUTE format('UPDATE public.player_skills SET %I = 0', column_name);
+      EXECUTE format('ALTER TABLE public.player_skills ALTER COLUMN %I SET NOT NULL', column_name);
+      present_skill_columns := array_append(present_skill_columns, column_name);
+      check_fragments := array_append(check_fragments, format('%I BETWEEN 0 AND 100', column_name));
+    END IF;
+  END LOOP;
+
+  IF array_length(present_skill_columns, 1) IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE public.player_skills DROP CONSTRAINT IF EXISTS player_skills_value_bounds_check';
+    check_sql := 'ALTER TABLE public.player_skills ADD CONSTRAINT player_skills_value_bounds_check CHECK (' ||
+      array_to_string(check_fragments, ' AND ') || ')';
+    EXECUTE check_sql;
+  END IF;
+END;
+$$;
+
+-- Ensure all tracked player attributes default to 0 and backfill data
+DO $$
+DECLARE
+  attribute_columns constant text[] := ARRAY[
+    'physical_endurance',
+    'mental_focus',
+    'stage_presence',
+    'crowd_engagement',
+    'social_reach'
+  ];
+  present_attribute_columns text[] := ARRAY[]::text[];
+  column_name text;
+  check_fragments text[] := ARRAY[]::text[];
+  check_sql text;
+BEGIN
+  FOREACH column_name IN ARRAY attribute_columns LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns AS cols
+      WHERE cols.table_schema = 'public'
+        AND cols.table_name = 'player_attributes'
+        AND cols.column_name = column_name
+    ) THEN
+      EXECUTE format('ALTER TABLE public.player_attributes ALTER COLUMN %I SET DEFAULT 0', column_name);
+      EXECUTE format('UPDATE public.player_attributes SET %I = 0', column_name);
+      EXECUTE format('ALTER TABLE public.player_attributes ALTER COLUMN %I SET NOT NULL', column_name);
+      present_attribute_columns := array_append(present_attribute_columns, column_name);
+      check_fragments := array_append(check_fragments, format('%I BETWEEN 0 AND 3', column_name));
+    END IF;
+  END LOOP;
+
+  IF array_length(present_attribute_columns, 1) IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE public.player_attributes DROP CONSTRAINT IF EXISTS player_attributes_value_bounds';
+    check_sql := 'ALTER TABLE public.player_attributes ADD CONSTRAINT player_attributes_value_bounds CHECK (' ||
+      array_to_string(check_fragments, ' AND ') || ')';
+    EXECUTE check_sql;
+  END IF;
+END;
+$$;
+
+-- Provision new accounts with zeroed skills and attributes
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $function$
+DECLARE
+  portsmouth_id uuid;
+  new_profile public.profiles%ROWTYPE;
+BEGIN
+  SELECT id INTO portsmouth_id
+  FROM public.cities
+  WHERE id = 'a5bf9a04-5c3b-4c7c-99bb-f3a4ed2d64d6';
+
+  IF portsmouth_id IS NULL THEN
+    RAISE EXCEPTION 'Default city Portsmouth is missing';
+  END IF;
+
+  INSERT INTO public.profiles (
+    user_id,
+    username,
+    display_name,
+    current_city_id,
+    current_location,
+    health,
+    gender,
+    city_of_birth,
+    age,
+    slot_number,
+    unlock_cost,
+    is_active
+  )
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'username', 'Player' || substr(NEW.id::text, 1, 8)),
+    COALESCE(NEW.raw_user_meta_data->>'display_name', 'New Player'),
+    portsmouth_id,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    1,
+    0,
+    true
+  )
+  RETURNING * INTO new_profile;
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, 'user');
+
+  INSERT INTO public.player_skills (
+    user_id,
+    profile_id,
+    guitar,
+    vocals,
+    drums,
+    bass,
+    performance,
+    songwriting,
+    composition
+  )
+  VALUES (
+    NEW.id,
+    new_profile.id,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  )
+  ON CONFLICT (profile_id) DO NOTHING;
+
+  INSERT INTO public.fan_demographics (user_id)
+  VALUES (NEW.id);
+
+  INSERT INTO public.activity_feed (user_id, profile_id, activity_type, message)
+  VALUES (NEW.id, new_profile.id, 'join', 'Welcome to Rockmundo! Your musical journey begins now.');
+
+  INSERT INTO public.player_attributes (
+    user_id,
+    profile_id,
+    physical_endurance,
+    mental_focus,
+    stage_presence,
+    crowd_engagement,
+    social_reach,
+    attribute_points
+  )
+  VALUES (
+    NEW.id,
+    new_profile.id,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  )
+  ON CONFLICT (profile_id) DO NOTHING;
+
+  INSERT INTO public.player_achievements (user_id, achievement_id)
+  SELECT NEW.id, id FROM public.achievements WHERE name = 'First Steps';
+
+  RETURN NEW;
+END;
+$function$;
+
+-- Ensure resets also zero out regenerated characters
+CREATE OR REPLACE FUNCTION public.reset_player_character()
+RETURNS TABLE (
+  profile public.profiles,
+  skills public.player_skills,
+  attributes public.player_attributes
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  generated_username text;
+  new_profile public.profiles%ROWTYPE;
+  new_skills public.player_skills%ROWTYPE;
+  new_attributes public.player_attributes%ROWTYPE;
+  portsmouth_id uuid;
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to reset character' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id INTO portsmouth_id
+  FROM public.cities
+  WHERE id = 'a5bf9a04-5c3b-4c7c-99bb-f3a4ed2d64d6';
+
+  IF portsmouth_id IS NULL THEN
+    RAISE EXCEPTION 'Default city Portsmouth is missing';
+  END IF;
+
+  generated_username := 'Player' || substr(current_user_id::text, 1, 8);
+
+  DELETE FROM public.social_comments WHERE user_id = current_user_id;
+  DELETE FROM public.social_reposts WHERE user_id = current_user_id;
+  DELETE FROM public.social_posts WHERE user_id = current_user_id;
+  DELETE FROM public.promotion_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.social_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.streaming_stats WHERE user_id = current_user_id;
+  DELETE FROM public.player_equipment WHERE user_id = current_user_id;
+  DELETE FROM public.player_streaming_accounts WHERE user_id = current_user_id;
+  DELETE FROM public.player_achievements WHERE user_id = current_user_id;
+  DELETE FROM public.contracts WHERE user_id = current_user_id;
+  DELETE FROM public.gig_performances WHERE user_id = current_user_id;
+  DELETE FROM public.tours WHERE user_id = current_user_id;
+  DELETE FROM public.venue_bookings WHERE user_id = current_user_id;
+  DELETE FROM public.venue_relationships WHERE user_id = current_user_id;
+  DELETE FROM public.user_actions WHERE user_id = current_user_id;
+  DELETE FROM public.global_chat WHERE user_id = current_user_id;
+  DELETE FROM public.activity_feed WHERE user_id = current_user_id;
+  DELETE FROM public.fan_demographics WHERE user_id = current_user_id;
+  DELETE FROM public.band_members WHERE user_id = current_user_id;
+  DELETE FROM public.player_attributes WHERE user_id = current_user_id;
+
+  DELETE FROM public.band_conflicts
+    WHERE band_id IN (
+      SELECT id FROM public.bands WHERE leader_id = current_user_id
+    );
+  DELETE FROM public.bands WHERE leader_id = current_user_id;
+
+  DELETE FROM public.songs WHERE user_id = current_user_id;
+
+  DELETE FROM public.player_skills WHERE user_id = current_user_id;
+  DELETE FROM public.profiles WHERE user_id = current_user_id;
+
+  INSERT INTO public.profiles (
+    user_id,
+    username,
+    display_name,
+    current_city_id,
+    current_location,
+    health,
+    gender,
+    city_of_birth,
+    age,
+    slot_number,
+    unlock_cost,
+    is_active
+  )
+  VALUES (
+    current_user_id,
+    generated_username,
+    'New Player',
+    portsmouth_id,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    1,
+    0,
+    true
+  )
+  RETURNING * INTO new_profile;
+
+  INSERT INTO public.player_skills (
+    user_id,
+    profile_id,
+    guitar,
+    vocals,
+    drums,
+    bass,
+    performance,
+    songwriting,
+    composition
+  )
+  VALUES (
+    current_user_id,
+    new_profile.id,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  )
+  RETURNING * INTO new_skills;
+
+  INSERT INTO public.player_attributes (
+    user_id,
+    profile_id,
+    physical_endurance,
+    mental_focus,
+    stage_presence,
+    crowd_engagement,
+    social_reach,
+    attribute_points
+  )
+  VALUES (
+    current_user_id,
+    new_profile.id,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  )
+  RETURNING * INTO new_attributes;
+
+  INSERT INTO public.fan_demographics (user_id)
+  VALUES (current_user_id);
+
+  INSERT INTO public.activity_feed (user_id, activity_type, message)
+  VALUES (
+    current_user_id,
+    'reset',
+    'Your journey has been reset. Time to create a new legend!'
+  );
+
+  RETURN QUERY SELECT new_profile, new_skills, new_attributes;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.reset_player_character() TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- allow character creation to start from zero skill and attribute values while updating validation messaging
- add migration to zero out player skill and attribute columns, set zero defaults, and update onboarding/reset routines

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf9375ef88325b8128e3cad418844