### PR TITLE
Fix Admin imports and mentor roster syntax

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,8 +1,6 @@
+import { Building2, Gift, GraduationCap, NotebookPen, Sparkles, Users } from "lucide-react";
+import { Link } from "react-router-dom";
 
-import { Gift, GraduationCap, NotebookPen, Sparkles } from "lucide-react";
-import { Link } from "react-router-dom";
-import { Gift, GraduationCap, NotebookPen, Users } from "lucide-react";
-import { Link } from "react-router-dom";
 import { AdminRoute } from "@/components/AdminRoute";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -42,6 +40,8 @@ const adminSections = [
     href: "/admin/band-learning",
     action: "Manage band sessions",
     Icon: Sparkles,
+  },
+  {
     title: "Mentors",
     description: "Control the mentor roster powering education XP and progression boosts.",
     href: "/admin/mentors",

--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -636,6 +636,9 @@ const mentorOptions: MentorOption[] = [
     requiredSkillValue: 160,
     skillGainRatio: 0.8,
     bonusDescription: "Adds sustain control exercises that accelerate range stability and nightly recovery."
+  }
+];
+
 const bandSessions: BandSession[] = [
   {
     id: "band-sync-lock",


### PR DESCRIPTION
## Summary
- consolidate lucide-react imports on the admin dashboard and restore the mentors section entry
- close the mentor options array in the education page so the following band session data compiles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe88083008325a27dc6ff5e5a78e6