### PR TITLE
Handle missing player skills table gracefully

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -205,11 +205,20 @@ const useGameDataInternal = (): UseGameDataReturn => {
   const [error, setError] = useState<string | null>(null);
   const assigningDefaultCityRef = useRef(false);
   const defaultCityAssignmentDisabledRef = useRef(false);
+  const playerSkillsTableMissingRef = useRef(false);
   const isSchemaCacheMissingColumnError = (error: unknown): error is { code?: string } =>
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
     (error as { code?: string }).code === "PGRST204";
+  const isSchemaCacheMissingTableError = (error: unknown, table: string): error is { code?: string } =>
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "PGRST205" &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string" &&
+    (error as { message: string }).message.includes(`public.${table}`);
 
   const loadProfileDetails = useCallback(
     async (activeProfile: PlayerProfile | null) => {
@@ -223,6 +232,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
         setActivities([]);
         setCurrentCity(null);
         setDailyXpGrant(null);
+        playerSkillsTableMissingRef.current = false;
         return;
       }
 
@@ -291,6 +301,15 @@ const useGameDataInternal = (): UseGameDataReturn => {
         }
       }
 
+      const skillsPromise = playerSkillsTableMissingRef.current
+        ? Promise.resolve({ data: null, error: null })
+        : supabase
+            .from("player_skills")
+            .select("*")
+            .eq("profile_id", effectiveProfile.id)
+            .eq("user_id", user.id)
+            .maybeSingle();
+
       const [
         skillsResult,
         attributesResult,
@@ -301,12 +320,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
         skillProgressResult,
         dailyGrantResult,
       ] = await Promise.all([
-        supabase
-          .from("player_skills")
-          .select("*")
-          .eq("profile_id", effectiveProfile.id)
-          .eq("user_id", user.id)
-          .maybeSingle(),
+        skillsPromise,
         supabase
           .from("player_attributes")
           .select("*")
@@ -349,7 +363,17 @@ const useGameDataInternal = (): UseGameDataReturn => {
       ]);
 
       if (skillsResult.error) {
-        console.error("Failed to load player skills", skillsResult.error);
+        if (isSchemaCacheMissingTableError(skillsResult.error, "player_skills")) {
+          if (!playerSkillsTableMissingRef.current) {
+            console.warn(
+              "Player skills table missing from schema cache. Disabling legacy skills features until the schema is refreshed.",
+              skillsResult.error,
+            );
+          }
+          playerSkillsTableMissingRef.current = true;
+        } else {
+          console.error("Failed to load player skills", skillsResult.error);
+        }
       }
       if (attributesResult.error) {
         console.error("Failed to load player attributes", attributesResult.error);
@@ -793,6 +817,14 @@ const useGameDataInternal = (): UseGameDataReturn => {
 
       if (!profile) {
         throw new Error("No active profile selected");
+      }
+
+      if (playerSkillsTableMissingRef.current) {
+        console.warn(
+          "Skipping player skill update - player_skills table unavailable in schema cache.",
+          updates,
+        );
+        return null;
       }
 
       const payload: Database["public"]["Tables"]["player_skills"]["Insert"] = {


### PR DESCRIPTION
## Summary
- guard `useGameData` against missing `player_skills` table entries and log a warning instead of throwing
- skip Supabase `player_skills` queries once the schema cache reports the table is absent and prevent subsequent updates

## Testing
- npm run lint *(fails: existing lint errors in src/pages/Travel.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f760b6c832599f7229ff372e2c6