### PR TITLE
Handle missing travel tables schema cache errors

### DIFF
--- a/src/pages/City.tsx
+++ b/src/pages/City.tsx
@@ -21,6 +21,7 @@ import {
   type City as CityRecord,
   type CityEnvironmentDetails,
 } from "@/utils/worldEnvironment";
+import { isTableMissingFromSchemaCache } from "@/utils/postgrestErrors";
 
 type CityRouteParams = {
   cityId?: string;
@@ -448,11 +449,10 @@ export const CityContent = ({
           .eq("city_from", city.id);
 
         if (response.error) {
-          const error = response.error as PostgrestError;
-          if (error?.code === "42P01") {
+          if (isTableMissingFromSchemaCache(response.error)) {
             continue;
           }
-          throw error;
+          throw response.error;
         }
 
         const rows = Array.isArray(response.data) ? (response.data as Record<string, unknown>[]) : [];
@@ -480,11 +480,11 @@ export const CityContent = ({
           });
         });
       } catch (unknownError) {
-        const error = unknownError as PostgrestError;
-        if (error?.code === "42P01") {
+        if (isTableMissingFromSchemaCache(unknownError)) {
           continue;
         }
-        throw error;
+
+        throw unknownError;
       }
     }
 

--- a/src/pages/Travel.tsx
+++ b/src/pages/Travel.tsx
@@ -3,6 +3,7 @@ import type { PostgrestError } from "@supabase/supabase-js";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { isTableMissingFromSchemaCache } from "@/utils/postgrestErrors";
 
 type TravelRecord = {
   id: string;
@@ -233,6 +234,14 @@ const Travel = () => {
                 error: null,
               };
             } catch (unknownError) {
+              if (isTableMissingFromSchemaCache(unknownError)) {
+                return {
+                  ...config,
+                  rows: [] as RawTravelRow[],
+                  error: unknownError as PostgrestError,
+                };
+              }
+
               const error = unknownError as PostgrestError | Error;
 
               if (error && typeof (error as PostgrestError).code === "string") {
@@ -263,7 +272,7 @@ const Travel = () => {
 
           fallbackTables.add(key);
 
-          if (error.code === "42P01") {
+          if (isTableMissingFromSchemaCache(error)) {
             missingTables.add(key);
           } else {
             fatalErrors.push(error);

--- a/src/pages/__tests__/city.test.tsx
+++ b/src/pages/__tests__/city.test.tsx
@@ -105,6 +105,15 @@ describe("City page", () => {
       fetchWorldEnvironmentSnapshot: snapshotMock,
       fetchCityEnvironmentDetails: detailsMock,
     }));
+    mock.module("@/hooks/usePlayerStatus", () => ({
+      usePlayerStatus: () => ({
+        status: null,
+        statusLoading: false,
+        statusError: null,
+        startTimedStatus: async () => {},
+        refreshStatus: async () => {},
+      }),
+    }));
     type MockTravelRow = {
       id: string;
       city_from: string;

--- a/src/utils/__tests__/postgrestErrors.test.ts
+++ b/src/utils/__tests__/postgrestErrors.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+
+import { isTableMissingFromSchemaCache } from "../postgrestErrors";
+
+describe("isTableMissingFromSchemaCache", () => {
+  it("returns true for Postgres undefined table error codes", () => {
+    expect(isTableMissingFromSchemaCache({ code: "42P01" })).toBe(true);
+  });
+
+  it("returns true for PostgREST schema cache table errors", () => {
+    expect(
+      isTableMissingFromSchemaCache({
+        code: "PGRST301",
+        message: "Could not find the table 'public.travel_flights' in the schema cache",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects table cache errors via message text when code is missing", () => {
+    expect(
+      isTableMissingFromSchemaCache({
+        message: "Could not find the table 'public.travel_flights' in the schema cache",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(
+      isTableMissingFromSchemaCache({
+        code: "PGRST205",
+        message: "Could not find foreign key in schema cache",
+      }),
+    ).toBe(false);
+
+    expect(isTableMissingFromSchemaCache(null)).toBe(false);
+    expect(isTableMissingFromSchemaCache({ message: "Random failure" })).toBe(false);
+  });
+});

--- a/src/utils/postgrestErrors.ts
+++ b/src/utils/postgrestErrors.ts
@@ -1,0 +1,49 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+const TABLE_SCHEMA_CACHE_CODES = new Set(["42P01", "PGRST301"]);
+
+const normalizeCode = (code: string | null | undefined): string => {
+  if (typeof code !== "string") {
+    return "";
+  }
+
+  return code.trim().toUpperCase();
+};
+
+const normalizeMessage = (message: string | null | undefined): string => {
+  if (typeof message !== "string") {
+    return "";
+  }
+
+  return message.trim().toLowerCase();
+};
+
+export const isTableMissingFromSchemaCache = (error: unknown): error is PostgrestError => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const { code, message } = error as {
+    code?: string | null;
+    message?: string | null;
+  };
+
+  const normalizedCode = normalizeCode(code);
+  if (normalizedCode && TABLE_SCHEMA_CACHE_CODES.has(normalizedCode)) {
+    return true;
+  }
+
+  const normalizedMessage = normalizeMessage(message);
+  if (
+    normalizedMessage.includes("schema cache") &&
+    (normalizedMessage.includes("table") || normalizedMessage.includes("relation"))
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export type SchemaCacheTableError = PostgrestError & {
+  code: "42P01" | "PGRST301";
+};


### PR DESCRIPTION
## Summary
- add a reusable PostgREST helper for detecting schema cache table errors
- fall back to seeded travel data when Supabase reports missing travel tables in the cache
- cover the helper with unit tests and update the city page test stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d23c21d6088325899ce0912b508a33