### PR TITLE
Ensure default wardrobe after character creation

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -829,6 +829,7 @@ export type Database = {
           age: number | null
           avatar_url: string | null
           bio: string | null
+          equipped_clothing: Json | null
           cash: number | null
           city_of_birth: string | null
           current_city_id: string | null
@@ -858,6 +859,7 @@ export type Database = {
           age?: number | null
           avatar_url?: string | null
           bio?: string | null
+          equipped_clothing?: Json | null
           cash?: number | null
           city_of_birth?: string | null
           current_city_id?: string | null
@@ -887,6 +889,7 @@ export type Database = {
           age?: number | null
           avatar_url?: string | null
           bio?: string | null
+          equipped_clothing?: Json | null
           cash?: number | null
           city_of_birth?: string | null
           current_city_id?: string | null

--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -36,6 +36,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth-context";
 import {
   useGameData,
+  type PlayerProfile,
   type SkillDefinition,
   type SkillProgressUpsertInput,
   type SkillUnlockUpsertInput,
@@ -755,6 +756,23 @@ const CharacterCreation = () => {
       if (!upsertedProfile) {
         throw new Error("Profile save did not return any data.");
       }
+
+      const ensuredLoadout = await ensureDefaultWardrobe(
+        upsertedProfile.id,
+        user.id,
+        parseClothingLoadout(
+          (existingProfile ?? upsertedProfile)?.equipped_clothing,
+        ),
+      );
+
+      if (ensuredLoadout) {
+        upsertedProfile = {
+          ...upsertedProfile,
+          equipped_clothing: ensuredLoadout as PlayerProfile["equipped_clothing"],
+        };
+      }
+
+      setExistingProfile(upsertedProfile);
 
       const attributePoints = existingAttributesRow?.attribute_points ?? 0;
       const normalizedSkillsPayload = (Object.keys(defaultSkills) as SkillKey[]).reduce<


### PR DESCRIPTION
## Summary
- trigger default wardrobe setup immediately after profile upsert in character creation
- persist the ensured clothing loadout in component state for immediate UI updates
- extend Supabase profile types with the equipped_clothing JSON column

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc07d38cf483259ac67a8b19793f9d