### PR TITLE
Fix missing RealtimeChatPanel import on dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import { useNavigate } from "react-router-dom";
 import { useGameData, type PlayerAttributes, type PlayerSkills } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
 import ChatWindow from "@/components/realtime/ChatWindow";
+import RealtimeChatPanel from "@/components/chat/RealtimeChatPanel";
 import { deriveCityChannel } from "@/utils/chat";
 
 type ChatScope = "general" | "city";


### PR DESCRIPTION
## Summary
- import the RealtimeChatPanel component into the dashboard page so it can render correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6eb5325c8325873e9fa26b86ab0e