### PR TITLE
Add migration to refresh profiles gender column for PostgREST

### DIFF
--- a/supabase/migrations/20270425140000_refresh_profile_gender_and_notify.sql
+++ b/supabase/migrations/20270425140000_refresh_profile_gender_and_notify.sql
@@ -1,0 +1,5 @@
+-- Ensure PostgREST sees the gender column on profiles
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS gender public.profile_gender NOT NULL DEFAULT 'prefer_not_to_say';
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a guard migration that re-adds the profiles.gender column if needed and triggers a PostgREST schema reload

## Testing
- n/a (supabase CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ceb967f3a88325bda8bc4d7b456fc8