### PR TITLE
Add demo banner to auth page

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -471,6 +471,9 @@ const Auth = () => {
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-4 py-8 sm:px-6">
+      <header className="w-full bg-primary text-primary-foreground text-center uppercase tracking-wide font-bebas text-sm sm:text-base py-2">
+        DEMO- In Developmen
+      </header>
       <div className="w-full max-w-sm sm:max-w-md">
         {/* Logo and Branding */}
         <div className="text-center mb-6 sm:mb-8">


### PR DESCRIPTION
## Summary
- add a prominent demo banner to the auth page layout to note the in-development status
- style the banner with Tailwind utilities for full-width uppercase messaging that adapts across breakpoints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d02bf4d2cc832591f82fdf565f088d