### PR TITLE
Add daily experience point conversion and surface spendable balances

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -825,6 +825,7 @@ export type Database = {
       }
       profiles: {
         Row: {
+          attribute_points_available: number | null
           age: number | null
           avatar_url: string | null
           bio: string | null
@@ -835,6 +836,7 @@ export type Database = {
           display_name: string | null
           engagement_rate: number | null
           experience: number | null
+          experience_at_last_conversion: number | null
           fame: number | null
           fans: number | null
           followers: number | null
@@ -842,7 +844,9 @@ export type Database = {
           health: number | null
           id: string
           is_active: boolean
+          last_point_conversion_at: string | null
           level: number | null
+          skill_points_available: number | null
           slot_number: number
           unlock_cost: number
           updated_at: string | null
@@ -850,6 +854,7 @@ export type Database = {
           username: string
         }
         Insert: {
+          attribute_points_available?: number | null
           age?: number | null
           avatar_url?: string | null
           bio?: string | null
@@ -860,6 +865,7 @@ export type Database = {
           display_name?: string | null
           engagement_rate?: number | null
           experience?: number | null
+          experience_at_last_conversion?: number | null
           fame?: number | null
           fans?: number | null
           followers?: number | null
@@ -867,7 +873,9 @@ export type Database = {
           health?: number | null
           id?: string
           is_active?: boolean
+          last_point_conversion_at?: string | null
           level?: number | null
+          skill_points_available?: number | null
           slot_number?: number
           unlock_cost?: number
           updated_at?: string | null
@@ -875,6 +883,7 @@ export type Database = {
           username: string
         }
         Update: {
+          attribute_points_available?: number | null
           age?: number | null
           avatar_url?: string | null
           bio?: string | null
@@ -885,6 +894,7 @@ export type Database = {
           display_name?: string | null
           engagement_rate?: number | null
           experience?: number | null
+          experience_at_last_conversion?: number | null
           fame?: number | null
           fans?: number | null
           followers?: number | null
@@ -892,7 +902,9 @@ export type Database = {
           health?: number | null
           id?: string
           is_active?: boolean
+          last_point_conversion_at?: string | null
           level?: number | null
+          skill_points_available?: number | null
           slot_number?: number
           unlock_cost?: number
           updated_at?: string | null

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -6,6 +6,7 @@ export interface Database {
     Tables: {
       profiles: {
         Row: {
+          attribute_points_available: number
           id: string
           user_id: string
           username: string
@@ -14,13 +15,17 @@ export interface Database {
           bio: string | null
           level: number
           experience: number
+          experience_at_last_conversion: number
           cash: number
           fame: number
           fans: number
+          skill_points_available: number
+          last_point_conversion_at: string | null
           created_at: string
           updated_at: string
         }
         Insert: {
+          attribute_points_available?: number
           id?: string
           user_id: string
           username: string
@@ -29,13 +34,17 @@ export interface Database {
           bio?: string | null
           level?: number
           experience?: number
+          experience_at_last_conversion?: number
           cash?: number
           fame?: number
           fans?: number
+          skill_points_available?: number
+          last_point_conversion_at?: string | null
           created_at?: string
           updated_at?: string
         }
         Update: {
+          attribute_points_available?: number
           id?: string
           user_id?: string
           username?: string
@@ -44,9 +53,12 @@ export interface Database {
           bio?: string | null
           level?: number
           experience?: number
+          experience_at_last_conversion?: number
           cash?: number
           fame?: number
           fans?: number
+          skill_points_available?: number
+          last_point_conversion_at?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -23,9 +23,13 @@ export interface Profile {
   bio: string | null;
   level: number;
   experience: number;
+  experience_at_last_conversion: number;
   cash: number;
   fame: number;
   fans: number;
+  skill_points_available: number;
+  attribute_points_available: number;
+  last_point_conversion_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20261002100000_add_experience_point_conversion.sql
+++ b/supabase/migrations/20261002100000_add_experience_point_conversion.sql
@@ -1,0 +1,164 @@
+-- Add spendable point columns to player profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS skill_points_available integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS attribute_points_available integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS experience_at_last_conversion integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_point_conversion_at timestamptz DEFAULT now();
+
+-- Align new bookkeeping columns with each profile's current state
+UPDATE public.profiles
+SET
+  skill_points_available = COALESCE(skill_points_available, 0),
+  attribute_points_available = COALESCE(attribute_points_available, 0),
+  experience_at_last_conversion = COALESCE(experience, 0),
+  last_point_conversion_at = COALESCE(last_point_conversion_at, now());
+
+-- Function to convert accrued experience into spendable points once per day
+CREATE OR REPLACE FUNCTION public.process_daily_point_conversions()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_profile RECORD;
+  v_xp_delta integer;
+  v_remaining_xp integer;
+  v_skill_points integer;
+  v_attribute_points integer;
+  v_consumed integer;
+  v_processed integer := 0;
+  v_message text;
+  v_metadata jsonb;
+  skill_rate constant integer := 150; -- XP required per skill point
+  attribute_rate constant integer := 400; -- XP required per attribute point
+BEGIN
+  FOR v_profile IN
+    SELECT id,
+           user_id,
+           COALESCE(experience, 0) AS experience,
+           COALESCE(experience_at_last_conversion, 0) AS experience_at_last_conversion,
+           last_point_conversion_at
+    FROM public.profiles
+  LOOP
+    -- Reset trackers if experience was reduced since the last run
+    IF v_profile.experience <= v_profile.experience_at_last_conversion THEN
+      UPDATE public.profiles
+      SET
+        experience_at_last_conversion = v_profile.experience,
+        last_point_conversion_at = timezone('utc', now())
+      WHERE id = v_profile.id;
+      CONTINUE;
+    END IF;
+
+    v_xp_delta := GREATEST(v_profile.experience - v_profile.experience_at_last_conversion, 0);
+    v_remaining_xp := v_xp_delta;
+
+    IF v_remaining_xp <= 0 THEN
+      UPDATE public.profiles
+      SET last_point_conversion_at = timezone('utc', now())
+      WHERE id = v_profile.id;
+      CONTINUE;
+    END IF;
+
+    v_attribute_points := v_remaining_xp / attribute_rate;
+    v_remaining_xp := v_remaining_xp - (v_attribute_points * attribute_rate);
+
+    v_skill_points := v_remaining_xp / skill_rate;
+    v_remaining_xp := v_remaining_xp - (v_skill_points * skill_rate);
+
+    v_consumed := v_xp_delta - v_remaining_xp;
+
+    UPDATE public.profiles
+    SET
+      skill_points_available = skill_points_available + v_skill_points,
+      attribute_points_available = attribute_points_available + v_attribute_points,
+      experience_at_last_conversion = v_profile.experience - v_remaining_xp,
+      last_point_conversion_at = timezone('utc', now())
+    WHERE id = v_profile.id;
+
+    IF v_skill_points > 0 OR v_attribute_points > 0 THEN
+      v_processed := v_processed + 1;
+
+      v_message := CASE
+        WHEN v_skill_points > 0 AND v_attribute_points > 0 THEN
+          format(
+            'Daily training converted into %s and %s.',
+            format('%s skill point%s', v_skill_points, CASE WHEN v_skill_points = 1 THEN '' ELSE 's' END),
+            format('%s attribute point%s', v_attribute_points, CASE WHEN v_attribute_points = 1 THEN '' ELSE 's' END)
+          )
+        WHEN v_skill_points > 0 THEN
+          format(
+            'Daily training converted into %s.',
+            format('%s skill point%s', v_skill_points, CASE WHEN v_skill_points = 1 THEN '' ELSE 's' END)
+          )
+        WHEN v_attribute_points > 0 THEN
+          format(
+            'Daily training converted into %s.',
+            format('%s attribute point%s', v_attribute_points, CASE WHEN v_attribute_points = 1 THEN '' ELSE 's' END)
+          )
+        ELSE
+          'Daily training conversion completed.'
+      END;
+
+      v_metadata := jsonb_build_object(
+        'skill_points', v_skill_points,
+        'attribute_points', v_attribute_points,
+        'experience_converted', v_consumed,
+        'experience_delta', v_xp_delta,
+        'experience_leftover', v_remaining_xp
+      );
+
+      INSERT INTO public.activity_feed (
+        user_id,
+        profile_id,
+        activity_type,
+        message,
+        metadata,
+        created_at
+      )
+      VALUES (
+        v_profile.user_id,
+        v_profile.id,
+        'point_grant',
+        v_message,
+        v_metadata,
+        timezone('utc', now())
+      );
+    END IF;
+  END LOOP;
+
+  RETURN v_processed;
+END;
+$$;
+
+COMMENT ON FUNCTION public.process_daily_point_conversions() IS 'Converts accrued experience into daily skill and attribute points for each profile.';
+
+GRANT EXECUTE ON FUNCTION public.process_daily_point_conversions() TO service_role;
+
+-- Ensure the pg_cron extension is available for scheduling the conversion job
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- Schedule the daily conversion at 04:30 UTC
+DO $$
+DECLARE
+  existing_job_id integer;
+BEGIN
+  SELECT jobid INTO existing_job_id
+  FROM cron.job
+  WHERE jobname = 'daily_experience_point_conversion';
+
+  IF existing_job_id IS NOT NULL THEN
+    PERFORM cron.unschedule(existing_job_id);
+  END IF;
+
+  PERFORM cron.schedule(
+    'daily_experience_point_conversion',
+    '30 4 * * *',
+    $$SELECT public.process_daily_point_conversions();$$
+  );
+END;
+$$;
+
+-- Run once so profiles created before this migration are initialized
+SELECT public.process_daily_point_conversions();


### PR DESCRIPTION
## Summary
- add spendable point bookkeeping columns along with a daily conversion function, scheduled job, and activity logging
- extend game data hooks to expose new point balances, persist acknowledgements, and flag fresh point grants
- surface unspent points on the dashboard and profile with calls to training along with richer activity details

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf938b9f08325836343844eb5697b