### PR TITLE
Fix band sessions query in education page

### DIFF
--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -464,7 +464,7 @@ const mentorOptions: MentorOption[] = [
   }
 ];
 
-const bandSessions: BandSession[] = [
+const FALLBACK_BAND_SESSIONS: BandSession[] = [
   {
     id: "band-sync-lock",
     title: "Sync Lock Intensive",
@@ -534,6 +534,28 @@ const Education = () => {
     staleTime: 1000 * 60 * 5,
   });
 
+  const {
+    data: bandSessionRows,
+    isLoading: bandSessionsLoading,
+    error: bandSessionsError,
+  } = useQuery({
+    queryKey: ["education", "band-sessions"] as const,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("education_band_sessions")
+        .select("*")
+        .order("difficulty", { ascending: true })
+        .order("title", { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as BandSessionRow[];
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+
   const skillLessons = useMemo<SkillLesson[]>(() => {
     if (!lessonRows) {
       return [];
@@ -592,7 +614,19 @@ const Education = () => {
       } satisfies BandSession;
     });
 
-    return sessions.sort((a, b) => {
+    const sorted = sessions.sort((a, b) => {
+      const difficultyComparison = DIFFICULTY_ORDER[a.difficulty] - DIFFICULTY_ORDER[b.difficulty];
+      if (difficultyComparison !== 0) {
+        return difficultyComparison;
+      }
+      return a.title.localeCompare(b.title);
+    });
+
+    if (sorted.length > 0) {
+      return sorted;
+    }
+
+    return [...FALLBACK_BAND_SESSIONS].sort((a, b) => {
       const difficultyComparison = DIFFICULTY_ORDER[a.difficulty] - DIFFICULTY_ORDER[b.difficulty];
       if (difficultyComparison !== 0) {
         return difficultyComparison;


### PR DESCRIPTION
## Summary
- fetch band session rows from Supabase and derive normalized band session data
- provide a sorted fallback dataset when no band sessions are returned
- retain toast error handling for band session loading issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b60b6d40832585a2e6ba430190e4