### PR TITLE
Fix duplicate band session query declaration

### DIFF
--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -572,28 +572,6 @@ const Education = () => {
     error: playlistsError,
   } = useEducationVideoPlaylists();
 
-  const {
-    data: bandSessionRows,
-    isLoading: bandSessionsLoading,
-    error: bandSessionsError,
-  } = useQuery({
-    queryKey: ["education", "band-sessions"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("education_band_sessions")
-        .select("*")
-        .order("difficulty", { ascending: true })
-        .order("title", { ascending: true });
-
-      if (error) {
-        throw error;
-      }
-
-      return (data ?? []) as BandSessionRow[];
-    },
-    staleTime: 1000 * 60 * 5,
-  });
-
   const videoPlaylists = playlistData ?? [];
   const lessonsErrorMessage =
     lessonsError instanceof Error


### PR DESCRIPTION
## Summary
- remove the duplicated education band sessions query that redeclared `bandSessionRows`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bbc4686083258f24141990b0cfc2