### PR TITLE
Add community stats to auth and layout banners

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,12 +6,21 @@ import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
+import PlayerCommunityStats from "@/components/PlayerCommunityStats";
+import { useCommunityStats } from "@/hooks/useCommunityStats";
 
 const Layout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, loading: authLoading } = useAuth();
   const { profile, loading: dataLoading, error: profileError } = useGameData();
+  const {
+    registeredPlayers,
+    registeredLoading,
+    registeredError,
+    livePlayers,
+    livePlayersConnected,
+  } = useCommunityStats({ presenceUserId: user?.id });
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -46,8 +55,21 @@ const Layout = () => {
     <div className="flex h-screen bg-background">
       <Navigation />
       <main className="flex-1 overflow-y-auto pb-16 lg:ml-0 lg:pb-0">
-        <header className="bg-muted py-2 text-center font-oswald text-sm uppercase tracking-wide text-muted-foreground">
-          DEMO- In Development
+        <header className="bg-muted py-2 text-muted-foreground">
+          <div className="mx-auto flex max-w-4xl flex-col items-center justify-center gap-1 px-4 text-center">
+            <span className="font-oswald text-xs uppercase tracking-[0.35em] text-muted-foreground/80 sm:text-sm">
+              DEMO - In Development
+            </span>
+            <PlayerCommunityStats
+              registeredPlayers={registeredPlayers}
+              registeredLoading={registeredLoading}
+              registeredError={registeredError}
+              livePlayers={livePlayers}
+              livePlayersConnected={livePlayersConnected}
+              size="sm"
+              className="text-muted-foreground/90"
+            />
+          </div>
         </header>
         <div className="pt-12 lg:pt-0">
           {profileError && (

--- a/src/components/PlayerCommunityStats.tsx
+++ b/src/components/PlayerCommunityStats.tsx
@@ -1,0 +1,72 @@
+import { Activity, Users } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface PlayerCommunityStatsProps {
+  registeredPlayers: number | null;
+  registeredLoading?: boolean;
+  registeredError?: string | null;
+  livePlayers: number;
+  livePlayersConnected?: boolean;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+const ICON_SIZES: Record<NonNullable<PlayerCommunityStatsProps["size"]>, number> = {
+  sm: 14,
+  md: 16,
+  lg: 18,
+};
+
+const textSizeMap: Record<NonNullable<PlayerCommunityStatsProps["size"]>, string> = {
+  sm: "text-[0.65rem] sm:text-xs",
+  md: "text-xs sm:text-sm",
+  lg: "text-sm sm:text-base",
+};
+
+const PlayerCommunityStats = ({
+  registeredPlayers,
+  registeredLoading = false,
+  registeredError = null,
+  livePlayers,
+  livePlayersConnected = false,
+  size = "md",
+  className,
+}: PlayerCommunityStatsProps) => {
+  const iconSize = ICON_SIZES[size];
+  const textSizing = textSizeMap[size];
+
+  const registeredDisplay = registeredLoading && registeredPlayers === null
+    ? "..."
+    : registeredPlayers !== null
+      ? registeredPlayers.toLocaleString()
+      : "—";
+
+  const liveDisplay = livePlayersConnected
+    ? livePlayers.toLocaleString()
+    : "…";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-center gap-2 sm:gap-4 font-oswald tracking-wide uppercase",
+        textSizing,
+        className,
+      )}
+    >
+      <span className="flex items-center gap-1.5" title={registeredError ?? undefined}>
+        <Users style={{ width: iconSize, height: iconSize }} className="opacity-80" />
+        <span className="opacity-80">Registered</span>
+        <span className="font-semibold tracking-widest">{registeredDisplay}</span>
+      </span>
+      <span className="hidden sm:inline-block opacity-50">•</span>
+      <span className="flex items-center gap-1.5">
+        <Activity style={{ width: iconSize, height: iconSize }} className="opacity-80" />
+        <span className="opacity-80">Live</span>
+        <span className="font-semibold tracking-widest">{liveDisplay}</span>
+      </span>
+    </div>
+  );
+};
+
+export default PlayerCommunityStats;

--- a/src/hooks/useCommunityStats.ts
+++ b/src/hooks/useCommunityStats.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { supabase } from "@/integrations/supabase/client";
+
+import useSupabasePresence from "./useSupabasePresence";
+
+const DEFAULT_PRESENCE_CHANNEL = "community-presence";
+const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
+
+interface UseCommunityStatsOptions {
+  /**
+   * User id to register with the presence channel. When omitted the hook will
+   * subscribe in read-only mode and avoid contributing to the live player count.
+   */
+  presenceUserId?: string;
+  /**
+   * Override presence channel name. Defaults to `community-presence`.
+   */
+  presenceChannel?: string;
+  /**
+   * Optional explicit presence key. Useful for deterministic observers.
+   */
+  presenceKey?: string;
+  /**
+   * Refresh interval for the registered player count. Defaults to 60 seconds.
+   * Set to `null` or `0` to disable automatic refreshes after the initial load.
+   */
+  refreshIntervalMs?: number | null;
+}
+
+interface UseCommunityStatsResult {
+  registeredPlayers: number | null;
+  registeredLoading: boolean;
+  registeredError: string | null;
+  refreshRegisteredPlayers: () => Promise<void>;
+  livePlayers: number;
+  livePlayersConnected: boolean;
+  livePlayerIds: string[];
+}
+
+const generateObserverKey = () => `observer-${Math.random().toString(36).slice(2, 10)}`;
+
+export const useCommunityStats = ({
+  presenceUserId,
+  presenceChannel = DEFAULT_PRESENCE_CHANNEL,
+  presenceKey,
+  refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS,
+}: UseCommunityStatsOptions = {}): UseCommunityStatsResult => {
+  const shouldTrackPresence = Boolean(presenceUserId);
+  const observerKey = useMemo(() => {
+    if (shouldTrackPresence && presenceUserId) {
+      return presenceUserId;
+    }
+
+    return presenceKey ?? generateObserverKey();
+  }, [presenceKey, presenceUserId, shouldTrackPresence]);
+
+  const [registeredPlayers, setRegisteredPlayers] = useState<number | null>(null);
+  const [registeredLoading, setRegisteredLoading] = useState(true);
+  const [registeredError, setRegisteredError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refreshRegisteredPlayers = useCallback(async () => {
+    setRegisteredLoading(true);
+
+    try {
+      const { count, error } = await supabase
+        .from("profiles")
+        .select("id", { count: "exact", head: true });
+
+      if (error) {
+        throw error;
+      }
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setRegisteredPlayers(count ?? 0);
+      setRegisteredError(null);
+    } catch (caught) {
+      console.error("Failed to fetch registered player count:", caught);
+      if (isMountedRef.current) {
+        setRegisteredError("Unable to load player count");
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setRegisteredLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshRegisteredPlayers();
+  }, [refreshRegisteredPlayers]);
+
+  useEffect(() => {
+    if (!refreshIntervalMs || refreshIntervalMs <= 0) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      void refreshRegisteredPlayers();
+    }, refreshIntervalMs);
+
+    return () => clearInterval(intervalId);
+  }, [refreshIntervalMs, refreshRegisteredPlayers]);
+
+  const { participantCount, isConnected, onlineUserIds } = useSupabasePresence({
+    channelName: presenceChannel,
+    userId: shouldTrackPresence ? presenceUserId : undefined,
+    presenceKey: observerKey,
+    trackSelf: shouldTrackPresence,
+  });
+
+  return {
+    registeredPlayers,
+    registeredLoading,
+    registeredError,
+    refreshRegisteredPlayers,
+    livePlayers: participantCount,
+    livePlayersConnected: isConnected,
+    livePlayerIds: onlineUserIds,
+  };
+};
+
+export default useCommunityStats;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -11,6 +11,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import logo from "@/assets/rockmundo-new-logo.png";
 import { cn } from "@/lib/utils";
+import PlayerCommunityStats from "@/components/PlayerCommunityStats";
+import { useCommunityStats } from "@/hooks/useCommunityStats";
 
 type AuthTab = "login" | "signup" | "forgot";
 
@@ -35,6 +37,14 @@ const Auth = () => {
   const [isResettingPassword, setIsResettingPassword] = useState(false);
   const [unverifiedEmail, setUnverifiedEmail] = useState("");
   const [resendingVerification, setResendingVerification] = useState(false);
+
+  const {
+    registeredPlayers,
+    registeredLoading,
+    registeredError,
+    livePlayers,
+    livePlayersConnected,
+  } = useCommunityStats({ presenceKey: "auth-landing" });
 
   const [loginData, setLoginData] = useState({
     email: "",
@@ -471,8 +481,21 @@ const Auth = () => {
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-4 py-8 sm:px-6">
-      <header className="w-full bg-primary text-primary-foreground text-center uppercase tracking-wide font-bebas text-sm sm:text-base py-2">
-        DEMO- In Development
+      <header className="w-full bg-primary text-primary-foreground">
+        <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-1 px-4 py-2 text-center">
+          <span className="font-bebas text-sm sm:text-base uppercase tracking-wide">
+            DEMO - In Development
+          </span>
+          <PlayerCommunityStats
+            registeredPlayers={registeredPlayers}
+            registeredLoading={registeredLoading}
+            registeredError={registeredError}
+            livePlayers={livePlayers}
+            livePlayersConnected={livePlayersConnected}
+            size="sm"
+            className="text-primary-foreground/90"
+          />
+        </div>
       </header>
       <div className="w-full max-w-sm sm:max-w-md">
         {/* Logo and Branding */}


### PR DESCRIPTION
## Summary
- add a reusable community stats hook and banner component for showing player counts
- extend the Supabase presence hook so observers can read live counts without being tracked
- update the auth screen and in-app banner to display registered and live player totals

## Testing
- npm run lint *(fails: existing lint errors in Travel.tsx and supabase/functions/progression/index.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1500818ac83259065d64572228b7d