### PR TITLE
Fix duplicate navigation keys

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -184,7 +184,7 @@ const Navigation = () => {
                 const Icon = item.icon;
                 return (
                   <Button
-                    key={item.path}
+                    key={`${item.path}-${item.label}`}
                     variant={isActive(item.path) ? "secondary" : "ghost"}
                     className={`w-full justify-start gap-3 ${
                       isActive(item.path)
@@ -256,7 +256,7 @@ const Navigation = () => {
             const Icon = item.icon;
             return (
               <Button
-                key={item.path}
+                key={`${item.path}-${item.label}`}
                 variant="ghost"
                 size="sm"
                 className={`flex flex-col gap-1 h-12 px-2 ${


### PR DESCRIPTION
## Summary
- ensure navigation item keys combine path and label to avoid duplicates when routes share the same path
- apply the same unique key strategy to mobile shortcuts to keep React reconciliation stable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d10edd920c8325a1d24848882d4ea3