### PR TITLE
Display extended player attributes on dashboard and profile

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -6,7 +6,21 @@ import { awardActionXp as awardActionXpUtility, type AwardActionXpInput } from "
 
 export type PlayerProfile = Database["public"]["Tables"]["profiles"]["Row"];
 export type PlayerSkills = Database["public"]["Tables"]["player_skills"]["Row"] | null;
-type AttributeCategory = "creativity" | "business" | "marketing" | "technical";
+type AttributeCategory =
+  | "creativity"
+  | "business"
+  | "marketing"
+  | "technical"
+  | "charisma"
+  | "looks"
+  | "mental_focus"
+  | "musicality"
+  | "physical_endurance"
+  | "stage_presence"
+  | "crowd_engagement"
+  | "social_reach"
+  | "business_acumen"
+  | "marketing_savvy";
 
 export type PlayerAttributes = Record<AttributeCategory, number>;
 export type PlayerXpWallet = Database["public"]["Tables"]["player_xp_wallet"]["Row"] | null;
@@ -28,6 +42,16 @@ const ATTRIBUTE_COLUMN_MAP: Record<AttributeCategory, keyof PlayerAttributesRow>
   business: "business_acumen",
   marketing: "marketing_savvy",
   technical: "technical_mastery",
+  charisma: "charisma",
+  looks: "looks",
+  mental_focus: "mental_focus",
+  musicality: "musicality",
+  physical_endurance: "physical_endurance",
+  stage_presence: "stage_presence",
+  crowd_engagement: "crowd_engagement",
+  social_reach: "social_reach",
+  business_acumen: "business_acumen",
+  marketing_savvy: "marketing_savvy",
 };
 
 const XP_LEDGER_FETCH_LIMIT = 20;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -82,6 +82,13 @@ const formatNotificationDate = (isoString: string | null | undefined) => {
   }).format(parsed);
 };
 
+const formatAttributeLabel = (attributeKey: keyof PlayerAttributes) =>
+  attributeKey
+    .toString()
+    .split("_")
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+
 const Dashboard = () => {
   const navigate = useNavigate();
   const {
@@ -117,10 +124,16 @@ const Dashboard = () => {
     "composition"
   ];
   const attributeKeys: (keyof PlayerAttributes)[] = [
-    "creativity",
-    "business",
-    "marketing",
-    "technical"
+    "charisma",
+    "looks",
+    "mental_focus",
+    "musicality",
+    "physical_endurance",
+    "stage_presence",
+    "crowd_engagement",
+    "social_reach",
+    "business_acumen",
+    "marketing_savvy"
   ];
 
   const handleChatTabChange = useCallback((value: string) => {
@@ -682,21 +695,22 @@ const Dashboard = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <TrendingUp className="h-5 w-5 text-primary" />
-                Professional Attributes
+                Core Attributes
               </CardTitle>
-              <CardDescription>Business and creative prowess</CardDescription>
+              <CardDescription>Signature traits that shape your performances</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {attributeKeys.map(attributeKey => {
                 const value = Number(attributes?.[attributeKey] ?? 0);
                 const percent = Math.min(100, (value / 1000) * 100);
+                const label = formatAttributeLabel(attributeKey);
                 return (
                   <div key={attributeKey} className="space-y-2">
-                    <span className="capitalize font-medium text-sm">{attributeKey}</span>
+                    <span className="font-medium text-sm">{label}</span>
                     <Progress
                       value={percent}
                       className="h-2"
-                      aria-label={`${attributeKey} attribute score ${value} out of 1000`}
+                      aria-label={`${label} attribute score ${value} out of 1000`}
                     />
                   </div>
                 );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -93,11 +93,24 @@ const instrumentSkillKeys: (keyof PlayerSkills)[] = [
 ];
 
 const attributeKeys: (keyof PlayerAttributes)[] = [
-  "creativity",
-  "business",
-  "marketing",
-  "technical"
+  "charisma",
+  "looks",
+  "mental_focus",
+  "musicality",
+  "physical_endurance",
+  "stage_presence",
+  "crowd_engagement",
+  "social_reach",
+  "business_acumen",
+  "marketing_savvy"
 ];
+
+const formatAttributeLabel = (attributeKey: keyof PlayerAttributes) =>
+  attributeKey
+    .toString()
+    .split("_")
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
 
 const genderOptions: { value: ProfileGender; label: string }[] = [
   { value: "female", label: "Female" },
@@ -1441,20 +1454,21 @@ const Profile = () => {
                     <TrendingUp className="h-5 w-5 text-primary" />
                     Professional Attributes
                   </CardTitle>
-                  <CardDescription>Business, creative, and technical strengths</CardDescription>
+                  <CardDescription>Signature traits that define your artistry and influence</CardDescription>
                 </CardHeader>
                 <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {attributeKeys.map(attributeKey => {
                       const value = Number(attributes?.[attributeKey] ?? 0);
                       const percent = Math.min(100, (value / 1000) * 100);
+                      const label = formatAttributeLabel(attributeKey);
                       return (
                         <div key={attributeKey} className="space-y-2">
-                          <span className="text-sm font-medium capitalize">{attributeKey}</span>
+                          <span className="text-sm font-medium">{label}</span>
                           <Progress
                             value={percent}
                             className="h-2"
-                            aria-label={`${attributeKey} attribute score ${value} out of 1000`}
+                            aria-label={`${label} attribute score ${value} out of 1000`}
                           />
                           <div className="text-xs text-muted-foreground">
                             High values unlock greater opportunities and campaign performance.


### PR DESCRIPTION
## Summary
- expand the player attribute mapping to include the extended attribute columns from Supabase
- surface charisma, looks, mental focus, musicality, and other core stats on the dashboard
- show the same extended attribute list with friendly labels on the profile attributes tab

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceaf24e8208325a98a65b209e9a062