### PR TITLE
Add band sessions query to education page

### DIFF
--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -464,7 +464,7 @@ const mentorOptions: MentorOption[] = [
   }
 ];
 
-const bandSessions: BandSession[] = [
+const DEFAULT_BAND_SESSIONS: BandSession[] = [
   {
     id: "band-sync-lock",
     title: "Sync Lock Intensive",
@@ -565,8 +565,34 @@ const Education = () => {
         ? "We couldn't load resource playlists. Please try again later."
         : "";
 
+  const {
+    data: bandSessionRows,
+    isLoading: bandSessionsLoading,
+    error: bandSessionsError,
+  } = useQuery({
+    queryKey: ["education", "band-sessions"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("education_band_sessions")
+        .select("*")
+        .order("difficulty", { ascending: true })
+        .order("title", { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as BandSessionRow[];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
   const bandSessions = useMemo<BandSession[]>(() => {
-    const sessions = (bandSessionRows ?? []).map((row) => {
+    if (!bandSessionRows) {
+      return DEFAULT_BAND_SESSIONS;
+    }
+
+    const sessions = bandSessionRows.map((row) => {
       const focusSkills = Array.isArray(row.focus_skills)
         ? row.focus_skills.filter((skill): skill is PrimarySkill => isPrimarySkill(skill))
         : [];


### PR DESCRIPTION
## Summary
- fetch education band sessions from Supabase using react-query and expose loading/error states
- fall back to default band sessions list when remote data is unavailable

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cffae817248325849b3cf39379035b