### PR TITLE
Add Supabase universities table and update client types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1319,33 +1319,33 @@ export type Database = {
       }
       universities: {
         Row: {
-          city: string
-          course_cost: number
-          created_at: string
           id: string
           name: string
+          city: string
           prestige: number
           quality_of_learning: number
+          course_cost: number
+          created_at: string
           updated_at: string
         }
         Insert: {
-          city: string
-          course_cost?: number
-          created_at?: string
           id?: string
           name: string
+          city: string
           prestige?: number
           quality_of_learning?: number
+          course_cost?: number
+          created_at?: string
           updated_at?: string
         }
         Update: {
-          city?: string
-          course_cost?: number
-          created_at?: string
           id?: string
           name?: string
+          city?: string
           prestige?: number
           quality_of_learning?: number
+          course_cost?: number
+          created_at?: string
           updated_at?: string
         }
         Relationships: []

--- a/src/integrations/supabase/universities.ts
+++ b/src/integrations/supabase/universities.ts
@@ -6,12 +6,19 @@ export type University = Database['public']['Tables']['universities']['Row'];
 export const fetchUniversities = async (): Promise<University[]> => {
   const { data, error } = await supabase
     .from('universities')
-    .select('*')
-    .order('prestige', { ascending: false });
+    .select('id, name, city, prestige, quality_of_learning, course_cost, created_at, updated_at')
+    .order('prestige', { ascending: false })
+    .order('name', { ascending: true });
 
   if (error) {
     throw new Error(`Failed to fetch universities: ${error.message}`);
   }
 
-  return data ?? [];
+  return (data ?? []).map((university) => ({
+    ...university,
+    course_cost:
+      typeof university.course_cost === 'string'
+        ? Number.parseFloat(university.course_cost)
+        : university.course_cost,
+  }));
 };

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -35,30 +35,7 @@ const universitySchema = z.object({
 
 type UniversityFormValues = z.infer<typeof universitySchema>;
 
-type UniversitiesTable = Database["public"]["Tables"] extends { universities: infer T }
-  ? T
-  : {
-      Row: {
-        id: string;
-        city: string;
-        prestige: number | null;
-        quality_of_learning: number | null;
-        course_cost: number | null;
-        created_at: string | null;
-      };
-      Insert: {
-        city: string;
-        prestige?: number | null;
-        quality_of_learning?: number | null;
-        course_cost?: number | null;
-      };
-      Update: {
-        city?: string;
-        prestige?: number | null;
-        quality_of_learning?: number | null;
-        course_cost?: number | null;
-      };
-    };
+type UniversitiesTable = Database["public"]["Tables"]["universities"];
 
 type UniversityRow = UniversitiesTable extends { Row: infer R } ? R : never;
 type UniversityInsert = UniversitiesTable extends { Insert: infer I } ? I : never;
@@ -87,12 +64,25 @@ export default function Admin() {
     try {
       const { data, error } = await supabase
         .from("universities")
-        .select("*")
-        .order("city", { ascending: true });
+        .select("id, name, city, prestige, quality_of_learning, course_cost, created_at, updated_at")
+        .order("city", { ascending: true })
+        .order("name", { ascending: true });
 
       if (error) throw error;
 
-      setUniversities((data as UniversityRow[] | null) ?? []);
+      type UniversityQueryRow = Omit<UniversityRow, "course_cost"> & {
+        course_cost: UniversityRow["course_cost"] | string;
+      };
+
+      const typedUniversities = ((data as UniversityQueryRow[] | null) ?? []).map((university) => ({
+        ...university,
+        course_cost:
+          typeof university.course_cost === "string"
+            ? Number.parseFloat(university.course_cost)
+            : university.course_cost,
+      }));
+
+      setUniversities(typedUniversities);
     } catch (error) {
       console.error("Failed to load universities", error);
       toast({

--- a/supabase/migrations/20261202090000_create_universities_table.sql
+++ b/supabase/migrations/20261202090000_create_universities_table.sql
@@ -1,0 +1,47 @@
+-- Create universities table to support education planning features
+CREATE TABLE IF NOT EXISTS public.universities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  city TEXT NOT NULL,
+  prestige INTEGER NOT NULL DEFAULT 50 CHECK (prestige BETWEEN 0 AND 100),
+  quality_of_learning INTEGER NOT NULL DEFAULT 50 CHECK (quality_of_learning BETWEEN 0 AND 100),
+  course_cost NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (course_cost >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT universities_name_city_unique UNIQUE (name, city)
+);
+
+CREATE INDEX IF NOT EXISTS universities_city_idx ON public.universities (city);
+CREATE INDEX IF NOT EXISTS universities_prestige_idx ON public.universities (prestige DESC);
+
+ALTER TABLE public.universities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Universities are viewable by everyone" ON public.universities;
+CREATE POLICY "Universities are viewable by everyone"
+  ON public.universities
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Service roles can manage universities" ON public.universities;
+CREATE POLICY "Service roles can manage universities"
+  ON public.universities
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP TRIGGER IF EXISTS set_universities_updated_at ON public.universities;
+CREATE TRIGGER set_universities_updated_at
+  BEFORE UPDATE ON public.universities
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Seed initial data used by the Education experience
+INSERT INTO public.universities (name, city, prestige, quality_of_learning, course_cost)
+SELECT * FROM (VALUES
+  ('Rockmundo Conservatory', 'London', 92, 95, 18500.00),
+  ('Skyline School of Sound', 'New York', 88, 90, 21000.00),
+  ('Harbor Lights Institute', 'Portsmouth', 76, 82, 12500.00)
+) AS seed(name, city, prestige, quality_of_learning, course_cost)
+ON CONFLICT (name, city) DO UPDATE
+SET prestige = EXCLUDED.prestige,
+    quality_of_learning = EXCLUDED.quality_of_learning,
+    course_cost = EXCLUDED.course_cost;


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates the public.universities table with policies, trigger, and seed rows for the education experience
- refresh the generated Supabase types so the universities table is available to clients and expose strongly-typed helpers
- normalize university fetching in the admin helper to select explicit columns and coerce numeric costs

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as SkillDefinitionsManager.tsx and profileSearch.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1318a4908325a57cd955036f89e9