### PR TITLE
Add character reset support to game data hook

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -120,7 +120,17 @@ const Profile = () => {
   const { toast } = useToast();
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { profile, skills, attributes, updateProfile, freshWeeklyBonusAvailable, xpLedger, xpWallet } = useGameData();
+  const {
+    profile,
+    skills,
+    attributes,
+    updateProfile,
+    freshWeeklyBonusAvailable,
+    xpLedger,
+    xpWallet,
+    resetCharacter,
+    refetch,
+  } = useGameData();
   const { items: equippedClothing } = useEquippedClothing();
 
   type MusicalSkill = { key: keyof PlayerSkills; value: number };


### PR DESCRIPTION
## Summary
- add a resetCharacter helper to the game data hook that invokes the Supabase RPC and clears cached state
- expose resetCharacter and refetch from useGameData so the profile page can trigger a reset
- update the profile page to destructure the new helpers for the reset handler

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0df6d71883258d93b02ebbd43f0b