### PR TITLE
Align education mentor attribute keys with supported set

### DIFF
--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -457,7 +457,7 @@ const mentorOptions: MentorOption[] = [
     cooldownHours: 36,
     baseXp: 190,
     difficulty: "intermediate",
-    attributeKeys: ["vocal_talent", "physical_endurance"],
+    attributeKeys: ["vocal_talent", "technical_mastery"],
     requiredSkillValue: 160,
     skillGainRatio: 0.8,
     bonusDescription: "Adds sustain control exercises that accelerate range stability and nightly recovery."


### PR DESCRIPTION
## Summary
- replace the mentor vocal attribute combination to use the supported `technical_mastery` key instead of `physical_endurance`
- keep mentor metadata aligned with the AttributeKey union so education pages compile cleanly

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cffae255f8832591c62ad6d6e8de72