### PR TITLE
Add friendships schema and client utilities

### DIFF
--- a/src/integrations/supabase/friendshipsClient.ts
+++ b/src/integrations/supabase/friendshipsClient.ts
@@ -1,0 +1,84 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Database, Tables } from "@/integrations/supabase/types";
+
+export type Friendship = Tables<"friendships">;
+export type FriendshipStatus = Database["public"]["Enums"]["friendship_status"];
+
+export class FriendshipsClientError extends Error {
+  status?: number;
+  details?: unknown;
+
+  constructor(message: string, options?: { status?: number; details?: unknown }) {
+    super(message);
+    this.name = "FriendshipsClientError";
+    this.status = options?.status;
+    this.details = options?.details;
+  }
+}
+
+const ensureProfileIdsAreDistinct = (requesterId: string, addresseeId: string) => {
+  if (requesterId === addresseeId) {
+    throw new FriendshipsClientError("Requester and addressee must be different profiles");
+  }
+};
+
+const handleSingleRow = <Row>(result: {
+  data: Row | null;
+  error: { message: string; details?: unknown; code?: string; hint?: string } | null;
+  status?: number;
+}): Row => {
+  if (result.error) {
+    throw new FriendshipsClientError(result.error.message ?? "Friendship operation failed", {
+      status: result.status,
+      details: result.error.details ?? result.error,
+    });
+  }
+
+  if (!result.data) {
+    throw new FriendshipsClientError("No friendship record was returned from Supabase", {
+      status: result.status,
+    });
+  }
+
+  return result.data;
+};
+
+export const friendshipsClient = {
+  async createRequest(params: { requesterId: string; addresseeId: string }): Promise<Friendship> {
+    ensureProfileIdsAreDistinct(params.requesterId, params.addresseeId);
+
+    const result = await supabase
+      .from("friendships")
+      .insert({
+        requester_id: params.requesterId,
+        addressee_id: params.addresseeId,
+      })
+      .select()
+      .single();
+
+    return handleSingleRow(result);
+  },
+
+  async updateStatus(friendshipId: string, status: FriendshipStatus): Promise<Friendship> {
+    const result = await supabase
+      .from("friendships")
+      .update({ status })
+      .eq("id", friendshipId)
+      .select()
+      .single();
+
+    return handleSingleRow(result);
+  },
+
+  accept(friendshipId: string) {
+    return this.updateStatus(friendshipId, "accepted");
+  },
+
+  decline(friendshipId: string) {
+    return this.updateStatus(friendshipId, "declined");
+  },
+
+  block(friendshipId: string) {
+    return this.updateStatus(friendshipId, "blocked");
+  },
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -136,6 +136,51 @@ export type Database = {
           },
         ]
       }
+      friendships: {
+        Row: {
+          addressee_id: string
+          created_at: string
+          id: string
+          requester_id: string
+          responded_at: string | null
+          status: Database["public"]["Enums"]["friendship_status"]
+          updated_at: string
+        }
+        Insert: {
+          addressee_id: string
+          created_at?: string
+          id?: string
+          requester_id: string
+          responded_at?: string | null
+          status?: Database["public"]["Enums"]["friendship_status"]
+          updated_at?: string
+        }
+        Update: {
+          addressee_id?: string
+          created_at?: string
+          id?: string
+          requester_id?: string
+          responded_at?: string | null
+          status?: Database["public"]["Enums"]["friendship_status"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "friendships_addressee_id_fkey"
+            columns: ["addressee_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "friendships_requester_id_fkey"
+            columns: ["requester_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       band_members: {
         Row: {
           band_id: string
@@ -1648,6 +1693,30 @@ export type Database = {
       }
     }
     Views: {
+      accepted_friendships: {
+        Row: {
+          addressee_id: string
+          created_at: string
+          id: string
+          requester_id: string
+          responded_at: string | null
+          status: Database["public"]["Enums"]["friendship_status"]
+          updated_at: string
+        }
+        Relationships: []
+      }
+      pending_friendships: {
+        Row: {
+          addressee_id: string
+          created_at: string
+          id: string
+          requester_id: string
+          responded_at: string | null
+          status: Database["public"]["Enums"]["friendship_status"]
+          updated_at: string
+        }
+        Relationships: []
+      }
       profile_action_xp_daily_totals: {
         Row: {
           action_type: string
@@ -1705,6 +1774,7 @@ export type Database = {
     }
     Enums: {
       app_role: "admin" | "moderator" | "user"
+      friendship_status: "accepted" | "blocked" | "declined" | "pending"
       profile_gender:
         | "female"
         | "male"

--- a/supabase/migrations/20261101100000_create_friendships_table.sql
+++ b/supabase/migrations/20261101100000_create_friendships_table.sql
@@ -1,0 +1,141 @@
+BEGIN;
+
+-- Create enum type for friendship status values
+CREATE TYPE IF NOT EXISTS public.friendship_status AS ENUM ('pending', 'accepted', 'declined', 'blocked');
+
+-- Table to manage friend relationships and requests between profiles
+CREATE TABLE public.friendships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  requester_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  addressee_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status public.friendship_status NOT NULL DEFAULT 'pending',
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  responded_at timestamptz,
+  CONSTRAINT friendships_no_self_reference CHECK (requester_id <> addressee_id)
+);
+
+-- Ensure each pair of profiles only has a single friendship record regardless of ordering
+CREATE UNIQUE INDEX friendships_unique_pair_idx
+  ON public.friendships (
+    LEAST(requester_id, addressee_id),
+    GREATEST(requester_id, addressee_id)
+  );
+
+CREATE INDEX friendships_requester_idx ON public.friendships (requester_id);
+CREATE INDEX friendships_addressee_idx ON public.friendships (addressee_id);
+CREATE INDEX friendships_status_idx ON public.friendships (status);
+
+-- Track update timestamps automatically
+CREATE TRIGGER update_friendships_updated_at
+  BEFORE UPDATE ON public.friendships
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Automatically record when a friendship leaves the pending state
+CREATE OR REPLACE FUNCTION public.set_friendship_responded_at()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.status <> 'pending'::public.friendship_status
+     AND (OLD.status IS NULL OR OLD.status = 'pending'::public.friendship_status)
+     AND NEW.responded_at IS NULL THEN
+    NEW.responded_at := timezone('utc', now());
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_friendships_responded_at
+  BEFORE UPDATE ON public.friendships
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_friendship_responded_at();
+
+-- Enable row level security so only participants can interact with their friendships
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Friendship participants can view"
+  ON public.friendships
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = requester_id AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = addressee_id AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Requesters can create friendships"
+  ON public.friendships
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = requester_id AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Participants manage friendships"
+  ON public.friendships
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = requester_id AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = addressee_id AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = requester_id AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = addressee_id AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Participants can delete friendships"
+  ON public.friendships
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = requester_id AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = addressee_id AND p.user_id = auth.uid()
+    )
+  );
+
+-- Convenience views for common friendship states
+CREATE OR REPLACE VIEW public.pending_friendships AS
+SELECT *
+FROM public.friendships
+WHERE status = 'pending'::public.friendship_status;
+
+CREATE OR REPLACE VIEW public.accepted_friendships AS
+SELECT *
+FROM public.friendships
+WHERE status = 'accepted'::public.friendship_status;
+
+-- Include friendships in realtime publication
+ALTER PUBLICATION supabase_realtime ADD TABLE public.friendships;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a friendships table with status tracking, RLS policies, and convenience views
- regenerate Supabase types to expose the new table, views, and enum
- provide a Supabase client helper for creating and updating friendship records

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc42987c5c8325944fa1ba267bcd25