### PR TITLE
feat: add supabase travel booking section for city view

### DIFF
--- a/src/pages/City.tsx
+++ b/src/pages/City.tsx
@@ -7,6 +7,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useToast } from "@/components/ui/use-toast";
+import { useGameData } from "@/hooks/useGameData";
+import { supabase } from "@/integrations/supabase/client";
+import type { PostgrestError } from "@supabase/supabase-js";
 import {
   fetchWorldEnvironmentSnapshot,
   fetchCityEnvironmentDetails,
@@ -50,6 +55,333 @@ const getTransportIcon = (type?: string): LucideIcon => {
   return TRANSPORT_ICON_MAP[normalized] ?? MapPin;
 };
 
+interface CityTravelOption {
+  id: string;
+  mode: string;
+  modeLabel: string;
+  destinationName: string;
+  destinationCityId: string | null;
+  description: string | null;
+  operator: string | null;
+  schedule: string | null;
+  sustainability: string | null;
+  comfort: number | null;
+  price: number | null;
+  currency: string | null;
+  durationMinutes: number | null;
+  healthImpact: number;
+}
+
+interface CityTravelOptionGroup {
+  key: string;
+  mode: string;
+  modeLabel: string;
+  options: CityTravelOption[];
+}
+
+const TRAVEL_TABLE_CANDIDATES: Array<{ table: string; cityColumns: string[] }> = [
+  { table: "city_travel_routes", cityColumns: ["origin_city_id", "city_id", "from_city_id"] },
+  { table: "city_travel_options", cityColumns: ["city_id", "origin_city_id"] },
+  { table: "city_travel_modes", cityColumns: ["city_id"] },
+  { table: "travel_routes", cityColumns: ["origin_city_id", "city_id"] },
+  { table: "travel_options", cityColumns: ["city_id", "origin_city_id"] },
+  { table: "travel_links", cityColumns: ["city_id", "origin_city_id"] },
+  { table: "travel_nodes", cityColumns: ["city_id", "origin_city_id"] },
+];
+
+const toStringOrNull = (value: unknown): string | null => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return null;
+};
+
+const pickString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    const result = toStringOrNull(value);
+    if (result) {
+      return result;
+    }
+  }
+  return null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9+\-.,hHmM ]/g, "");
+    const hourMatch = cleaned.match(/([0-9]+(?:\.[0-9]+)?)\s*h/i);
+    const minuteMatch = cleaned.match(/([0-9]+(?:\.[0-9]+)?)\s*m/i);
+    if (hourMatch || minuteMatch) {
+      const hours = hourMatch ? Number.parseFloat(hourMatch[1]) : 0;
+      const minutes = minuteMatch ? Number.parseFloat(minuteMatch[1]) : 0;
+      const totalMinutes = hours * 60 + minutes;
+      return Number.isFinite(totalMinutes) ? totalMinutes : null;
+    }
+    const parsed = Number.parseFloat(cleaned.replace(/,/g, ""));
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+};
+
+const pickNumber = (...values: unknown[]): number | null => {
+  for (const value of values) {
+    const result = toNumberOrNull(value);
+    if (result !== null) {
+      return result;
+    }
+  }
+  return null;
+};
+
+const formatModeLabel = (mode: string): string => {
+  if (!mode) {
+    return "Travel";
+  }
+  return mode
+    .split(/[-_\s]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+const normalizeComfortValue = (comfort: number | null): number | null => {
+  if (comfort === null) {
+    return null;
+  }
+  if (!Number.isFinite(comfort)) {
+    return null;
+  }
+  if (comfort <= 1) {
+    return Math.round(comfort * 100);
+  }
+  if (comfort <= 10) {
+    return Math.round((comfort / 10) * 100);
+  }
+  return Math.round(comfort);
+};
+
+const formatDuration = (minutes: number | null): string => {
+  if (minutes === null || !Number.isFinite(minutes) || minutes <= 0) {
+    return "Varies";
+  }
+  const totalMinutes = Math.round(minutes);
+  const hours = Math.floor(totalMinutes / 60);
+  const remainder = totalMinutes % 60;
+  if (hours > 0 && remainder > 0) {
+    return `${hours}h ${remainder}m`;
+  }
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+  return `${remainder}m`;
+};
+
+const formatPrice = (value: number | null, currency: string | null): string => {
+  if (value === null || !Number.isFinite(value) || value < 0) {
+    return "Varies";
+  }
+  const normalizedCurrency = currency && currency.trim().length === 3 ? currency.trim().toUpperCase() : "USD";
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: normalizedCurrency,
+      maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+    }).format(value);
+  } catch (intlError) {
+    console.warn("Falling back to simple currency formatting", intlError);
+    const symbol = normalizedCurrency === "USD" ? "$" : `${normalizedCurrency} `;
+    return `${symbol}${value.toLocaleString()}`;
+  }
+};
+
+const normalizeTravelOptionRow = (
+  row: Record<string, unknown>,
+  index: number,
+): CityTravelOption | null => {
+  if (!row) {
+    return null;
+  }
+
+  const modeRaw = pickString(
+    row.mode,
+    row.mode_id,
+    row.mode_slug,
+    row.travel_mode,
+    row.transport_mode,
+    row.modeKey,
+    row.type,
+    row.transport_type,
+    row.route_mode,
+  );
+  const mode = (modeRaw ?? "").toString().toLowerCase();
+  const modeLabel = pickString(row.mode_label, row.modeLabel, row.mode_name, row.mode_display, row.modeTitle) ?? formatModeLabel(mode || "Travel");
+
+  const destinationName =
+    pickString(
+      row.destination_name,
+      row.destination_city_name,
+      row.destination,
+      row.destination_city,
+      row.destination_label,
+      row.destinationTitle,
+      row.arrival_city_name,
+    ) ?? "Confirmed destination";
+
+  const destinationCityId =
+    pickString(
+      row.destination_city_id,
+      row.destinationCityId,
+      row.destination_id,
+      row.arrival_city_id,
+      row.destinationCityID,
+    ) ?? null;
+
+  const description = pickString(row.description, row.summary, row.details, row.notes, row.narrative, row.pitch) ?? null;
+  const operator = pickString(row.operator, row.carrier, row.provider, row.company, row.operator_name) ?? null;
+  const schedule = pickString(row.schedule, row.departure_window, row.frequency, row.cadence, row.service_window) ?? null;
+  const sustainability =
+    pickString(
+      row.sustainability,
+      row.sustainability_note,
+      row.sustainability_score,
+      row.environmental_note,
+      row.carbon_impact,
+    ) ?? null;
+  const comfort = normalizeComfortValue(pickNumber(row.comfort, row.comfort_score, row.comfort_rating, row.quality_rating));
+  const price = pickNumber(row.cost, row.base_cost, row.price, row.ticket_price, row.average_cost, row.estimated_cost);
+  const currency = pickString(row.currency, row.price_currency, row.cost_currency, row.fare_currency);
+
+  const durationCandidate = pickNumber(
+    row.duration_minutes,
+    row.durationMinutes,
+    row.travel_time_minutes,
+    row.travel_minutes,
+    row.duration,
+  );
+  const durationHours = pickNumber(
+    row.duration_hours,
+    row.durationHours,
+    row.travel_time_hours,
+    row.time_hours,
+    row.estimated_hours,
+  );
+  const durationText = pickString(row.duration_text, row.duration_display, row.travel_time_text);
+
+  let durationMinutes: number | null = durationCandidate;
+  if (durationMinutes === null && durationHours !== null) {
+    durationMinutes = Math.round(durationHours * 60);
+  }
+  if (durationMinutes === null && durationText) {
+    durationMinutes = toNumberOrNull(durationText);
+  }
+
+  const healthImpact = pickNumber(row.health_impact, row.healthImpact, row.health_penalty, row.health_cost, row.health_delta) ?? 0;
+
+  const identifier =
+    pickString(row.id, row.route_id, row.option_id, row.travel_option_id, row.travelRouteId, row.travelOptionId) ??
+    `${mode || "travel"}-${destinationCityId ?? destinationName}-${index}`;
+
+  return {
+    id: identifier,
+    mode: mode || "travel",
+    modeLabel,
+    destinationName,
+    destinationCityId,
+    description,
+    operator,
+    schedule,
+    sustainability,
+    comfort,
+    price,
+    currency: currency ? currency.toUpperCase() : null,
+    durationMinutes,
+    healthImpact: healthImpact < 0 ? 0 : healthImpact,
+  };
+};
+
+const flattenTravelRows = (rows: Record<string, unknown>[]): CityTravelOption[] => {
+  const options: CityTravelOption[] = [];
+
+  rows.forEach((entry, index) => {
+    if (!entry || typeof entry !== "object") {
+      return;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const nestedCandidates = [
+      record.options,
+      record.routes,
+      record.travel_options,
+      record.travelRoutes,
+      record.mode_options,
+    ];
+
+    const nested = nestedCandidates.find((candidate) => Array.isArray(candidate)) as unknown[] | undefined;
+
+    if (nested && nested.length > 0) {
+      nested.forEach((nestedEntry, nestedIndex) => {
+        if (!nestedEntry || typeof nestedEntry !== "object") {
+          return;
+        }
+        const mergedRecord = {
+          ...record,
+          ...(nestedEntry as Record<string, unknown>),
+        } as Record<string, unknown>;
+        const normalized = normalizeTravelOptionRow(mergedRecord, Number(`${index}${nestedIndex}`));
+        if (normalized) {
+          options.push(normalized);
+        }
+      });
+      return;
+    }
+
+    const normalized = normalizeTravelOptionRow(record, index);
+    if (normalized) {
+      options.push(normalized);
+    }
+  });
+
+  return options;
+};
+
+const groupTravelOptionsByMode = (options: CityTravelOption[]): CityTravelOptionGroup[] => {
+  const groups = new Map<string, CityTravelOptionGroup>();
+
+  options.forEach((option) => {
+    const key = option.mode.toLowerCase();
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        mode: option.mode,
+        modeLabel: option.modeLabel,
+        options: [],
+      });
+    }
+    const group = groups.get(key);
+    if (group) {
+      group.options.push(option);
+    }
+  });
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      options: group.options.sort((a, b) => {
+        const priceA = a.price ?? Number.POSITIVE_INFINITY;
+        const priceB = b.price ?? Number.POSITIVE_INFINITY;
+        if (priceA === priceB) {
+          const durationA = a.durationMinutes ?? Number.POSITIVE_INFINITY;
+          const durationB = b.durationMinutes ?? Number.POSITIVE_INFINITY;
+          return durationA - durationB;
+        }
+        return priceA - priceB;
+      }),
+    }))
+    .sort((a, b) => a.modeLabel.localeCompare(b.modeLabel));
+};
+
 export const CityContent = ({
   city,
   details,
@@ -59,6 +391,8 @@ export const CityContent = ({
   detailsError,
   onRetry,
 }: CityContentProps) => {
+  const { toast } = useToast();
+  const { profile, currentCity, updateProfile, addActivity } = useGameData();
   const culturalEvents = useMemo(
     () => (city?.cultural_events ?? []).filter((event) => typeof event === "string" && event.trim().length > 0),
     [city?.cultural_events],
@@ -68,6 +402,205 @@ export const CityContent = ({
   const studioProfiles = city?.studioProfiles ?? [];
   const transportLinks = city?.transportLinks ?? [];
   const metadata = details?.metadata ?? null;
+  const [travelGroups, setTravelGroups] = useState<CityTravelOptionGroup[]>([]);
+  const [travelLoading, setTravelLoading] = useState(false);
+  const [travelError, setTravelError] = useState<string | null>(null);
+  const [bookingOptionId, setBookingOptionId] = useState<string | null>(null);
+
+  const loadTravelOptions = useCallback(async (): Promise<CityTravelOptionGroup[]> => {
+    if (!city?.id) {
+      return [];
+    }
+
+    for (const candidate of TRAVEL_TABLE_CANDIDATES) {
+      for (const column of candidate.cityColumns) {
+        try {
+          const response = await supabase.from(candidate.table).select("*").eq(column, city.id);
+          if (response.error) {
+            const error = response.error as PostgrestError;
+            if (error?.code === "42703") {
+              continue;
+            }
+            if (error?.code === "42P01") {
+              break;
+            }
+            throw error;
+          }
+
+          const rows = Array.isArray(response.data) ? (response.data as Record<string, unknown>[]) : [];
+          const normalized = flattenTravelRows(rows);
+          if (normalized.length > 0) {
+            return groupTravelOptionsByMode(normalized);
+          }
+        } catch (unknownError) {
+          const error = unknownError as PostgrestError;
+          if (error?.code === "42703") {
+            continue;
+          }
+          if (error?.code === "42P01") {
+            break;
+          }
+          throw error;
+        }
+      }
+    }
+
+    return [];
+  }, [city?.id]);
+
+  const refreshTravelOptions = useCallback(async () => {
+    if (!city?.id) {
+      setTravelGroups([]);
+      return;
+    }
+
+    setTravelLoading(true);
+    setTravelError(null);
+
+    try {
+      const groups = await loadTravelOptions();
+      setTravelGroups(groups);
+    } catch (error) {
+      console.error("Failed to load travel options", error);
+      setTravelGroups([]);
+      setTravelError("We couldn't load travel options right now. Please try again.");
+    } finally {
+      setTravelLoading(false);
+    }
+  }, [city?.id, loadTravelOptions]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      if (!city?.id) {
+        setTravelGroups([]);
+        return;
+      }
+
+      setTravelLoading(true);
+      setTravelError(null);
+
+      try {
+        const groups = await loadTravelOptions();
+        if (!cancelled) {
+          setTravelGroups(groups);
+        }
+      } catch (error) {
+        console.error("Failed to load travel options", error);
+        if (!cancelled) {
+          setTravelGroups([]);
+          setTravelError("We couldn't load travel options right now. Please try again.");
+        }
+      } finally {
+        if (!cancelled) {
+          setTravelLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [city?.id, loadTravelOptions]);
+
+  const handleBookTravel = useCallback(
+    async (option: CityTravelOption) => {
+      if (!profile) {
+        toast({
+          title: "Profile required",
+          description: "Create or load your artist profile to confirm travel plans.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      if (!city) {
+        toast({
+          title: "Unable to book travel",
+          description: "We couldn't determine the origin city for this booking.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const currentHealth = typeof profile.health === "number" ? profile.health : 100;
+      const nextHealth = Math.max(0, currentHealth - option.healthImpact);
+
+      setBookingOptionId(option.id);
+
+      try {
+        const updates: Record<string, unknown> = {
+          health: nextHealth,
+        };
+
+        if (option.destinationCityId) {
+          updates.current_city_id = option.destinationCityId;
+        }
+
+        await updateProfile(updates as Parameters<typeof updateProfile>[0]);
+
+        const bookingPayload = {
+          profile_id: profile.id,
+          travel_option_id: option.id,
+          origin_city_id: city.id,
+          destination_city_id: option.destinationCityId,
+          travel_mode: option.mode,
+          cost: option.price,
+          currency: option.currency,
+        };
+
+        try {
+          const { error: bookingError } = await supabase.from("travel_bookings").insert(bookingPayload);
+          if (bookingError && (bookingError as PostgrestError)?.code !== "42P01") {
+            console.warn("Failed to log travel booking", bookingError);
+          }
+        } catch (bookingInsertError) {
+          const postgrestError = bookingInsertError as PostgrestError;
+          if (postgrestError?.code !== "42P01") {
+            console.warn("Unexpected error while logging travel booking", bookingInsertError);
+          }
+        }
+
+        try {
+          await addActivity(
+            "travel",
+            `Booked travel to ${option.destinationName} via ${option.modeLabel}`,
+            undefined,
+            {
+              origin_city_id: city.id,
+              origin_city_name: city.name,
+              destination_city_id: option.destinationCityId,
+              destination_name: option.destinationName,
+              travel_mode: option.mode,
+              travel_option_id: option.id,
+            },
+          );
+        } catch (activityError) {
+          console.warn("Failed to log travel activity", activityError);
+        }
+
+        toast({
+          title: "Travel booked",
+          description: option.destinationCityId
+            ? `Heading to ${option.destinationName} via ${option.modeLabel}. Your city profile will update shortly.`
+            : `Heading to ${option.destinationName} via ${option.modeLabel}.`,
+        });
+      } catch (error) {
+        console.error("Failed to confirm travel booking", error);
+        toast({
+          title: "Unable to book travel",
+          description: "Something went wrong while confirming this route. Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setBookingOptionId(null);
+      }
+    },
+    [addActivity, city, profile, toast, updateProfile],
+  );
 
   const summary = useMemo(() => {
     if (metadata?.summary && metadata.summary.trim().length > 0) {
@@ -292,6 +825,134 @@ export const CityContent = ({
             ) : (
               <div className="rounded-lg border border-dashed border-border/60 p-6 text-center text-sm text-muted-foreground">
                 Transport data will appear here once routes are confirmed.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Plane className="h-5 w-5 text-primary" />
+              Travel Booking Desk
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {travelLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Gathering live travel itineraries...
+              </div>
+            ) : travelError ? (
+              <Alert variant="destructive">
+                <AlertTitle>Travel options unavailable</AlertTitle>
+                <AlertDescription>{travelError}</AlertDescription>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button size="sm" variant="outline" onClick={() => refreshTravelOptions()}>
+                    Try again
+                  </Button>
+                </div>
+              </Alert>
+            ) : travelGroups.length ? (
+              <div className="space-y-4">
+                {travelGroups.map((group) => {
+                  const Icon = getTransportIcon(group.mode);
+                  return (
+                    <div key={group.key} className="space-y-3 rounded-lg border border-border/60 p-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-2">
+                          <Icon className="h-5 w-5 text-muted-foreground" />
+                          <h3 className="text-lg font-semibold leading-tight">{group.modeLabel}</h3>
+                        </div>
+                        {currentCity && (
+                          <Badge variant="secondary" className="text-xs">
+                            Departing {currentCity.name}
+                          </Badge>
+                        )}
+                      </div>
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Destination</TableHead>
+                            <TableHead className="hidden sm:table-cell">Operator</TableHead>
+                            <TableHead className="hidden md:table-cell">Duration</TableHead>
+                            <TableHead className="hidden md:table-cell">Cost</TableHead>
+                            <TableHead className="w-[160px] text-right">Action</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {group.options.map((option) => {
+                            const bookingInProgress = bookingOptionId === option.id;
+                            const destinationMatchesCurrent = Boolean(
+                              option.destinationCityId &&
+                                (profile?.current_city_id === option.destinationCityId ||
+                                  currentCity?.id === option.destinationCityId),
+                            );
+                            return (
+                              <TableRow key={option.id} className="align-top">
+                                <TableCell>
+                                  <div className="flex flex-col gap-1">
+                                    <span className="font-medium text-foreground">{option.destinationName}</span>
+                                    {option.description && (
+                                      <span className="text-xs text-muted-foreground">{option.description}</span>
+                                    )}
+                                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                      {option.schedule && <span className="rounded bg-muted px-2 py-0.5">{option.schedule}</span>}
+                                      {option.sustainability && (
+                                        <span className="rounded bg-emerald-100 px-2 py-0.5 text-emerald-700">
+                                          {option.sustainability}
+                                        </span>
+                                      )}
+                                      {typeof option.comfort === "number" && (
+                                        <span className="rounded bg-muted px-2 py-0.5">
+                                          Comfort {option.comfort}%
+                                        </span>
+                                      )}
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="hidden sm:table-cell">
+                                  {option.operator ? option.operator : <span className="text-muted-foreground">—</span>}
+                                </TableCell>
+                                <TableCell className="hidden md:table-cell">
+                                  <span>{formatDuration(option.durationMinutes)}</span>
+                                </TableCell>
+                                <TableCell className="hidden md:table-cell">
+                                  <span>{formatPrice(option.price, option.currency)}</span>
+                                </TableCell>
+                                <TableCell className="w-[160px] text-right">
+                                  <Button
+                                    size="sm"
+                                    className="w-full"
+                                    disabled={bookingInProgress || destinationMatchesCurrent}
+                                    onClick={() => handleBookTravel(option)}
+                                  >
+                                    {bookingInProgress ? (
+                                      <span className="flex items-center justify-center gap-2">
+                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                        Booking...
+                                      </span>
+                                    ) : destinationMatchesCurrent ? (
+                                      "Already here"
+                                    ) : profile ? (
+                                      "Book travel"
+                                    ) : (
+                                      "Sign in to book"
+                                    )}
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-border/60 p-6 text-center text-sm text-muted-foreground">
+                Dedicated travel itineraries will appear here as routes are unlocked for {city.name}.
               </div>
             )}
           </CardContent>

--- a/src/pages/__tests__/city.test.tsx
+++ b/src/pages/__tests__/city.test.tsx
@@ -105,6 +105,59 @@ describe("City page", () => {
       fetchWorldEnvironmentSnapshot: snapshotMock,
       fetchCityEnvironmentDetails: detailsMock,
     }));
+    mock.module("@/integrations/supabase/client", () => ({
+      supabase: {
+        from: () => ({
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
+          insert: async () => ({ error: null }),
+        }),
+      },
+    }));
+    mock.module("@/hooks/useGameData", () => ({
+      useGameData: () => ({
+        profile: {
+          id: "profile-1",
+          health: 100,
+          current_city_id: sampleCity.id,
+        },
+        skills: null,
+        attributes: null,
+        xpWallet: null,
+        xpLedger: [],
+        skillProgress: [],
+        unlockedSkills: {},
+        activities: [],
+        dailyXpGrant: null,
+        freshWeeklyBonusAvailable: false,
+        currentCity: sampleCity,
+        loading: false,
+        error: null,
+        refetch: async () => {},
+        updateProfile: async () => ({
+          id: "profile-1",
+          health: 100,
+          current_city_id: sampleCity.id,
+        }),
+        updateSkills: async () => null,
+        updateXpWallet: async () => null,
+        updateAttributes: async () => null,
+        addActivity: async () => {},
+        awardActionXp: async () => {},
+        claimDailyXp: async () => {},
+        spendAttributeXp: async () => {},
+        spendSkillXp: async () => {},
+        upsertProfileWithDefaults: async () => ({
+          profile: {
+            id: "profile-1",
+            health: 100,
+            current_city_id: sampleCity.id,
+          },
+          attributes: null,
+        }),
+      }),
+    }));
 
     const { CityContent } = await import("../City");
     const { loadCityPageData } = await import("../city-data");
@@ -148,6 +201,47 @@ describe("City page", () => {
         randomEvents: [],
       })),
       fetchCityEnvironmentDetails: mock(async () => sampleDetails),
+    }));
+    mock.module("@/integrations/supabase/client", () => ({
+      supabase: {
+        from: () => ({
+          select: () => ({
+            eq: async () => ({ data: [], error: null }),
+          }),
+          insert: async () => ({ error: null }),
+        }),
+      },
+    }));
+    mock.module("@/hooks/useGameData", () => ({
+      useGameData: () => ({
+        profile: null,
+        skills: null,
+        attributes: null,
+        xpWallet: null,
+        xpLedger: [],
+        skillProgress: [],
+        unlockedSkills: {},
+        activities: [],
+        dailyXpGrant: null,
+        freshWeeklyBonusAvailable: false,
+        currentCity: null,
+        loading: false,
+        error: null,
+        refetch: async () => {},
+        updateProfile: async () => ({ id: "profile-1" }),
+        updateSkills: async () => null,
+        updateXpWallet: async () => null,
+        updateAttributes: async () => null,
+        addActivity: async () => {},
+        awardActionXp: async () => {},
+        claimDailyXp: async () => {},
+        spendAttributeXp: async () => {},
+        spendSkillXp: async () => {},
+        upsertProfileWithDefaults: async () => ({
+          profile: { id: "profile-1" },
+          attributes: null,
+        }),
+      }),
     }));
 
     const { loadCityPageData, CITY_NOT_FOUND_ERROR } = await import("../city-data");


### PR DESCRIPTION
## Summary
- fetch travel itineraries for the active city from Supabase travel tables, normalize the records, and group them by mode for display
- add a booking workflow that updates player health and current city, logs travel activity, and surfaces confirmations and errors in the City page UI
- stub Supabase and game data hooks inside the City page tests so the new dependencies can be exercised without hitting real clients

## Testing
- npm run lint
- npm run test *(fails: existing SetlistDesigner snapshot expectation)*
- bun test src/pages/__tests__/city.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d10d141d708325a2ebf9a7c9c19795