### PR TITLE
Handle chunk load failures with cache-busting reload

### DIFF
--- a/src/utils/lazyWithRetry.ts
+++ b/src/utils/lazyWithRetry.ts
@@ -48,7 +48,9 @@ export const lazyWithRetry = <T extends ComponentType<unknown>>(
         }
 
         if (typeof window !== "undefined") {
-          window.location.reload();
+          const currentUrl = new URL(window.location.href);
+          currentUrl.searchParams.set("forceReload", Date.now().toString());
+          window.location.replace(currentUrl.toString());
         }
       }
     }


### PR DESCRIPTION
## Summary
- add a cache-busting reload when a lazy chunk repeatedly fails to load so stale module URLs are refreshed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd544e43108325b34b2505303776db