### PR TITLE
Add profile activity timing metadata and extend activity feed status fields

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -54,28 +54,34 @@ export type Database = {
         Row: {
           activity_type: string
           created_at: string | null
+          duration_minutes: number | null
           earnings: number | null
           id: string
           message: string
           metadata: Json | null
+          status: string | null
           user_id: string
         }
         Insert: {
           activity_type: string
           created_at?: string | null
+          duration_minutes?: number | null
           earnings?: number | null
           id?: string
           message: string
           metadata?: Json | null
+          status?: string | null
           user_id: string
         }
         Update: {
           activity_type?: string
           created_at?: string | null
+          duration_minutes?: number | null
           earnings?: number | null
           id?: string
           message?: string
           metadata?: Json | null
+          status?: string | null
           user_id?: string
         }
         Relationships: []
@@ -1546,6 +1552,9 @@ export type Database = {
           bio: string | null
           cash: number | null
           current_activity: string | null
+          current_activity_duration_minutes: number | null
+          current_activity_ends_at: string | null
+          current_activity_started_at: string | null
           current_city_id: string | null
           primary_instrument: string | null
           travel_mode: string | null
@@ -1573,6 +1582,9 @@ export type Database = {
           cash?: number | null
           created_at?: string | null
           current_activity?: string | null
+          current_activity_duration_minutes?: number | null
+          current_activity_ends_at?: string | null
+          current_activity_started_at?: string | null
           current_city_id?: string | null
           display_name?: string | null
           experience?: number | null
@@ -1598,6 +1610,9 @@ export type Database = {
           bio?: string | null
           cash?: number | null
           current_activity?: string | null
+          current_activity_duration_minutes?: number | null
+          current_activity_ends_at?: string | null
+          current_activity_started_at?: string | null
           current_city_id?: string | null
           created_at?: string | null
           display_name?: string | null

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -21,6 +21,10 @@ export interface Database {
           age: number;
           level?: number;
           experience?: number;
+          current_activity?: string;
+          current_activity_started_at?: string;
+          current_activity_duration_minutes?: number;
+          current_activity_ends_at?: string;
           cash?: number;
           fame?: number;
           fans?: number;
@@ -43,6 +47,10 @@ export interface Database {
           age?: number;
           level?: number;
           experience?: number;
+          current_activity?: string;
+          current_activity_started_at?: string;
+          current_activity_duration_minutes?: number;
+          current_activity_ends_at?: string;
           cash?: number;
           fame?: number;
           fans?: number;
@@ -65,6 +73,10 @@ export interface Database {
           age?: number;
           level?: number;
           experience?: number;
+          current_activity?: string;
+          current_activity_started_at?: string;
+          current_activity_duration_minutes?: number;
+          current_activity_ends_at?: string;
           cash?: number;
           fame?: number;
           fans?: number;
@@ -469,6 +481,8 @@ export interface Database {
           message: string;
           metadata?: Json;
           earnings?: number;
+          status?: string;
+          duration_minutes?: number;
           created_at: string;
         };
         Insert: {
@@ -478,6 +492,8 @@ export interface Database {
           message: string;
           metadata?: Json;
           earnings?: number;
+          status?: string;
+          duration_minutes?: number;
           created_at?: string;
         };
         Update: {
@@ -487,6 +503,8 @@ export interface Database {
           message?: string;
           metadata?: Json;
           earnings?: number;
+          status?: string;
+          duration_minutes?: number;
           created_at?: string;
         };
       };

--- a/supabase/migrations/20270612150000_add_profile_activity_timing.sql
+++ b/supabase/migrations/20270612150000_add_profile_activity_timing.sql
@@ -1,0 +1,13 @@
+-- Track timing metadata for active profile sessions and reflect it in the activity feed
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_activity_started_at timestamptz,
+  ADD COLUMN IF NOT EXISTS current_activity_duration_minutes integer,
+  ADD COLUMN IF NOT EXISTS current_activity_ends_at timestamptz;
+
+ALTER TABLE public.activity_feed
+  ADD COLUMN IF NOT EXISTS status text,
+  ADD COLUMN IF NOT EXISTS duration_minutes integer;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a migration that tracks activity start/end metadata on profiles and includes optional status fields on activity_feed
- sync Supabase TypeScript definitions with the new columns and update the fallback database typings

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any violations in Travel.tsx and progression edge function tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d20de75c8325ba845cfc5b1365d3