### PR TITLE
Relax profile completion skill requirement

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,8 +29,12 @@ const Index = () => {
       setError(null);
 
       try {
-        const { isComplete } = await checkProfileCompletion(user.id);
+        const { isComplete, profile } = await checkProfileCompletion(user.id);
         if (!isActive) {
+          return;
+        }
+        if (!profile) {
+          navigate("/character-create");
           return;
         }
         navigate(isComplete ? "/dashboard" : "/character-create");

--- a/src/utils/__tests__/profileCompletion.test.ts
+++ b/src/utils/__tests__/profileCompletion.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+
+type EvaluateProfileCompletion = typeof import("../profileCompletion") extends infer Module
+  ? Module extends { evaluateProfileCompletion: infer Fn }
+    ? Fn
+    : never
+  : never;
+
+type StorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+  key: (index: number) => string | null;
+  length: number;
+};
+
+let evaluateProfileCompletion: EvaluateProfileCompletion;
+
+beforeAll(async () => {
+  (globalThis as unknown as { localStorage: StorageLike }).localStorage ??= {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  } satisfies StorageLike;
+
+  ({ evaluateProfileCompletion } = await import("../profileCompletion"));
+});
+
+describe("evaluateProfileCompletion", () => {
+  const baseProfile = {
+    id: "profile-123",
+    username: "rocker123",
+    display_name: "Rock Legend",
+    avatar_url: "https://example.com/avatar.png",
+    bio: "Ready to take the stage.",
+  };
+
+  const zeroedSkills = {
+    id: "skills-123",
+    guitar: 0,
+    vocals: 0,
+    drums: 0,
+    bass: 0,
+    performance: 0,
+    songwriting: 0,
+    composition: 0,
+  };
+
+  it("treats zero-valued skills as complete when identity fields are filled", () => {
+    const result = evaluateProfileCompletion("user-123", baseProfile, zeroedSkills);
+
+    expect(result.isComplete).toBe(true);
+  });
+
+  it("requires a profile row before considering the account complete", () => {
+    const result = evaluateProfileCompletion("user-123", null, zeroedSkills);
+
+    expect(result.isComplete).toBe(false);
+  });
+
+  it("requires an avatar and bio to mark a profile complete", () => {
+    const result = evaluateProfileCompletion("user-123", {
+      ...baseProfile,
+      avatar_url: "",
+    }, zeroedSkills);
+
+    expect(result.isComplete).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- update profile completion logic to rely on required identity fields and the presence of a skill record rather than non-zero skill values
- ensure the landing page keeps new players in character creation while letting returning players reach the dashboard
- add unit coverage for profile completion scenarios, including zero-valued skills

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd50a32468832589e77b4d93a87ed7