### PR TITLE
Allow character creation routes without character gate

### DIFF
--- a/src/components/CharacterGate.tsx
+++ b/src/components/CharacterGate.tsx
@@ -13,7 +13,12 @@ export const CharacterGate = ({ children }: CharacterGateProps) => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const allowWithoutCharacter = location.pathname === "/profile" || location.pathname === "/";
+  const allowWithoutCharacter =
+    location.pathname === "/" ||
+    location.pathname === "/profile" ||
+    ["/character-create", "/character/create"].some((path) =>
+      location.pathname === path || location.pathname.startsWith(`${path}/`),
+    );
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- allow the character gate to consider character creation routes as accessible without an existing character
- keep the gate logic intact for all other routes that require an active character

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfd6acc348325992dbc8408d1b45e