### PR TITLE
Refresh PostgREST schema cache after travel tables migration

### DIFF
--- a/supabase/migrations/20270611100000_create_travel_tables.sql
+++ b/supabase/migrations/20270611100000_create_travel_tables.sql
@@ -199,3 +199,6 @@ from route_data
 join public.cities cf on cf.name = route_data.city_from_name
 join public.cities ct on ct.name = route_data.city_to_name
 on conflict (city_from, city_to) do nothing;
+
+-- Refresh PostgREST schema cache so the new travel tables are immediately available
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- ensure the travel tables migration triggers a PostgREST schema reload so the API can access the new tables immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d10fe1cbf48325add8fb84ca045422