### PR TITLE
Adjust dashboard stats grid for xl layout

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1020,7 +1020,7 @@ const Dashboard = () => {
         </Card>
 
         {/* Stats Overview */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-3">
           <Card className="bg-card/80 backdrop-blur-sm border-primary/20">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Level</CardTitle>


### PR DESCRIPTION
## Summary
- allow the dashboard stats overview grid to expand to six columns on extra large screens
- reduce spacing between stat cards to keep the layout compact on wider viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d109f344b08325b37950f6166e2ec8