### PR TITLE
Add health service placeholders and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,11 @@ const PlayerStatistics = lazyWithRetry(() => import("./pages/PlayerStatistics"))
 const Busking = lazyWithRetry(() => import("./pages/Busking"));
 const Education = lazyWithRetry(() => import("./pages/Education"));
 const Health = lazyWithRetry(() => import("./pages/Health"));
+const Therapy = lazyWithRetry(() => import("./pages/Therapy"));
+const Rehab = lazyWithRetry(() => import("./pages/Rehab"));
+const WonderDrugs = lazyWithRetry(() => import("./pages/WonderDrugs"));
+const CosmeticSurgery = lazyWithRetry(() => import("./pages/CosmeticSurgery"));
+const Doctor = lazyWithRetry(() => import("./pages/Doctor"));
 const Underworld = lazyWithRetry(() => import("./pages/Underworld"));
 const Finances = lazyWithRetry(() => import("./pages/Finances"));
 const Merchandise = lazyWithRetry(() => import("./pages/Merchandise"));
@@ -142,6 +147,11 @@ function App() {
                     <Route path="merchandise" element={<Merchandise />} />
                     <Route path="statistics" element={<PlayerStatistics />} />
                     <Route path="health" element={<Health />} />
+                    <Route path="health/therapy" element={<Therapy />} />
+                    <Route path="health/rehab" element={<Rehab />} />
+                    <Route path="health/wonder-drugs" element={<WonderDrugs />} />
+                    <Route path="health/cosmetic-surgery" element={<CosmeticSurgery />} />
+                    <Route path="health/doctor" element={<Doctor />} />
                     <Route path="my-character/edit" element={<MyCharacterEdit />} />
                     <Route path="*" element={<NotFound />} />
                   </Route>

--- a/src/pages/CosmeticSurgery.tsx
+++ b/src/pages/CosmeticSurgery.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+const CosmeticSurgeryPage = () => {
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Cosmetic Surgery</h1>
+        <p className="text-muted-foreground">
+          Plan elective procedures while balancing recovery timelines and public relations.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Feature Placeholder</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          <p>
+            This feature will allow you to weigh brand opportunities, downtime, and medical risks before proceeding
+            with cosmetic changes.
+          </p>
+          <Separator />
+          <ul className="list-disc space-y-2 pl-4">
+            <li>Consult with specialists and align recovery with tour gaps.</li>
+            <li>Track cost estimates alongside insurance coverage.</li>
+            <li>Coordinate media strategies to manage fan expectations.</li>
+          </ul>
+          <Button asChild variant="outline" className="mt-4 w-fit">
+            <Link to="/health">Back to Health Overview</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default CosmeticSurgeryPage;

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+const DoctorPage = () => {
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Primary Doctor</h1>
+        <p className="text-muted-foreground">
+          Manage regular checkups, track prescriptions, and keep your touring crew informed.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Roadmap Preview</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          <p>
+            Soon you will be able to share lab results, manage appointments, and set reminders directly with your
+            primary care physician.
+          </p>
+          <Separator />
+          <ul className="list-disc space-y-2 pl-4">
+            <li>Keep vaccination and preventive care schedules up to date.</li>
+            <li>Log prescriptions and dosage adjustments across the team.</li>
+            <li>Receive alerts when medical clearance is required for events.</li>
+          </ul>
+          <Button asChild variant="outline" className="mt-4 w-fit">
+            <Link to="/health">Back to Health Overview</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DoctorPage;

--- a/src/pages/Health.tsx
+++ b/src/pages/Health.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { useGameData } from "@/hooks/useGameData";
@@ -12,6 +13,7 @@ import {
   Moon,
   Syringe,
 } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const clampToPercent = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
 
@@ -268,6 +270,30 @@ const HealthPage = () => {
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Health Services</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Connect with specialist support teams when you need targeted recovery plans or advanced care.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {[
+              { label: "Therapy", to: "/health/therapy" },
+              { label: "Rehab", to: "/health/rehab" },
+              { label: "Wonder Drugs", to: "/health/wonder-drugs" },
+              { label: "Cosmetic Surgery", to: "/health/cosmetic-surgery" },
+              { label: "Doctor", to: "/health/doctor" },
+            ].map((service) => (
+              <Button key={service.to} asChild variant="outline" className="justify-start">
+                <Link to={service.to}>{service.label}</Link>
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/pages/Rehab.tsx
+++ b/src/pages/Rehab.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+const RehabPage = () => {
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Rehab Programs</h1>
+        <p className="text-muted-foreground">
+          Coordinate intensive recovery tracks after injuries, burnout, or demanding tour schedules.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>In Development</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          <p>
+            The rehab planner will surface local facilities, outline timelines, and keep your crew informed about
+            progress milestones.
+          </p>
+          <Separator />
+          <ul className="list-disc space-y-2 pl-4">
+            <li>Assign specialized rehab partners and support staff.</li>
+            <li>Track daily recovery activities and rest compliance.</li>
+            <li>Balance show commitments with medically approved workloads.</li>
+          </ul>
+          <Button asChild variant="outline" className="mt-4 w-fit">
+            <Link to="/health">Back to Health Overview</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default RehabPage;

--- a/src/pages/Therapy.tsx
+++ b/src/pages/Therapy.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+const TherapyPage = () => {
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Therapy Services</h1>
+        <p className="text-muted-foreground">
+          Work with trusted mental health professionals to help your artist decompress between tour legs.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Coming Soon</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          <p>
+            The therapy module will let you schedule guided sessions, track wellbeing goals, and receive progress
+            updates from your support staff.
+          </p>
+          <Separator />
+          <ul className="list-disc space-y-2 pl-4">
+            <li>Plan recurring check-ins with performance psychologists.</li>
+            <li>Review mindfulness routines tailored to high-pressure events.</li>
+            <li>Coordinate with your manager to align wellness and touring calendars.</li>
+          </ul>
+          <Button asChild variant="outline" className="mt-4 w-fit">
+            <Link to="/health">Back to Health Overview</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default TherapyPage;

--- a/src/pages/WonderDrugs.tsx
+++ b/src/pages/WonderDrugs.tsx
@@ -1,0 +1,40 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+const WonderDrugsPage = () => {
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Wonder Drugs</h1>
+        <p className="text-muted-foreground">
+          Explore experimental treatments and supplements under strict medical supervision.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Concept Preview</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-muted-foreground">
+          <p>
+            Future updates will introduce risk-versus-reward decisions, sourcing challenges, and compliance tracking
+            for cutting-edge therapies.
+          </p>
+          <Separator />
+          <ul className="list-disc space-y-2 pl-4">
+            <li>Compare performance boosts against potential side effects.</li>
+            <li>Secure approvals from doctors, management, and league officials.</li>
+            <li>Monitor withdrawal windows before major shows or competitions.</li>
+          </ul>
+          <Button asChild variant="outline" className="mt-4 w-fit">
+            <Link to="/health">Back to Health Overview</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default WonderDrugsPage;


### PR DESCRIPTION
## Summary
- add a health services call-to-action card on the Health page
- introduce placeholder pages for therapy, rehab, wonder drugs, cosmetic surgery, and doctor services
- register routes for the new health service pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02915b7388325a901e5ad38bac959