### PR TITLE
Add profile activity status tracking schema

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -58,6 +58,10 @@ export type Database = {
           id: string
           message: string
           metadata: Json | null
+          duration_minutes: number | null
+          profile_id: string
+          status: string | null
+          status_id: string | null
           user_id: string
         }
         Insert: {
@@ -67,6 +71,10 @@ export type Database = {
           id?: string
           message: string
           metadata?: Json | null
+          duration_minutes?: number | null
+          profile_id: string
+          status?: string | null
+          status_id?: string | null
           user_id: string
         }
         Update: {
@@ -76,9 +84,28 @@ export type Database = {
           id?: string
           message?: string
           metadata?: Json | null
+          duration_minutes?: number | null
+          profile_id?: string
+          status?: string | null
+          status_id?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "activity_feed_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "activity_feed_status_id_fkey"
+            columns: ["status_id"]
+            isOneToOne: false
+            referencedRelation: "profile_activity_statuses"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       band_members: {
         Row: {
@@ -919,6 +946,55 @@ export type Database = {
             columns: ["profile_id"]
             isOneToOne: true
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profile_activity_statuses: {
+        Row: {
+          created_at: string
+          duration_minutes: number | null
+          ends_at: string | null
+          id: string
+          profile_id: string
+          song_id: string | null
+          started_at: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          duration_minutes?: number | null
+          id?: string
+          profile_id: string
+          song_id?: string | null
+          started_at?: string
+          status: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          duration_minutes?: number | null
+          id?: string
+          profile_id?: string
+          song_id?: string | null
+          started_at?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profile_activity_statuses_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "profile_activity_statuses_song_id_fkey"
+            columns: ["song_id"]
+            isOneToOne: false
+            referencedRelation: "songs"
             referencedColumns: ["id"]
           },
         ]

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -72,6 +72,39 @@ export interface Database {
           updated_at?: string;
         };
       };
+      profile_activity_statuses: {
+        Row: {
+          id: string;
+          profile_id: string;
+          status: string;
+          started_at: string;
+          duration_minutes?: number | null;
+          ends_at?: string | null;
+          song_id?: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          profile_id: string;
+          status: string;
+          started_at?: string;
+          duration_minutes?: number | null;
+          song_id?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          profile_id?: string;
+          status?: string;
+          started_at?: string;
+          duration_minutes?: number | null;
+          song_id?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       cities: {
         Row: {
           id: string;
@@ -450,29 +483,41 @@ export interface Database {
         Row: {
           id: string;
           user_id: string;
+          profile_id: string;
           activity_type: string;
           message: string;
           metadata?: Json;
           earnings?: number;
           created_at: string;
+          status?: string | null;
+          duration_minutes?: number | null;
+          status_id?: string | null;
         };
         Insert: {
           id?: string;
           user_id: string;
+          profile_id: string;
           activity_type: string;
           message: string;
           metadata?: Json;
           earnings?: number;
           created_at?: string;
+          status?: string | null;
+          duration_minutes?: number | null;
+          status_id?: string | null;
         };
         Update: {
           id?: string;
           user_id?: string;
+          profile_id?: string;
           activity_type?: string;
           message?: string;
           metadata?: Json;
           earnings?: number;
           created_at?: string;
+          status?: string | null;
+          duration_minutes?: number | null;
+          status_id?: string | null;
         };
       };
       band_members: {

--- a/supabase/migrations/20270606100000_add_profile_activity_statuses.sql
+++ b/supabase/migrations/20270606100000_add_profile_activity_statuses.sql
@@ -1,0 +1,82 @@
+-- Adds activity timing metadata to profiles via dedicated status table and extends activity_feed
+
+-- Create table to track the current timed activity for a profile
+CREATE TABLE IF NOT EXISTS public.profile_activity_statuses (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  status text NOT NULL,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  duration_minutes integer,
+  ends_at timestamptz GENERATED ALWAYS AS (
+    CASE
+      WHEN duration_minutes IS NULL THEN NULL
+      ELSE started_at + make_interval(mins => duration_minutes)
+    END
+  ) STORED,
+  song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT profile_activity_statuses_duration_check CHECK (duration_minutes IS NULL OR duration_minutes >= 0)
+);
+
+-- Ensure one active status per profile
+CREATE UNIQUE INDEX IF NOT EXISTS profile_activity_statuses_profile_id_key
+  ON public.profile_activity_statuses (profile_id);
+
+-- Helpful lookup index for song based lookups
+CREATE INDEX IF NOT EXISTS profile_activity_statuses_song_id_idx
+  ON public.profile_activity_statuses (song_id);
+
+-- Keep updated_at fresh on change
+CREATE OR REPLACE FUNCTION public.set_profile_activity_status_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS profile_activity_statuses_set_updated_at
+  ON public.profile_activity_statuses;
+
+CREATE TRIGGER profile_activity_statuses_set_updated_at
+  BEFORE UPDATE ON public.profile_activity_statuses
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_profile_activity_status_updated_at();
+
+-- Enable row level security and policies
+ALTER TABLE public.profile_activity_statuses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Profile activity statuses are viewable by everyone"
+  ON public.profile_activity_statuses
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY IF NOT EXISTS "Profiles manage their own activity status"
+  ON public.profile_activity_statuses
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = profile_id AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = profile_id AND p.user_id = auth.uid()
+    )
+  );
+
+-- Extend activity_feed to reference timed statuses
+ALTER TABLE public.activity_feed
+  ADD COLUMN IF NOT EXISTS status text,
+  ADD COLUMN IF NOT EXISTS duration_minutes integer,
+  ADD COLUMN IF NOT EXISTS status_id uuid REFERENCES public.profile_activity_statuses(id) ON DELETE SET NULL;
+
+-- Maintain data quality on new duration column
+ALTER TABLE public.activity_feed
+  ADD CONSTRAINT IF NOT EXISTS activity_feed_duration_check
+  CHECK (duration_minutes IS NULL OR duration_minutes >= 0);


### PR DESCRIPTION
## Summary
- add a `profile_activity_statuses` table to track timed profile sessions and hook it into the activity feed
- extend `activity_feed` records with optional status and duration metadata plus a foreign key to timed statuses
- sync Supabase TypeScript definitions, including the fallback schema, with the new columns and table

## Testing
- npm run lint *(fails: pre-existing lint errors about `any` usage in types files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3095d6e24832595b57801237a93ad