### PR TITLE
Add profile status sessions schema and Supabase type updates

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -59,6 +59,7 @@ export type Database = {
           id: string
           message: string
           metadata: Json | null
+          profile_id: string
           status: string | null
           user_id: string
         }
@@ -70,6 +71,7 @@ export type Database = {
           id?: string
           message: string
           metadata?: Json | null
+          profile_id: string
           status?: string | null
           user_id: string
         }
@@ -81,10 +83,19 @@ export type Database = {
           id?: string
           message?: string
           metadata?: Json | null
+          profile_id?: string
           status?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "activity_feed_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       band_members: {
         Row: {
@@ -1508,6 +1519,41 @@ export type Database = {
         }
         Relationships: []
       }
+      profile_daily_xp_grants: {
+        Row: {
+          claimed_at: string
+          grant_date: string
+          id: string
+          metadata: Json
+          profile_id: string
+          xp_awarded: number
+        }
+        Insert: {
+          claimed_at?: string
+          grant_date: string
+          id?: string
+          metadata?: Json
+          profile_id: string
+          xp_awarded: number
+        }
+        Update: {
+          claimed_at?: string
+          grant_date?: string
+          id?: string
+          metadata?: Json
+          profile_id?: string
+          xp_awarded?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_daily_xp_grants_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       player_xp_wallet: {
         Row: {
           attribute_points_earned: number | null
@@ -1635,6 +1681,50 @@ export type Database = {
           weekly_bonus_streak?: number | null
         }
         Relationships: []
+      }
+      profile_status_sessions: {
+        Row: {
+          closed_at: string | null
+          created_at: string
+          ends_at: string | null
+          id: string
+          metadata: Json | null
+          profile_id: string
+          started_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          closed_at?: string | null
+          created_at?: string
+          ends_at?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id: string
+          started_at?: string | null
+          status: string
+          updated_at?: string
+        }
+        Update: {
+          closed_at?: string | null
+          created_at?: string
+          ends_at?: string | null
+          id?: string
+          metadata?: Json | null
+          profile_id?: string
+          started_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_status_sessions_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       skill_definitions: {
         Row: {

--- a/supabase/migrations/20270613100000_create_profile_status_sessions.sql
+++ b/supabase/migrations/20270613100000_create_profile_status_sessions.sql
@@ -1,0 +1,90 @@
+-- Create table to track profile status sessions and ensure XP configuration tables are accessible
+set check_function_bodies = off;
+
+-- Profile status sessions capture the lifecycle of timed statuses that players start from the game client
+create table if not exists public.profile_status_sessions (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  status text not null,
+  metadata jsonb default '{}'::jsonb,
+  started_at timestamptz default timezone('utc', now()),
+  ends_at timestamptz,
+  closed_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint profile_status_sessions_metadata_object check (
+    metadata is null or jsonb_typeof(metadata) = 'object'
+  )
+);
+
+comment on table public.profile_status_sessions is 'Tracks individual active status sessions for a profile including timing metadata.';
+comment on column public.profile_status_sessions.metadata is 'Optional JSON metadata describing the status session context.';
+comment on column public.profile_status_sessions.ends_at is 'UTC timestamp representing when the status session is scheduled to end.';
+comment on column public.profile_status_sessions.closed_at is 'UTC timestamp representing when the session was explicitly closed.';
+
+create index if not exists profile_status_sessions_profile_id_idx
+  on public.profile_status_sessions (profile_id);
+
+create unique index if not exists profile_status_sessions_active_idx
+  on public.profile_status_sessions (profile_id)
+  where closed_at is null;
+
+alter table public.profile_status_sessions enable row level security;
+
+create policy if not exists "Users manage their status sessions"
+  on public.profile_status_sessions
+  for all
+  using (
+    auth.role() in ('service_role', 'supabase_admin')
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = profile_status_sessions.profile_id
+        and p.user_id = auth.uid()
+    )
+  )
+  with check (
+    auth.role() in ('service_role', 'supabase_admin')
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = profile_status_sessions.profile_id
+        and p.user_id = auth.uid()
+    )
+  );
+
+create trigger profile_status_sessions_set_updated_at
+  before update on public.profile_status_sessions
+  for each row
+  execute function public.update_updated_at_column();
+
+grant select, insert, update, delete on public.profile_status_sessions to authenticated;
+
+-- Ensure the daily XP tables participate in RLS so authenticated clients can query them directly
+alter table if exists public.daily_xp_settings enable row level security;
+
+create policy if not exists "XP settings readable"
+  on public.daily_xp_settings
+  for select
+  using (auth.role() in ('service_role', 'supabase_admin', 'authenticated', 'anon'));
+
+grant select on public.daily_xp_settings to authenticated;
+grant select on public.daily_xp_settings to anon;
+
+alter table if exists public.profile_daily_xp_grants enable row level security;
+
+create policy if not exists "Users read their daily XP grants"
+  on public.profile_daily_xp_grants
+  for select
+  using (
+    auth.role() in ('service_role', 'supabase_admin')
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = profile_daily_xp_grants.profile_id
+        and p.user_id = auth.uid()
+    )
+  );
+
+grant select on public.profile_daily_xp_grants to authenticated;
+


### PR DESCRIPTION
## Summary
- create the profile_status_sessions table with RLS policies and grants so timed status data can be stored
- enable RLS + grants for daily XP tables that the client queries directly
- update Supabase TypeScript definitions for activity_feed, profile_daily_xp_grants, and profile_status_sessions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d26096b2188325be16054a72b9b471