### PR TITLE
Expand character creation skills

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -183,6 +183,10 @@ const defaultSkills = {
   performance: 0,
   songwriting: 0,
   composition: 0,
+  business: 0,
+  marketing: 0,
+  creativity: 0,
+  technical: 0,
 };
 
 const ATTRIBUTE_KEYS = [
@@ -389,7 +393,9 @@ const CharacterCreation = () => {
             .maybeSingle(),
           supabase
             .from("player_skills")
-            .select("id, guitar, vocals, drums, bass, performance, songwriting, composition")
+            .select(
+              "id, guitar, vocals, drums, bass, performance, songwriting, composition, business, marketing, creativity, technical",
+            )
             .eq("user_id", user.id)
             .maybeSingle(),
           supabase
@@ -1299,7 +1305,7 @@ const CharacterCreation = () => {
               Skill Distribution
             </CardTitle>
             <CardDescription>
-              Allocate your starting strengths. Every skill ranges from 0-10 and influences early gameplay systems.
+              Allocate your starting strengths across musical and career disciplines. Every skill ranges from 0-10 and influences early gameplay systems.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">


### PR DESCRIPTION
## Summary
- add business, marketing, creativity, and technical defaults so they persist with skill state updates
- load the new skill columns from Supabase and refresh copy to reflect the wider spread of skills

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc07d17c1483259f49f8003fadc60a