### PR TITLE
Fix player targeting schema extension

### DIFF
--- a/src/pages/admin/PlayerBoosts.tsx
+++ b/src/pages/admin/PlayerBoosts.tsx
@@ -32,15 +32,14 @@ import {
   describeAllRecipientCount,
   getAffectedCount,
   playerTargetingDefaultValues,
-  playerTargetingSchema,
+  extendPlayerTargetingSchema,
   resolveTargetProfileIds,
   usePlayerProfiles,
   useTargetScopeSynchronization,
 } from "./playerBoosts.helpers";
 import { adminAdjustMomentum, adminAwardSpecialXp, adminSetDailyXpAmount } from "@/utils/progression";
 
-const momentumSchema = playerTargetingSchema
-  .extend({
+const momentumSchema = extendPlayerTargetingSchema({
     amount: z
       .coerce
       .number({ invalid_type_error: "Momentum change must be a number" })
@@ -64,7 +63,7 @@ const momentumDefaultValues: MomentumFormValues = {
   reason: "",
 };
 
-const xpBoostSchema = playerTargetingSchema.extend({
+const xpBoostSchema = extendPlayerTargetingSchema({
   amount: z
     .coerce
     .number({ invalid_type_error: "XP amount must be a number" })
@@ -80,7 +79,7 @@ const xpBoostDefaultValues: XpBoostFormValues = {
   reason: "Community momentum boost",
 };
 
-const stipendSchema = playerTargetingSchema.extend({
+const stipendSchema = extendPlayerTargetingSchema({
   amount: z
     .coerce
     .number({ invalid_type_error: "Daily XP must be a number" })


### PR DESCRIPTION
## Summary
- add a helper to re-apply targeting refinements when extending the player targeting schema
- update the admin player boosts forms to use the new helper when defining their schemas

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ba8b2f4c832598b05ec89e266ede