### PR TITLE
Fix duplicate declarations causing runtime errors

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -36,7 +36,6 @@ import {
   Store,
   Guitar,
   Handshake,
-  PenSquare,
 } from "lucide-react";
 
 const Navigation = () => {
@@ -68,7 +67,6 @@ const Navigation = () => {
         { icon: PenSquare, label: "Songwriting", path: "/songwriting" },
         { icon: ListMusic, label: "Song Manager", path: "/songs" },
         { icon: GraduationCap, label: "Education", path: "/education" },
-        { icon: PenSquare, label: "Songwriting", path: "/songwriting" },
       ],
     },
     {

--- a/src/utils/worldEnvironment.ts
+++ b/src/utils/worldEnvironment.ts
@@ -696,8 +696,6 @@ const normalizeCityRecord = (item: Record<string, unknown>): City => {
     famousResident: famousResidentRaw || "Local legend emerging",
     travelHub: travelHubRaw || travelOptions[0]?.name || "",
     travelOptions,
-    latitude,
-    longitude,
     distanceKm: null,
   };
 };


### PR DESCRIPTION
## Summary
- remove duplicate PenSquare import and redundant nav item from the navigation component to avoid runtime redeclaration errors
- eliminate repeated latitude/longitude assignments in the world environment normalizer to satisfy the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1d02c99948325bfd331c285089860