### PR TITLE
Fix missing callback closing paren

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -2012,6 +2012,8 @@ const useProvideGameData = (): GameDataContextValue => {
       }
     },
     [applyCooldownState, fetchProgressionSnapshot, loadXpLedger, profile, selectedCharacterId]
+  );
+
   const upsertSkillProgress = useCallback(async (profileId: string, entries: SkillProgressUpsertInput[]) => {
     return [];
   }, []);


### PR DESCRIPTION
## Summary
- fix the syntax error in useGameData's refreshProgressionState callback by adding the missing closing parenthesis

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc6b7d14b4832588be9b8427fe02ea