### PR TITLE
Align skill provisioning functions with current player skills schema

### DIFF
--- a/supabase/migrations/20270431170000_fix_player_skills_columns.sql
+++ b/supabase/migrations/20270431170000_fix_player_skills_columns.sql
@@ -1,0 +1,337 @@
+-- Align handle_new_user and reset_player_character skill inserts with actual table columns
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $function$
+DECLARE
+  portsmouth_id uuid;
+  new_profile public.profiles%ROWTYPE;
+BEGIN
+  SELECT id INTO portsmouth_id
+  FROM public.cities
+  WHERE id = 'a5bf9a04-5c3b-4c7c-99bb-f3a4ed2d64d6';
+
+  IF portsmouth_id IS NULL THEN
+    RAISE EXCEPTION 'Default city Portsmouth is missing';
+  END IF;
+
+  INSERT INTO public.profiles (
+    user_id,
+    username,
+    display_name,
+    current_city_id,
+    current_location,
+    health,
+    gender,
+    city_of_birth,
+    age,
+    slot_number,
+    unlock_cost,
+    is_active
+  )
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'username', 'Player' || substr(NEW.id::text, 1, 8)),
+    COALESCE(NEW.raw_user_meta_data->>'display_name', 'New Player'),
+    portsmouth_id,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    1,
+    0,
+    true
+  )
+  RETURNING * INTO new_profile;
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, 'user');
+
+  INSERT INTO public.player_skills (
+    user_id,
+    profile_id,
+    guitar,
+    vocals,
+    drums,
+    bass,
+    performance,
+    songwriting
+  )
+  VALUES (
+    NEW.id,
+    new_profile.id,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5
+  )
+  ON CONFLICT (profile_id) DO NOTHING;
+
+  INSERT INTO public.fan_demographics (user_id)
+  VALUES (NEW.id);
+
+  INSERT INTO public.activity_feed (user_id, profile_id, activity_type, message)
+  VALUES (
+    NEW.id,
+    new_profile.id,
+    'join',
+    'Welcome to Rockmundo! Your musical journey begins now.'
+  );
+
+  INSERT INTO public.player_attributes (
+    user_id,
+    profile_id,
+    physical_endurance,
+    mental_focus,
+    stage_presence,
+    crowd_engagement,
+    social_reach,
+    looks,
+    charisma,
+    musicality,
+    creativity,
+    technical,
+    business,
+    marketing,
+    composition,
+    musical_ability,
+    vocal_talent,
+    rhythm_sense,
+    creative_insight,
+    technical_mastery,
+    business_acumen,
+    marketing_savvy,
+    attribute_points,
+    attribute_points_spent
+  )
+  VALUES (
+    NEW.id,
+    new_profile.id,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    0,
+    0
+  )
+  ON CONFLICT (profile_id) DO NOTHING;
+
+  INSERT INTO public.player_achievements (user_id, achievement_id)
+  SELECT NEW.id, id
+  FROM public.achievements
+  WHERE name = 'First Steps';
+
+  RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.reset_player_character()
+RETURNS TABLE (
+  profile public.profiles,
+  skills public.player_skills,
+  attributes public.player_attributes
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  generated_username text;
+  new_profile public.profiles%ROWTYPE;
+  new_skills public.player_skills%ROWTYPE;
+  new_attributes public.player_attributes%ROWTYPE;
+  portsmouth_id uuid;
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to reset character' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id INTO portsmouth_id
+  FROM public.cities
+  WHERE id = 'a5bf9a04-5c3b-4c7c-99bb-f3a4ed2d64d6';
+
+  IF portsmouth_id IS NULL THEN
+    RAISE EXCEPTION 'Default city Portsmouth is missing';
+  END IF;
+
+  generated_username := 'Player' || substr(current_user_id::text, 1, 8);
+
+  DELETE FROM public.social_comments WHERE user_id = current_user_id;
+  DELETE FROM public.social_reposts WHERE user_id = current_user_id;
+  DELETE FROM public.social_posts WHERE user_id = current_user_id;
+  DELETE FROM public.promotion_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.social_campaigns WHERE user_id = current_user_id;
+  DELETE FROM public.streaming_stats WHERE user_id = current_user_id;
+  DELETE FROM public.player_equipment WHERE user_id = current_user_id;
+  DELETE FROM public.player_streaming_accounts WHERE user_id = current_user_id;
+  DELETE FROM public.player_achievements WHERE user_id = current_user_id;
+  DELETE FROM public.contracts WHERE user_id = current_user_id;
+  DELETE FROM public.gig_performances WHERE user_id = current_user_id;
+  DELETE FROM public.tours WHERE user_id = current_user_id;
+  DELETE FROM public.venue_bookings WHERE user_id = current_user_id;
+  DELETE FROM public.venue_relationships WHERE user_id = current_user_id;
+  DELETE FROM public.user_actions WHERE user_id = current_user_id;
+  DELETE FROM public.global_chat WHERE user_id = current_user_id;
+  DELETE FROM public.activity_feed WHERE user_id = current_user_id;
+  DELETE FROM public.fan_demographics WHERE user_id = current_user_id;
+  DELETE FROM public.band_members WHERE user_id = current_user_id;
+  DELETE FROM public.player_attributes WHERE user_id = current_user_id;
+
+  DELETE FROM public.band_conflicts
+    WHERE band_id IN (
+      SELECT id
+      FROM public.bands
+      WHERE leader_id = current_user_id
+    );
+  DELETE FROM public.bands WHERE leader_id = current_user_id;
+
+  DELETE FROM public.songs WHERE user_id = current_user_id;
+
+  DELETE FROM public.player_skills WHERE user_id = current_user_id;
+  DELETE FROM public.profiles WHERE user_id = current_user_id;
+
+  INSERT INTO public.profiles (
+    user_id,
+    username,
+    display_name,
+    current_city_id,
+    current_location,
+    health,
+    gender,
+    city_of_birth,
+    age,
+    slot_number,
+    unlock_cost,
+    is_active
+  )
+  VALUES (
+    current_user_id,
+    generated_username,
+    'New Player',
+    portsmouth_id,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    DEFAULT,
+    1,
+    0,
+    true
+  )
+  RETURNING * INTO new_profile;
+
+  INSERT INTO public.player_skills (
+    user_id,
+    profile_id,
+    guitar,
+    vocals,
+    drums,
+    bass,
+    performance,
+    songwriting
+  )
+  VALUES (
+    current_user_id,
+    new_profile.id,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5
+  )
+  RETURNING * INTO new_skills;
+
+  INSERT INTO public.player_attributes (
+    user_id,
+    profile_id,
+    physical_endurance,
+    mental_focus,
+    stage_presence,
+    crowd_engagement,
+    social_reach,
+    looks,
+    charisma,
+    musicality,
+    creativity,
+    technical,
+    business,
+    marketing,
+    composition,
+    musical_ability,
+    vocal_talent,
+    rhythm_sense,
+    creative_insight,
+    technical_mastery,
+    business_acumen,
+    marketing_savvy,
+    attribute_points,
+    attribute_points_spent
+  )
+  VALUES (
+    current_user_id,
+    new_profile.id,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    5,
+    0,
+    0
+  )
+  RETURNING * INTO new_attributes;
+
+  INSERT INTO public.player_achievements (user_id, achievement_id)
+  SELECT current_user_id, id
+  FROM public.achievements
+  WHERE name = 'First Steps';
+
+  INSERT INTO public.fan_demographics (user_id)
+  VALUES (current_user_id);
+
+  INSERT INTO public.activity_feed (user_id, profile_id, activity_type, message)
+  VALUES (
+    current_user_id,
+    new_profile.id,
+    'reset',
+    'Your journey restarts with renewed determination!'
+  );
+
+  RETURN QUERY SELECT new_profile, new_skills, new_attributes;
+END;
+$$;


### PR DESCRIPTION
## Summary
- update the player onboarding and reset routines so they only populate the skill columns that exist in public.player_skills

## Testing
- supabase db reset --force *(fails: Supabase CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be9c214083258020ed69fc83a7ba