### PR TITLE
Display current city badge on dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -128,6 +128,7 @@ const Dashboard = () => {
   }, [currentCity]);
 
   const cityTabLabel = cityNameLabel ? `${cityNameLabel} Chat` : "City Chat";
+  const currentCityDisplay = `Current City: ${cityNameLabel ?? "London"}`;
   const activeOnlineCount = chatOnlineCounts[activeChatTab];
   const activeConnection = chatConnections[activeChatTab];
   const cityChatPlaceholder = "Say hello to fellow musicians...";
@@ -334,6 +335,9 @@ const Dashboard = () => {
               </Badge>
               <Badge variant="outline" className="border-border text-foreground/80">
                 Rising Artist
+              </Badge>
+              <Badge variant="outline" className="border-border text-foreground/80">
+                {currentCityDisplay}
               </Badge>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- derive a dashboard header display string from the existing cityNameLabel with a London fallback
- surface the current city value alongside the existing header badges

## Testing
- bun test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd829c171c8325b2ec80f4fc1ca156