### PR TITLE
Add city reference to venues

### DIFF
--- a/supabase/migrations/20261030120000_add_city_reference_to_venues.sql
+++ b/supabase/migrations/20261030120000_add_city_reference_to_venues.sql
@@ -1,0 +1,22 @@
+-- Ensure venues link to a city record for geographic context
+ALTER TABLE public.venues
+  ADD COLUMN IF NOT EXISTS city_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.venues'::regclass
+      AND conname = 'venues_city_id_fkey'
+  ) THEN
+    ALTER TABLE public.venues
+      ADD CONSTRAINT venues_city_id_fkey
+      FOREIGN KEY (city_id)
+      REFERENCES public.cities(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS venues_city_id_idx ON public.venues(city_id);


### PR DESCRIPTION
## Summary
- add a backwards-compatible migration that ensures venues have a nullable city_id column
- create a foreign key from venues.city_id to cities.id with cascading updates and safe constraint creation
- add an index on venues.city_id to support filtering by city

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc201e8f4c83259b8017738e1be2a4