### PR TITLE
Add city of birth column to profiles

### DIFF
--- a/supabase/migrations/20270415100000_add_city_of_birth_to_profiles.sql
+++ b/supabase/migrations/20270415100000_add_city_of_birth_to_profiles.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS city_of_birth uuid REFERENCES public.cities(id);
+
+COMMENT ON COLUMN public.profiles.city_of_birth IS 'City where the player character was born';
+
+CREATE OR REPLACE VIEW public.public_profiles AS
+SELECT
+  id,
+  user_id,
+  username,
+  display_name,
+  avatar_url,
+  bio,
+  gender,
+  city_of_birth,
+  age
+FROM public.profiles;
+
+GRANT SELECT ON public.public_profiles TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration to add the `city_of_birth` column to the `profiles` table and document its purpose
- refresh the `public_profiles` view so the new column is exposed to PostgREST consumers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd44fdd90c8325a77a5e51c54a15a9