### PR TITLE
Set default skill point budget to 13

### DIFF
--- a/src/pages/CharacterCreation.tsx
+++ b/src/pages/CharacterCreation.tsx
@@ -77,7 +77,7 @@ const backgrounds = [
   },
 ];
 
-const DEFAULT_TOTAL_SKILL_POINTS = 0;
+const DEFAULT_TOTAL_SKILL_POINTS = 13;
 const MIN_SKILL_VALUE = 0;
 const MAX_SKILL_VALUE = 100;
 const ATTRIBUTE_MIN_VALUE = 0;


### PR DESCRIPTION
## Summary
- update the character creation fallback skill budget to 13 points so caps and messaging apply before server data loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc448b4d0c8325a29b00cbe7592da3