### PR TITLE
Refresh characters after creation

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -270,6 +270,8 @@ const CharacterCreation = () => {
     skillDefinitions: contextSkillDefinitions,
     upsertSkillProgress,
     upsertSkillUnlocks,
+    refreshCharacters,
+    setActiveCharacter,
   } = useGameData();
 
   const [skillDefinitions, setSkillDefinitions] = useState<SkillDefinition[]>([]);
@@ -910,6 +912,9 @@ const CharacterCreation = () => {
         );
         setAttributes(buildAttributeState(sourceRecord));
       }
+
+      await refreshCharacters();
+      await setActiveCharacter(upsertedProfile.id);
 
       toast({
         title: "Character ready!",


### PR DESCRIPTION
## Summary
- ensure character creation page updates the game data context after saving a profile
- select the newly created or updated profile so the dashboard immediately reflects the change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfd6b6ce88325a6a05fd95bd3629d