### PR TITLE
chore: update supabase song and songwriting types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1253,8 +1253,111 @@ export type Database = {
         }
         Relationships: []
       }
+      songwriting_projects: {
+        Row: {
+          created_at: string
+          id: string
+          locked_until: string | null
+          lyrics: string | null
+          sessions_completed: number
+          song_id: string | null
+          status: string
+          title: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          locked_until?: string | null
+          lyrics?: string | null
+          sessions_completed?: number
+          song_id?: string | null
+          status?: string
+          title?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          locked_until?: string | null
+          lyrics?: string | null
+          sessions_completed?: number
+          song_id?: string | null
+          status?: string
+          title?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "songwriting_projects_song_id_fkey"
+            columns: ["song_id"]
+            isOneToOne: false
+            referencedRelation: "songs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_projects_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      songwriting_sessions: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          id: string
+          locked_until: string
+          notes: string | null
+          project_id: string
+          started_at: string
+          user_id: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          locked_until: string
+          notes?: string | null
+          project_id: string
+          started_at?: string
+          user_id: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          id?: string
+          locked_until?: string
+          notes?: string | null
+          project_id?: string
+          started_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "songwriting_sessions_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "songwriting_projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_sessions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       songs: {
         Row: {
+          audio_layers: Json[] | null
           chart_position: number | null
           created_at: string
           genre: string
@@ -1270,6 +1373,7 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          audio_layers?: Json[] | null
           chart_position?: number | null
           created_at?: string
           genre: string
@@ -1285,6 +1389,7 @@ export type Database = {
           user_id: string
         }
         Update: {
+          audio_layers?: Json[] | null
           chart_position?: number | null
           created_at?: string
           genre?: string

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -723,25 +723,49 @@ export interface Database {
       songs: {
         Row: {
           id: string;
+          user_id: string;
           title: string;
-          artist_id: string;
           genre: string;
+          lyrics: string | null;
+          audio_layers: Json[] | null;
+          quality_score: number;
+          status: string;
+          streams: number;
+          revenue: number;
+          chart_position: number | null;
+          release_date: string | null;
           created_at: string;
           updated_at: string;
         };
         Insert: {
           id?: string;
-          title: string;
-          artist_id: string;
+          user_id: string;
+          title?: string;
           genre: string;
+          lyrics?: string | null;
+          audio_layers?: Json[] | null;
+          quality_score?: number;
+          status?: string;
+          streams?: number;
+          revenue?: number;
+          chart_position?: number | null;
+          release_date?: string | null;
           created_at?: string;
           updated_at?: string;
         };
         Update: {
           id?: string;
+          user_id?: string;
           title?: string;
-          artist_id?: string;
           genre?: string;
+          lyrics?: string | null;
+          audio_layers?: Json[] | null;
+          quality_score?: number;
+          status?: string;
+          streams?: number;
+          revenue?: number;
+          chart_position?: number | null;
+          release_date?: string | null;
           created_at?: string;
           updated_at?: string;
         };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,5 +1,6 @@
-// Working database types to override the problematic generated types
+import type { Json } from "@/integrations/supabase/types";
 
+// Working database types to override the problematic generated types
 export type RequirementValue = number | string | boolean | null;
 
 export type RequirementRecord = Record<string, RequirementValue>;
@@ -90,6 +91,7 @@ export interface Song {
   title: string;
   genre: string;
   lyrics: string | null;
+  audio_layers: Json[] | null;
   status: string;
   quality_score: number;
   streams: number;


### PR DESCRIPTION
## Summary
- add the songwriting_projects and songwriting_sessions tables to the generated Supabase types
- expose the songs.audio_layers column and keep local song models in sync with the widened quality score range
- align the fallback database types with the regenerated Supabase definitions

## Testing
- not run (types-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6539c98fc8325b728c010d8b4797d