### PR TITLE
feat: load dynamic daily xp stipend

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -86,6 +86,81 @@ const XP_LEDGER_FETCH_LIMIT = 20;
 const WEEKLY_WINDOW_ANCHOR_UTC_HOUR = 5;
 const WEEKLY_WINDOW_ANCHOR_UTC_MINUTE = 15;
 
+const parseNumericValue = (candidate: unknown): number | null => {
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate;
+  }
+
+  if (typeof candidate === "string") {
+    const parsed = Number(candidate);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const extractDailyXpStipend = (row: DailyXpConfigurationRow): number | null => {
+  if (!row || typeof row !== "object") {
+    return null;
+  }
+
+  const candidate = row as Record<string, unknown>;
+  const directKeys = [
+    "daily_xp_stipend",
+    "dailyXpStipend",
+    "daily_xp_amount",
+    "dailyXpAmount",
+    "xp_stipend",
+    "xpAmount",
+    "amount",
+  ];
+
+  for (const key of directKeys) {
+    if (key in candidate) {
+      const numeric = parseNumericValue(candidate[key]);
+      if (numeric !== null) {
+        return numeric;
+      }
+    }
+  }
+
+  const keyedSources: Array<[unknown, unknown[]]> = [
+    [candidate.config_key, [candidate.config_value, candidate.value, candidate.numeric_value]],
+    [candidate.key, [candidate.value, candidate.numeric_value]],
+    [candidate.slug, [candidate.numeric_value, candidate.value]],
+    [candidate.name, [candidate.numeric_value, candidate.value]],
+    [candidate.setting_key, [candidate.setting_value, candidate.value]],
+  ];
+
+  for (const [rawKey, rawValues] of keyedSources) {
+    if (typeof rawKey === "string" && rawKey.toLowerCase() === "daily_xp_stipend") {
+      for (const valueCandidate of rawValues) {
+        const numeric = parseNumericValue(valueCandidate);
+        if (numeric !== null) {
+          return numeric;
+        }
+      }
+    }
+  }
+
+  if (candidate.metadata && typeof candidate.metadata === "object") {
+    const metadata = candidate.metadata as Record<string, unknown>;
+    const metadataKeys = ["daily_xp_stipend", "dailyXpStipend", "daily_xp_amount", "dailyXpAmount"] as const;
+    for (const key of metadataKeys) {
+      if (key in metadata) {
+        const numeric = parseNumericValue(metadata[key]);
+        if (numeric !== null) {
+          return numeric;
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
 const getCurrentWeeklyWindowStart = (referenceDate: Date): Date => {
   const result = new Date(referenceDate);
   const utcDay = result.getUTCDay();
@@ -130,6 +205,7 @@ type PlayerAttributesRow = Database["public"]["Tables"]["player_attributes"]["Ro
 type RawAttributes = PlayerAttributesRow | null;
 type PlayerAttributesInsert = Database["public"]["Tables"]["player_attributes"]["Insert"];
 type DailyXpGrantRow = Database["public"]["Tables"]["profile_daily_xp_grants"]["Row"];
+type DailyXpConfigurationRow = Record<string, unknown> | null;
 
 type UseGameDataReturn = {
   profile: PlayerProfile | null;
@@ -141,6 +217,7 @@ type UseGameDataReturn = {
   unlockedSkills: UnlockedSkillsMap;
   activities: ActivityFeedRow[];
   dailyXpGrant: DailyXpGrantRow | null;
+  dailyXpStipend: number | null;
   freshWeeklyBonusAvailable: boolean;
   currentCity: CityRow | null;
   loading: boolean;
@@ -200,6 +277,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
   const [unlockedSkills, setUnlockedSkills] = useState<UnlockedSkillsMap>({});
   const [activities, setActivities] = useState<ActivityFeedRow[]>([]);
   const [dailyXpGrant, setDailyXpGrant] = useState<DailyXpGrantRow | null>(null);
+  const [dailyXpStipend, setDailyXpStipend] = useState<number | null>(null);
   const [currentCity, setCurrentCity] = useState<CityRow | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -383,6 +461,63 @@ const useGameDataInternal = (): UseGameDataReturn => {
       setUnlockedSkills({});
       const grantRow = dailyGrantResult.data ? (dailyGrantResult.data as DailyXpGrantRow) : null;
       setDailyXpGrant(grantRow);
+
+      let stipendResolved = false;
+      let resolvedStipend: number | null = null;
+      let stipendErrored = false;
+
+      try {
+        const configClient = supabase as unknown as { from: (table: string) => any };
+        const stipendAttempt = await configClient
+          .from("game_configuration")
+          .select("*")
+          .eq("config_key", "daily_xp_stipend")
+          .limit(1)
+          .maybeSingle();
+
+        if (stipendAttempt?.error) {
+          stipendErrored = true;
+          console.error("Failed to load daily XP configuration", stipendAttempt.error);
+        } else {
+          stipendResolved = true;
+          resolvedStipend = extractDailyXpStipend((stipendAttempt?.data ?? null) as DailyXpConfigurationRow);
+        }
+
+        if (!stipendResolved || resolvedStipend === null) {
+          const stipendFallback = await configClient
+            .from("game_configuration")
+            .select("*")
+            .limit(20);
+
+          if (stipendFallback?.error) {
+            stipendErrored = true;
+            if (!stipendAttempt?.error) {
+              console.error("Failed to load daily XP configuration", stipendFallback.error);
+            }
+          } else if (Array.isArray(stipendFallback?.data)) {
+            stipendResolved = true;
+            for (const entry of stipendFallback.data as DailyXpConfigurationRow[]) {
+              const extracted = extractDailyXpStipend(entry);
+              if (extracted !== null) {
+                resolvedStipend = extracted;
+                break;
+              }
+            }
+          } else if (stipendFallback?.data) {
+            stipendResolved = true;
+            resolvedStipend = extractDailyXpStipend(stipendFallback.data as DailyXpConfigurationRow);
+          }
+        }
+      } catch (configurationError) {
+        stipendErrored = true;
+        console.error("Unexpected error loading daily XP configuration", configurationError);
+      }
+
+      if (resolvedStipend !== null) {
+        setDailyXpStipend(resolvedStipend);
+      } else if (stipendResolved || stipendErrored) {
+        setDailyXpStipend(null);
+      }
     },
     [user],
   );
@@ -399,6 +534,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
       setActivities([]);
       setCurrentCity(null);
       setDailyXpGrant(null);
+      setDailyXpStipend(null);
       return;
     }
 
@@ -1021,6 +1157,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
       unlockedSkills,
       activities,
       dailyXpGrant,
+      dailyXpStipend,
       freshWeeklyBonusAvailable,
       currentCity,
       loading,
@@ -1047,6 +1184,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
       unlockedSkills,
       activities,
       dailyXpGrant,
+      dailyXpStipend,
       freshWeeklyBonusAvailable,
       currentCity,
       loading,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -120,7 +120,6 @@ const formatSkillName = (slug: string) =>
     .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(" ");
 
-const DAILY_XP_STIPEND = 150;
 const MIN_FRIEND_SEARCH_LENGTH = 2;
 const FRIEND_SEARCH_DEBOUNCE_MS = 400;
 const NON_REQUESTABLE_STATUSES: FriendshipRow["status"][] = [
@@ -139,6 +138,7 @@ const Dashboard = () => {
     xpLedger,
     skillProgress,
     dailyXpGrant,
+    dailyXpStipend,
     freshWeeklyBonusAvailable,
     currentCity,
     activities,
@@ -508,9 +508,16 @@ const Dashboard = () => {
 
   const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const dailyXpClaimedToday = (dailyXpGrant?.grant_date ?? null) === todayIso;
+  const configuredDailyStipend = useMemo(() => {
+    if (typeof dailyXpStipend === "number" && Number.isFinite(dailyXpStipend)) {
+      return Math.max(0, dailyXpStipend);
+    }
+
+    return 150;
+  }, [dailyXpStipend]);
   const dailyXpAmount = dailyXpClaimedToday
-    ? Math.max(0, Number(dailyXpGrant?.xp_awarded ?? DAILY_XP_STIPEND))
-    : DAILY_XP_STIPEND;
+    ? Math.max(0, Number(dailyXpGrant?.xp_awarded ?? configuredDailyStipend))
+    : configuredDailyStipend;
   const dailyXpClaimedAtLabel = dailyXpGrant?.claimed_at ? formatNotificationDate(dailyXpGrant.claimed_at) : undefined;
   const spendableXpBalance = Math.max(0, Number(xpWallet?.xp_balance ?? 0));
 

--- a/src/pages/MyCharacter.tsx
+++ b/src/pages/MyCharacter.tsx
@@ -58,7 +58,6 @@ const PROFILE_META_FIELDS: Array<{ key: keyof PlayerProfile; label: string; icon
 ];
 
 const MIN_ATTRIBUTE_SCORE = 5;
-const DAILY_XP_STIPEND = 150;
 const DEFAULT_ATTRIBUTE_SPEND = 10;
 const DEFAULT_SKILL_SPEND = 25;
 
@@ -98,6 +97,7 @@ const MyCharacter = () => {
     xpWallet,
     skillProgress,
     dailyXpGrant,
+    dailyXpStipend,
     claimDailyXp,
     spendAttributeXp,
     spendSkillXp,
@@ -128,9 +128,16 @@ const MyCharacter = () => {
   );
   const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
   const hasClaimedDailyXp = (dailyXpGrant?.grant_date ?? null) === todayIso;
+  const configuredDailyStipend = useMemo(() => {
+    if (typeof dailyXpStipend === "number" && Number.isFinite(dailyXpStipend)) {
+      return Math.max(0, dailyXpStipend);
+    }
+
+    return 150;
+  }, [dailyXpStipend]);
   const todaysStipend = hasClaimedDailyXp
-    ? Math.max(0, Number(dailyXpGrant?.xp_awarded ?? DAILY_XP_STIPEND))
-    : DAILY_XP_STIPEND;
+    ? Math.max(0, Number(dailyXpGrant?.xp_awarded ?? configuredDailyStipend))
+    : configuredDailyStipend;
   const momentum = Math.max(0, Number(profile?.momentum ?? 0));
   const inspiration = Math.max(0, Number(profile?.inspiration ?? 0));
   const momentumProgress = Math.max(0, Math.min(100, momentum));


### PR DESCRIPTION
## Summary
- fetch the daily XP stipend configuration in the game data loader and expose it via the context
- update dashboard and My Character messaging to consume the dynamic stipend with a 150 XP fallback
- add defensive parsing to handle multiple configuration payload shapes when resolving the stipend amount

## Testing
- npm run lint
- npm run test -- SetlistDesigner.test.tsx (fails: expected Setlist Designer markup to include "Twilight Spark Warmup")

------
https://chatgpt.com/codex/tasks/task_e_68d10dfb890883258bf1bbcd167b270e