### PR TITLE
Add grants for songwriting tables

### DIFF
--- a/supabase/migrations/20270620120000_grant_songwriting_privileges.sql
+++ b/supabase/migrations/20270620120000_grant_songwriting_privileges.sql
@@ -1,0 +1,2 @@
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.songwriting_projects TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.songwriting_sessions TO authenticated;


### PR DESCRIPTION
## Summary
- add a migration granting authenticated users CRUD access to songwriting projects and sessions

## Testing
- supabase --version (fails: supabase CLI not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5bb07b4008325912c1a0e010c17d7