### PR TITLE
Export UnlockedSkillsMap type

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -53,7 +53,7 @@ type ProfileAttribute = any;
 export type SkillDefinition = any;
 export type SkillProgressRow = any;
 export type SkillUnlockRow = any;
-type UnlockedSkillsMap = Record<string, boolean>;
+export type UnlockedSkillsMap = Record<string, boolean>;
 type SkillProgressUpsertInput = any;
 type SkillUnlockUpsertInput = any;
 


### PR DESCRIPTION
## Summary
- export the UnlockedSkillsMap type from `useGameData` so it can be re-used externally

## Testing
- npm run build *(fails: existing duplicate declarations in src/hooks/useGameData.tsx unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc62188a1c8325b38065eaeacafb11