### PR TITLE
Fix addActivity initialization order

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -666,6 +666,41 @@ const useGameDataInternal = (): UseGameDataReturn => {
     return normalized as ActivityInsert["metadata"];
   };
 
+  const addActivity = useCallback(
+    async (
+      type: string,
+      message: string,
+      earnings: number | undefined = undefined,
+      metadata: ActivityInsert["metadata"] = null,
+      statusExtras?: { status?: string | null; durationMinutes?: number | null },
+    ) => {
+      if (!user) {
+        throw new Error("Authentication required to log activity");
+      }
+
+      if (!profile) {
+        throw new Error("No active profile selected");
+      }
+
+      const normalizedMetadata = mergeActivityMetadata(metadata, statusExtras);
+
+      const payload: ActivityInsert = {
+        user_id: user.id,
+        profile_id: profile.id,
+        activity_type: type,
+        message,
+        earnings: typeof earnings === "number" ? earnings : null,
+        metadata: normalizedMetadata,
+      };
+
+      const { error: insertError } = await supabase.from("activity_feed").insert(payload);
+      if (insertError) {
+        throw insertError;
+      }
+    },
+    [mergeActivityMetadata, profile, user],
+  );
+
   const closeActiveStatusSession = useCallback(
     async (
       profileId: string,
@@ -1966,41 +2001,6 @@ const useGameDataInternal = (): UseGameDataReturn => {
       return (data ?? null) as PlayerXpWallet;
     },
     [profile],
-  );
-
-  const addActivity = useCallback(
-    async (
-      type: string,
-      message: string,
-      earnings: number | undefined = undefined,
-      metadata: ActivityInsert["metadata"] = null,
-      statusExtras?: { status?: string | null; durationMinutes?: number | null },
-    ) => {
-      if (!user) {
-        throw new Error("Authentication required to log activity");
-      }
-
-      if (!profile) {
-        throw new Error("No active profile selected");
-      }
-
-      const normalizedMetadata = mergeActivityMetadata(metadata, statusExtras);
-
-      const payload: ActivityInsert = {
-        user_id: user.id,
-        profile_id: profile.id,
-        activity_type: type,
-        message,
-        earnings: typeof earnings === "number" ? earnings : null,
-        metadata: normalizedMetadata,
-      };
-
-      const { error: insertError } = await supabase.from("activity_feed").insert(payload);
-      if (insertError) {
-        throw insertError;
-      }
-    },
-    [mergeActivityMetadata, profile, user],
   );
 
   const awardActionXp = useCallback(


### PR DESCRIPTION
## Summary
- move the addActivity hook above its first usage so it is defined before being referenced

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any errors in supabase/functions/progression/index.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d23a4b5f28832586b3640fd1d2cfd2