### PR TITLE
Add migration to reapply profile columns and refresh PostgREST

### DIFF
--- a/supabase/migrations/20270426150000_refresh_profiles_columns_and_schema_cache.sql
+++ b/supabase/migrations/20270426150000_refresh_profiles_columns_and_schema_cache.sql
@@ -1,0 +1,24 @@
+-- Ensure required profile columns exist and refresh PostgREST schema cache
+DO $$
+BEGIN
+  CREATE TYPE public.profile_gender AS ENUM (
+    'female',
+    'male',
+    'non_binary',
+    'other',
+    'prefer_not_to_say'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS gender public.profile_gender NOT NULL DEFAULT 'prefer_not_to_say',
+  ADD COLUMN IF NOT EXISTS current_city_id uuid REFERENCES public.cities(id);
+
+ALTER TABLE public.profiles
+  ALTER COLUMN gender SET DEFAULT 'prefer_not_to_say',
+  ALTER COLUMN gender SET NOT NULL;
+
+-- Refresh PostgREST schema cache so the new columns are immediately available
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a follow-up migration that reasserts the `profiles.gender` and `profiles.current_city_id` columns
- refresh PostgREST's schema cache so the columns become visible immediately after applying migrations

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cebcecaa9083259aefae383d4a6c5c