### PR TITLE
Export UnlockedSkillsMap from useGameData

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -53,7 +53,7 @@ type ProfileAttribute = any;
 export type SkillDefinition = any;
 export type SkillProgressRow = any;
 export type SkillUnlockRow = any;
-type UnlockedSkillsMap = Record<string, boolean>;
+export type UnlockedSkillsMap = Record<string, boolean>;
 type SkillProgressUpsertInput = any;
 type SkillUnlockUpsertInput = any;
 


### PR DESCRIPTION
## Summary
- export the `UnlockedSkillsMap` type from `useGameData` so it can be imported elsewhere

## Testing
- npm run build *(fails: existing duplicate declarations in useGameData.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc470e719083259206283198a72b0f