### PR TITLE
Add stub GameData provider export

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/lib/supabase-types";
 import { useAuth } from "@/hooks/use-auth-context";
@@ -1065,6 +1066,4 @@ export const useGameData = (): UseGameDataReturn => {
   return value;
 };
 
-export const GameDataProvider = ({ children }: { children: ReactNode }) => {
-  return <>{children}</>;
-};
+export const GameDataProvider = ({ children }: { children: ReactNode }) => <>{children}</>;


### PR DESCRIPTION
## Summary
- import the ReactNode type to support a typed GameDataProvider children prop
- expose a stub GameDataProvider that simply renders its children so App.tsx can use it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cffd8d0c3c8325aa6ccdc98a33efde