### PR TITLE
Fetch travel data from Supabase

### DIFF
--- a/src/pages/__tests__/travel.test.tsx
+++ b/src/pages/__tests__/travel.test.tsx
@@ -10,7 +10,8 @@ describe("Travel page", () => {
 
     expect(html).toContain("Flights");
     expect(html).toContain("Trains");
-    expect(html).toContain("Rideshare");
+    expect(html).toContain("Taxis");
+    expect(html).toContain("Ferries");
     expect(html).toContain("Private Jet");
     expect(html).toContain("Band Vehicle");
   });


### PR DESCRIPTION
## Summary
- load travel tables from Supabase on the Travel planner page instead of hard-coded sample data
- display loading, error, and empty states while keeping the shared table layout for each transport mode
- update the travel page test to align with the Taxi and Ferry sections

## Testing
- bun test src/pages/__tests__/travel.test.tsx
- bun test src/pages/__tests__/SetlistDesigner.test.tsx *(fails: expected "Twilight Spark Warmup" in rendered output)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d13a4b08325a35923677e1a2590