### PR TITLE
Expand player skills to 0-1000 scale

### DIFF
--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -1337,10 +1337,11 @@ const BandManager = () => {
                             const isLocked = rawValue === undefined || rawValue === null;
                             const numericValue = Number(rawValue ?? 0);
                             const sanitizedValue = Number.isFinite(numericValue) ? numericValue : 0;
-                            const clampedValue = Math.max(0, Math.min(100, sanitizedValue));
+                            const clampedValue = Math.max(0, Math.min(1000, sanitizedValue));
+                            const percent = Math.min(100, (clampedValue / 1000) * 100);
                             const ariaLabel = isLocked
                               ? `${skillSlug} skill locked`
-                              : `${skillSlug} skill level ${clampedValue} out of 100`;
+                              : `${skillSlug} skill level ${clampedValue} out of 1000`;
 
                             return (
                               <div key={skillSlug} className="space-y-1">
@@ -1357,7 +1358,7 @@ const BandManager = () => {
                                     <span className="text-xs text-muted-foreground">Lv. {Math.round(clampedValue)}</span>
                                   )}
                                 </div>
-                                <Progress value={clampedValue} className="h-1.5" aria-label={ariaLabel} />
+                                <Progress value={percent} className="h-1.5" aria-label={ariaLabel} />
                               </div>
                             );
                           })}

--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -759,9 +759,17 @@ const Busking = () => {
   const attributeScores = useMemo(() => extractAttributeScores(attributes), [attributes]);
 
   const skillScore = useMemo(() => {
-    const performance = skills?.performance ?? 55;
-    const vocals = skills?.vocals ?? 50;
-    const guitar = skills?.guitar ?? 45;
+    const toSkillValue = (value: unknown, fallback: number) => {
+      const numeric = typeof value === "number" ? value : Number(value ?? NaN);
+      return Number.isFinite(numeric) ? numeric : fallback;
+    };
+
+    const performanceRaw = toSkillValue(skills?.performance, 550);
+    const vocalsRaw = toSkillValue(skills?.vocals, 500);
+    const guitarRaw = toSkillValue(skills?.guitar, 450);
+    const performance = performanceRaw / 10;
+    const vocals = vocalsRaw / 10;
+    const guitar = guitarRaw / 10;
     const baseScore = performance * 0.4 + vocals * 0.25 + guitar * 0.2;
     const charismaBonus = (attributeScores.charisma ?? 0) * 0.012;
     const looksBonus = (attributeScores.looks ?? 0) * 0.008;
@@ -859,7 +867,7 @@ const Busking = () => {
     const environmentMultiplier = environmentDetails.combined.fameMultiplier;
     const expectancy = successChance / 100;
     const baseFans = selectedLocation.fame_reward * modifierMultiplier * environmentMultiplier * (0.5 + expectancy * 0.5);
-    return Math.max(0, calculateFanGain(baseFans, skillScore, attributeScores));
+    return Math.max(0, calculateFanGain(baseFans, skillScore * 10, attributeScores));
   }, [attributeScores, environmentDetails, selectedLocation, selectedModifier, skillScore, successChance]);
 
   const expectedExperience = useMemo(() => {
@@ -1001,7 +1009,11 @@ const Busking = () => {
         : baseFame * 0.4 * combinedFameMultiplier * (0.6 + Math.random() * 0.3);
       const fameGained = Math.max(
         0,
-        calculateFanGain(rawFame, success ? skillScore : Math.max(10, skillScore * 0.7), attributeScores)
+        calculateFanGain(
+          rawFame,
+          success ? skillScore * 10 : Math.max(100, skillScore * 7),
+          attributeScores
+        )
       );
 
       const baseExperience =

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -267,13 +267,14 @@ const Dashboard = () => {
             <CardContent className="space-y-4">
               {instrumentSkillKeys.map(skillKey => {
                 const value = Number(skills?.[skillKey] ?? 0);
+                const percent = Math.min(100, (value / 1000) * 100);
                 return (
                   <div key={skillKey} className="space-y-2">
                     <span className="capitalize font-medium text-sm">{skillKey}</span>
                     <Progress
-                      value={value}
+                      value={percent}
                       className="h-2"
-                      aria-label={`${skillKey} skill level ${value} out of 100`}
+                      aria-label={`${skillKey} skill level ${value} out of 1000`}
                     />
                   </div>
                 );

--- a/src/pages/MusicStudio.tsx
+++ b/src/pages/MusicStudio.tsx
@@ -463,16 +463,16 @@ const MusicStudio = () => {
           const bassGain = applyAttributeToValue(1, attributes, SKILL_ATTRIBUTE_MAP.bass).value;
           const drumsGain = applyAttributeToValue(1, attributes, SKILL_ATTRIBUTE_MAP.drums).value;
           await updateSkills({
-            guitar: Math.min(100, skillLevels.guitar + 1),
-            bass: Math.min(100, skillLevels.bass + 1),
-            drums: Math.min(100, skillLevels.drums + 1)
+            guitar: Math.min(1000, skillLevels.guitar + 1),
+            bass: Math.min(1000, skillLevels.bass + 1),
+            drums: Math.min(1000, skillLevels.drums + 1)
           });
         } else if (stage === "mastering") {
           const performanceGain = applyAttributeToValue(1, attributes, SKILL_ATTRIBUTE_MAP.performance).value;
           const songwritingGain = applyAttributeToValue(1, attributes, SKILL_ATTRIBUTE_MAP.songwriting).value;
           await updateSkills({
-            performance: Math.min(100, skillLevels.performance + 1),
-            songwriting: Math.min(100, skillLevels.songwriting + 1)
+            performance: Math.min(1000, skillLevels.performance + 1),
+            songwriting: Math.min(1000, skillLevels.songwriting + 1)
           });
         }
       }

--- a/src/pages/PerformGig.tsx
+++ b/src/pages/PerformGig.tsx
@@ -217,13 +217,13 @@ const PerformGig = () => {
     const successRatio = Math.min(Math.max(finalScore / 100, 0), 1);
     const baselinePayment = calculateGigPayment(
       basePayment,
-      skills?.performance ?? finalScore,
+      skills?.performance ?? finalScore * 10,
       profile?.fame ?? 0,
       successRatio,
     );
     const adjustedPayment = calculateGigPayment(
       basePayment,
-      skills?.performance ?? finalScore,
+      skills?.performance ?? finalScore * 10,
       profile?.fame ?? 0,
       successRatio,
       attributeBonuses,
@@ -235,12 +235,12 @@ const PerformGig = () => {
     const stagePresenceMetric = performance.stage_presence || finalScore;
     const baselineFanGain = calculateFanGain(
       Math.max(1, baseFanGain),
-      skills?.performance ?? finalScore,
+      skills?.performance ?? finalScore * 10,
       stagePresenceMetric,
     );
     const adjustedFanGain = calculateFanGain(
       Math.max(1, baseFanGain),
-      skills?.performance ?? finalScore,
+      skills?.performance ?? finalScore * 10,
       stagePresenceMetric,
       attributeBonuses,
     );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -795,20 +795,21 @@ const Profile = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {instrumentSkillKeys.map(skillKey => {
                     const value = Number(skills?.[skillKey] ?? 0);
+                    const percent = Math.min(100, (value / 1000) * 100);
                     return (
                       <div key={skillKey} className="space-y-2">
                         <span className="text-sm font-medium capitalize">{skillKey}</span>
                         <Progress
-                          value={value}
+                          value={percent}
                           className="h-2"
-                          aria-label={`${skillKey} skill level ${value} out of 100`}
+                          aria-label={`${skillKey} skill level ${value} out of 1000`}
                         />
                         <div className="text-xs text-muted-foreground">
-                          {value >= 80
+                          {value >= 800
                             ? "Expert"
-                            : value >= 60
+                            : value >= 600
                               ? "Advanced"
-                              : value >= 40
+                              : value >= 400
                                 ? "Intermediate"
                                 : "Beginner"}
                         </div>

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1123,7 +1123,7 @@ const Schedule = () => {
             }
           } else if (activeSkills) {
             const currentValue = Number(activeSkills[skillKey as keyof PlayerSkills] ?? 0);
-            const nextValue = Math.min(100, currentValue + numericDelta);
+            const nextValue = Math.min(1000, currentValue + numericDelta);
             const actualGain = nextValue - currentValue;
             if (actualGain > 0) {
               skillUpdates[skillKey as keyof PlayerSkills] = nextValue;

--- a/src/pages/SkillTraining.tsx
+++ b/src/pages/SkillTraining.tsx
@@ -306,20 +306,20 @@ const SkillTrainingContent = () => {
   const isLoading = gameDataLoading || skillSystemLoading;
 
   const getSkillLevel = (value: number) => {
-    if (value >= 90) return "Master";
-    if (value >= 75) return "Expert";
-    if (value >= 60) return "Advanced";
-    if (value >= 40) return "Intermediate";
-    if (value >= 20) return "Beginner";
+    if (value >= 900) return "Master";
+    if (value >= 750) return "Expert";
+    if (value >= 600) return "Advanced";
+    if (value >= 400) return "Intermediate";
+    if (value >= 200) return "Beginner";
     return "Novice";
   };
 
   const getSkillColor = (value: number) => {
-    if (value >= 90) return "text-purple-400";
-    if (value >= 75) return "text-blue-400";
-    if (value >= 60) return "text-green-400";
-    if (value >= 40) return "text-yellow-400";
-    if (value >= 20) return "text-orange-400";
+    if (value >= 900) return "text-purple-400";
+    if (value >= 750) return "text-blue-400";
+    if (value >= 600) return "text-green-400";
+    if (value >= 400) return "text-yellow-400";
+    if (value >= 200) return "text-orange-400";
     return "text-red-400";
   };
 

--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -1160,7 +1160,7 @@ const TourManager = () => {
 
     try {
       // Calculate show success based on skills and venue prestige
-      const successRate = Math.min(0.9, skills.performance / 100);
+      const successRate = Math.min(0.9, (skills.performance ?? 0) / 1000);
       const capacity = venueInfo.capacity || 500;
       const environmentModifiers = tourVenue.environment_modifiers;
       const attendanceMultiplier = environmentModifiers?.attendanceMultiplier ?? 1;

--- a/src/utils/gameBalance.ts
+++ b/src/utils/gameBalance.ts
@@ -19,10 +19,10 @@ const toFiniteNumber = (value: unknown, fallback = 0) => {
 };
 
 export const SKILL_CAPS = {
-  beginner: 30, // 0-1000 exp
-  amateur: 50, // 1000-5000 exp
-  professional: 80, // 5000-20000 exp
-  master: 100 // 20000+ exp
+  beginner: 300, // 0-1000 exp
+  amateur: 500, // 1000-5000 exp
+  professional: 800, // 5000-20000 exp
+  master: 1000 // 20000+ exp
 } as const;
 
 export const LEVEL_REQUIREMENTS = {
@@ -264,7 +264,8 @@ export function calculateTrainingCost(
   attributes?: AttributeScores,
   focus: AttributeFocus = "general"
 ): number {
-  const baseCost = TRAINING_COSTS.skillTraining(currentSkillLevel);
+  const normalizedSkillLevel = clampNumber(currentSkillLevel / 10, 0, 100);
+  const baseCost = TRAINING_COSTS.skillTraining(normalizedSkillLevel);
   if (baseCost <= 0) {
     return 0;
   }
@@ -320,7 +321,8 @@ export function calculateGigPayment(
     return 0;
   }
 
-  const skillMultiplier = 1 + performanceSkill / 100;
+  const normalizedSkill = clampNumber(performanceSkill / 1000, 0, 1);
+  const skillMultiplier = 1 + normalizedSkill;
   const fameMultiplier = 1 + fameLevel / 10000;
   const performanceMultiplier = 0.5 + successRate * 0.5;
 
@@ -349,7 +351,8 @@ export function calculateFanGain(
     return 0;
   }
 
-  const skillMultiplier = 1 + performanceSkill / 200;
+  const normalizedSkill = clampNumber(performanceSkill / 1000, 0, 1);
+  const skillMultiplier = 1 + normalizedSkill * 0.5;
   const charismaMultiplier = attributeScoreToMultiplier(attributes?.charisma ?? null, 0.5);
   const looksMultiplier = attributeScoreToMultiplier(attributes?.looks ?? null, 0.3);
 

--- a/src/utils/skillLevels.ts
+++ b/src/utils/skillLevels.ts
@@ -123,5 +123,5 @@ export const estimateSkillTier = (
   }
 
   const average = values.reduce((sum, value) => sum + value, 0) / values.length;
-  return Math.max(1, Math.round(average / 10));
+  return Math.max(1, Math.round(average / 100));
 };

--- a/supabase/migrations/20261005120000_expand_player_skills_scale.sql
+++ b/supabase/migrations/20261005120000_expand_player_skills_scale.sql
@@ -1,0 +1,40 @@
+-- Expand player skill range to support 0-1000 scale
+BEGIN;
+
+ALTER TABLE public.player_skills
+  DROP CONSTRAINT IF EXISTS player_skills_value_bounds_check;
+
+UPDATE public.player_skills
+SET
+  guitar = LEAST(GREATEST(COALESCE(guitar, 0), 0), 100) * 10,
+  vocals = LEAST(GREATEST(COALESCE(vocals, 0), 0), 100) * 10,
+  drums = LEAST(GREATEST(COALESCE(drums, 0), 0), 100) * 10,
+  bass = LEAST(GREATEST(COALESCE(bass, 0), 0), 100) * 10,
+  performance = LEAST(GREATEST(COALESCE(performance, 0), 0), 100) * 10,
+  songwriting = LEAST(GREATEST(COALESCE(songwriting, 0), 0), 100) * 10,
+  composition = LEAST(GREATEST(COALESCE(composition, 0), 0), 100) * 10,
+  technical = LEAST(GREATEST(COALESCE(technical, 0), 0), 100) * 10;
+
+ALTER TABLE public.player_skills
+  ALTER COLUMN guitar SET DEFAULT 100,
+  ALTER COLUMN vocals SET DEFAULT 100,
+  ALTER COLUMN drums SET DEFAULT 100,
+  ALTER COLUMN bass SET DEFAULT 100,
+  ALTER COLUMN performance SET DEFAULT 100,
+  ALTER COLUMN songwriting SET DEFAULT 100,
+  ALTER COLUMN composition SET DEFAULT 100,
+  ALTER COLUMN technical SET DEFAULT 100;
+
+ALTER TABLE public.player_skills
+  ADD CONSTRAINT player_skills_value_bounds_check CHECK (
+    guitar BETWEEN 0 AND 1000 AND
+    vocals BETWEEN 0 AND 1000 AND
+    drums BETWEEN 0 AND 1000 AND
+    bass BETWEEN 0 AND 1000 AND
+    performance BETWEEN 0 AND 1000 AND
+    songwriting BETWEEN 0 AND 1000 AND
+    composition BETWEEN 0 AND 1000 AND
+    technical BETWEEN 0 AND 1000
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that widens `player_skills` defaults and constraints to a 0–1000 scale and rescales existing rows
- normalize skill progress UI to the new range across dashboard, profile, band management, and training flows
- adjust gameplay calculations and utilities (training costs, gig payouts/fan gains, schedule rewards, busking logic, etc.) to expect 0–1000 skill values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbf937d72083258ba7d2182842a326