### PR TITLE
Fix form context destructuring error

### DIFF
--- a/src/components/ui/form-context.ts
+++ b/src/components/ui/form-context.ts
@@ -34,8 +34,7 @@ const useFormField = () => {
   }
 
   const { id } = itemContext;
-  const { getFieldState, formState } = formContext;
-  const fieldState = getFieldState(fieldContext.name, formState);
+  const fieldState = formContext.getFieldState(fieldContext.name, formContext.formState);
 
   return {
     id,


### PR DESCRIPTION
## Summary
- use the form context instance directly when retrieving field state to avoid destructuring null values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd568217fc83258e583eb9064deb1e