### PR TITLE
feat: show age on character page

### DIFF
--- a/src/pages/MyCharacter.tsx
+++ b/src/pages/MyCharacter.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type ElementType } from "react";
 import {
+  Cake,
   CalendarDays,
   MapPin,
   Mic,
@@ -34,6 +35,7 @@ const sanitizeSkillLabel = (label: string) =>
 
 const PROFILE_META_FIELDS: Array<{ key: keyof PlayerProfile; label: string; icon: ElementType }> = [
   { key: "current_location", label: "Hometown", icon: MapPin },
+  { key: "age", label: "Age", icon: Cake },
   { key: "genre", label: "Primary Genre", icon: Music },
   { key: "fame", label: "Fame", icon: Sparkles },
   { key: "fans", label: "Fans", icon: Users },


### PR DESCRIPTION
## Summary
- add the age field from the Supabase profile to the My Character metadata section
- include a cake icon so the age appears alongside the rest of the profile badges

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0da9f27c8325a088a9be3e3c61a4