### PR TITLE
Rename Street Busking page references

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -77,7 +77,7 @@ const Navigation = () => {
         { icon: Settings, label: "Stage Setup", path: "/stage-setup" },
         { icon: MapPin, label: "City Overview", path: cityOverviewPath },
         { icon: Globe, label: "World Map", path: "/cities" },
-        { icon: Mic, label: "Street Busking", path: "/busking" },
+        { icon: Mic, label: "Busking", path: "/busking" },
         { icon: Plane, label: "Travel Planner", path: "/travel" },
         { icon: Globe, label: "Tour System", path: "/tours-system" },
       ],

--- a/src/pages/Busking.tsx
+++ b/src/pages/Busking.tsx
@@ -85,7 +85,7 @@ export default function Busking() {
     <div className="container mx-auto p-6">
       <Card>
         <CardHeader>
-          <CardTitle>Street Busking</CardTitle>
+          <CardTitle>Busking</CardTitle>
           <CardDescription>
             Pick a spot, choose how long to play, and see what kind of experience and cash you might pull in.
           </CardDescription>


### PR DESCRIPTION
## Summary
- rename the navigation item label from Street Busking to Busking
- update the Busking page title to match the new name

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d31d8a6d588325bbaaf735a6e396d7