### PR TITLE
Add structured logging for songwriting flows

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,25 @@
+export type LogLevel = "info" | "error";
+
+export type LogContext = Record<string, unknown>;
+
+const log = (level: LogLevel, message: string, context?: LogContext) => {
+  const payload = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(context ? { context } : {})
+  };
+
+  if (level === "error") {
+    console.error(payload);
+  } else {
+    console.info(payload);
+  }
+};
+
+export const logger = {
+  info: (message: string, context?: LogContext) => log("info", message, context),
+  error: (message: string, context?: LogContext) => log("error", message, context)
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- introduce a lightweight logger utility to standardize structured info and error logging
- instrument the songwriting page fetch, create/update, and delete flows with contextual success and failure logs

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6550e789c8325b721445310493fb2