### PR TITLE
Ensure profiles support demographic fields

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -979,16 +979,22 @@ export type Database = {
       }
       profiles: {
         Row: {
+          age: number
           avatar_url: string | null
           bio: string | null
           cash: number | null
+          city_of_birth: string | null
           created_at: string | null
+          current_city_id: string | null
+          current_location: string
           display_name: string | null
           equipment_loadout: Json | null
           experience: number | null
           experience_at_last_weekly_bonus: number | null
           fame: number | null
           fans: number | null
+          gender: Database["public"]["Enums"]["profile_gender"]
+          health: number
           id: string
           last_weekly_bonus_at: string | null
           level: number | null
@@ -999,16 +1005,22 @@ export type Database = {
           weekly_bonus_streak: number | null
         }
         Insert: {
+          age?: number
           avatar_url?: string | null
           bio?: string | null
           cash?: number | null
+          city_of_birth?: string | null
           created_at?: string | null
+          current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
           equipment_loadout?: Json | null
           experience?: number | null
           experience_at_last_weekly_bonus?: number | null
           fame?: number | null
           fans?: number | null
+          gender?: Database["public"]["Enums"]["profile_gender"]
+          health?: number
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
@@ -1019,16 +1031,22 @@ export type Database = {
           weekly_bonus_streak?: number | null
         }
         Update: {
+          age?: number
           avatar_url?: string | null
           bio?: string | null
           cash?: number | null
+          city_of_birth?: string | null
           created_at?: string | null
+          current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
           equipment_loadout?: Json | null
           experience?: number | null
           experience_at_last_weekly_bonus?: number | null
           fame?: number | null
           fans?: number | null
+          gender?: Database["public"]["Enums"]["profile_gender"]
+          health?: number
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
@@ -1038,7 +1056,22 @@ export type Database = {
           weekly_bonus_metadata?: Json | null
           weekly_bonus_streak?: number | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "profiles_city_of_birth_fkey"
+            columns: ["city_of_birth"]
+            isOneToOne: false
+            referencedRelation: "cities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profiles_current_city_id_fkey"
+            columns: ["current_city_id"]
+            isOneToOne: false
+            referencedRelation: "cities"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       skill_definitions: {
         Row: {
@@ -1449,6 +1482,12 @@ export type Database = {
       app_role: "admin" | "moderator" | "user"
       chat_participant_status: "online" | "offline" | "typing" | "away"
       friendship_status: "pending" | "accepted" | "declined" | "blocked"
+      profile_gender:
+        | "female"
+        | "male"
+        | "non_binary"
+        | "other"
+        | "prefer_not_to_say"
       show_type_enum: "concert" | "festival" | "private" | "street"
     }
     CompositeTypes: {

--- a/supabase/migrations/20270426100000_extend_profiles_demographics.sql
+++ b/supabase/migrations/20270426100000_extend_profiles_demographics.sql
@@ -1,0 +1,88 @@
+BEGIN;
+
+-- Ensure the profile_gender enum exists with all expected values
+DO $$
+BEGIN
+  CREATE TYPE public.profile_gender AS ENUM (
+    'female',
+    'male',
+    'non_binary',
+    'other',
+    'prefer_not_to_say'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add any missing profile columns used by the application
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS gender public.profile_gender,
+  ADD COLUMN IF NOT EXISTS age integer,
+  ADD COLUMN IF NOT EXISTS city_of_birth uuid REFERENCES public.cities(id),
+  ADD COLUMN IF NOT EXISTS current_city_id uuid REFERENCES public.cities(id),
+  ADD COLUMN IF NOT EXISTS current_location text,
+  ADD COLUMN IF NOT EXISTS health integer;
+
+-- Apply defaults and constraints expected by the UI
+UPDATE public.profiles
+SET gender = COALESCE(gender, 'prefer_not_to_say')
+WHERE gender IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN gender SET DEFAULT 'prefer_not_to_say',
+  ALTER COLUMN gender SET NOT NULL;
+
+UPDATE public.profiles
+SET age = COALESCE(age, 16)
+WHERE age IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN age SET DEFAULT 16,
+  ALTER COLUMN age SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_age_check'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_age_check CHECK (age BETWEEN 13 AND 120);
+  END IF;
+END $$;
+
+UPDATE public.profiles
+SET current_location = COALESCE(current_location, 'Unknown')
+WHERE current_location IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN current_location SET DEFAULT 'Unknown',
+  ALTER COLUMN current_location SET NOT NULL;
+
+UPDATE public.profiles
+SET health = COALESCE(health, 100)
+WHERE health IS NULL;
+
+ALTER TABLE public.profiles
+  ALTER COLUMN health SET DEFAULT 100,
+  ALTER COLUMN health SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_health_check'
+      AND conrelid = 'public.profiles'::regclass
+  ) THEN
+    ALTER TABLE public.profiles
+      ADD CONSTRAINT profiles_health_check CHECK (health BETWEEN 0 AND 100);
+  END IF;
+END $$;
+
+-- Make the new schema available to the API without a restart
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a safety migration that ensures the `profile_gender` enum and demographic/location columns exist on `public.profiles`
- enforce the defaults and constraints required by the UI so profile mutations succeed out of the box
- refresh the generated Supabase TypeScript definitions to expose the new profile fields and enum

## Testing
- npm run lint *(fails: existing repository lint errors about `any` usage in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb84b06248325be9c96c16d724e57