### PR TITLE
Import useRef in FanManagement

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useMemo,
   useCallback,
+  useRef,
   FormEvent,
   ChangeEvent
 } from "react";


### PR DESCRIPTION
## Summary
- add the missing `useRef` import in `FanManagement.tsx` so the runtime can access the hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc760345488325bd758c585d2f0c6e