### PR TITLE
Add city profile metadata columns and parsing

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -267,44 +267,80 @@ export type Database = {
       }
       cities: {
         Row: {
+          bonuses: string | null
+          busking_value: number | null
           cost_of_living: number | null
           country: string
           created_at: string | null
           cultural_events: string[] | null
+          description: string | null
+          districts: Json | null
           dominant_genre: string | null
+          featured_studios: Json
+          featured_venues: Json
+          famous_resident: string | null
           id: string
           local_bonus: number | null
           music_scene: number | null
           name: string
           population: number | null
+          profile_description: string | null
+          transport_links: Json
+          travel_hub: string | null
+          travel_nodes: Json | null
+          unlocked: boolean | null
           updated_at: string | null
           venues: number | null
         }
         Insert: {
+          bonuses?: string | null
+          busking_value?: number | null
           cost_of_living?: number | null
           country: string
           created_at?: string | null
           cultural_events?: string[] | null
+          description?: string | null
+          districts?: Json | null
           dominant_genre?: string | null
+          featured_studios?: Json
+          featured_venues?: Json
+          famous_resident?: string | null
           id?: string
           local_bonus?: number | null
           music_scene?: number | null
           name: string
           population?: number | null
+          profile_description?: string | null
+          transport_links?: Json
+          travel_hub?: string | null
+          travel_nodes?: Json | null
+          unlocked?: boolean | null
           updated_at?: string | null
           venues?: number | null
         }
         Update: {
+          bonuses?: string | null
+          busking_value?: number | null
           cost_of_living?: number | null
           country?: string
           created_at?: string | null
           cultural_events?: string[] | null
+          description?: string | null
+          districts?: Json | null
           dominant_genre?: string | null
+          featured_studios?: Json
+          featured_venues?: Json
+          famous_resident?: string | null
           id?: string
           local_bonus?: number | null
           music_scene?: number | null
           name?: string
           population?: number | null
+          profile_description?: string | null
+          transport_links?: Json
+          travel_hub?: string | null
+          travel_nodes?: Json | null
+          unlocked?: boolean | null
           updated_at?: string | null
           venues?: number | null
         }

--- a/supabase/migrations/20270602120000_add_city_profile_fields.sql
+++ b/supabase/migrations/20270602120000_add_city_profile_fields.sql
@@ -1,0 +1,21 @@
+-- Add structured profile metadata for cities to support the City page content
+alter table public.cities
+  add column if not exists profile_description text,
+  add column if not exists featured_venues jsonb not null default '[]'::jsonb,
+  add column if not exists featured_studios jsonb not null default '[]'::jsonb,
+  add column if not exists transport_links jsonb not null default '[]'::jsonb;
+
+update public.cities
+  set featured_venues = coalesce(featured_venues, '[]'::jsonb),
+      featured_studios = coalesce(featured_studios, '[]'::jsonb),
+      transport_links = coalesce(transport_links, '[]'::jsonb)
+  where featured_venues is null
+     or featured_studios is null
+     or transport_links is null;
+
+-- Ensure the JSON columns always store arrays for consistent downstream parsing
+alter table public.cities
+  alter column featured_venues set default '[]'::jsonb,
+  alter column featured_studios set default '[]'::jsonb,
+  alter column transport_links set default '[]'::jsonb;
+


### PR DESCRIPTION
## Summary
- add a Supabase migration that introduces city profile description plus featured venue, studio, and transport metadata columns
- refresh the generated Supabase TypeScript definitions so the new city fields are available in the client
- extend the world environment loader to normalize the new city profile data for use in the City page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfdfbaba7c8325bc15b3ae77c21e1e