### PR TITLE
feat: add progression edge function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,7 @@
 project_id = "yztogmdixmchsmimtent"
+
+[functions.promotions]
+verify_jwt = false
+
+[functions.progression]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- scaffold a new progression edge function that routes incoming requests to XP and attribute handlers with shared auth and profile loading
- add transactional RPC wrappers, anti-abuse safeguards, and cooldown reporting so ledger, wallet, and profile state stay consistent after each action
- register the progression edge function in Supabase configuration for deployment alongside existing edge functions

## Testing
- `deno fmt supabase/functions/progression/index.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2e045e9483258fcc2929b71e2adc