### PR TITLE
Fix admin useCallback dependency warnings

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -687,7 +687,14 @@ export default function Admin() {
         setDeletingUniversityId(null);
       }
     },
-    [editingUniversity?.id, handleFetchUniversities, resetFormState, toast],
+    [
+      editingUniversity?.id,
+      handleFetchUniversities,
+      resetFormState,
+      toast,
+      totalUniversities,
+      universities.length,
+    ],
   );
 
   const handleDeleteSkillBook = useCallback(
@@ -717,7 +724,7 @@ export default function Admin() {
         setDeletingBookId(null);
       }
     },
-    [editingUniversity?.id, handleFetchUniversities, resetFormState, toast],
+    [editingSkillBook?.id, resetSkillBookForm, toast],
   );
 
   return (


### PR DESCRIPTION
## Summary
- include state-dependent values in the admin deletion handler dependencies to satisfy react-hooks lint rules

## Testing
- npx eslint src/pages/Admin.tsx
- npm run lint *(fails: existing parsing error in src/pages/Education.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cd31d447b083258a9ce92d81ea9468