### PR TITLE
Use xp_ledger for XP history

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -34,7 +34,7 @@ type AttributeCategory =
 export type PlayerAttributes = Record<AttributeCategory, number>;
 export type PlayerXpWallet = Database["public"]["Tables"]["player_xp_wallet"]["Row"] | null;
 export type SkillProgressRow = Database["public"]["Tables"]["skill_progress"]["Row"];
-export type ExperienceLedgerRow = any; // Will be updated when types regenerate
+export type ExperienceLedgerRow = Database["public"]["Tables"]["xp_ledger"]["Row"];
 export type UnlockedSkillsMap = Record<string, boolean>;
 export type ActivityFeedRow = Database["public"]["Tables"]["activity_feed"]["Row"];
 
@@ -454,7 +454,7 @@ const useGameDataInternal = (): UseGameDataReturn => {
           .eq("profile_id", effectiveProfile.id)
           .maybeSingle(),
         supabase
-          .from("experience_ledger")
+          .from("xp_ledger")
           .select("*")
           .eq("profile_id", effectiveProfile.id)
           .order("created_at", { ascending: false })

--- a/src/hooks/useGameData.tsx.disabled
+++ b/src/hooks/useGameData.tsx.disabled
@@ -33,7 +33,7 @@ type AttributeCategory =
 export type PlayerAttributes = Record<AttributeCategory, number>;
 export type PlayerXpWallet = Database["public"]["Tables"]["player_xp_wallet"]["Row"] | null;
 export type SkillProgressRow = Database["public"]["Tables"]["skill_progress"]["Row"];
-export type ExperienceLedgerRow = any; // Will be updated when types regenerate
+export type ExperienceLedgerRow = Database["public"]["Tables"]["xp_ledger"]["Row"];
 export type UnlockedSkillsMap = Record<string, boolean>;
 export type ActivityFeedRow = Database["public"]["Tables"]["activity_feed"]["Row"];
 
@@ -315,7 +315,7 @@ export const useGameData = (): UseGameDataReturn => {
           .eq("profile_id", effectiveProfile.id)
           .maybeSingle(),
         supabase
-          .from("experience_ledger")
+          .from("xp_ledger")
           .select("*")
           .eq("profile_id", effectiveProfile.id)
           .order("created_at", { ascending: false })

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -617,38 +617,49 @@ export type Database = {
           },
         ]
       }
-      experience_ledger: {
+      xp_ledger: {
         Row: {
-          activity_type: string
-          created_at: string | null
+          attribute_points_delta: number
+          balance_after: number
+          created_at: string
+          event_type: string
           id: string
           metadata: Json | null
-          profile_id: string | null
-          skill_slug: string | null
-          user_id: string
-          xp_amount: number
+          profile_id: string
+          skill_points_delta: number
+          xp_delta: number
         }
         Insert: {
-          activity_type: string
-          created_at?: string | null
+          attribute_points_delta?: number
+          balance_after: number
+          created_at?: string
+          event_type: string
           id?: string
           metadata?: Json | null
-          profile_id?: string | null
-          skill_slug?: string | null
-          user_id: string
-          xp_amount?: number
+          profile_id: string
+          skill_points_delta?: number
+          xp_delta: number
         }
         Update: {
-          activity_type?: string
-          created_at?: string | null
+          attribute_points_delta?: number
+          balance_after?: number
+          created_at?: string
+          event_type?: string
           id?: string
           metadata?: Json | null
-          profile_id?: string | null
-          skill_slug?: string | null
-          user_id?: string
-          xp_amount?: number
+          profile_id?: string
+          skill_points_delta?: number
+          xp_delta?: number
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "xp_ledger_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       fan_demographics: {
         Row: {


### PR DESCRIPTION
## Summary
- update the game data hook to read XP history from the new `xp_ledger` table
- regenerate the Supabase typings so `ExperienceLedgerRow` reflects the ledger schema
- mirror the ledger updates in the disabled hook variant to keep both copies aligned

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b8270a988325a6751dc53f6724c4