### PR TITLE
Fix admin card icons

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,4 @@
-import { Building2, Gift, GraduationCap, NotebookPen, Sparkles, Users } from "lucide-react";
+import { Building2, Gift, GraduationCap, NotebookPen, PlaySquare, Sparkles, Users } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { AdminRoute } from "@/components/AdminRoute";
@@ -40,6 +40,8 @@ const adminSections = [
     href: "/admin/youtube-videos",
     action: "Manage YouTube content",
     Icon: PlaySquare,
+  },
+  {
     title: "Band Learning",
     description: "Curate collaborative sessions that power the band's education track.",
     href: "/admin/band-learning",
@@ -51,6 +53,7 @@ const adminSections = [
     description: "Control the mentor roster powering education XP and progression boosts.",
     href: "/admin/mentors",
     action: "Manage mentors",
+    Icon: Users,
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- import the missing PlaySquare icon for the YouTube playlists admin card
- ensure the Band Learning admin card is defined separately with its Sparkles icon
- assign the Mentors card the Users icon to avoid rendering an undefined component

## Testing
- npm run lint *(fails: existing parsing errors in src/integrations/supabase/types.ts and src/pages/Education.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cfea6c5758832587ca0bdbb8877ea0