### PR TITLE
Fix studio city select item placeholder value

### DIFF
--- a/src/pages/admin/Studios.tsx
+++ b/src/pages/admin/Studios.tsx
@@ -375,7 +375,7 @@ export default function Studios() {
                           </FormControl>
                           <SelectContent>
                             {cities.length === 0 ? (
-                              <SelectItem value="" disabled>
+                              <SelectItem value="__no_cities__" disabled>
                                 {isLoadingCities ? "Loading cities..." : "No cities available"}
                               </SelectItem>
                             ) : (


### PR DESCRIPTION
## Summary
- replace the disabled studio city Select item value with a non-empty placeholder string to satisfy Radix UI requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b5a930208325a61f8cb065430e9a