### PR TITLE
Replace venue city_id column with city reference

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1706,7 +1706,7 @@ export type Database = {
         Row: {
           base_payment: number | null
           capacity: number | null
-          city_id: string | null
+          city: string | null
           created_at: string | null
           id: string
           location: string | null
@@ -1718,7 +1718,7 @@ export type Database = {
         Insert: {
           base_payment?: number | null
           capacity?: number | null
-          city_id?: string | null
+          city?: string | null
           created_at?: string | null
           id?: string
           location?: string | null
@@ -1730,7 +1730,7 @@ export type Database = {
         Update: {
           base_payment?: number | null
           capacity?: number | null
-          city_id?: string | null
+          city?: string | null
           created_at?: string | null
           id?: string
           location?: string | null
@@ -1741,8 +1741,8 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "venues_city_id_fkey"
-            columns: ["city_id"]
+            foreignKeyName: "venues_city_fkey"
+            columns: ["city"]
             isOneToOne: false
             referencedRelation: "cities"
             referencedColumns: ["id"]

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -162,7 +162,7 @@ export interface Database {
           name: string
           location: string | null
           capacity: number | null
-          city_id: string | null
+          city: string | null
           base_payment: number
           venue_type: string | null
           prestige_level: number
@@ -174,7 +174,7 @@ export interface Database {
           name: string
           location?: string | null
           capacity?: number | null
-          city_id?: string | null
+          city?: string | null
           base_payment?: number
           venue_type?: string | null
           prestige_level?: number
@@ -186,7 +186,7 @@ export interface Database {
           name?: string
           location?: string | null
           capacity?: number | null
-          city_id?: string | null
+          city?: string | null
           base_payment?: number
           venue_type?: string | null
           prestige_level?: number

--- a/src/pages/GigBooking.tsx
+++ b/src/pages/GigBooking.tsx
@@ -123,7 +123,7 @@ interface Venue {
   id: string;
   name: string;
   location: string;
-  city_id?: string | null;
+  city?: string | null;
   capacity: number;
   venue_type: string;
   base_payment: number;
@@ -269,7 +269,7 @@ const GigBooking = () => {
         .select('*');
 
       if (selectedCityId !== ALL_CITIES_VALUE) {
-        query = query.eq('city_id', selectedCityId);
+        query = query.eq('city', selectedCityId);
       }
 
       const { data, error } = await query
@@ -286,7 +286,7 @@ const GigBooking = () => {
         id: venue.id,
         name: venue.name,
         location: venue.location ?? 'Unknown',
-        city_id: venue.city_id ?? null,
+        city: venue.city ?? null,
         capacity: venue.capacity ?? 0,
         venue_type: venue.venue_type ?? 'general',
         base_payment: venue.base_payment ?? 0,
@@ -328,7 +328,7 @@ const GigBooking = () => {
           id: venueDetails?.id ?? gig.venue_id,
           name: venueDetails?.name ?? 'Unknown Venue',
           location: venueDetails?.location ?? 'Unknown',
-          city_id: venueDetails?.city_id ?? null,
+          city: venueDetails?.city ?? null,
           capacity: venueDetails?.capacity ?? 0,
           venue_type: venueDetails?.venue_type ?? 'general',
           base_payment: venueDetails?.base_payment ?? 0,

--- a/src/pages/TourManager.tsx
+++ b/src/pages/TourManager.tsx
@@ -487,7 +487,7 @@ const TourManager = () => {
         .select('*');
 
       if (selectedCityId !== ALL_CITIES_VALUE) {
-        query = query.eq('city_id', selectedCityId);
+        query = query.eq('city', selectedCityId);
       }
 
       const { data, error } = await query

--- a/src/pages/VenueManagement.tsx
+++ b/src/pages/VenueManagement.tsx
@@ -26,7 +26,7 @@ import {
 type CityRow = Database["public"]["Tables"]["cities"]["Row"];
 type VenueRowBase = Database["public"]["Tables"]["venues"]["Row"];
 type VenueRow = VenueRowBase & {
-  city?: Pick<CityRow, "id" | "name" | "country"> | null;
+  city_details?: Pick<CityRow, "id" | "name" | "country"> | null;
 };
 
 interface VenueRelationshipRow {
@@ -275,7 +275,7 @@ const VenueManagement = () => {
         .from("venues")
         .select(`
           *,
-          city:city_id (
+          city_details:city (
             id,
             name,
             country
@@ -387,9 +387,9 @@ const VenueManagement = () => {
       const relationshipState = relationships[venue.id] ?? { score: 0 };
       const relationshipScore = Math.min(100, Math.max(0, relationshipState.score));
       const venueBookings = bookingRows.filter((booking) => booking.venue_id === venue.id);
-      const cityId = venue.city_id ?? null;
-      const cityName = venue.city?.name ?? null;
-      const cityCountry = venue.city?.country ?? null;
+      const cityId = venue.city ?? null;
+      const cityName = venue.city_details?.name ?? null;
+      const cityCountry = venue.city_details?.country ?? null;
       const locationLabel = cityName
         ? cityCountry
           ? `${cityName}, ${cityCountry}`

--- a/supabase/migrations/20261105120000_replace_venue_city_id_with_city.sql
+++ b/supabase/migrations/20261105120000_replace_venue_city_id_with_city.sql
@@ -1,0 +1,77 @@
+-- Replace the venues.city_id column with a city column that references cities(id)
+ALTER TABLE public.venues
+  ADD COLUMN IF NOT EXISTS city uuid;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'venues'
+      AND column_name = 'city_id'
+  ) THEN
+    EXECUTE $$
+      UPDATE public.venues
+      SET city = city_id
+      WHERE city IS NULL
+        AND city_id IS NOT NULL;
+    $$;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'venues'
+      AND column_name = 'city'
+  ) THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conrelid = 'public.venues'::regclass
+        AND conname = 'venues_city_fkey'
+    ) THEN
+      ALTER TABLE public.venues
+        ADD CONSTRAINT venues_city_fkey
+        FOREIGN KEY (city)
+        REFERENCES public.cities(id)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS venues_city_idx ON public.venues(city);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.venues'::regclass
+      AND conname = 'venues_city_id_fkey'
+  ) THEN
+    ALTER TABLE public.venues
+      DROP CONSTRAINT venues_city_id_fkey;
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS venues_city_id_idx;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'venues'
+      AND column_name = 'city_id'
+  ) THEN
+    ALTER TABLE public.venues
+      DROP COLUMN city_id;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a migration that replaces the `venues.city_id` column with a `city` column linked to `cities(id)` and drops the legacy constraint/index
- refresh Supabase-generated types and application logic to use the new `city` column on venues
- update venue-related pages to filter and map venues by the new `city` reference and keep relational city details available

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc764297bc8325ab57cf5f2ee93991