### PR TITLE
Embed realtime chat in dashboard tabs

### DIFF
--- a/src/components/chat/RealtimeChatPanel.tsx
+++ b/src/components/chat/RealtimeChatPanel.tsx
@@ -1,11 +1,14 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/hooks/use-auth-context';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { toast } from 'sonner';
+import React, { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/hooks/use-auth-context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 interface Message {
   id: string;
@@ -19,16 +22,22 @@ interface RealtimeChatPanelProps {
   channelKey?: string;
   className?: string;
   title?: string;
+  onConnectionStatusChange?: (connected: boolean) => void;
+  onParticipantCountChange?: (count: number) => void;
 }
 
 export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
   channelKey = 'general',
   className = '',
-  title = 'Chat'
+  title = 'Chat',
+  onConnectionStatusChange,
+  onParticipantCountChange
 }) => {
   const { user } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [message, setMessage] = useState('');
+  const [isConnected, setIsConnected] = useState(false);
+  const [participantCount, setParticipantCount] = useState(0);
 
   const fetchMessages = useCallback(async () => {
     if (!user) return;
@@ -85,10 +94,41 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
   }, [user, channelKey, fetchMessages]);
 
   useEffect(() => {
-    if (!user) return;
+    if (!user) {
+      setIsConnected(false);
+      setParticipantCount(0);
+      onConnectionStatusChange?.(false);
+      onParticipantCountChange?.(0);
+      return;
+    }
 
-    const channel = supabase
-      .channel('global-chat-updates')
+    let isMounted = true;
+    const channelName = `global-chat-${channelKey}`;
+    const channel = supabase.channel(channelName, {
+      config: {
+        presence: { key: user.id }
+      }
+    });
+
+    const updatePresence = () => {
+      if (!isMounted) return;
+      const presenceState = channel.presenceState<{ user_id: string }>();
+      const participantIds = new Set<string>();
+
+      Object.values(presenceState).forEach((entries) => {
+        entries.forEach((entry) => {
+          if (entry?.user_id) {
+            participantIds.add(entry.user_id);
+          }
+        });
+      });
+
+      const count = participantIds.size;
+      setParticipantCount(count);
+      onParticipantCountChange?.(count);
+    };
+
+    channel
       .on(
         'postgres_changes',
         {
@@ -101,12 +141,40 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
           void fetchMessages();
         }
       )
-      .subscribe();
+      .on('presence', { event: 'sync' }, updatePresence)
+      .on('presence', { event: 'join' }, updatePresence)
+      .on('presence', { event: 'leave' }, updatePresence)
+      .subscribe((status) => {
+        if (!isMounted) return;
+
+        if (status === 'SUBSCRIBED') {
+          setIsConnected(true);
+          onConnectionStatusChange?.(true);
+          void channel
+            .track({ user_id: user.id })
+            .then(() => {
+              if (isMounted) {
+                updatePresence();
+              }
+            })
+            .catch((presenceError) => {
+              console.error('Error updating presence:', presenceError);
+            });
+        } else if (status === 'TIMED_OUT' || status === 'CHANNEL_ERROR' || status === 'CLOSED') {
+          setIsConnected(false);
+          onConnectionStatusChange?.(false);
+        }
+      });
 
     return () => {
+      isMounted = false;
+      setIsConnected(false);
+      setParticipantCount(0);
+      onConnectionStatusChange?.(false);
+      onParticipantCountChange?.(0);
       supabase.removeChannel(channel);
     };
-  }, [user, channelKey, fetchMessages]);
+  }, [user, channelKey, fetchMessages, onConnectionStatusChange, onParticipantCountChange]);
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -115,10 +183,35 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
     }
   };
 
+  const renderHeaderMeta = () => (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-full px-3 py-1",
+          isConnected ? "bg-emerald-100 text-emerald-600" : "bg-amber-100 text-amber-600"
+        )}
+      >
+        <span
+          className={cn(
+            "h-2 w-2 rounded-full",
+            isConnected ? "bg-emerald-500" : "bg-amber-500"
+          )}
+        />
+        {isConnected ? "Connected" : "Connecting"}
+      </div>
+      <Badge variant="secondary" className="border-border/40 bg-muted/50 text-foreground/70">
+        {participantCount} online
+      </Badge>
+    </div>
+  );
+
   if (!user) {
     return (
-      <Card className={className}>
-        <CardContent className="p-6">
+      <Card className={cn("flex h-full flex-col", className)}>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-1 items-center justify-center p-6">
           <p className="text-center text-muted-foreground">
             Please log in to use the chat
           </p>
@@ -128,42 +221,49 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
   }
 
   return (
-    <div className={`flex gap-4 h-96 ${className}`}>
-      <Card className="flex-1">
-        <CardHeader>
-          <CardTitle>{title} - {channelKey}</CardTitle>
-        </CardHeader>
-        <CardContent className="p-0">
-          <ScrollArea className="h-64 p-4">
-            <div className="space-y-2">
-              {messages.map((msg) => (
-                <div key={msg.id} className="p-2 bg-muted/50 rounded">
-                  <div className="text-sm font-medium">User {msg.user_id.slice(0, 8)}</div>
-                  <div className="text-sm">{msg.message}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {new Date(msg.created_at).toLocaleTimeString()}
-                  </div>
+    <Card className={cn("flex h-full flex-col", className)}>
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+          {renderHeaderMeta()}
+        </div>
+        <p className="text-xs text-muted-foreground">Channel: {channelKey}</p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4 p-4">
+        <ScrollArea className="flex-1 rounded-md border border-border/50 bg-muted/20 p-3">
+          <div className="space-y-2">
+            {messages.map((msg) => (
+              <div key={msg.id} className="rounded-md bg-muted/60 p-2">
+                <div className="text-xs font-semibold text-muted-foreground">
+                  User {msg.user_id.slice(0, 8)}
                 </div>
-              ))}
-            </div>
-          </ScrollArea>
-          <div className="p-4 border-t">
-            <div className="flex gap-2">
-              <Input
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                onKeyPress={handleKeyPress}
-                placeholder="Type a message..."
-                className="flex-1"
-              />
-              <Button onClick={sendMessage} disabled={!message.trim()}>
-                Send
-              </Button>
-            </div>
+                <div className="text-sm text-foreground">{msg.message}</div>
+                <div className="text-[10px] text-muted-foreground/80">
+                  {new Date(msg.created_at).toLocaleTimeString()}
+                </div>
+              </div>
+            ))}
+            {messages.length === 0 && (
+              <p className="text-center text-xs text-muted-foreground">
+                No messages yet. Start the conversation!
+              </p>
+            )}
           </div>
-        </CardContent>
-      </Card>
-    </div>
+        </ScrollArea>
+        <div className="flex gap-2">
+          <Input
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder="Type a message..."
+            className="flex-1"
+          />
+          <Button onClick={sendMessage} disabled={!message.trim()}>
+            Send
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -527,15 +527,23 @@ const Dashboard = () => {
                   </Badge>
                 </TabsTrigger>
               </TabsList>
-              <TabsContent value="general">
-                <div className="text-center text-muted-foreground py-8">
-                  Chat system coming soon!
-                </div>
+              <TabsContent value="general" className="mt-4">
+                <RealtimeChatPanel
+                  channelKey="general"
+                  title="Global Chat"
+                  className="h-[28rem] border border-primary/20 bg-card/90 backdrop-blur-sm"
+                  onConnectionStatusChange={handleGeneralConnection}
+                  onParticipantCountChange={handleGeneralOnlineCount}
+                />
               </TabsContent>
-              <TabsContent value="city">
-                <div className="text-center text-muted-foreground py-8">
-                  City chat coming soon!
-                </div>
+              <TabsContent value="city" className="mt-4">
+                <RealtimeChatPanel
+                  channelKey={`city-${currentCity?.id ?? 'lobby'}`}
+                  title={cityTabLabel}
+                  className="h-[28rem] border border-primary/20 bg-card/90 backdrop-blur-sm"
+                  onConnectionStatusChange={handleCityConnection}
+                  onParticipantCountChange={handleCityOnlineCount}
+                />
               </TabsContent>
             </Tabs>
           </CardContent>
@@ -755,11 +763,6 @@ const Dashboard = () => {
               </CardContent>
             </Card>
           </div>
-          <RealtimeChatPanel
-            channelKey="general"
-            title="Live Chat"
-            className="bg-card/80 backdrop-blur-sm border-primary/20"
-          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enhance the realtime chat panel with presence tracking callbacks and refreshed styling
- embed the chat panel directly in the dashboard tabs for global and city rooms while wiring badge counts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7bbd66cc832590fcac0350171357