### PR TITLE
Update world events to use game events table

### DIFF
--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -600,26 +600,44 @@ export interface Database {
         Row: {
           id: string;
           title: string;
-          description: string;
+          description: string | null;
+          event_type: string;
           start_date: string;
           end_date: string;
-          created_at: string;
+          rewards: Json | null;
+          requirements: Json | null;
+          max_participants: number | null;
+          current_participants: number | null;
+          is_active: boolean | null;
+          created_at: string | null;
         };
         Insert: {
           id?: string;
           title: string;
-          description: string;
+          description?: string | null;
+          event_type: string;
           start_date: string;
           end_date: string;
-          created_at?: string;
+          rewards?: Json | null;
+          requirements?: Json | null;
+          max_participants?: number | null;
+          current_participants?: number | null;
+          is_active?: boolean | null;
+          created_at?: string | null;
         };
         Update: {
           id?: string;
           title?: string;
-          description?: string;
+          description?: string | null;
+          event_type?: string;
           start_date?: string;
           end_date?: string;
-          created_at?: string;
+          rewards?: Json | null;
+          requirements?: Json | null;
+          max_participants?: number | null;
+          current_participants?: number | null;
+          is_active?: boolean | null;
+          created_at?: string | null;
         };
       };
       gigs: {

--- a/src/utils/worldEnvironment.ts
+++ b/src/utils/worldEnvironment.ts
@@ -684,29 +684,132 @@ const normalizeCityRecord = (item: Record<string, unknown>): City => {
 };
 
 const normalizeWorldEventRecord = (item: Record<string, unknown>): WorldEvent => {
-  const typeRaw = typeof item.type === "string" ? item.type : "";
-  const type = WORLD_EVENT_TYPES.includes(typeRaw as WorldEvent["type"]) ?
-    (typeRaw as WorldEvent["type"]) : "festival";
+  const typeCandidates = [item.event_type, item.type]
+    .map((value) => (typeof value === "string" ? value.trim().toLowerCase() : ""))
+    .filter((value) => value.length > 0);
 
-  const globalEffects = parseNumericRecord(item.global_effects as Record<string, unknown> | null | undefined);
-  const affectedCities = Array.isArray(item.affected_cities)
-    ? item.affected_cities.filter((city: unknown): city is string => typeof city === "string")
-    : [];
+  const type = typeCandidates.find((candidate) =>
+    WORLD_EVENT_TYPES.includes(candidate as WorldEvent["type"]),
+  ) as WorldEvent["type"] | undefined;
 
-  const startDate = typeof item.start_date === "string" ? item.start_date : new Date().toISOString();
-  const endDate = typeof item.end_date === "string" ? item.end_date : startDate;
+  const requirementsRecord = isRecord(item.requirements) ? item.requirements : undefined;
+  const rewardsRecord = isRecord(item.rewards) ? item.rewards : undefined;
+  const metadataRecord = isRecord(item.metadata) ? item.metadata : undefined;
+
+  const affectedCitySources: unknown[] = [
+    item.affected_cities,
+    requirementsRecord?.affected_cities,
+    requirementsRecord?.cities,
+    requirementsRecord?.locations,
+    requirementsRecord?.regions,
+    rewardsRecord?.affected_cities,
+    rewardsRecord?.cities,
+    rewardsRecord?.locations,
+    metadataRecord?.affected_cities,
+    metadataRecord?.cities,
+    metadataRecord?.locations,
+  ];
+
+  const affectedCitiesSet = affectedCitySources.reduce<Set<string>>((acc, source) => {
+    parseStringArray(source).forEach((city) => acc.add(city));
+    return acc;
+  }, new Set());
+
+  const locationCandidates = [
+    requirementsRecord?.location,
+    requirementsRecord?.city,
+    requirementsRecord?.region,
+    rewardsRecord?.location,
+    metadataRecord?.location,
+    metadataRecord?.city,
+    item.location,
+  ];
+
+  locationCandidates.forEach((entry) => {
+    if (typeof entry === "string" && entry.trim()) {
+      affectedCitiesSet.add(entry.trim());
+    }
+  });
+
+  const affectedCities = affectedCitiesSet.size > 0 ? Array.from(affectedCitiesSet) : ["all"];
+
+  const effectSources: unknown[] = [
+    item.global_effects,
+    rewardsRecord?.global_effects,
+    rewardsRecord?.effects,
+    rewardsRecord?.multipliers,
+    metadataRecord?.global_effects,
+    metadataRecord?.effects,
+    requirementsRecord?.global_effects,
+  ];
+
+  const effectRecord = effectSources.find((entry) => isRecord(entry)) as
+    | Record<string, unknown>
+    | undefined;
+
+  const globalEffects = parseNumericRecord(effectRecord);
+
+  const rewardCandidates = [
+    item.participation_reward,
+    rewardsRecord?.participation_reward,
+    rewardsRecord?.cash,
+    rewardsRecord?.money,
+    rewardsRecord?.payout,
+    rewardsRecord?.reward,
+    rewardsRecord?.credits,
+    rewardsRecord?.amount,
+    rewardsRecord?.cash_reward,
+  ];
+
+  let participationReward = 0;
+  for (const candidate of rewardCandidates) {
+    const numericValue = toNumber(candidate, Number.NaN);
+    if (!Number.isNaN(numericValue)) {
+      participationReward = numericValue;
+      break;
+    }
+  }
+
+  const startDate = typeof item.start_date === "string"
+    ? item.start_date
+    : typeof item.startDate === "string"
+      ? item.startDate
+      : new Date().toISOString();
+
+  const endDate = typeof item.end_date === "string"
+    ? item.end_date
+    : typeof item.endDate === "string"
+      ? item.endDate
+      : startDate;
+
+  const startTimestamp = Date.parse(startDate);
+  const endTimestamp = Date.parse(endDate);
+  const scheduleActive = !Number.isNaN(startTimestamp) && !Number.isNaN(endTimestamp)
+    ? Date.now() >= startTimestamp && Date.now() <= endTimestamp
+    : false;
+
+  const isActive = typeof item.is_active === "boolean"
+    ? item.is_active
+    : typeof item.isActive === "boolean"
+      ? item.isActive
+      : scheduleActive;
 
   return {
     id: String(item.id ?? crypto.randomUUID()),
-    title: typeof item.title === "string" ? item.title : "Global Event",
-    description: typeof item.description === "string" ? item.description : "",
-    type,
+    title: typeof item.title === "string" ? item.title : typeof item.name === "string" ? item.name : "Global Event",
+    description:
+      typeof item.description === "string"
+        ? item.description
+        : typeof metadataRecord?.description === "string"
+          ? metadataRecord.description
+          : "",
+    type: type ?? "festival",
     start_date: startDate,
     end_date: endDate,
     affected_cities: affectedCities,
     global_effects: globalEffects,
-    participation_reward: toNumber(item.participation_reward),
-    is_active: Boolean(item.is_active),
+    participation_reward: participationReward,
+    is_active: Boolean(isActive),
   };
 };
 
@@ -973,7 +1076,7 @@ const locationMatches = (needle: string, haystack: string) => {
 export const fetchWorldEnvironmentSnapshot = async (): Promise<WorldEnvironmentSnapshot> => {
   const [citiesResponse, worldEventsResponse, randomEventsResponse] = await Promise.all([
     supabase.from("cities").select("*").order("name", { ascending: true }),
-    supabase.from("world_events").select("*").order("start_date", { ascending: true }),
+    supabase.from("game_events").select("*").order("start_date", { ascending: true }),
     supabase.from("random_events").select("*").order("expiry", { ascending: true }),
   ]);
 
@@ -1181,7 +1284,7 @@ export const fetchEnvironmentModifiers = async (
 ): Promise<EnvironmentModifierSummary> => {
   const [weatherResponse, worldEventsResponse] = await Promise.all([
     supabase.from("weather").select("*"),
-    supabase.from("world_events").select("*"),
+    supabase.from("game_events").select("*"),
   ]);
 
   if (weatherResponse.error) throw weatherResponse.error;


### PR DESCRIPTION
## Summary
- read world events from the Supabase `game_events` table and normalize the payload so missing fields are handled safely
- align the fallback database typings for `game_events` with the live schema to keep generated and manual types consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d015bdcd208325bee733b9069f6720