### PR TITLE
Handle Supabase invalid refresh token errors globally

### DIFF
--- a/src/lib/auth-error-handlers.ts
+++ b/src/lib/auth-error-handlers.ts
@@ -2,6 +2,21 @@ import { AuthApiError } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
 /**
+ * Determines whether the provided error was caused by an invalid
+ * Supabase refresh token. This allows different parts of the app to
+ * perform early checks before invoking the async recovery handler.
+ */
+export const isInvalidRefreshTokenError = (error: unknown): error is AuthApiError => {
+  if (error instanceof AuthApiError) {
+    const message = error.message.toLowerCase();
+
+    return message.includes("invalid refresh token");
+  }
+
+  return false;
+};
+
+/**
  * Clears any persisted Supabase session if the provided error indicates
  * an invalid refresh token. This helps recover from stale browser storage
  * where Supabase is unable to find the referenced refresh token.
@@ -9,20 +24,16 @@ import { supabase } from "@/integrations/supabase/client";
  * @returns A boolean indicating whether the error was handled.
  */
 export const handleInvalidRefreshTokenError = async (error: unknown): Promise<boolean> => {
-  if (error instanceof AuthApiError) {
-    const message = error.message.toLowerCase();
-
-    if (message.includes("invalid refresh token")) {
-      console.warn("Clearing stale Supabase session due to invalid refresh token.", error);
-
-      const { error: signOutError } = await supabase.auth.signOut({ scope: "local" });
-      if (signOutError) {
-        console.error("Failed to clear stale Supabase session:", signOutError);
-      }
-
-      return true;
-    }
+  if (!isInvalidRefreshTokenError(error)) {
+    return false;
   }
 
-  return false;
+  console.warn("Clearing stale Supabase session due to invalid refresh token.", error);
+
+  const { error: signOutError } = await supabase.auth.signOut({ scope: "local" });
+  if (signOutError) {
+    console.error("Failed to clear stale Supabase session:", signOutError);
+  }
+
+  return true;
 };

--- a/src/lib/setup-auth-error-handlers.ts
+++ b/src/lib/setup-auth-error-handlers.ts
@@ -1,0 +1,23 @@
+import { handleInvalidRefreshTokenError, isInvalidRefreshTokenError } from "./auth-error-handlers";
+
+type GlobalWithAuthHandler = typeof globalThis & {
+  __supabaseInvalidRefreshHandler__?: boolean;
+};
+
+const globalScope = globalThis as GlobalWithAuthHandler;
+
+if (typeof window !== "undefined" && !globalScope.__supabaseInvalidRefreshHandler__) {
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+
+    if (!isInvalidRefreshTokenError(reason)) {
+      return;
+    }
+
+    event.preventDefault();
+    void handleInvalidRefreshTokenError(reason);
+  };
+
+  window.addEventListener("unhandledrejection", handleUnhandledRejection);
+  globalScope.__supabaseInvalidRefreshHandler__ = true;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import "./lib/setup-auth-error-handlers";
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- add a shared helper to detect Supabase invalid refresh token errors and reuse it in the recovery path
- register a single global unhandled rejection handler to clear stale Supabase sessions and prevent noisy console errors

## Testing
- npm run lint *(fails: existing lint violations in supabase/functions/progression/index.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d23bbbcbc88325b6591ba739f928ad