### PR TITLE
Add metadata column to skill definitions

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1563,6 +1563,7 @@ export type Database = {
           display_name: string
           id: string
           slug: string
+          metadata: Json
           tier_caps: Json | null
           updated_at: string | null
         }
@@ -1572,6 +1573,7 @@ export type Database = {
           display_name: string
           id?: string
           slug: string
+          metadata?: Json
           tier_caps?: Json | null
           updated_at?: string | null
         }
@@ -1581,6 +1583,7 @@ export type Database = {
           display_name?: string
           id?: string
           slug?: string
+          metadata?: Json
           tier_caps?: Json | null
           updated_at?: string | null
         }

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -362,6 +362,7 @@ export interface Database {
           slug: string;
           display_name: string;
           description?: string;
+          metadata: Json;
           tier_caps?: Json;
           created_at: string;
           updated_at: string;
@@ -371,6 +372,7 @@ export interface Database {
           slug: string;
           display_name: string;
           description?: string;
+          metadata?: Json;
           tier_caps?: Json;
           created_at?: string;
           updated_at?: string;
@@ -380,6 +382,7 @@ export interface Database {
           slug?: string;
           display_name?: string;
           description?: string;
+          metadata?: Json;
           tier_caps?: Json;
           created_at?: string;
           updated_at?: string;

--- a/supabase/migrations/20270612110000_add_metadata_to_skill_definitions.sql
+++ b/supabase/migrations/20270612110000_add_metadata_to_skill_definitions.sql
@@ -1,0 +1,7 @@
+-- Add metadata column to skill definitions for admin catalog usage
+ALTER TABLE public.skill_definitions
+  ADD COLUMN metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.skill_definitions
+  ADD CONSTRAINT skill_definitions_metadata_is_object
+  CHECK (jsonb_typeof(metadata) = 'object');

--- a/supabase/migrations/20270612110000_add_metadata_to_skill_definitions_down.sql
+++ b/supabase/migrations/20270612110000_add_metadata_to_skill_definitions_down.sql
@@ -1,0 +1,6 @@
+-- Remove metadata column from skill definitions
+ALTER TABLE public.skill_definitions
+  DROP CONSTRAINT IF EXISTS skill_definitions_metadata_is_object;
+
+ALTER TABLE public.skill_definitions
+  DROP COLUMN IF EXISTS metadata;


### PR DESCRIPTION
## Summary
- add a migration that extends `public.skill_definitions` with a `metadata` JSONB column constrained to JSON objects
- provide the down migration to remove the column and constraint if needed
- update the generated Supabase TypeScript definitions (and the fallback types) to expose the new `metadata` field

## Testing
- `npm run lint` *(fails: pre-existing eslint complaints about `any` usage in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c156fec88325a163c719e3d54d53