### PR TITLE
Ensure city overview can load player activity columns

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1492,6 +1492,10 @@ export type Database = {
           age: number
           bio: string | null
           cash: number | null
+          current_activity: string | null
+          current_city_id: string | null
+          primary_instrument: string | null
+          travel_mode: string | null
           created_at: string | null
           display_name: string | null
           experience: number | null
@@ -1515,6 +1519,8 @@ export type Database = {
           bio?: string | null
           cash?: number | null
           created_at?: string | null
+          current_activity?: string | null
+          current_city_id?: string | null
           display_name?: string | null
           experience?: number | null
           experience_at_last_weekly_bonus?: number | null
@@ -1525,7 +1531,9 @@ export type Database = {
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
+          primary_instrument?: string | null
           momentum?: number
+          travel_mode?: string | null
           updated_at?: string | null
           user_id: string
           username: string
@@ -1536,6 +1544,8 @@ export type Database = {
           age?: number
           bio?: string | null
           cash?: number | null
+          current_activity?: string | null
+          current_city_id?: string | null
           created_at?: string | null
           display_name?: string | null
           experience?: number | null
@@ -1547,7 +1557,9 @@ export type Database = {
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
+          primary_instrument?: string | null
           momentum?: number
+          travel_mode?: string | null
           updated_at?: string | null
           user_id?: string
           username?: string

--- a/supabase/migrations/20270431193000_add_profile_activity_and_instrument.sql
+++ b/supabase/migrations/20270431193000_add_profile_activity_and_instrument.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_activity text,
+  ADD COLUMN IF NOT EXISTS primary_instrument text,
+  ADD COLUMN IF NOT EXISTS travel_mode text,
+  ADD COLUMN IF NOT EXISTS current_city_id uuid REFERENCES public.cities(id);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that ensures profile rows expose current activity, instrument, travel mode, and current city references
- refresh the generated Supabase types so the new profile columns are available to the frontend

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d1c15c53488325a4a05d8448593052