### PR TITLE
Handle missing public_profiles view with profiles fallback

### DIFF
--- a/src/integrations/supabase/public-profiles.ts
+++ b/src/integrations/supabase/public-profiles.ts
@@ -1,0 +1,67 @@
+import { supabase } from "./client";
+import type { Database } from "./types";
+
+export type BasicPublicProfile = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "user_id" | "display_name" | "username"
+>;
+
+const PROFILE_SELECT_FIELDS = "user_id, display_name, username";
+
+const isMissingPublicProfilesView = (errorCode: string | undefined) => errorCode === "PGRST205";
+
+export const fetchPublicProfilesByUserIds = async (
+  userIds: string[],
+): Promise<Map<string, BasicPublicProfile>> => {
+  const profilesById = new Map<string, BasicPublicProfile>();
+
+  if (userIds.length === 0) {
+    return profilesById;
+  }
+
+  const { data, error } = await supabase
+    .from("public_profiles")
+    .select(PROFILE_SELECT_FIELDS)
+    .in("user_id", userIds);
+
+  if (error) {
+    if (isMissingPublicProfilesView(error.code)) {
+      console.warn("public_profiles view unavailable, falling back to profiles table", error);
+
+      const { data: fallbackData, error: fallbackError } = await supabase
+        .from("profiles")
+        .select(PROFILE_SELECT_FIELDS)
+        .in("user_id", userIds);
+
+      if (fallbackError) {
+        throw fallbackError;
+      }
+
+      (fallbackData ?? []).forEach((profile) => {
+        if (profile?.user_id) {
+          profilesById.set(profile.user_id, {
+            user_id: profile.user_id,
+            display_name: profile.display_name ?? null,
+            username: profile.username ?? null,
+          });
+        }
+      });
+
+      return profilesById;
+    }
+
+    throw error;
+  }
+
+  (data ?? []).forEach((profile) => {
+    if (profile?.user_id) {
+      profilesById.set(profile.user_id, {
+        user_id: profile.user_id,
+        display_name: profile.display_name ?? null,
+        username: profile.username ?? null,
+      });
+    }
+  });
+
+  return profilesById;
+};

--- a/src/pages/WorldPulse.tsx
+++ b/src/pages/WorldPulse.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
 import { supabase } from "@/integrations/supabase/client";
+import { fetchPublicProfilesByUserIds } from "@/integrations/supabase/public-profiles";
 import type { Database } from "@/lib/supabase-types";
 import { format, getISOWeek } from "date-fns";
 import {
@@ -73,7 +74,6 @@ interface SalesSummary {
 
 type GlobalChartRow = Database["public"]["Tables"]["global_charts"]["Row"];
 type SongRow = Database["public"]["Tables"]["songs"]["Row"];
-type PublicProfileRow = Database["public"]["Views"]["public_profiles"]["Row"];
 
 const formatDailyValue = (dateString: string) => {
   const parsed = new Date(dateString);
@@ -182,21 +182,7 @@ const WorldPulse = () => {
         )
       );
 
-      const profilesByUserId = new Map<string, PublicProfileRow>();
-      if (userIds.length > 0) {
-        const { data: profilesData, error: profilesError } = await supabase
-          .from("public_profiles")
-          .select("user_id, display_name, username")
-          .in("user_id", userIds);
-
-        if (profilesError) {
-          throw profilesError;
-        }
-
-        (profilesData ?? []).forEach((profile) => {
-          profilesByUserId.set(profile.user_id, profile as PublicProfileRow);
-        });
-      }
+      const profilesByUserId = await fetchPublicProfilesByUserIds(userIds);
 
       const maxStreams = rows.reduce((max, row) => Math.max(max, Number(row.total_streams ?? 0)), 0);
       const maxSales = rows.reduce((max, row) => Math.max(max, Number(row.total_sales ?? 0)), 0);


### PR DESCRIPTION
## Summary
- add a supabase helper that loads public profile fields and falls back to the core profiles table when the view is missing
- refactor the WorldPulse and SocialMedia pages to reuse the helper so player names keep loading even without the public_profiles view
- update the admin experience rewards picker to retry the profiles table when the view lookup fails

## Testing
- npm run lint *(fails: existing `src/pages/Travel.tsx` `any` type violations)*
- npx eslint src/integrations/supabase/public-profiles.ts src/pages/WorldPulse.tsx src/pages/SocialMedia.tsx src/pages/admin/ExperienceRewards.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d10f46ff708325b8b530cadcdda76e