### PR TITLE
Update Supabase types for profiles and record labels

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -200,6 +200,30 @@ export type Database = {
         }
         Relationships: []
       }
+      chat_participants: {
+        Row: {
+          channel: string
+          id: string
+          status: Database["public"]["Enums"]["chat_participant_status"]
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          channel?: string
+          id?: string
+          status?: Database["public"]["Enums"]["chat_participant_status"]
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          channel?: string
+          id?: string
+          status?: Database["public"]["Enums"]["chat_participant_status"]
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       chat_messages: {
         Row: {
           channel: string
@@ -883,49 +907,121 @@ export type Database = {
       }
       profiles: {
         Row: {
+          age: number
           avatar_url: string | null
           bio: string | null
           cash: number | null
+          city_of_birth: string | null
           created_at: string | null
+          current_city_id: string | null
+          current_location: string
           display_name: string | null
+          equipped_clothing: Json | null
           experience: number | null
+          experience_at_last_weekly_bonus: number
           fame: number | null
           fans: number | null
+          gender: Database["public"]["Enums"]["profile_gender"]
+          health: number
           id: string
+          last_weekly_bonus_at: string | null
           level: number | null
           updated_at: string | null
           user_id: string
           username: string
+          weekly_bonus_metadata: Json
+          weekly_bonus_streak: number
         }
         Insert: {
+          age?: number
           avatar_url?: string | null
           bio?: string | null
           cash?: number | null
+          city_of_birth?: string | null
           created_at?: string | null
+          current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
+          equipped_clothing?: Json | null
           experience?: number | null
+          experience_at_last_weekly_bonus?: number
           fame?: number | null
           fans?: number | null
+          gender?: Database["public"]["Enums"]["profile_gender"]
+          health?: number
           id?: string
+          last_weekly_bonus_at?: string | null
           level?: number | null
           updated_at?: string | null
           user_id: string
           username: string
+          weekly_bonus_metadata?: Json
+          weekly_bonus_streak?: number
         }
         Update: {
+          age?: number
           avatar_url?: string | null
           bio?: string | null
           cash?: number | null
+          city_of_birth?: string | null
           created_at?: string | null
+          current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
+          equipped_clothing?: Json | null
           experience?: number | null
+          experience_at_last_weekly_bonus?: number
           fame?: number | null
           fans?: number | null
+          gender?: Database["public"]["Enums"]["profile_gender"]
+          health?: number
           id?: string
+          last_weekly_bonus_at?: string | null
           level?: number | null
           updated_at?: string | null
           user_id?: string
           username?: string
+          weekly_bonus_metadata?: Json
+          weekly_bonus_streak?: number
+        }
+        Relationships: []
+      }
+      record_labels: {
+        Row: {
+          advance_payment: number
+          benefits: string[]
+          created_at: string
+          description: string
+          id: string
+          name: string
+          prestige: number
+          requirements: Json
+          royalty_rate: number
+          updated_at: string
+        }
+        Insert: {
+          advance_payment?: number
+          benefits?: string[]
+          created_at?: string
+          description: string
+          id?: string
+          name: string
+          prestige: number
+          requirements?: Json
+          royalty_rate?: number
+          updated_at?: string
+        }
+        Update: {
+          advance_payment?: number
+          benefits?: string[]
+          created_at?: string
+          description?: string
+          id?: string
+          name?: string
+          prestige?: number
+          requirements?: Json
+          royalty_rate?: number
+          updated_at?: string
         }
         Relationships: []
       }
@@ -1330,6 +1426,13 @@ export type Database = {
     }
     Enums: {
       app_role: "admin" | "moderator" | "user"
+      chat_participant_status: "muted" | "online" | "typing"
+      profile_gender:
+        | "female"
+        | "male"
+        | "non_binary"
+        | "other"
+        | "prefer_not_to_say"
       show_type_enum: "concert" | "festival" | "private" | "street"
     }
     CompositeTypes: {
@@ -1459,6 +1562,14 @@ export const Constants = {
   public: {
     Enums: {
       app_role: ["admin", "moderator", "user"],
+      chat_participant_status: ["online", "typing", "muted"],
+      profile_gender: [
+        "female",
+        "male",
+        "non_binary",
+        "other",
+        "prefer_not_to_say",
+      ],
       show_type_enum: ["concert", "festival", "private", "street"],
     },
   },

--- a/src/lib/supabase-types.ts
+++ b/src/lib/supabase-types.ts
@@ -18,6 +18,13 @@ export interface Database {
           cash: number
           fame: number
           fans: number
+          current_city_id: string | null
+          current_location: string
+          health: number
+          gender: "female" | "male" | "non_binary" | "other" | "prefer_not_to_say"
+          city_of_birth: string | null
+          age: number
+          equipped_clothing: Json | null
           last_weekly_bonus_at: string | null
           weekly_bonus_streak: number
           weekly_bonus_metadata: Json
@@ -37,6 +44,13 @@ export interface Database {
           cash?: number
           fame?: number
           fans?: number
+          current_city_id?: string | null
+          current_location?: string
+          health?: number
+          gender?: "female" | "male" | "non_binary" | "other" | "prefer_not_to_say"
+          city_of_birth?: string | null
+          age?: number
+          equipped_clothing?: Json | null
           last_weekly_bonus_at?: string | null
           weekly_bonus_streak?: number
           weekly_bonus_metadata?: Json
@@ -56,9 +70,54 @@ export interface Database {
           cash?: number
           fame?: number
           fans?: number
+          current_city_id?: string | null
+          current_location?: string
+          health?: number
+          gender?: "female" | "male" | "non_binary" | "other" | "prefer_not_to_say"
+          city_of_birth?: string | null
+          age?: number
+          equipped_clothing?: Json | null
           last_weekly_bonus_at?: string | null
           weekly_bonus_streak?: number
           weekly_bonus_metadata?: Json
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      record_labels: {
+        Row: {
+          id: string
+          name: string
+          prestige: number
+          advance_payment: number
+          royalty_rate: number
+          description: string
+          requirements: Json
+          benefits: string[]
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          prestige: number
+          advance_payment?: number
+          royalty_rate?: number
+          description: string
+          requirements?: Json
+          benefits?: string[]
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          prestige?: number
+          advance_payment?: number
+          royalty_rate?: number
+          description?: string
+          requirements?: Json
+          benefits?: string[]
           created_at?: string
           updated_at?: string
         }


### PR DESCRIPTION
## Summary
- add chat participant status and profile gender enums plus record_labels table to the generated Supabase types
- expand the generated profiles table definition with demographic and weekly bonus bookkeeping fields
- sync the handcrafted supabase snapshot with the regenerated schema for profiles and record labels

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68cd0dd9f408832595a78af43123f6ad