### PR TITLE
Ensure navigation keys remain unique

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -182,7 +182,7 @@ const Navigation = () => {
                 const Icon = item.icon;
                 return (
                   <Button
-                    key={item.path}
+                    key={`${item.path}-${item.label}`}
                     variant={isActive(item.path) ? "secondary" : "ghost"}
                     className={`w-full justify-start gap-3 ${
                       isActive(item.path)


### PR DESCRIPTION
## Summary
- ensure navigation button keys combine the path and label so duplicate routes no longer produce React key warnings

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d320b78a348325b19f975f52ab1b27