### PR TITLE
Fix Radix manual chunk bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,12 @@ export default defineConfig(({ mode }) => ({
               return "recharts";
             }
             if (id.includes("@radix-ui")) {
-              return "radix";
+              // Radix UI depends on React DOM internals. Forcing those modules
+              // into a dedicated manual chunk can reorder the evaluation of
+              // React's runtime and surface "Cannot access '$t' before
+              // initialization" errors in production. Let Vite manage the
+              // optimal split for these files instead.
+              return undefined;
             }
             if (id.includes("react-router")) {
               return "react-router";


### PR DESCRIPTION
## Summary
- allow Vite to manage chunking for @radix-ui modules to avoid reordering React internals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23b140ee88325b8b2e5374b10c2d8