### PR TITLE
Fix lint parse errors in education and admin pages

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -10,7 +10,6 @@ import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, For
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -21,11 +20,8 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { useToast } from "@/components/ui/use-toast";
-import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
-import { AdminRoute } from "@/components/AdminRoute";
 import { SKILL_TREE_DEFINITIONS, type TierName } from "@/data/skillTree";
 import type { SkillDefinitionRecord } from "@/hooks/useSkillSystem.types";
 
@@ -762,21 +758,10 @@ export default function Admin() {
                               <FormControl>
                                 <Input placeholder="Enter city name" autoComplete="address-level2" {...field} />
                               </FormControl>
-                              <SelectContent>
-                                {skillOptions.map((option) => (
-                                  <SelectItem key={option.value} value={option.value}>
-                                    <div className="flex items-center justify-between gap-2">
-                                      <span>{option.label}</span>
-                                      {option.tier ? <Badge variant="outline">{option.tier}</Badge> : null}
-                                    </div>
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
                       <FormField
                         control={skillBookForm.control}

--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -411,6 +411,9 @@ const videoCollections = [
         link: "https://www.youtube.com/results?search_query=ear+training+intervals",
         summary: "Speed up interval recognition with call-and-response challenges."
       }
+    ]
+  }
+];
 
 const skillLessons: SkillLesson[] = [
   {
@@ -1356,33 +1359,35 @@ const Education = () => {
               </CardDescription>
             </CardHeader>
             <CardContent className="grid gap-6 lg:grid-cols-3">
-              {universityTracks.map((track) => (
-                <Card key={track.title} className="border-dashed">
-                  <CardHeader className="space-y-2">
-                    <CardTitle className="text-lg">{track.title}</CardTitle>
-                    <CardDescription>{track.description}</CardDescription>
-                  </CardHeader>
-                  <CardContent className="space-y-4">
-                    <div className="space-y-3">
-                      {track.highlights.map((highlight) => (
-                        <div key={highlight.name} className="rounded-lg border bg-muted/40 p-4">
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <p className="text-sm font-semibold">{highlight.name}</p>
-                              <p className="text-xs text-muted-foreground">{highlight.school}</p>
+              {group.skills.length > 0 ? (
+                universityTracks.map((track) => (
+                  <Card key={track.title} className="border-dashed">
+                    <CardHeader className="space-y-2">
+                      <CardTitle className="text-lg">{track.title}</CardTitle>
+                      <CardDescription>{track.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div className="space-y-3">
+                        {track.highlights.map((highlight) => (
+                          <div key={highlight.name} className="rounded-lg border bg-muted/40 p-4">
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className="text-sm font-semibold">{highlight.name}</p>
+                                <p className="text-xs text-muted-foreground">{highlight.school}</p>
+                              </div>
+                              <Badge variant="outline" className="text-xs">
+                                {highlight.focus}
+                              </Badge>
                             </div>
-                            <Badge variant="outline" className="text-xs">
-                              {highlight.focus}
-                            </Badge>
+                            <p className="mt-3 text-xs text-muted-foreground">{highlight.details}</p>
                           </div>
-                          <p className="mt-3 text-xs text-muted-foreground">{highlight.details}</p>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                      {group.skills.map((definition) => renderSkillCard(definition))}
-                    </div>
-                  </div>
+                        ))}
+                      </div>
+                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {group.skills.map((definition) => renderSkillCard(definition))}
+                      </div>
+                    </CardContent>
+                  </Card>
                 ))
               ) : (
                 <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- close the video collections data structure and properly gate the university track cards behind a skill check
- clean up the admin city form field by removing stray select markup and unused imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd33f864dc8325a70ad2aab9e6bde2