### PR TITLE
Fix undefined book journeys constant in Education page

### DIFF
--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -160,7 +160,7 @@ interface BandMemberWithProfile {
   };
 }
 
-const bookCollections = [
+const bookJourneys = [
   {
     title: "Creative Foundations",
     description:


### PR DESCRIPTION
## Summary
- rename the book collections constant to match the Curated Reading Journeys usage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd534e792c8325853a3c3c1133ccce