### PR TITLE
Add latitude and longitude data for cities

### DIFF
--- a/src/pages/WorldMap.tsx
+++ b/src/pages/WorldMap.tsx
@@ -35,7 +35,12 @@ const WorldMap = () => {
     }
 
     return cityList.map((city) => {
-      const coordinates = getCoordinatesForCity(city.name, city.country);
+      const coordinates = getCoordinatesForCity(
+        city.name,
+        city.country,
+        city.latitude ?? null,
+        city.longitude ?? null,
+      );
       const point = projectCoordinates(coordinates, MAP_DIMENSIONS);
       const left = `${(point.x / MAP_DIMENSIONS.width) * 100}%`;
       const top = `${(point.y / MAP_DIMENSIONS.height) * 100}%`;

--- a/src/utils/worldEnvironment.ts
+++ b/src/utils/worldEnvironment.ts
@@ -433,6 +433,8 @@ export interface City {
   venues: number;
   local_bonus: number;
   busking_value: number;
+  latitude?: number;
+  longitude?: number;
   cultural_events: string[];
   locations: CityLocation[];
   venueHighlights: CityVenueHighlight[];
@@ -647,6 +649,10 @@ const normalizeCityRecord = (item: Record<string, unknown>): City => {
     typeof item.profile_description === "string" ? item.profile_description : undefined;
   const bonuses = typeof item.bonuses === "string" ? item.bonuses : undefined;
   const unlocked = typeof item.unlocked === "boolean" ? item.unlocked : undefined;
+  const latitudeValue = toNumber(item.latitude, Number.NaN);
+  const longitudeValue = toNumber(item.longitude, Number.NaN);
+  const latitude = Number.isFinite(latitudeValue) ? latitudeValue : undefined;
+  const longitude = Number.isFinite(longitudeValue) ? longitudeValue : undefined;
 
   return {
     id: String(item.id ?? crypto.randomUUID()),
@@ -663,6 +669,8 @@ const normalizeCityRecord = (item: Record<string, unknown>): City => {
     venues: toNumber(item.venues),
     local_bonus: toNumber(item.local_bonus, 1),
     busking_value: toNumber(item.busking_value, 1),
+    latitude,
+    longitude,
     cultural_events: culturalEvents,
     locations,
     venueHighlights,

--- a/src/utils/worldTravel.ts
+++ b/src/utils/worldTravel.ts
@@ -117,7 +117,7 @@ const CITY_COORDINATES: Record<string, Coordinates> = {
   'solace-city': { lat: 37.7749, lng: -122.4194 },
   'vela horizonte': { lat: -22.9068, lng: -43.1729 },
   'vela-horizonte': { lat: -22.9068, lng: -43.1729 },
-  'asterhaven': { lat: 52.4862, lng: -1.8904 },
+  'asterhaven': { lat: 51.5072, lng: -0.1276 },
 };
 
 const DISTRICT_COORDINATES: Record<string, Coordinates> = {
@@ -263,10 +263,29 @@ export const getCoordinatesForLocation = (
   return hashToCoordinate(`${location}`);
 };
 
+const parseCoordinateOverride = (value?: number | null) => {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  return Number.isFinite(value) ? value : null;
+};
+
 export const getCoordinatesForCity = (
   cityName?: string | null,
   country?: string | null,
-): Coordinates => getCoordinatesForLocation(cityName, { country });
+  latitudeOverride?: number | null,
+  longitudeOverride?: number | null,
+): Coordinates => {
+  const latitude = parseCoordinateOverride(latitudeOverride);
+  const longitude = parseCoordinateOverride(longitudeOverride);
+
+  if (latitude !== null && longitude !== null) {
+    return { lat: latitude, lng: longitude };
+  }
+
+  return getCoordinatesForLocation(cityName, { country });
+};
 
 const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
 

--- a/supabase/migrations/20270602140000_add_latitude_longitude_to_cities.sql
+++ b/supabase/migrations/20270602140000_add_latitude_longitude_to_cities.sql
@@ -1,0 +1,19 @@
+-- Add latitude and longitude columns to cities and backfill existing records
+alter table public.cities
+  add column if not exists latitude double precision,
+  add column if not exists longitude double precision;
+
+update public.cities as c
+set latitude = coords.latitude,
+    longitude = coords.longitude
+from (
+  values
+    ('Neo Tokyo', 35.6762, 139.6503),
+    ('Solace City', 37.7749, -122.4194),
+    ('Vela Horizonte', -22.9068, -43.1729),
+    ('Asterhaven', 51.5072, -0.1276)
+) as coords(name, latitude, longitude)
+where c.name = coords.name;
+
+comment on column public.cities.latitude is 'Latitude coordinate for the city centre.';
+comment on column public.cities.longitude is 'Longitude coordinate for the city centre.';


### PR DESCRIPTION
## Summary
- add latitude/longitude columns to the `public.cities` table and populate existing seed cities
- surface optional latitude/longitude fields through the world environment utilities
- prefer database-provided coordinates when plotting cities on the world map

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d00f2bd5fc8325ae5850377e079b6a