### PR TITLE
Fix undefined skills promise in game data hook

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -377,6 +377,15 @@ const useGameDataInternal = (): UseGameDataReturn => {
         }
       }
 
+      const skillsPromise = playerSkillsTableMissingRef.current
+        ? Promise.resolve({ data: null, error: null })
+        : supabase
+            .from("player_skills")
+            .select("*")
+            .eq("profile_id", effectiveProfile.id)
+            .eq("user_id", user.id)
+            .maybeSingle();
+
       const dailyGrantPromise = dailyXpGrantUnavailableRef.current
         ? Promise.resolve({ data: null, error: null })
         : supabase


### PR DESCRIPTION
## Summary
- initialize the player skills fetch promise before loading game data to prevent runtime errors when loading profiles

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d117d6923c83258cb1cbf6de701477