### PR TITLE
Handle missing daily XP grant table in client

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -369,8 +369,14 @@ const useGameDataInternal = (): UseGameDataReturn => {
       if (skillProgressResult.error) {
         console.error("Failed to load skill progress", skillProgressResult.error);
       }
-      if (dailyGrantResult.error) {
+      const shouldIgnoreDailyGrantError =
+        dailyGrantResult.error?.code === "PGRST205" || dailyGrantResult.error?.code === "42P01";
+
+      if (dailyGrantResult.error && !shouldIgnoreDailyGrantError) {
         console.error("Failed to load daily XP grant", dailyGrantResult.error);
+      }
+      if (dailyGrantResult.error && shouldIgnoreDailyGrantError) {
+        console.info("Daily XP grant data is unavailable on this schema version; skipping.");
       }
 
       setSkills((skillsResult.data ?? null) as PlayerSkills);
@@ -381,7 +387,10 @@ const useGameDataInternal = (): UseGameDataReturn => {
       setActivities((activitiesResult.data ?? []) as ActivityFeedRow[]);
       setSkillProgress((skillProgressResult.data ?? []) as SkillProgressRow[]);
       setUnlockedSkills({});
-      const grantRow = dailyGrantResult.data ? (dailyGrantResult.data as DailyXpGrantRow) : null;
+      const grantRow =
+        shouldIgnoreDailyGrantError || !dailyGrantResult.data
+          ? null
+          : (dailyGrantResult.data as DailyXpGrantRow);
       setDailyXpGrant(grantRow);
     },
     [user],

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -334,20 +334,26 @@ export interface Database {
         Row: {
           id: string;
           profile_id: string;
-          amount: number;
-          created_at: string;
+          grant_date: string;
+          xp_awarded: number;
+          metadata: Json;
+          claimed_at: string;
         };
         Insert: {
           id?: string;
           profile_id: string;
-          amount: number;
-          created_at?: string;
+          grant_date: string;
+          xp_awarded: number;
+          metadata?: Json;
+          claimed_at?: string;
         };
         Update: {
           id?: string;
           profile_id?: string;
-          amount?: number;
-          created_at?: string;
+          grant_date?: string;
+          xp_awarded?: number;
+          metadata?: Json;
+          claimed_at?: string;
         };
       };
       skill_definitions: {


### PR DESCRIPTION
## Summary
- avoid logging an error when the `profile_daily_xp_grants` table is unavailable so older Supabase schemas do not break the dashboard
- update the fallback Supabase types for `profile_daily_xp_grants` to match the current schema fields

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in src/pages/Travel.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f5dcbf88325b8c551d597122037