### PR TITLE
Handle missing daily XP table error code

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -344,7 +344,7 @@ const useProvideGameData = (): UseGameDataReturn => {
     details?: string | null;
   } => {
     const code = getPostgrestErrorCode(error);
-    if (code === "PGRST201" || code === "PGRST202") {
+    if (code === "PGRST201" || code === "PGRST202" || code === "PGRST205") {
       return true;
     }
 


### PR DESCRIPTION
## Summary
- treat Supabase PGRST205 errors as missing daily XP grant table during game data loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ae382c348325948dcb12b28fc3d4