### PR TITLE
Fix supabase presence cleanup error handling

### DIFF
--- a/src/components/chat/RealtimeChatPanel.tsx
+++ b/src/components/chat/RealtimeChatPanel.tsx
@@ -168,11 +168,17 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
       isMounted = false;
       void channel.unsubscribe();
 
-      void supabase
-        .from("chat_participants")
-        .delete()
-        .eq("user_id", user.id)
-        .eq("channel", channelKey);
+      void (async () => {
+        const { error } = await supabase
+          .from("chat_participants")
+          .delete()
+          .eq("user_id", user.id)
+          .eq("channel", channelKey);
+
+        if (error) {
+          console.error("Error unregistering presence:", error);
+        }
+      })();
     };
   }, [channelKey, user]);
 

--- a/src/components/realtime/ChatWindow.tsx
+++ b/src/components/realtime/ChatWindow.tsx
@@ -200,14 +200,17 @@ const ChatWindow: React.FC<ChatWindowProps> = ({
 
       void realtimeChannel.unsubscribe();
 
-      void supabase
-        .from("chat_participants")
-        .delete()
-        .eq("user_id", user.id)
-        .eq("channel", effectiveChannel)
-        .catch(error => {
+      void (async () => {
+        const { error } = await supabase
+          .from("chat_participants")
+          .delete()
+          .eq("user_id", user.id)
+          .eq("channel", effectiveChannel);
+
+        if (error) {
           console.error("Error unregistering presence:", error);
-        });
+        }
+      })();
     };
   }, [effectiveChannel, onConnectionStatusChange, onOnlineCountChange, user]);
 


### PR DESCRIPTION
## Summary
- replace the supabase chat presence cleanup with an async helper so we can await the delete call
- log any errors from the unregister call without relying on an unavailable `.catch` method

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc71c6d9848325ab17d07a23577e28