### PR TITLE
Add migration to reset profile-related data

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ supabase db reset
 The migration pulls in the generated `supabase/seed/skills_seed.sql` file, so running the script keeps migrations and runtime data
 in sync.
 
+## Profile data reset for the new flow
+
+Deployments that introduce the refreshed profile flow must run the `20270431150000_reset_profile_data.sql` migration before
+serving traffic. The migration truncates all profile-linked XP, attribute, skill, wallet, and progression tables (using
+`TRUNCATE ... RESTART IDENTITY CASCADE`) and then clears `public.profiles`. This guarantees dependent sequences are reset and no
+stale profile data survives the reset.
+
+Run the Supabase migrations in your target environment prior to rollout:
+
+```sh
+supabase db push
+# or for a full local refresh
+supabase db reset
+```
+
+This data-only migration does not change the schema, so the generated Supabase TypeScript definitions stay in sync without any
+additional regeneration.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/c3d67299-48a1-4744-a78e-1169f70eea31) and click on Share -> Publish.

--- a/supabase/migrations/20270431150000_reset_profile_data.sql
+++ b/supabase/migrations/20270431150000_reset_profile_data.sql
@@ -1,0 +1,32 @@
+-- Migration: 20270431150000_reset_profile_data
+-- SAFETY NOTE: This migration performs a full reset of profile-related progression data
+-- ahead of the new profile flow rollout. It truncates all XP, attribute, and skill tables
+-- before clearing the profile records themselves. Only run this in environments where a
+-- complete player reset is acceptable.
+
+BEGIN;
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Resetting all profile-linked tables prior to deleting profile rows.';
+  RAISE NOTICE 'This will truncate XP, attribute, skill, and wallet tables and restart their sequences.';
+END;
+$$;
+
+TRUNCATE TABLE
+  public.experience_ledger,
+  public.xp_ledger,
+  public.attribute_spend,
+  public.player_daily_cats,
+  public.player_weekly_activity,
+  public.player_skill_books,
+  public.player_skills,
+  public.profile_attributes,
+  public.player_attributes,
+  public.player_xp_wallet
+RESTART IDENTITY CASCADE;
+
+-- Truncate profiles last so any remaining foreign-key dependencies are cleared via CASCADE.
+TRUNCATE TABLE public.profiles RESTART IDENTITY CASCADE;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a guarded Supabase migration that truncates XP, attribute, skill, and wallet tables before clearing profiles for a full reset
- document the reset procedure in the README so deployments know to run the migration ahead of the new profile flow

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cefb72c124832581a775fcdced23fe