### PR TITLE
Fix World Map navigation link

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -77,7 +77,7 @@ const Navigation = () => {
         { icon: Building2, label: "Venue Management", path: "/venues" },
         { icon: Settings, label: "Stage Setup", path: "/stage-setup" },
         { icon: MapPin, label: "City Overview", path: cityOverviewPath },
-        { icon: Globe, label: "World Map", path: "/cities" },
+        { icon: Globe, label: "World Map", path: "/world-map" },
         { icon: Mic, label: "Street Busking", path: "/busking" },
         { icon: Plane, label: "Travel Planner", path: "/travel" },
         { icon: Globe, label: "Tour System", path: "/tours-system" },


### PR DESCRIPTION
## Summary
- update the World Map navigation entry to point at the `/world-map` route so it aligns with the app routing configuration

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: existing duplicate export errors in src/utils/progression.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d11686f08483259473b6a09b838904