### PR TITLE
Fix avatar image source fallback in Profile

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -301,7 +301,10 @@ const Profile = () => {
             <div className="space-y-4">
               <div className="flex flex-col items-center gap-4">
                 <Avatar className="h-32 w-32 border-4 border-background shadow-lg">
-                  <AvatarImage src={formState.avatarUrl || profile?.avatar_url ?? undefined} alt={`${profileDisplayName} avatar`} />
+                  <AvatarImage
+                    src={formState.avatarUrl || profile?.avatar_url || undefined}
+                    alt={`${profileDisplayName} avatar`}
+                  />
                   <AvatarFallback>{avatarFallback}</AvatarFallback>
                 </Avatar>
 


### PR DESCRIPTION
## Summary
- update the profile avatar image source selection to avoid mixing nullish coalescing and logical OR operators which broke bundling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf05b74c088325b800d7ec0823aed1