### PR TITLE
Add dashboard friend discovery and prevent duplicate requests

### DIFF
--- a/src/integrations/supabase/friends.ts
+++ b/src/integrations/supabase/friends.ts
@@ -1,9 +1,9 @@
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/lib/supabase-types";
 
-type FriendshipRow = Database["public"]["Tables"]["friendships"]["Row"];
-type FriendshipStatus = Database["public"]["Enums"]["friendship_status"];
-type FriendProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+export type FriendshipRow = Database["public"]["Tables"]["friendships"]["Row"];
+export type FriendshipStatus = Database["public"]["Enums"]["friendship_status"];
+export type FriendProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 
 export interface SendFriendRequestParams {
   senderProfileId: string;
@@ -14,6 +14,52 @@ export interface SendFriendRequestParams {
 }
 
 const PROFILE_SELECTION = "id, user_id, username, display_name, bio, level, fame";
+const FRIENDSHIP_SELECTION =
+  "id, user_id, friend_user_id, user_profile_id, friend_profile_id, status, created_at, updated_at";
+
+const formatInFilterList = (values: string[]) =>
+  `(${values.map(value => `"${value}"`).join(",")})`;
+
+const escapeIlikeTerm = (term: string) => term.replace(/[%_]/g, match => `\\${match}`);
+
+export interface ProfileSearchParams {
+  query: string;
+  limit?: number;
+  excludeProfileIds?: string[];
+}
+
+export const searchProfilesByDisplayNameOrUsername = async ({
+  query,
+  limit = 8,
+  excludeProfileIds = [],
+}: ProfileSearchParams): Promise<FriendProfileRow[]> => {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  const sanitized = escapeIlikeTerm(trimmed);
+  const searchExpression = `display_name.ilike.%${sanitized}%,username.ilike.%${sanitized}%`;
+
+  let builder = supabase
+    .from("profiles")
+    .select(PROFILE_SELECTION)
+    .or(searchExpression)
+    .order("fame", { ascending: false })
+    .limit(Math.max(1, limit));
+
+  if (excludeProfileIds.length > 0) {
+    builder = builder.not("id", "in", formatInFilterList(excludeProfileIds));
+  }
+
+  const { data, error } = await builder;
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as FriendProfileRow[]) ?? [];
+};
 
 export const fetchPrimaryProfileForUser = async (
   userId: string,
@@ -38,9 +84,7 @@ export const fetchFriendshipsForProfile = async (
 ): Promise<FriendshipRow[]> => {
   const { data, error } = await supabase
     .from("friendships")
-    .select(
-      "id, user_id, friend_user_id, user_profile_id, friend_profile_id, status, created_at, updated_at",
-    )
+    .select(FRIENDSHIP_SELECTION)
     .or(`user_profile_id.eq.${profileId},friend_profile_id.eq.${profileId}`)
     .order("created_at", { ascending: false });
 
@@ -59,9 +103,7 @@ export const updateFriendshipStatus = async (
     .from("friendships")
     .update({ status })
     .eq("id", friendshipId)
-    .select(
-      "id, user_id, friend_user_id, user_profile_id, friend_profile_id, status, created_at, updated_at",
-    )
+    .select(FRIENDSHIP_SELECTION)
     .single();
 
   if (error) {
@@ -69,6 +111,31 @@ export const updateFriendshipStatus = async (
   }
 
   return data as FriendshipRow;
+};
+
+export const findExistingFriendshipBetweenProfiles = async (
+  profileAId: string,
+  profileBId: string,
+): Promise<FriendshipRow | null> => {
+  if (!profileAId || !profileBId || profileAId === profileBId) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("friendships")
+    .select(FRIENDSHIP_SELECTION)
+    .or(
+      `and(user_profile_id.eq.${profileAId},friend_profile_id.eq.${profileBId}),and(user_profile_id.eq.${profileBId},friend_profile_id.eq.${profileAId})`,
+    )
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as FriendshipRow | null) ?? null;
 };
 
 export const fetchProfilesByIds = async (


### PR DESCRIPTION
## Summary
- add Supabase helpers to search profiles and detect existing friendships
- add a dashboard social card for searching musicians with preview modal and request actions
- hook send request to Supabase with optimistic updates, toasts, and friend list refresh

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0227470a083259537c550d4865153