### PR TITLE
Fix syntax error in useGameData daily grant assignment

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -492,7 +492,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
       setSkillProgress((skillProgressResult.data ?? []) as SkillProgressRow[]);
       setUnlockedSkills({});
       const grantRow =
-yeah         dailyGrantResult.error || !dailyGrantResult.data
+        dailyGrantResult.error || !dailyGrantResult.data
           ? null
           : ((dailyGrantResult.data ?? null) as DailyXpGrantRow | null);
       setDailyXpGrant(grantRow);


### PR DESCRIPTION
## Summary
- remove stray debug text from the daily grant assignment in `useGameData`

## Testing
- npm run build *(fails: existing duplicate exports in src/utils/progression.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1143067a88325b92a87097926753d