### PR TITLE
Update XP displays to use wallet data

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -186,7 +186,8 @@ const Dashboard = () => {
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   };
 
-  const experienceProgress = (xpWallet?.xp_balance ?? profile.experience) % 1000;
+  const lifetimeXp = Math.max(0, Number(xpWallet?.lifetime_xp ?? 0));
+  const experienceProgress = lifetimeXp % 1000;
   const latestWeeklyBonus = xpLedger.find(entry => entry.event_type === "weekly_bonus");
   const latestWeeklyMetadata = (latestWeeklyBonus?.metadata as Record<string, unknown> | null) ?? null;
   const weeklyBonusAmount = latestWeeklyBonus

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -326,7 +326,13 @@ const Profile = () => {
       }).format(weeklyBonusRecorded)
     : null;
   const recentLedgerEntries = xpLedger.slice(0, 5);
-  const xpBalance = xpWallet?.xp_balance ?? profile?.experience ?? 0;
+  const xpBalance = Math.max(0, Number(xpWallet?.xp_balance ?? 0));
+  const lifetimeXp = Math.max(0, Number(xpWallet?.lifetime_xp ?? 0));
+  const experienceTowardsNextLevel = lifetimeXp % 1000;
+  const levelProgressPercent = Math.min(100, (experienceTowardsNextLevel / 1000) * 100);
+  const formattedLifetimeXp = lifetimeXp.toLocaleString();
+  const formattedXpBalance = xpBalance.toLocaleString();
+  const formattedXpTowardsNextLevel = experienceTowardsNextLevel.toLocaleString();
 
   useEffect(() => {
     if (!showProfileDetails) {
@@ -1293,8 +1299,10 @@ const Profile = () => {
                 </CardHeader>
                 <CardContent>
                   <div className="text-2xl font-bold text-primary">{profile.level || 1}</div>
-                  <Progress value={((xpBalance || 0) % 1000) / 10} className="h-2 mt-2" />
-                  <p className="text-xs text-muted-foreground mt-1">{xpBalance || 0} XP</p>
+                  <Progress value={levelProgressPercent} className="h-2 mt-2" />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {formattedXpTowardsNextLevel}/1000 XP to level {(profile.level ?? 1) + 1}
+                  </p>
                 </CardContent>
               </Card>
 
@@ -1326,8 +1334,10 @@ const Profile = () => {
                   <Trophy className="h-4 w-4 text-warning" />
                 </CardHeader>
                 <CardContent>
-                  <div className="text-2xl font-bold text-warning">{xpBalance || 0}</div>
-                  <p className="text-xs text-muted-foreground">Total XP earned</p>
+                  <div className="text-2xl font-bold text-warning">{formattedLifetimeXp}</div>
+                  <p className="text-xs text-muted-foreground">
+                    Lifetime XP · {formattedXpBalance} spendable
+                  </p>
                 </CardContent>
               </Card>
 

--- a/src/pages/SkillTraining.tsx
+++ b/src/pages/SkillTraining.tsx
@@ -259,11 +259,13 @@ const SkillTrainingContent = () => {
     () => ({
       wallet: xpWallet ?? null,
       attributeStars: attributeStarTotal,
-      legacyExperience: profile?.experience ?? null
+      legacyExperience: xpWallet?.lifetime_xp ?? null
     }),
-    [xpWallet, attributeStarTotal, profile?.experience]
+    [xpWallet, attributeStarTotal]
   );
-  const totalExperience = Number(profile?.experience ?? 0);
+  const spendableXp = Math.max(0, Number(xpWallet?.xp_balance ?? 0));
+  const lifetimeXp = Math.max(0, Number(xpWallet?.lifetime_xp ?? 0));
+  const formattedSpendableXp = spendableXp.toLocaleString();
   const skillCap = getSkillCap(playerLevel, progressionSnapshot);
 
   const availableDefinitions = useMemo(() => {
@@ -535,10 +537,10 @@ const SkillTrainingContent = () => {
     const currentSkill = getSkillValue(session.slug);
     const playerCash = Number(profile.cash ?? 0);
     const playerLevel = Number(profile.level ?? 1);
-    const totalExperience = Number(profile.experience ?? 0);
+    const totalLifetimeXp = Math.max(0, Number(xpWallet?.lifetime_xp ?? 0));
     const sessionProgression = {
       ...progressionSnapshot,
-      legacyExperience: totalExperience
+      legacyExperience: totalLifetimeXp
     };
     const skillCap = getSkillCap(playerLevel, sessionProgression);
     const trainingCost = calculateTrainingCost(currentSkill);
@@ -669,12 +671,7 @@ const SkillTrainingContent = () => {
       return;
     }
 
-    const profileExperience = Number(profile.experience ?? 0);
-    const walletBalance =
-      typeof xpWallet?.xp_balance === "number" && Number.isFinite(xpWallet.xp_balance)
-        ? xpWallet.xp_balance
-        : null;
-    const availableExperience = Math.max(0, walletBalance ?? profileExperience);
+    const availableXp = Math.max(0, Number(xpWallet?.xp_balance ?? 0));
     const trainingCost = getAttributeTrainingCost(currentValue);
 
     if (availableXp < trainingCost) {
@@ -775,7 +772,7 @@ const SkillTrainingContent = () => {
           </div>
           <div className="flex items-center gap-2">
             <Wallet className="h-4 w-4 text-blue-400" />
-            <span className="font-oswald">{walletBalance.toLocaleString()} XP available</span>
+            <span className="font-oswald">{formattedSpendableXp} XP available</span>
           </div>
           <div className="flex items-center gap-2">
             <TrendingUp className="h-4 w-4 text-green-400" />


### PR DESCRIPTION
## Summary
- derive dashboard level progress from the XP wallet lifetime balance instead of legacy profile columns
- surface lifetime XP and spendable XP in the profile stats cards for clearer wallet context
- update skill and attribute training flows to read wallet balances when calculating caps, costs, and header summaries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2b38f74c8325811eb3ff205fc726