### PR TITLE
Add logging for Supabase signup errors

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -282,6 +282,10 @@ const Auth = () => {
       });
 
       if (error) {
+        console.error("Supabase signUp failed", {
+          error,
+          context: { email, username, displayName }
+        });
         setError(error.message);
       } else if (data.user) {
         setUnverifiedEmail(email);
@@ -297,8 +301,11 @@ const Auth = () => {
           description: "Check your email to confirm your account",
         });
         // Don't navigate immediately - wait for email confirmation
+      } else {
+        console.warn("Supabase signUp returned without user", { data, email });
       }
     } catch (err) {
+      console.error("Unexpected error during signUp", err);
       const message = err instanceof Error ? err.message : "An unexpected error occurred";
       setError(message);
     } finally {


### PR DESCRIPTION
## Summary
- add console logging when Supabase sign-up returns an error or no user payload
- log unexpected exceptions thrown during sign-up handling for easier debugging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d59f550dfc8325852800012828550b