### PR TITLE
feat: scaffold xp progression tables and types

### DIFF
--- a/docs/xp-schema.md
+++ b/docs/xp-schema.md
@@ -1,0 +1,101 @@
+# XP Progression Schema
+
+This document outlines the database primitives that back the upcoming XP and attribute progression systems. All tables live in the `public` schema and use `profiles.id` as the canonical foreign key for player-facing rows.
+
+## Tables
+
+### `player_xp_wallet`
+- **Purpose:** Stores the running totals for spendable XP and derived point balances.
+- **Columns:**
+  - `profile_id uuid PK` – references `profiles.id` with `ON DELETE CASCADE`.
+  - `xp_balance integer` – spendable XP remaining after deductions.
+  - `lifetime_xp integer` – cumulative XP earned by the profile.
+  - `xp_spent integer` – total XP consumed for any sink.
+  - `attribute_points_earned integer` – total attribute points granted from conversions.
+  - `skill_points_earned integer` – total skill points granted from conversions.
+  - `last_recalculated timestamptz` – timestamp of the last wallet reconciliation.
+- **Indexes:** `idx_player_xp_wallet_updated_at` (`last_recalculated DESC`).
+
+### `xp_ledger`
+- **Purpose:** Immutable audit trail of XP mutations for analytics and support.
+- **Columns:**
+  - `id uuid PK`.
+  - `profile_id uuid` – FK to `profiles` (`ON DELETE CASCADE`).
+  - `event_type text` – categorises the source (e.g. `gig_reward`, `daily_conversion`).
+  - `xp_delta integer` – signed XP change for the event.
+  - `balance_after integer` – wallet balance immediately after applying the entry.
+  - `attribute_points_delta integer` – attribute points granted/consumed in the same action.
+  - `skill_points_delta integer` – skill points granted/consumed in the same action.
+  - `metadata jsonb` – optional structured context (payload IDs, modifiers, etc.).
+  - `created_at timestamptz` – UTC timestamp of the event.
+- **Constraints:** `xp_ledger_non_zero_change` ensures at least one of the deltas is non-zero.
+- **Indexes:**
+  - `idx_xp_ledger_profile_created_at` on (`profile_id`, `created_at DESC`).
+  - `idx_xp_ledger_event_type` on (`event_type`).
+
+### `player_attributes`
+- **Purpose:** Canonical snapshot of a profile's attribute distribution.
+- **Columns:**
+  - `id uuid PK`.
+  - `profile_id uuid` – FK to `profiles` (`ON DELETE CASCADE`).
+  - `created_at`, `updated_at` timestamptz.
+  - `attribute_points integer` – total points currently banked.
+  - `attribute_points_spent integer` – lifetime points invested into attributes.
+  - Eight legacy progression stats kept for backwards compatibility: `physical_endurance`, `mental_focus`, `stage_presence`, `crowd_engagement`, `social_reach`, `creativity`, `technical`, `business`, `marketing`, `composition`.
+  - New growth-focused attributes: `musical_ability`, `vocal_talent`, `rhythm_sense`, `creative_insight`, `technical_mastery`, `business_acumen`, `marketing_savvy`.
+- **Constraints:** `player_attributes_value_bounds` clamps all tracked attributes between 0 and 1,000.
+- **Indexes:** `idx_player_attributes_profile_id` enforces a one-to-one relationship with `profiles`.
+
+### `player_weekly_activity`
+- **Purpose:** Aggregated XP and activity counters for cadence dashboards and streak systems.
+- **Columns:**
+  - `id uuid PK`.
+  - `profile_id uuid` – FK to `profiles` (`ON DELETE CASCADE`).
+  - `week_start date` – Monday-aligned week anchor.
+  - `xp_earned`, `xp_spent integer`.
+  - `sessions_completed`, `quests_completed`, `rehearsals_logged integer` – gameplay counters.
+  - `created_at`, `updated_at` timestamptz.
+- **Constraints/Indexes:**
+  - Unique constraint on (`profile_id`, `week_start`).
+  - Indexes on `profile_id` and `week_start DESC` for reporting queries.
+
+### `player_daily_cats`
+- **Purpose:** Daily XP rollups by gameplay category to power streaks and balancing logic.
+- **Columns:**
+  - `id uuid PK`.
+  - `profile_id uuid` – FK to `profiles` (`ON DELETE CASCADE`).
+  - `activity_date date` – UTC day bucket.
+  - `category text` – constrained to `practice`, `performance`, `quest`, `social`, `other`.
+  - `xp_earned`, `xp_spent integer` – per-category totals.
+  - `activity_count integer` – number of contributing actions.
+  - `metadata jsonb` – optional payload details (event IDs, multipliers, etc.).
+  - `created_at`, `updated_at` timestamptz.
+- **Constraints/Indexes:**
+  - Unique constraint on (`profile_id`, `activity_date`, `category`).
+  - Indexes on `profile_id` and `activity_date DESC`.
+
+### `attribute_spend`
+- **Purpose:** Lightweight ledger of attribute upgrade purchases.
+- **Columns:**
+  - `id uuid PK`.
+  - `profile_id uuid` – FK to `profiles` (`ON DELETE CASCADE`).
+  - `attribute_key text` – one of the seven modern attributes listed above.
+  - `points_spent integer` – number of attribute points consumed (> 0).
+  - `xp_cost integer` – XP cost charged for the spend (>= 0).
+  - `metadata jsonb` – optional context (source screen, modifiers, etc.).
+  - `created_at timestamptz` – UTC timestamp.
+- **Indexes:** on (`profile_id`, `created_at DESC`) and on `attribute_key`.
+
+## XP Cost Curve Reference
+
+Keep the following constants aligned across database procedures and frontend helpers:
+
+- **Daily conversion rates** (see `process_daily_point_conversions`):
+  - `skill_rate = 150` XP → 1 skill point.
+  - `attribute_rate = 400` XP → 1 attribute point.
+- **Attribute training helpers** (`src/utils/attributeProgression.ts`):
+  - `ATTRIBUTE_MAX_VALUE = 1000`.
+  - `ATTRIBUTE_TRAINING_INCREMENT = 10` points per training session.
+  - `getAttributeTrainingCost(currentValue) = ceil(120 + currentValue × 0.85)` XP.
+
+Future services should use these tables and constants when granting rewards, spending XP, or surfacing UI summaries so player balances stay consistent end-to-end.

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -91,6 +91,44 @@ export type Database = {
           },
         ]
       }
+      attribute_spend: {
+        Row: {
+          attribute_key: string
+          created_at: string
+          id: string
+          metadata: Json | null
+          points_spent: number
+          profile_id: string
+          xp_cost: number
+        }
+        Insert: {
+          attribute_key: string
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          points_spent: number
+          profile_id: string
+          xp_cost: number
+        }
+        Update: {
+          attribute_key?: string
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          points_spent?: number
+          profile_id?: string
+          xp_cost?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "attribute_spend_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       band_members: {
         Row: {
           band_id: string
@@ -594,60 +632,131 @@ export type Database = {
           },
         ]
       }
+      player_daily_cats: {
+        Row: {
+          activity_count: number
+          activity_date: string
+          category: string
+          created_at: string
+          id: string
+          metadata: Json | null
+          profile_id: string
+          updated_at: string
+          xp_earned: number
+          xp_spent: number
+        }
+        Insert: {
+          activity_count?: number
+          activity_date: string
+          category: string
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          updated_at?: string
+          xp_earned?: number
+          xp_spent?: number
+        }
+        Update: {
+          activity_count?: number
+          activity_date?: string
+          category?: string
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          updated_at?: string
+          xp_earned?: number
+          xp_spent?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "player_daily_cats_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       player_attributes: {
         Row: {
           attribute_points: number | null
+          attribute_points_spent: number | null
           business: number | null
+          business_acumen: number | null
           composition: number | null
           created_at: string | null
+          creative_insight: number | null
           creativity: number | null
           crowd_engagement: number | null
           id: string
           marketing: number | null
+          marketing_savvy: number | null
           mental_focus: number | null
+          musical_ability: number | null
           physical_endurance: number | null
           profile_id: string | null
+          rhythm_sense: number | null
           social_reach: number | null
           stage_presence: number | null
           technical: number | null
+          technical_mastery: number | null
           updated_at: string | null
-          user_id: string
+          user_id: string | null
+          vocal_talent: number | null
         }
         Insert: {
           attribute_points?: number | null
+          attribute_points_spent?: number | null
           business?: number | null
+          business_acumen?: number | null
           composition?: number | null
           created_at?: string | null
+          creative_insight?: number | null
           creativity?: number | null
           crowd_engagement?: number | null
           id?: string
           marketing?: number | null
+          marketing_savvy?: number | null
           mental_focus?: number | null
+          musical_ability?: number | null
           physical_endurance?: number | null
           profile_id?: string | null
+          rhythm_sense?: number | null
           social_reach?: number | null
           stage_presence?: number | null
           technical?: number | null
+          technical_mastery?: number | null
           updated_at?: string | null
-          user_id: string
+          user_id?: string | null
+          vocal_talent?: number | null
         }
         Update: {
           attribute_points?: number | null
+          attribute_points_spent?: number | null
           business?: number | null
+          business_acumen?: number | null
           composition?: number | null
           created_at?: string | null
+          creative_insight?: number | null
           creativity?: number | null
           crowd_engagement?: number | null
           id?: string
           marketing?: number | null
+          marketing_savvy?: number | null
           mental_focus?: number | null
+          musical_ability?: number | null
           physical_endurance?: number | null
           profile_id?: string | null
+          rhythm_sense?: number | null
           social_reach?: number | null
           stage_presence?: number | null
           technical?: number | null
+          technical_mastery?: number | null
           updated_at?: string | null
-          user_id?: string
+          user_id?: string | null
+          vocal_talent?: number | null
         }
         Relationships: [
           {
@@ -767,6 +876,91 @@ export type Database = {
             foreignKeyName: "player_skills_profile_id_fkey"
             columns: ["profile_id"]
             isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      player_weekly_activity: {
+        Row: {
+          created_at: string
+          id: string
+          profile_id: string
+          quests_completed: number
+          rehearsals_logged: number
+          sessions_completed: number
+          updated_at: string
+          week_start: string
+          xp_earned: number
+          xp_spent: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          profile_id: string
+          quests_completed?: number
+          rehearsals_logged?: number
+          sessions_completed?: number
+          updated_at?: string
+          week_start: string
+          xp_earned?: number
+          xp_spent?: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          profile_id?: string
+          quests_completed?: number
+          rehearsals_logged?: number
+          sessions_completed?: number
+          updated_at?: string
+          week_start?: string
+          xp_earned?: number
+          xp_spent?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "player_weekly_activity_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      player_xp_wallet: {
+        Row: {
+          attribute_points_earned: number
+          lifetime_xp: number
+          profile_id: string
+          skill_points_earned: number
+          xp_balance: number
+          xp_spent: number
+          last_recalculated: string
+        }
+        Insert: {
+          attribute_points_earned?: number
+          lifetime_xp?: number
+          profile_id: string
+          skill_points_earned?: number
+          xp_balance?: number
+          xp_spent?: number
+          last_recalculated?: string
+        }
+        Update: {
+          attribute_points_earned?: number
+          lifetime_xp?: number
+          profile_id?: string
+          skill_points_earned?: number
+          xp_balance?: number
+          xp_spent?: number
+          last_recalculated?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "player_xp_wallet_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: true
             referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
@@ -1165,6 +1359,50 @@ export type Database = {
             columns: ["band_id"]
             isOneToOne: false
             referencedRelation: "bands"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      xp_ledger: {
+        Row: {
+          attribute_points_delta: number
+          balance_after: number
+          created_at: string
+          event_type: string
+          id: string
+          metadata: Json | null
+          profile_id: string
+          skill_points_delta: number
+          xp_delta: number
+        }
+        Insert: {
+          attribute_points_delta?: number
+          balance_after: number
+          created_at?: string
+          event_type: string
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          skill_points_delta?: number
+          xp_delta: number
+        }
+        Update: {
+          attribute_points_delta?: number
+          balance_after?: number
+          created_at?: string
+          event_type?: string
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          skill_points_delta?: number
+          xp_delta?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "xp_ledger_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -203,6 +203,255 @@ export interface Database {
           updated_at?: string
         }
       }
+      player_attributes: {
+        Row: {
+          id: string
+          profile_id: string
+          created_at: string
+          updated_at: string
+          attribute_points: number
+          attribute_points_spent: number
+          physical_endurance: number
+          mental_focus: number
+          stage_presence: number
+          crowd_engagement: number
+          social_reach: number
+          creativity: number
+          technical: number
+          business: number
+          marketing: number
+          composition: number
+          musical_ability: number
+          vocal_talent: number
+          rhythm_sense: number
+          creative_insight: number
+          technical_mastery: number
+          business_acumen: number
+          marketing_savvy: number
+          user_id: string | null
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          created_at?: string
+          updated_at?: string
+          attribute_points?: number
+          attribute_points_spent?: number
+          physical_endurance?: number
+          mental_focus?: number
+          stage_presence?: number
+          crowd_engagement?: number
+          social_reach?: number
+          creativity?: number
+          technical?: number
+          business?: number
+          marketing?: number
+          composition?: number
+          musical_ability?: number
+          vocal_talent?: number
+          rhythm_sense?: number
+          creative_insight?: number
+          technical_mastery?: number
+          business_acumen?: number
+          marketing_savvy?: number
+          user_id?: string | null
+        }
+        Update: {
+          id?: string
+          profile_id?: string
+          created_at?: string
+          updated_at?: string
+          attribute_points?: number
+          attribute_points_spent?: number
+          physical_endurance?: number
+          mental_focus?: number
+          stage_presence?: number
+          crowd_engagement?: number
+          social_reach?: number
+          creativity?: number
+          technical?: number
+          business?: number
+          marketing?: number
+          composition?: number
+          musical_ability?: number
+          vocal_talent?: number
+          rhythm_sense?: number
+          creative_insight?: number
+          technical_mastery?: number
+          business_acumen?: number
+          marketing_savvy?: number
+          user_id?: string | null
+        }
+      }
+      player_daily_cats: {
+        Row: {
+          id: string
+          profile_id: string
+          activity_date: string
+          category: string
+          xp_earned: number
+          xp_spent: number
+          activity_count: number
+          metadata: Json | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          activity_date: string
+          category: string
+          xp_earned?: number
+          xp_spent?: number
+          activity_count?: number
+          metadata?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          profile_id?: string
+          activity_date?: string
+          category?: string
+          xp_earned?: number
+          xp_spent?: number
+          activity_count?: number
+          metadata?: Json | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      player_weekly_activity: {
+        Row: {
+          id: string
+          profile_id: string
+          week_start: string
+          xp_earned: number
+          xp_spent: number
+          sessions_completed: number
+          quests_completed: number
+          rehearsals_logged: number
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          week_start: string
+          xp_earned?: number
+          xp_spent?: number
+          sessions_completed?: number
+          quests_completed?: number
+          rehearsals_logged?: number
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          profile_id?: string
+          week_start?: string
+          xp_earned?: number
+          xp_spent?: number
+          sessions_completed?: number
+          quests_completed?: number
+          rehearsals_logged?: number
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      player_xp_wallet: {
+        Row: {
+          profile_id: string
+          xp_balance: number
+          lifetime_xp: number
+          xp_spent: number
+          attribute_points_earned: number
+          skill_points_earned: number
+          last_recalculated: string
+        }
+        Insert: {
+          profile_id: string
+          xp_balance?: number
+          lifetime_xp?: number
+          xp_spent?: number
+          attribute_points_earned?: number
+          skill_points_earned?: number
+          last_recalculated?: string
+        }
+        Update: {
+          profile_id?: string
+          xp_balance?: number
+          lifetime_xp?: number
+          xp_spent?: number
+          attribute_points_earned?: number
+          skill_points_earned?: number
+          last_recalculated?: string
+        }
+      }
+      attribute_spend: {
+        Row: {
+          id: string
+          profile_id: string
+          attribute_key: string
+          points_spent: number
+          xp_cost: number
+          metadata: Json | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          attribute_key: string
+          points_spent: number
+          xp_cost: number
+          metadata?: Json | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          profile_id?: string
+          attribute_key?: string
+          points_spent?: number
+          xp_cost?: number
+          metadata?: Json | null
+          created_at?: string
+        }
+      }
+      xp_ledger: {
+        Row: {
+          id: string
+          profile_id: string
+          event_type: string
+          xp_delta: number
+          balance_after: number
+          attribute_points_delta: number
+          skill_points_delta: number
+          metadata: Json | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          profile_id: string
+          event_type: string
+          xp_delta: number
+          balance_after: number
+          attribute_points_delta?: number
+          skill_points_delta?: number
+          metadata?: Json | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          profile_id?: string
+          event_type?: string
+          xp_delta?: number
+          balance_after?: number
+          attribute_points_delta?: number
+          skill_points_delta?: number
+          metadata?: Json | null
+          created_at?: string
+        }
+      }
     }
     Views: Record<string, never>
     Functions: Record<string, never>

--- a/supabase/migrations/20261030130000_create_xp_tables.sql
+++ b/supabase/migrations/20261030130000_create_xp_tables.sql
@@ -1,0 +1,174 @@
+-- XP progression and attribute tracking foundations
+
+-- Wallet storing spendable XP and aggregated counters
+CREATE TABLE IF NOT EXISTS public.player_xp_wallet (
+  profile_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  xp_balance integer NOT NULL DEFAULT 0 CHECK (xp_balance >= 0),
+  lifetime_xp integer NOT NULL DEFAULT 0 CHECK (lifetime_xp >= 0),
+  xp_spent integer NOT NULL DEFAULT 0 CHECK (xp_spent >= 0),
+  attribute_points_earned integer NOT NULL DEFAULT 0 CHECK (attribute_points_earned >= 0),
+  skill_points_earned integer NOT NULL DEFAULT 0 CHECK (skill_points_earned >= 0),
+  last_recalculated timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_xp_wallet_updated_at
+  ON public.player_xp_wallet (last_recalculated DESC);
+
+-- Ledger capturing individual XP movements for auditing and analytics
+CREATE TABLE IF NOT EXISTS public.xp_ledger (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  xp_delta integer NOT NULL,
+  balance_after integer NOT NULL CHECK (balance_after >= 0),
+  attribute_points_delta integer NOT NULL DEFAULT 0,
+  skill_points_delta integer NOT NULL DEFAULT 0,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT xp_ledger_non_zero_change CHECK (
+    xp_delta <> 0 OR attribute_points_delta <> 0 OR skill_points_delta <> 0
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_xp_ledger_profile_created_at
+  ON public.xp_ledger (profile_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_xp_ledger_event_type
+  ON public.xp_ledger (event_type);
+
+-- Ensure a consistent structure for player attributes focused on profiles
+CREATE TABLE IF NOT EXISTS public.player_attributes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.player_attributes
+  ADD COLUMN IF NOT EXISTS attribute_points integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS attribute_points_spent integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS physical_endurance integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS mental_focus integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS stage_presence integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS crowd_engagement integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS social_reach integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS creativity integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS technical integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS business integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS marketing integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS composition integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS musical_ability integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS vocal_talent integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rhythm_sense integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS creative_insight integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS technical_mastery integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS business_acumen integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS marketing_savvy integer NOT NULL DEFAULT 0;
+
+ALTER TABLE public.player_attributes
+  DROP CONSTRAINT IF EXISTS player_attributes_profile_id_fkey,
+  ADD CONSTRAINT player_attributes_profile_id_fkey
+    FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_player_attributes_profile_id
+  ON public.player_attributes (profile_id);
+
+ALTER TABLE public.player_attributes
+  DROP CONSTRAINT IF EXISTS player_attributes_value_bounds;
+
+ALTER TABLE public.player_attributes
+  ADD CONSTRAINT player_attributes_value_bounds CHECK (
+    physical_endurance BETWEEN 0 AND 1000 AND
+    mental_focus BETWEEN 0 AND 1000 AND
+    stage_presence BETWEEN 0 AND 1000 AND
+    crowd_engagement BETWEEN 0 AND 1000 AND
+    social_reach BETWEEN 0 AND 1000 AND
+    creativity BETWEEN 0 AND 1000 AND
+    technical BETWEEN 0 AND 1000 AND
+    business BETWEEN 0 AND 1000 AND
+    marketing BETWEEN 0 AND 1000 AND
+    composition BETWEEN 0 AND 1000 AND
+    musical_ability BETWEEN 0 AND 1000 AND
+    vocal_talent BETWEEN 0 AND 1000 AND
+    rhythm_sense BETWEEN 0 AND 1000 AND
+    creative_insight BETWEEN 0 AND 1000 AND
+    technical_mastery BETWEEN 0 AND 1000 AND
+    business_acumen BETWEEN 0 AND 1000 AND
+    marketing_savvy BETWEEN 0 AND 1000
+  );
+
+-- Weekly aggregation of player XP activity for dashboards and cadence systems
+CREATE TABLE IF NOT EXISTS public.player_weekly_activity (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  week_start date NOT NULL,
+  xp_earned integer NOT NULL DEFAULT 0,
+  xp_spent integer NOT NULL DEFAULT 0,
+  sessions_completed integer NOT NULL DEFAULT 0,
+  quests_completed integer NOT NULL DEFAULT 0,
+  rehearsals_logged integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT player_weekly_activity_unique_week UNIQUE (profile_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_weekly_activity_profile
+  ON public.player_weekly_activity (profile_id);
+
+CREATE INDEX IF NOT EXISTS idx_player_weekly_activity_week
+  ON public.player_weekly_activity (week_start DESC);
+
+-- Daily category rollups support streaks and balancing across activity types
+CREATE TABLE IF NOT EXISTS public.player_daily_cats (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  activity_date date NOT NULL,
+  category text NOT NULL,
+  xp_earned integer NOT NULL DEFAULT 0,
+  xp_spent integer NOT NULL DEFAULT 0,
+  activity_count integer NOT NULL DEFAULT 0,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT player_daily_cats_unique_day UNIQUE (profile_id, activity_date, category),
+  CONSTRAINT player_daily_cats_valid_category CHECK (
+    category = ANY (ARRAY['practice', 'performance', 'quest', 'social', 'other'])
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_daily_cats_profile
+  ON public.player_daily_cats (profile_id);
+
+CREATE INDEX IF NOT EXISTS idx_player_daily_cats_date
+  ON public.player_daily_cats (activity_date DESC);
+
+-- Attribute spend receipts provide a lightweight audit of player growth decisions
+CREATE TABLE IF NOT EXISTS public.attribute_spend (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  attribute_key text NOT NULL,
+  points_spent integer NOT NULL CHECK (points_spent > 0),
+  xp_cost integer NOT NULL CHECK (xp_cost >= 0),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  metadata jsonb,
+  CONSTRAINT attribute_spend_valid_key CHECK (
+    attribute_key = ANY (
+      ARRAY[
+        'musical_ability',
+        'vocal_talent',
+        'rhythm_sense',
+        'stage_presence',
+        'creative_insight',
+        'technical_mastery',
+        'business_acumen',
+        'marketing_savvy'
+      ]
+    )
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_attribute_spend_profile
+  ON public.attribute_spend (profile_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_attribute_spend_attribute
+  ON public.attribute_spend (attribute_key);


### PR DESCRIPTION
## Summary
- add an XP progression migration that seeds wallet, ledger, daily/weekly rollups, and attribute spend tracking tied to profiles
- expose the new tables plus expanded attribute columns through the generated Supabase types and the simplified wrapper
- document the schema additions and XP cost curve constants for follow-up service and UI work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2b37bff08325a042bd24ab708fe3