### PR TITLE
Ensure new signups succeed by adding unlocked flag to cities

### DIFF
--- a/supabase/migrations/20270620140000_add_unlocked_flag_to_cities.sql
+++ b/supabase/migrations/20270620140000_add_unlocked_flag_to_cities.sql
@@ -1,0 +1,8 @@
+-- Ensure the cities table exposes an unlocked flag for onboarding logic
+ALTER TABLE public.cities
+  ADD COLUMN IF NOT EXISTS unlocked boolean DEFAULT true;
+
+-- Make sure existing rows are marked as unlocked when the column is introduced
+UPDATE public.cities
+SET unlocked = true
+WHERE unlocked IS NULL;


### PR DESCRIPTION
## Summary
- add a migration that guarantees the `public.cities` table exposes an `unlocked` flag required by onboarding triggers
- default all existing cities to unlocked so the signup provisioning logic can find a valid city

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bf8ffb3c8325b51312e9db7e3ae8