### PR TITLE
Fix lint warnings and replace any types

### DIFF
--- a/src/pages/City.tsx
+++ b/src/pages/City.tsx
@@ -28,14 +28,6 @@ interface CityContentProps {
   onRetry: () => void;
 }
 
-export interface CityPageLoadResult {
-  city: CityRecord;
-  details: CityEnvironmentDetails | null;
-  detailsError: string | null;
-}
-
-export const CITY_NOT_FOUND_ERROR = "CITY_NOT_FOUND";
-
 const TRANSPORT_ICON_MAP: Record<string, LucideIcon> = {
   rail: Train,
   train: Train,
@@ -56,34 +48,6 @@ const getTransportIcon = (type?: string): LucideIcon => {
 
   const normalized = type.toLowerCase().trim();
   return TRANSPORT_ICON_MAP[normalized] ?? MapPin;
-};
-
-export const loadCityPageData = async (cityId: string): Promise<CityPageLoadResult> => {
-  const snapshot = await fetchWorldEnvironmentSnapshot();
-  const matchedCity = snapshot.cities.find((entry) => entry.id === cityId);
-
-  if (!matchedCity) {
-    throw new Error(CITY_NOT_FOUND_ERROR);
-  }
-
-  let details: CityEnvironmentDetails | null = null;
-  let detailsError: string | null = null;
-
-  try {
-    details = await fetchCityEnvironmentDetails(matchedCity.id, {
-      cityName: matchedCity.name,
-      country: matchedCity.country,
-    });
-  } catch (error) {
-    console.error(`Failed to load city environment details for ${matchedCity.name}`, error);
-    detailsError = "We couldn't load extended city details right now.";
-  }
-
-  return {
-    city: matchedCity,
-    details,
-    detailsError,
-  };
 };
 
 export const CityContent = ({

--- a/src/pages/WorldMap.tsx
+++ b/src/pages/WorldMap.tsx
@@ -21,10 +21,10 @@ const WorldMap = () => {
     staleTime: 5 * 60 * 1000,
   });
 
-  const cities = data?.cities ?? [];
-
   const pins = useMemo(() => {
-    if (!cities.length) {
+    const cityList = data?.cities ?? [];
+
+    if (!cityList.length) {
       return [] as Array<{
         id: string;
         label: string;
@@ -34,7 +34,7 @@ const WorldMap = () => {
       }>;
     }
 
-    return cities.map((city) => {
+    return cityList.map((city) => {
       const coordinates = getCoordinatesForCity(city.name, city.country);
       const point = projectCoordinates(coordinates, MAP_DIMENSIONS);
       const left = `${(point.x / MAP_DIMENSIONS.width) * 100}%`;
@@ -52,7 +52,7 @@ const WorldMap = () => {
         description,
       };
     });
-  }, [cities]);
+  }, [data?.cities]);
 
   const renderMap = () => {
     if (isLoading) {

--- a/src/pages/__tests__/city.test.tsx
+++ b/src/pages/__tests__/city.test.tsx
@@ -106,7 +106,8 @@ describe("City page", () => {
       fetchCityEnvironmentDetails: detailsMock,
     }));
 
-    const { CityContent, loadCityPageData } = await import("../City");
+    const { CityContent } = await import("../City");
+    const { loadCityPageData } = await import("../city-data");
 
     const result = await loadCityPageData(sampleCity.id);
 
@@ -149,7 +150,7 @@ describe("City page", () => {
       fetchCityEnvironmentDetails: mock(async () => sampleDetails),
     }));
 
-    const { loadCityPageData, CITY_NOT_FOUND_ERROR } = await import("../City");
+    const { loadCityPageData, CITY_NOT_FOUND_ERROR } = await import("../city-data");
 
     await expect(loadCityPageData("missing-city"))
       .rejects.toThrow(CITY_NOT_FOUND_ERROR);

--- a/src/pages/city-data.ts
+++ b/src/pages/city-data.ts
@@ -1,0 +1,42 @@
+import {
+  fetchCityEnvironmentDetails,
+  fetchWorldEnvironmentSnapshot,
+  type City as CityRecord,
+  type CityEnvironmentDetails,
+} from "@/utils/worldEnvironment";
+
+export interface CityPageLoadResult {
+  city: CityRecord;
+  details: CityEnvironmentDetails | null;
+  detailsError: string | null;
+}
+
+export const CITY_NOT_FOUND_ERROR = "CITY_NOT_FOUND";
+
+export const loadCityPageData = async (cityId: string): Promise<CityPageLoadResult> => {
+  const snapshot = await fetchWorldEnvironmentSnapshot();
+  const matchedCity = snapshot.cities.find((entry) => entry.id === cityId);
+
+  if (!matchedCity) {
+    throw new Error(CITY_NOT_FOUND_ERROR);
+  }
+
+  let details: CityEnvironmentDetails | null = null;
+  let detailsError: string | null = null;
+
+  try {
+    details = await fetchCityEnvironmentDetails(matchedCity.id, {
+      cityName: matchedCity.name,
+      country: matchedCity.country,
+    });
+  } catch (error) {
+    console.error(`Failed to load city environment details for ${matchedCity.name}`, error);
+    detailsError = "We couldn't load extended city details right now.";
+  }
+
+  return {
+    city: matchedCity,
+    details,
+    detailsError,
+  };
+};

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -801,20 +801,20 @@ export interface Database {
     };
     Views: {
       [key: string]: {
-        Row: Record<string, any>;
+        Row: Record<string, unknown>;
       };
     };
     Functions: {
       [key: string]: {
-        Args: Record<string, any>;
-        Returns: any;
+        Args: Record<string, unknown>;
+        Returns: unknown;
       };
     };
     Enums: {
       [key: string]: string;
     };
     CompositeTypes: {
-      [key: string]: Record<string, any>;
+      [key: string]: Record<string, unknown>;
     };
   };
 }

--- a/src/types/emergency-types.ts
+++ b/src/types/emergency-types.ts
@@ -1,19 +1,33 @@
-// Minimal emergency types to bypass corrupted Supabase types
-export type Json = any;
+// Minimal emergency types to bypass corrupted Supabase types without relying on `any`
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
 
-// Use any for everything until types are regenerated
-export const supabase: any = null;
+// Placeholder supabase client used when the generated types are unavailable
+export const supabase = null;
 
 export interface Database {
   public: {
-    Tables: any;
-    Views: any;
-    Functions: any;
-    Enums: any;
-    CompositeTypes: any;
+    Tables: Record<string, unknown>;
+    Views: Record<string, unknown>;
+    Functions: Record<string, unknown>;
+    Enums: Record<string, string>;
+    CompositeTypes: Record<string, unknown>;
   };
 }
 
-export type Tables<T extends string> = any;
-export type TablesInsert<T extends string> = any;
-export type TablesUpdate<T extends string> = any;
+type PublicSchema = Database["public"];
+
+export type Tables<T extends string> = T extends keyof PublicSchema["Tables"]
+  ? PublicSchema["Tables"][T]
+  : unknown;
+export type TablesInsert<T extends string> = T extends keyof PublicSchema["Tables"]
+  ? PublicSchema["Tables"][T]
+  : unknown;
+export type TablesUpdate<T extends string> = T extends keyof PublicSchema["Tables"]
+  ? PublicSchema["Tables"][T]
+  : unknown;


### PR DESCRIPTION
## Summary
- move city data loading helpers into a dedicated module so City.tsx only exports components
- stabilize the WorldMap pin memoization dependencies to satisfy react-hooks linting
- replace remaining `any` usages in fallback Supabase type definitions with safer alternatives

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00834ba1483259754db7752c41221