### PR TITLE
Handle missing profile_id column for activity feed

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -222,6 +222,12 @@ const useProvideGameData = (): UseGameDataReturn => {
     "code" in error &&
     (error as { code?: string }).code === "PGRST204";
 
+  const isActivityFeedMissingProfileIdError = (error: unknown): error is { code?: string } =>
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ["42703", "PGRST204"].includes((error as { code?: string }).code ?? "");
+
   const sanitizeActivityFeedRows = useCallback(
     (
       rows: ActivityFeedRow[] | null | undefined,
@@ -433,7 +439,7 @@ const useProvideGameData = (): UseGameDataReturn => {
       let nextActivities: ActivityFeedRow[] = [];
 
       if (activitiesResult.error) {
-        if (activitiesResult.error.code === "42703") {
+        if (isActivityFeedMissingProfileIdError(activitiesResult.error)) {
           if (activityFeedSupportsProfileId) {
             setActivityFeedSupportsProfileId(false);
           }


### PR DESCRIPTION
## Summary
- treat activity feed queries as missing the profile_id column when Supabase returns PGRST204
- fall back to querying by user_id without triggering repeated 400 errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d323f081b48325b2bb904dfb3b5ec0