### PR TITLE
Fix runtime error by removing FormControl from admin sort select

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -972,11 +972,9 @@ export default function Admin() {
                       <span>Universities</span>
                       <div className="flex items-center gap-2">
                         <Select value={sortColumn} onValueChange={(value) => handleSortColumnChange(value as SortColumn)}>
-                          <FormControl>
-                            <SelectTrigger className="w-[180px]">
-                              <SelectValue placeholder="Sort by" />
-                            </SelectTrigger>
-                          </FormControl>
+                          <SelectTrigger className="w-[180px]">
+                            <SelectValue placeholder="Sort by" />
+                          </SelectTrigger>
                           <SelectContent>
                             {sortColumnOptions.map((option) => (
                               <SelectItem key={option.value} value={option.value}>


### PR DESCRIPTION
## Summary
- remove the standalone FormControl wrapper from the universities sort select to avoid using the form context hook outside a form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd833791688325a5439f596768e957