### PR TITLE
Handle anon username lookup errors and grant access

### DIFF
--- a/supabase/migrations/20270620130000_grant_public_profiles_select_to_anon.sql
+++ b/supabase/migrations/20270620130000_grant_public_profiles_select_to_anon.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON TABLE public.public_profiles TO anon;


### PR DESCRIPTION
## Summary
- allow signup to proceed when the username availability check returns permission errors by logging and continuing
- add a migration that grants the anon role SELECT access to public.public_profiles to keep the availability check working

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5bcc7faec83258ac22c504419fc18