### PR TITLE
Add auto scroll behavior to realtime chat panel

### DIFF
--- a/src/components/chat/RealtimeChatPanel.tsx
+++ b/src/components/chat/RealtimeChatPanel.tsx
@@ -49,6 +49,7 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
   const [isConnected, setIsConnected] = useState(false);
   const [participantCount, setParticipantCount] = useState(0);
   const profileCacheRef = useRef<Record<string, string>>({});
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
 
   const fetchMessages = useCallback(async () => {
     if (!user) return;
@@ -164,6 +165,16 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
       void fetchMessages();
     }
   }, [user, channelKey, fetchMessages]);
+
+  useEffect(() => {
+    const viewport = scrollAreaRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]"
+    ) as HTMLDivElement | null;
+
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight;
+    }
+  }, [messages]);
 
   useEffect(() => {
     if (!user) {
@@ -302,7 +313,10 @@ export const RealtimeChatPanel: React.FC<RealtimeChatPanelProps> = ({
         <p className="text-xs text-muted-foreground">Channel: {channelKey}</p>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col gap-4 p-4">
-        <ScrollArea className="flex-1 rounded-md border border-border/50 bg-muted/20 p-3">
+        <ScrollArea
+          ref={scrollAreaRef}
+          className="flex-1 max-h-64 rounded-md border border-border/50 bg-muted/20 p-3"
+        >
           <div className="space-y-2">
             {messages.map((msg) => (
               <div key={msg.id} className="rounded-md bg-muted/60 p-2">


### PR DESCRIPTION
## Summary
- attach a scroll area ref to the realtime chat panel and scroll to the bottom whenever messages change
- constrain the chat message list height so the scroll area shows a limited set of cards while enabling overflow scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd8db7ec7483259631d972e7089324