### PR TITLE
Ensure PostgREST recognizes profile gender column

### DIFF
--- a/supabase/migrations/20270415110000_refresh_profiles_gender_column.sql
+++ b/supabase/migrations/20270415110000_refresh_profiles_gender_column.sql
@@ -1,0 +1,26 @@
+-- Ensure the gender column exists on profiles and refresh PostgREST schema cache
+DO $$
+BEGIN
+  CREATE TYPE public.profile_gender AS ENUM (
+    'female',
+    'male',
+    'non_binary',
+    'other',
+    'prefer_not_to_say'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS gender public.profile_gender NOT NULL DEFAULT 'prefer_not_to_say';
+
+UPDATE public.profiles
+SET gender = COALESCE(gender, 'prefer_not_to_say')
+WHERE gender IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN gender SET DEFAULT 'prefer_not_to_say',
+  ALTER COLUMN gender SET NOT NULL;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a migration that reasserts the profiles.gender column definition
- trigger a PostgREST schema cache reload so the API exposes the gender field

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd4f216154832586772389fa27b4da