### PR TITLE
Fix duplicate weekly bonus state initialization

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -70,7 +70,6 @@ export const useGameData = (): UseGameDataReturn => {
   const [xpLedger, setXpLedger] = useState<ExperienceLedgerRow[]>([]);
   const [skillProgress, setSkillProgress] = useState<SkillProgressRow[]>([]);
   const [unlockedSkills, setUnlockedSkills] = useState<UnlockedSkillsMap>({});
-  const [freshWeeklyBonusAvailable] = useState(false);
   const [currentCity, setCurrentCity] = useState<CityRow | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- remove the duplicate `freshWeeklyBonusAvailable` state declaration in `useGameData`
- ensure only the state value with its setter remains to avoid the runtime syntax error

## Testing
- npm run lint *(fails: existing parsing errors in Admin.tsx and Education.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3420f8688325a3cba8e25c21c7fa