### PR TITLE
Add shared formatDateTimeLocal helper

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -39,6 +39,7 @@ import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 import { calculateFanGain, type PerformanceAttributeBonuses } from "@/utils/gameBalance";
 import { resolveAttributeValue } from "@/utils/attributeModifiers";
+import { formatDateTimeLocal } from "@/utils/datetime";
 
 interface SocialPost {
   id: string;
@@ -249,11 +250,6 @@ const FanManagement = () => {
       console.error('Error loading social posts:', errorMessage, error);
     }
   }, [user]);
-
-  const formatDateTimeLocal = (date: Date) => {
-    const pad = (value: number) => value.toString().padStart(2, "0");
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-  };
 
   const clearMediaSelection = () => {
     setMediaFile(null);

--- a/src/pages/SongManager.tsx
+++ b/src/pages/SongManager.tsx
@@ -14,6 +14,7 @@ import { useGameData } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/components/ui/use-toast";
 import { applyRoyaltyRecoupment } from "@/utils/contracts";
+import { formatDateTimeLocal } from "@/utils/datetime";
 import { Music, Plus, TrendingUp, Star, Calendar, Play, Edit3, Trash2 } from "lucide-react";
 import type { Database, Json } from "@/integrations/supabase/types";
 

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,4 @@
+export const formatDateTimeLocal = (date: Date) => {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};


### PR DESCRIPTION
## Summary
- add a reusable `formatDateTimeLocal` helper under `src/utils`
- update SongManager and FanManagement pages to consume the shared helper for release scheduling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc74894eec83259475618f3f847868