### PR TITLE
Add runtime fallback for formatDateTimeLocal

### DIFF
--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -39,7 +39,7 @@ import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 import { calculateFanGain, type PerformanceAttributeBonuses } from "@/utils/gameBalance";
 import { resolveAttributeValue } from "@/utils/attributeModifiers";
-import { formatDateTimeLocal } from "@/utils/datetime";
+import * as datetimeUtils from "@/utils/datetime";
 
 interface SocialPost {
   id: string;
@@ -112,6 +112,16 @@ type MessageFormState = {
 declare const applyScheduledPostEffects:
   | ((posts: SocialPost[], activityDescription: string) => Promise<void> | void)
   | undefined;
+
+const fallbackFormatDateTimeLocal = (date: Date) => {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+const formatDateTimeLocal =
+  datetimeUtils.formatDateTimeLocal ?? fallbackFormatDateTimeLocal;
 
 const PLATFORM_OPTIONS = [
   { value: "instagram", label: "Instagram" },

--- a/src/pages/SongManager.tsx
+++ b/src/pages/SongManager.tsx
@@ -14,7 +14,7 @@ import { useGameData } from "@/hooks/useGameData";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/components/ui/use-toast";
 import { applyRoyaltyRecoupment } from "@/utils/contracts";
-import { formatDateTimeLocal } from "@/utils/datetime";
+import * as datetimeUtils from "@/utils/datetime";
 import { Music, Plus, TrendingUp, Star, Calendar, Play, Edit3, Trash2 } from "lucide-react";
 import type { Database, Json } from "@/integrations/supabase/types";
 
@@ -105,6 +105,16 @@ interface GrowthSummary {
 }
 
 const DEFAULT_REVENUE_PER_PLAY = 0.003;
+
+const fallbackFormatDateTimeLocal = (date: Date) => {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+const formatDateTimeLocal =
+  datetimeUtils.formatDateTimeLocal ?? fallbackFormatDateTimeLocal;
 
 const DEFAULT_STREAMING_PLATFORM_DISTRIBUTION: BreakdownSource[] = [
   { key: "spotify", name: "Spotify", weight: 45, revenuePerPlay: 0.003 },


### PR DESCRIPTION
## Summary
- guard SongManager and FanManagement against missing `formatDateTimeLocal` by importing the datetime utilities as a namespace
- provide a local fallback formatter to keep datetime inputs working even if the shared utility is unavailable

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc75a1bc508325a312c5a0ad000694