### PR TITLE
Stop lazy loading CharacterCreation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Auth from "./pages/Auth";
 import WorldPulse from "./pages/WorldPulse";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import WorldPulsePage from "./pages/WorldPulse";
+import CharacterCreation from "./pages/CharacterCreation";
 
 const Layout = lazyWithRetry(() => import("./components/Layout"));
 const Index = lazyWithRetry(() => import("./pages/Index"));
@@ -18,7 +19,6 @@ const Dashboard = lazyWithRetry(() => import("./pages/Dashboard"));
 const BandManager = lazyWithRetry(() => import("./pages/BandManager"));
 const GigBooking = lazyWithRetry(() => import("./pages/GigBooking"));
 const Profile = lazyWithRetry(() => import("./pages/Profile"));
-const CharacterCreation = lazyWithRetry(() => import("./pages/CharacterCreation"));
 const MusicStudio = lazyWithRetry(() => import("./pages/MusicStudio"));
 const Schedule = lazyWithRetry(() => import("./pages/Schedule"));
 const EquipmentStore = lazyWithRetry(() => import("./pages/EquipmentStore"));


### PR DESCRIPTION
## Summary
- import the CharacterCreation page synchronously to avoid relying on a separate chunk fetch

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8d6ce4348325a55d19e16cb66118