### PR TITLE
Refine Supabase typing across character, skill, and friend hooks

### DIFF
--- a/src/components/CharacterSelect.tsx
+++ b/src/components/CharacterSelect.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { useToast } from "@/components/ui/use-toast";
 import { useGameData } from "@/hooks/useGameData";
+import type { CreateCharacterInput } from "@/hooks/useGameData";
 import { Sparkles, Lock, Unlock } from "lucide-react";
 
 const CHARACTER_SLOT_COST: Record<number, number> = {
@@ -58,12 +59,15 @@ const CharacterSelect = () => {
 
     try {
       const username = normalizeUsername(trimmed);
-      await createCharacter({
+      const payload: CreateCharacterInput = {
         username,
         display_name: trimmed,
-        // slotNumber and unlockCost are handled by createCharacter internally
+        slotNumber: nextSlotNumber,
+        unlockCost: requiredUnlockCost,
         makeActive
-      } as any);
+      };
+
+      await createCharacter(payload);
 
       setStageName("");
       toast({

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -5,25 +5,12 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
 import { useGameData } from '@/hooks/useGameData';
 import { Lock, Star, Trophy, Music, Users, Mic, Zap } from 'lucide-react';
 
-interface SkillDefinition {
-  id: string;
-  slug: string;
-  display_name: string;
-  description: string;
-  tier_caps: any;
-}
-
-interface SkillProgress {
-  id: string;
-  profile_id: string;
-  skill_slug: string;
-  current_level: number;
-  current_xp: number;
-  required_xp: number;
-}
+type SkillDefinition = Database['public']['Tables']['skill_definitions']['Row'];
+type SkillProgress = Database['public']['Tables']['skill_progress']['Row'];
 
 interface SkillCategory {
   name: string;
@@ -65,21 +52,21 @@ export const SkillTree: React.FC = () => {
       try {
         const { data: skillsData, error: skillsError } = await supabase
           .from('skill_definitions')
-          .select('*')
+          .select<SkillDefinition>('*')
           .order('display_name');
 
         if (skillsError) throw skillsError;
 
-        setSkills((skillsData || []) as SkillDefinition[]);
+        setSkills(skillsData ?? []);
 
         if (profile) {
           const { data: progressData, error: progressError } = await supabase
             .from('skill_progress')
-            .select('*')
+            .select<SkillProgress>('*')
             .eq('profile_id', profile.id);
 
           if (progressError) throw progressError;
-          setProgress(progressData || []);
+          setProgress(progressData ?? []);
         }
       } catch (error) {
         console.error('Error fetching skills:', error);

--- a/src/hooks/SkillSystemProvider.tsx
+++ b/src/hooks/SkillSystemProvider.tsx
@@ -102,7 +102,7 @@ export const SkillSystemProvider = ({ children }: PropsWithChildren): JSX.Elemen
         current_xp: nextXp,
         required_xp: existing?.required_xp ?? null,
         last_practiced_at: lastPracticedAt,
-        metadata: metadata as any,
+        metadata: metadata as SkillProgressInsert["metadata"],
       };
 
       const { data, error: upsertError } = await supabase

--- a/src/hooks/useEquippedClothing.tsx
+++ b/src/hooks/useEquippedClothing.tsx
@@ -29,9 +29,11 @@ export const useEquippedClothing = (): UseEquippedClothingResult => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const equipmentLoadout = profile?.equipment_loadout ?? null;
+
   const loadout = useMemo(() => {
-    return parseClothingLoadout((profile as any)?.equipment_loadout ?? null);
-  }, [(profile as any)?.equipment_loadout]);
+    return parseClothingLoadout(equipmentLoadout);
+  }, [equipmentLoadout]);
 
   const fetchClothing = useCallback(async () => {
     if (!profile) {

--- a/src/utils/wardrobe.ts
+++ b/src/utils/wardrobe.ts
@@ -18,7 +18,9 @@ export const DEFAULT_OUTFIT: WardrobeDefaultPiece[] = [
   { slot: "top", name: "Rockmundo Logo Tee" }
 ];
 
-export const parseClothingLoadout = (value: ProfileRow["equipped_clothing"] | null | undefined): ClothingLoadout => {
+export const parseClothingLoadout = (
+  value: ProfileRow["equipment_loadout"] | null | undefined,
+): ClothingLoadout => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {};
   }
@@ -153,7 +155,7 @@ export const ensureDefaultWardrobe = async (
 
   const { error: profileUpdateError } = await supabase
     .from("profiles")
-    .update({ equipped_clothing: currentLoadout as ProfileRow["equipped_clothing"] })
+    .update({ equipment_loadout: currentLoadout as ProfileRow["equipment_loadout"] })
     .eq("id", profileId);
 
   if (profileUpdateError) {


### PR DESCRIPTION
## Summary
- ensure character creation payloads conform to `CreateCharacterInput` including slot metadata
- load skill definitions and progress with generated Supabase row types instead of `any`
- tighten Supabase typing across friendship and wardrobe utilities while removing `any` casts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceb950f21083259a3dcd854f8ab0e2