### PR TITLE
Fix attribute training summaries and context actions

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -369,6 +369,8 @@ interface GameDataContextValue {
     earnings?: number,
     metadata?: ActivityItem["metadata"]
   ) => Promise<ActivityItem>;
+  awardActionXp: (input: AwardActionXpInput) => Promise<ProgressionResponse>;
+  buyAttributeStar: (input: BuyAttributeStarInput) => Promise<ProgressionResponse>;
   applyProgressionUpdate: (response: ProgressionActionSuccessResponse) => void;
   refreshProgressionState: (
     options?: RefreshProgressionOptions
@@ -446,6 +448,14 @@ const defaultGameDataContext: GameDataContextValue = {
   addActivity: async () => {
     warnMissingProvider();
     return Promise.reject(new Error(missingProviderMessage)) as Promise<ActivityItem>;
+  },
+  awardActionXp: async () => {
+    warnMissingProvider();
+    return Promise.reject(new Error(missingProviderMessage)) as Promise<ProgressionResponse>;
+  },
+  buyAttributeStar: async () => {
+    warnMissingProvider();
+    return Promise.reject(new Error(missingProviderMessage)) as Promise<ProgressionResponse>;
   },
   applyProgressionUpdate: () => {
     warnMissingProvider();
@@ -2288,6 +2298,8 @@ const useProvideGameData = (): GameDataContextValue => {
     updateSkills,
     updateAttributes,
     addActivity,
+    awardActionXp,
+    buyAttributeStar,
     applyProgressionUpdate,
     refreshProgressionState,
     acknowledgeWeeklyBonus,


### PR DESCRIPTION
## Summary
- compute attribute summary data in the skill training page, including icons and sanitized values for the attribute tab
- ensure attribute training updates are propagated and award action XP metadata uses the progression API shape
- expose awardActionXp and buyAttributeStar helpers through the game data context so training can consume them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc7a6762448325a6ab14a56aea5dc9