### PR TITLE
Integrate gig/tour XP awards with progression service

### DIFF
--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -555,6 +555,7 @@ const Busking = () => {
     profile,
     skills,
     attributes,
+    xpWallet,
     updateProfile,
     updateAttributes,
     addActivity,
@@ -585,6 +586,7 @@ const Busking = () => {
       socialReach: resolveAttributeValue(source, "social_reach", 1),
     };
   }, [cachedAttributes]);
+  const totalExperience = Number(xpWallet?.lifetime_xp ?? profile?.experience ?? 0);
 
   const cityBuskingValue = useMemo(() => {
     if (!currentCity) return 1;
@@ -1291,7 +1293,7 @@ const Busking = () => {
               <Award className="h-4 w-4 text-accent" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-accent">{profile.experience ?? 0}</div>
+              <div className="text-2xl font-bold text-accent">{totalExperience}</div>
               <p className="text-xs text-muted-foreground">Every street set sharpens your craft.</p>
             </CardContent>
           </Card>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -38,6 +38,7 @@ const Dashboard = () => {
     attributes,
     activities,
     experienceLedger,
+    xpWallet,
     loading,
     error,
     freshWeeklyBonusAvailable
@@ -185,7 +186,8 @@ const Dashboard = () => {
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   };
 
-  const experienceProgress = profile.experience % 1000;
+  const totalExperience = Number(xpWallet?.lifetime_xp ?? profile?.experience ?? 0);
+  const experienceProgress = totalExperience % 1000;
   const latestWeeklyBonus = experienceLedger.find(entry => entry.reason === "weekly_bonus");
   const latestWeeklyMetadata = (latestWeeklyBonus?.metadata as Record<string, unknown> | null) ?? null;
   const weeklyBonusAmount = latestWeeklyBonus

--- a/src/pages/GigBooking.tsx
+++ b/src/pages/GigBooking.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/utils/gameBalance";
 import { applyEquipmentWear } from "@/utils/equipmentWear";
 import { fetchEnvironmentModifiers, type EnvironmentModifierSummary, type AppliedEnvironmentEffect } from "@/utils/worldEnvironment";
+import { awardActionXp } from "@/utils/progression";
 import type { Database, Json } from "@/integrations/supabase/types";
 
 type VenueRow = Database["public"]["Tables"]["venues"]["Row"];
@@ -69,6 +70,16 @@ const SHOW_TYPE_DETAILS: Record<ShowType, {
     fanMultiplier: 1.2,
     experienceModifier: 1.15,
   },
+};
+
+const SHOW_TYPE_DURATION_SECONDS: Record<ShowType, number> = {
+  standard: 7200,
+  acoustic: 5400,
+};
+
+const SHOW_TYPE_COLLABORATION_SIZE: Record<ShowType, number> = {
+  standard: 5,
+  acoustic: 3,
 };
 
 const SHOW_TYPE_OPTIONS: Array<{ value: ShowType; label: string; description: string }> = Object.entries(SHOW_TYPE_DETAILS).map(([value, detail]) => ({
@@ -167,7 +178,16 @@ const normalizeVenueRequirements = (
 const GigBooking = () => {
   const { toast } = useToast();
   const { user } = useAuth();
-  const { profile, skills, attributes, currentCity, updateProfile, updateAttributes, addActivity } = useGameData();
+  const {
+    profile,
+    skills,
+    attributes,
+    currentCity,
+    updateProfile,
+    updateAttributes,
+    addActivity,
+    refreshProgressionState,
+  } = useGameData();
   const attributeScores = useMemo(() => extractAttributeScores(attributes), [attributes]);
   const [venues, setVenues] = useState<Venue[]>([]);
   const [playerGigs, setPlayerGigs] = useState<Gig[]>([]);
@@ -698,11 +718,49 @@ const GigBooking = () => {
       const newFame = (profile.fame || 0) + fanGain;
       const baseExperience = (attendance / 10) * showTypeDetails.experienceModifier;
       const expGain = Math.max(1, calculateExperienceReward(baseExperience, attributeScores, "performance"));
+      const performanceRatio = Math.max(0, Math.min(1, isSuccess ? successBase : failureBase));
+      const finalScore = Number((performanceRatio * 100).toFixed(2));
+      const showDurationSeconds = SHOW_TYPE_DURATION_SECONDS[showType] ?? SHOW_TYPE_DURATION_SECONDS[DEFAULT_SHOW_TYPE];
+      const collaborationSize = SHOW_TYPE_COLLABORATION_SIZE[showType] ?? SHOW_TYPE_COLLABORATION_SIZE[DEFAULT_SHOW_TYPE];
+      const attendanceCapacityRatio = capacity > 0 ? Number((attendance / capacity).toFixed(3)) : null;
+      const professionalismIndicators = {
+        crowd_engagement: performanceRatio >= 0.65,
+        technical_precision: moraleMultiplier >= 1,
+        stayed_on_schedule: true,
+      };
+
+      const xpMetadata: Record<string, unknown> = {
+        gig_id: gig.id,
+        show_type: showType,
+        show_duration_seconds: showDurationSeconds,
+        venue_tier: gig.venue.prestige_level ?? 0,
+        final_score: finalScore,
+        attendance,
+        collaboration_size: collaborationSize,
+        professionalism: professionalismIndicators,
+        success: isSuccess,
+      };
+
+      if (attendanceCapacityRatio !== null) {
+        xpMetadata.attendance_capacity_ratio = attendanceCapacityRatio;
+      }
+
+      if (environmentModifiers?.applied) {
+        xpMetadata.environment_modifiers_applied = environmentModifiers.applied.length;
+      }
+
+      await awardActionXp({
+        amount: expGain,
+        actionKey: "gig_booking_performance",
+        metadata: xpMetadata,
+        uniqueEventId: gig.id,
+      });
+
+      await refreshProgressionState();
 
       await updateProfile({
         cash: newCash,
         fame: newFame,
-        experience: (profile.experience || 0) + expGain
       });
 
       const attributeUpdates: Partial<Record<AttributeKey, number>> = {};

--- a/src/pages/PlayerStatistics.tsx
+++ b/src/pages/PlayerStatistics.tsx
@@ -358,7 +358,7 @@ const resolveSkillBadge = (value: number) => {
 
 const PlayerStatistics = () => {
   const { user } = useAuth();
-  const { profile, skills, attributes, skillDefinitions } = useGameData();
+  const { profile, skills, attributes, skillDefinitions, xpWallet } = useGameData();
   const instrumentSkillKeys: (keyof PlayerSkills)[] = [
     "performance",
     "songwriting",
@@ -827,7 +827,8 @@ const PlayerStatistics = () => {
     );
   }
 
-  const playerLevel = calculateLevel(profile.experience);
+  const totalExperience = Number(xpWallet?.lifetime_xp ?? profile.experience ?? 0);
+  const playerLevel = calculateLevel(totalExperience);
   const fameTitle = getFameTitle(profile.fame);
   const playerAvatarLabel = (profile.display_name || profile.username || 'P').slice(0, 2).toUpperCase();
   const MetricIcon = metricConfig.icon;
@@ -1416,7 +1417,7 @@ const PlayerStatistics = () => {
                   </div>
                   <div className="flex justify-between">
                     <span>Experience:</span>
-                    <span className="font-bold text-blue-600">{profile.experience.toLocaleString()}</span>
+                    <span className="font-bold text-blue-600">{totalExperience.toLocaleString()}</span>
                   </div>
                 </CardContent>
               </Card>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -93,7 +93,15 @@ const Profile = () => {
   const { toast } = useToast();
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { profile, skills, attributes, updateProfile, freshWeeklyBonusAvailable, experienceLedger } = useGameData();
+  const {
+    profile,
+    skills,
+    attributes,
+    xpWallet,
+    updateProfile,
+    freshWeeklyBonusAvailable,
+    experienceLedger
+  } = useGameData();
   const { items: equippedClothing } = useEquippedClothing();
 
   const instrumentSkillKeys: (keyof PlayerSkills)[] = [
@@ -183,6 +191,7 @@ const Profile = () => {
       }).format(weeklyBonusRecorded)
     : null;
   const recentLedgerEntries = experienceLedger.slice(0, 5);
+  const totalExperience = Number(xpWallet?.lifetime_xp ?? profile?.experience ?? 0);
 
   useEffect(() => {
     if (!showProfileDetails) {
@@ -811,8 +820,8 @@ const Profile = () => {
                 </CardHeader>
                 <CardContent>
                   <div className="text-2xl font-bold text-primary">{profile.level || 1}</div>
-                  <Progress value={((profile.experience || 0) % 1000) / 10} className="h-2 mt-2" />
-                  <p className="text-xs text-muted-foreground mt-1">{profile.experience || 0} XP</p>
+                  <Progress value={(totalExperience % 1000) / 10} className="h-2 mt-2" />
+                  <p className="text-xs text-muted-foreground mt-1">{totalExperience} XP</p>
                 </CardContent>
               </Card>
 
@@ -844,7 +853,7 @@ const Profile = () => {
                   <Trophy className="h-4 w-4 text-warning" />
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold text-warning">{profile.experience || 0}</div>
+                  <div className="text-2xl font-bold text-warning">{totalExperience}</div>
                   <p className="text-xs text-muted-foreground">Total XP earned</p>
                 </CardContent>
               </Card>

--- a/src/pages/SkillTraining.tsx
+++ b/src/pages/SkillTraining.tsx
@@ -197,6 +197,7 @@ const SkillTrainingContent = () => {
     profile,
     skills,
     attributes,
+    xpWallet,
     updateProfile,
     addActivity,
     loading: gameDataLoading
@@ -215,6 +216,7 @@ const SkillTrainingContent = () => {
 
   const playerLevel = Number(profile?.level ?? 1);
   const totalExperience = Number(profile?.experience ?? 0);
+  const displayExperience = Number(xpWallet?.lifetime_xp ?? totalExperience);
   const skillCap = getSkillCap(playerLevel, totalExperience);
 
   const availableDefinitions = useMemo(() => {
@@ -686,7 +688,7 @@ const SkillTrainingContent = () => {
           </div>
           <div className="flex items-center gap-2">
             <TrendingUp className="h-4 w-4 text-blue-400" />
-            <span className="font-oswald">{profile.experience || 0} XP</span>
+            <span className="font-oswald">{displayExperience} XP</span>
           </div>
           <div className="flex items-center gap-2">
             <Clock className="h-4 w-4 text-purple-400" />

--- a/src/utils/progression.ts
+++ b/src/utils/progression.ts
@@ -1,0 +1,66 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { PlayerXpWallet } from "@/hooks/useGameData";
+
+export type ProgressionAction = "award_action_xp";
+
+export interface ProgressionProfileSummary {
+  id: string;
+  user_id: string;
+  username: string;
+  display_name: string | null;
+  level: number;
+  experience: number;
+  attribute_points_available?: number;
+  skill_points_available?: number;
+  updated_at: string;
+}
+
+export interface ProgressionResponse {
+  success: boolean;
+  action: ProgressionAction;
+  message?: string;
+  profile: ProgressionProfileSummary;
+  wallet: PlayerXpWallet | null;
+  attributes: Record<string, unknown> | null;
+  cooldowns: Record<string, number>;
+  result?: unknown;
+}
+
+export interface AwardActionXpInput {
+  amount: number;
+  category?: string;
+  actionKey?: string;
+  metadata?: Record<string, unknown>;
+  uniqueEventId?: string;
+}
+
+export const awardActionXp = async ({
+  amount,
+  category = "performance",
+  actionKey = "gameplay_action",
+  metadata = {},
+  uniqueEventId,
+}: AwardActionXpInput): Promise<ProgressionResponse> => {
+  const payload = {
+    action: "award_action_xp" as const,
+    amount,
+    category,
+    action_key: actionKey,
+    metadata,
+    event_id: uniqueEventId,
+  };
+
+  const { data, error } = await supabase.functions.invoke<ProgressionResponse>("progression", {
+    body: payload,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data?.success) {
+    throw new Error(data?.message ?? "Failed to award experience points");
+  }
+
+  return data;
+};


### PR DESCRIPTION
## Summary
- add a progression utility for calling the progression edge function and normalise its response
- extend the game data provider to track the XP wallet and expose a refresh helper
- update gig and tour completion handlers to award XP with metadata, refresh progression state, and then apply cash/fame/equipment updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc37c9735c8325ae6f11ba7ed109cb