### PR TITLE
Fix form field context guards

### DIFF
--- a/src/components/ui/form-context.ts
+++ b/src/components/ui/form-context.ts
@@ -12,22 +12,30 @@ type FormItemContextValue = {
   id: string;
 };
 
-const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(null);
 
-const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+const FormItemContext = React.createContext<FormItemContextValue | null>(null);
 
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
-  const { getFieldState, formState } = useFormContext();
-
-  const fieldState = getFieldState(fieldContext.name, formState);
+  const formContext = useFormContext();
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>");
   }
 
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>");
+  }
+
+  if (!formContext) {
+    throw new Error("useFormField should be used within <Form>");
+  }
+
   const { id } = itemContext;
+  const { getFieldState, formState } = formContext;
+  const fieldState = getFieldState(fieldContext.name, formState);
 
   return {
     id,


### PR DESCRIPTION
## Summary
- guard form and item contexts before using form utilities to prevent null destructuring
- provide clearer error messages when form components are rendered outside their providers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd54698848832586b33676e2579558