### PR TITLE
Expand skill range to match backend

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -79,7 +79,7 @@ const backgrounds = [
 
 const TOTAL_SKILL_POINTS = 0;
 const MIN_SKILL_VALUE = 0;
-const MAX_SKILL_VALUE = 10;
+const MAX_SKILL_VALUE = 100;
 const ATTRIBUTE_MIN_VALUE = 0;
 const ATTRIBUTE_MAX_VALUE = 3;
 const ATTRIBUTE_SLIDER_STEP = 0.1;
@@ -190,6 +190,19 @@ const defaultSkills = {
   technical: 0,
 };
 
+const normalizeSkillValue = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(MIN_SKILL_VALUE, Math.min(MAX_SKILL_VALUE, value));
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return MIN_SKILL_VALUE;
+  }
+
+  return Math.max(MIN_SKILL_VALUE, Math.min(MAX_SKILL_VALUE, numeric));
+};
+
 const ATTRIBUTE_KEYS = [
   "mental_focus",
   "physical_endurance",
@@ -219,13 +232,8 @@ const buildSkillState = (
   }
 
   (Object.keys(defaultSkills) as SkillKey[]).forEach((key) => {
-    const value = record[key];
-
-    if (typeof value === "number") {
-      resolved[key] = Math.max(
-        MIN_SKILL_VALUE,
-        Math.min(MAX_SKILL_VALUE, value),
-      );
+    if (key in record) {
+      resolved[key] = normalizeSkillValue(record[key]);
     }
   });
 
@@ -482,7 +490,7 @@ const CharacterCreation = () => {
           });
         }
 
-        setSkills(mergedSkills);
+        setSkills(buildSkillState(mergedSkills));
 
         setExistingAttributesRow(attributesRow);
         setAttributes(buildAttributeState(attributesRow));
@@ -576,7 +584,7 @@ const CharacterCreation = () => {
   const handleSkillChange = (key: SkillKey, value: number) => {
     setSkills((prev) => {
       const currentValue = prev[key];
-      const clampedValue = Math.max(MIN_SKILL_VALUE, Math.min(MAX_SKILL_VALUE, value));
+      const clampedValue = normalizeSkillValue(value);
 
       if (clampedValue === currentValue) {
         return prev;
@@ -785,14 +793,7 @@ const CharacterCreation = () => {
         Record<string, number>
       >((accumulator, key) => {
         const rawValue = skills[key];
-        const numericValue = Math.max(
-          MIN_SKILL_VALUE,
-          Math.min(
-            MAX_SKILL_VALUE,
-            Number.isFinite(rawValue) ? Number(rawValue) : MIN_SKILL_VALUE,
-          ),
-        );
-        accumulator[key] = numericValue;
+        accumulator[key] = normalizeSkillValue(rawValue);
         return accumulator;
       }, {});
 
@@ -1323,7 +1324,7 @@ const CharacterCreation = () => {
               Skill Distribution
             </CardTitle>
             <CardDescription>
-              Allocate your starting strengths across musical and career disciplines. Every skill ranges from 0-10 and influences early gameplay systems.
+              Allocate your starting strengths across musical and career disciplines. Every skill ranges from 0-100 and influences early gameplay systems.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">


### PR DESCRIPTION
## Summary
- raise the front-end skill cap to 100 and update related copy to match the backend schema
- normalize skill value handling when loading, editing, and persisting profiles to honor the expanded bounds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2a3401a88325863bae047b4a40ab