### PR TITLE
Ensure profiles expose current_city_id column

### DIFF
--- a/supabase/migrations/20270430110000_add_current_city_id_to_profiles.sql
+++ b/supabase/migrations/20270430110000_add_current_city_id_to_profiles.sql
@@ -1,0 +1,6 @@
+-- Ensure current_city_id exists on profiles and refresh schema cache
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_city_id uuid REFERENCES public.cities(id);
+
+-- Refresh PostgREST schema cache so the new column is immediately available
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a safety migration that creates the profiles.current_city_id column with the proper UUID reference
- trigger a PostgREST schema reload so the column becomes available immediately after running migrations

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ced4ed057c83259fe8be71a3f63693