### PR TITLE
Load activity feed in game data hook

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -65,13 +65,10 @@ const Dashboard = () => {
     xpLedger,
     freshWeeklyBonusAvailable,
     currentCity,
-
+    activities,
     loading,
     error
   } = useGameData();
-
-  // Simplified - these features not yet implemented
-  const activities: ActivityFeedRow[] = [];
   const [birthCityLabel, setBirthCityLabel] = useState<string | null>(null);
   const [activeChatTab, setActiveChatTab] = useState<ChatScope>("general");
   const [chatOnlineCounts, setChatOnlineCounts] = useState<Record<ChatScope, number>>({


### PR DESCRIPTION
## Summary
- extend the game data hook with typed activity feed support, including initial fetch by profile, resets, and realtime updates for new events
- expose the fetched activities through the hook return value for consumers
- update the dashboard to use the hook-supplied activities instead of a placeholder array

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7bbb982c8325b5caca9c780964ec