### PR TITLE
Check username availability before Supabase signup

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -267,6 +267,31 @@ const Auth = () => {
         return;
       }
 
+      const normalizedUsername = username.toLowerCase();
+      const escapedUsernamePattern = normalizedUsername.replace(/_/g, "\\\\_");
+
+      const { data: existingProfiles, error: usernameLookupError } = await supabase
+        .from("profiles")
+        .select("id")
+        .ilike("username", escapedUsernamePattern)
+        .limit(1);
+
+      if (usernameLookupError) {
+        console.error("Failed to verify username availability", {
+          error: usernameLookupError,
+          context: { username },
+        });
+        setError("We couldn't confirm that username is available. Please try again.");
+        setLoading(false);
+        return;
+      }
+
+      if (existingProfiles && existingProfiles.length > 0) {
+        setError("That username is already taken. Try another rockstar alias.");
+        setLoading(false);
+        return;
+      }
+
       const redirectUrl = `${origin}/`;
 
       const { data, error } = await supabase.auth.signUp({


### PR DESCRIPTION
## Summary
- prevent duplicate usernames from causing Supabase sign-up failures by querying the profiles table before registration
- surface clear feedback when the username lookup fails or the alias is already taken
- escape underscores in the availability query so literal usernames are matched precisely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5a2fba52c8325b2024e01a0541c20