### PR TITLE
Protect admin page with role guard

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/components/ui/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
+import { AdminRoute } from "@/components/AdminRoute";
 
 const universitySchema = z.object({
   city: z.string().min(1, "City is required"),
@@ -223,7 +224,8 @@ export default function Admin() {
   );
 
   return (
-    <div className="container mx-auto max-w-6xl p-6 space-y-6">
+    <AdminRoute>
+      <div className="container mx-auto max-w-6xl p-6 space-y-6">
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Admin Panel</h1>
         <p className="text-muted-foreground">Configure world data and manage gameplay balancing parameters.</p>
@@ -435,6 +437,7 @@ export default function Admin() {
           </Tabs>
         </CardContent>
       </Card>
-    </div>
+      </div>
+    </AdminRoute>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the admin management experience in the existing AdminRoute gate so the new university tooling remains restricted to administrators

## Testing
- npm run lint *(fails: existing lint violations in unrelated modules such as SkillDefinitionsManager.tsx and profileSearch.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1318ef1883259fba44a44975803d