### PR TITLE
Handle schema cache missing table errors

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -177,12 +177,32 @@ const extractMissingColumn = (error: PostgrestError | null | undefined) => {
   return null;
 };
 
-const isMissingTableError = (error: PostgrestError | null | undefined) =>
-  Boolean(
-    error?.code === "42P01" ||
-      error?.code === "PGRST201" ||
-      error?.message?.toLowerCase().includes("does not exist")
+const isMissingTableError = (error: PostgrestError | null | undefined) => {
+  if (!error) {
+    return false;
+  }
+
+  if (error.code === "42P01" || error.code === "PGRST201") {
+    return true;
+  }
+
+  const haystacks = [error.message, error.details, error.hint].filter(
+    (value): value is string => typeof value === "string" && value.length > 0
   );
+
+  if (haystacks.length === 0) {
+    return false;
+  }
+
+  const patterns = [
+    /does not exist/i,
+    /could not find the table/i,
+    /schema cache/i
+  ];
+
+  // PostgREST sometimes bubbles missing-table errors through the schema cache.
+  return haystacks.some(haystack => patterns.some(pattern => pattern.test(haystack)));
+};
 
 const omitFromRecord = <T extends Record<string, unknown>>(source: T, key: string) => {
   if (!(key in source)) {


### PR DESCRIPTION
## Summary
- broaden the missing-table detection helpers so PostgREST schema cache messages are treated as non-fatal
- document the schema-cache scenario inline for future regression awareness

## Testing
- npm test *(fails: bun test cannot parse src/hooks/useGameData.tsx and reports TypeScript syntax errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6aeb9dec8325bec9e2fdd636987b