### PR TITLE
Define daily grant error guard

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -474,6 +474,8 @@ const useGameDataInternal = (): UseGameDataReturn => {
       if (skillProgressResult.error) {
         console.error("Failed to load skill progress", skillProgressResult.error);
       }
+      let shouldIgnoreDailyGrantError = false;
+
       if (dailyGrantResult.error) {
         if (isSchemaCacheMissingTableError(dailyGrantResult.error)) {
           if (!dailyXpGrantUnavailableRef.current) {
@@ -483,6 +485,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
               dailyGrantResult.error,
             );
           }
+          shouldIgnoreDailyGrantError = true;
         } else if (dailyGrantResult.error.code !== "PGRST116") {
           console.error("Failed to load daily XP grant", dailyGrantResult.error);
         }


### PR DESCRIPTION
## Summary
- define a local flag before handling daily XP grant errors so the later guard is valid

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d11a720ae0832594d40712b619a7cf