### PR TITLE
Add stub profiles export for Supabase integration

### DIFF
--- a/src/integrations/supabase/public-profiles.ts
+++ b/src/integrations/supabase/public-profiles.ts
@@ -1,2 +1,88 @@
-// This file is temporarily disabled due to missing tables in schema
-export const fetchPublicProfiles = () => Promise.resolve([]);
+export interface BasicPublicProfile {
+  user_id: string;
+  username: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+}
+
+const MOCK_PROFILES: BasicPublicProfile[] = [
+  {
+    user_id: "artist-aurora",
+    username: "aurora",
+    display_name: "Aurora Skye",
+    avatar_url: "https://api.dicebear.com/7.x/personas/svg?seed=Aurora",
+    bio: "Dream pop vocalist and synth enthusiast exploring cosmic sounds.",
+  },
+  {
+    user_id: "producer-harbor",
+    username: "harborwave",
+    display_name: "Harbor Wave",
+    avatar_url: "https://api.dicebear.com/7.x/personas/svg?seed=Harbor",
+    bio: "Indie producer blending field recordings with downtempo beats.",
+  },
+  {
+    user_id: "dj-nightfall",
+    username: "nightfall",
+    display_name: "DJ Nightfall",
+    avatar_url: "https://api.dicebear.com/7.x/personas/svg?seed=Nightfall",
+    bio: "Late-night selector bringing together future garage and bass music.",
+  },
+  {
+    user_id: "songwriter-ember",
+    username: "emberlane",
+    display_name: "Ember Lane",
+    avatar_url: "https://api.dicebear.com/7.x/personas/svg?seed=Ember",
+    bio: "Acoustic storyteller inspired by city lights and quiet moments.",
+  },
+  {
+    user_id: "beatmaker-echo",
+    username: "echoforge",
+    display_name: "Echo Forge",
+    avatar_url: "https://api.dicebear.com/7.x/personas/svg?seed=Echo",
+    bio: "Experimental beatmaker crafting textures from modular synth jams.",
+  },
+];
+
+const createFallbackProfile = (userId: string): BasicPublicProfile => {
+  const shortId = userId.slice(0, 8) || "artist";
+  return {
+    user_id: userId,
+    username: `user-${shortId}`,
+    display_name: `Creator ${shortId}`,
+    avatar_url: `https://api.dicebear.com/7.x/identicon/svg?seed=${encodeURIComponent(shortId)}`,
+    bio: "Independent creator sharing their work on Rockmundo.",
+  };
+};
+
+const mapProfilesByUserId = (
+  profiles: BasicPublicProfile[],
+): Map<string, BasicPublicProfile> => {
+  const lookup = new Map<string, BasicPublicProfile>();
+  profiles.forEach((profile) => {
+    lookup.set(profile.user_id, profile);
+  });
+  return lookup;
+};
+
+export const fetchPublicProfiles = async (): Promise<BasicPublicProfile[]> => {
+  return MOCK_PROFILES;
+};
+
+export const fetchPublicProfilesByUserIds = async (
+  userIds: string[],
+): Promise<Map<string, BasicPublicProfile>> => {
+  if (!userIds.length) {
+    return new Map();
+  }
+
+  const lookup = mapProfilesByUserId(MOCK_PROFILES);
+
+  userIds.forEach((userId) => {
+    if (!lookup.has(userId)) {
+      lookup.set(userId, createFallbackProfile(userId));
+    }
+  });
+
+  return lookup;
+};


### PR DESCRIPTION
## Summary
- define a `BasicPublicProfile` type for the stubbed public profile integration
- provide deterministic mock profile data and a fallback generator
- expose `fetchPublicProfiles` and `fetchPublicProfilesByUserIds` so pages can resolve user display info

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d29df2c82c8325822f2c245990119d