### PR TITLE
Fix runtime reference error in RecordLabel tabs

### DIFF
--- a/src/pages/RecordLabel.tsx
+++ b/src/pages/RecordLabel.tsx
@@ -117,6 +117,7 @@ const RecordLabel = () => {
   const [benefitInput, setBenefitInput] = useState("");
   const [savingLabel, setSavingLabel] = useState(false);
   const [deletingLabelId, setDeletingLabelId] = useState<string | null>(null);
+  const canManageLabels = !roleLoading && (typeof isAdminRole === 'function' ? isAdminRole() : Boolean(isAdminRole));
 
   const loadLabels = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- derive the `canManageLabels` flag from the loaded user role to avoid undefined references
- ensure label management UI only appears once the role lookup has finished

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bf49adf48325bbacae5987eabcf4