### PR TITLE
Add universities table and Supabase type definitions

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1221,6 +1221,39 @@ export type Database = {
           },
         ]
       }
+      universities: {
+        Row: {
+          city: string
+          course_cost: number
+          created_at: string
+          id: string
+          name: string
+          prestige: number
+          quality_of_learning: number
+          updated_at: string
+        }
+        Insert: {
+          city: string
+          course_cost?: number
+          created_at?: string
+          id?: string
+          name: string
+          prestige?: number
+          quality_of_learning?: number
+          updated_at?: string
+        }
+        Update: {
+          city?: string
+          course_cost?: number
+          created_at?: string
+          id?: string
+          name?: string
+          prestige?: number
+          quality_of_learning?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_roles: {
         Row: {
           created_at: string | null

--- a/src/integrations/supabase/universities.ts
+++ b/src/integrations/supabase/universities.ts
@@ -1,0 +1,17 @@
+import { supabase } from './client';
+import type { Database } from './types';
+
+export type University = Database['public']['Tables']['universities']['Row'];
+
+export const fetchUniversities = async (): Promise<University[]> => {
+  const { data, error } = await supabase
+    .from('universities')
+    .select('*')
+    .order('prestige', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch universities: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/supabase/migrations/20261106090000_create_universities_table.sql
+++ b/supabase/migrations/20261106090000_create_universities_table.sql
@@ -1,0 +1,46 @@
+-- Create universities table to support the education planning experience
+CREATE TABLE IF NOT EXISTS public.universities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  city TEXT NOT NULL,
+  prestige INTEGER NOT NULL DEFAULT 50 CHECK (prestige BETWEEN 0 AND 100),
+  quality_of_learning INTEGER NOT NULL DEFAULT 50 CHECK (quality_of_learning BETWEEN 0 AND 100),
+  course_cost NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (course_cost >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT universities_name_city_unique UNIQUE (name, city)
+);
+
+CREATE INDEX IF NOT EXISTS universities_city_idx ON public.universities (city);
+CREATE INDEX IF NOT EXISTS universities_prestige_idx ON public.universities (prestige DESC);
+
+ALTER TABLE public.universities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Universities are viewable by everyone" ON public.universities;
+CREATE POLICY "Universities are viewable by everyone"
+  ON public.universities
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Service roles can manage universities" ON public.universities;
+CREATE POLICY "Service roles can manage universities"
+  ON public.universities
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE TRIGGER set_universities_updated_at
+  BEFORE UPDATE ON public.universities
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Seed initial universities for the Education page
+INSERT INTO public.universities (name, city, prestige, quality_of_learning, course_cost)
+SELECT * FROM (VALUES
+  ('Rockmundo Conservatory', 'London', 92, 95, 18500.00),
+  ('Skyline School of Sound', 'New York', 88, 90, 21000.00),
+  ('Harbor Lights Institute', 'Portsmouth', 76, 82, 12500.00)
+) AS seed(name, city, prestige, quality_of_learning, course_cost)
+ON CONFLICT (name, city) DO UPDATE
+SET prestige = EXCLUDED.prestige,
+    quality_of_learning = EXCLUDED.quality_of_learning,
+    course_cost = EXCLUDED.course_cost;


### PR DESCRIPTION
## Summary
- add a migration creating the public.universities table with indexes, policies, trigger, and starter rows
- extend the Supabase generated types and provide a typed helper for fetching universities

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0cc3398c832585ae150b867551a1