### PR TITLE
Add admin player boosts page placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ const AdminBandLearning = lazyWithRetry(() => import("./pages/admin/BandLearning
 const AdminMentors = lazyWithRetry(() => import("./pages/admin/Mentors"));
 const AdminStageSetup = lazyWithRetry(() => import("./pages/admin/StageSetup"));
 const AdminUnderworldStore = lazyWithRetry(() => import("./pages/admin/UnderworldStore"));
+const AdminPlayerBoosts = lazyWithRetry(() => import("./pages/admin/PlayerBoosts"));
 const WorldEnvironment = lazyWithRetry(() => import("./pages/WorldEnvironment"));
 const SongManager = lazyWithRetry(() => import("./pages/SongManager"));
 const InventoryManager = lazyWithRetry(() => import("./pages/InventoryManager"));
@@ -139,6 +140,7 @@ function App() {
                     <Route path="admin/mentors" element={<AdminMentors />} />
                     <Route path="admin/stage-setup" element={<AdminStageSetup />} />
                     <Route path="admin/underworld-store" element={<AdminUnderworldStore />} />
+                    <Route path="admin/player-boosts" element={<AdminPlayerBoosts />} />
                     <Route path="world" element={<WorldEnvironment />} />
                     <Route path="world-map" element={<WorldMap />} />
                     <Route path="songs" element={<SongManager />} />

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,14 @@
-import { Building2, Gift, GraduationCap, NotebookPen, PlaySquare, Sparkles, Store, Users } from "lucide-react";
+import {
+  Building2,
+  Gift,
+  GraduationCap,
+  NotebookPen,
+  PlaySquare,
+  Rocket,
+  Sparkles,
+  Store,
+  Users,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { AdminRoute } from "@/components/AdminRoute";
@@ -61,6 +71,13 @@ const adminSections = [
     href: "/admin/mentors",
     action: "Manage mentors",
     Icon: Users,
+  },
+  {
+    title: "Player Boosts",
+    description: "Calibrate temporary boosts and bonuses that accelerate individual player growth.",
+    href: "/admin/player-boosts",
+    action: "Configure player boosts",
+    Icon: Rocket,
   },
 ] as const;
 

--- a/src/pages/admin/PlayerBoosts.tsx
+++ b/src/pages/admin/PlayerBoosts.tsx
@@ -1,0 +1,38 @@
+import { AdminRoute } from "@/components/AdminRoute";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+export default function PlayerBoosts() {
+  return (
+    <AdminRoute>
+      <div className="container mx-auto max-w-4xl space-y-6 p-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Player Boosts</h1>
+          <p className="text-muted-foreground">
+            Configure temporary boosts and acceleration modifiers that can be assigned to individual
+            players. This placeholder will evolve into the full management interface.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Coming Soon</CardTitle>
+            <CardDescription>
+              The Player Boosts admin tool is under construction. Check back soon to manage custom
+              boost windows and reward schedules.
+            </CardDescription>
+          </CardHeader>
+          <Separator />
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <p>Once completed you&apos;ll be able to:</p>
+            <ul className="list-disc space-y-1 pl-4">
+              <li>Define boost templates with duration, effect, and eligibility rules.</li>
+              <li>Grant boosts directly to specific player profiles or cohorts.</li>
+              <li>Review historical boost activity and upcoming expirations.</li>
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+    </AdminRoute>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Player Boosts card to the admin landing page that links to the new tool
- register the Player Boosts admin route with a lazy-loaded placeholder component

## Testing
- npm run build *(fails: Duplicate key "latitude" in src/utils/worldEnvironment.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d10df9ac748325ac6f49b803f1be8b