### PR TITLE
Add studio booking schema and Supabase types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1406,6 +1406,227 @@ export type Database = {
         }
         Relationships: []
       }
+      studio_booking_artists: {
+        Row: {
+          booking_id: string
+          character_id: string
+          daily_cost: number
+          id: string
+          role: Database["public"]["Enums"]["studio_booking_artist_role"]
+        }
+        Insert: {
+          booking_id: string
+          character_id: string
+          daily_cost?: number
+          id?: string
+          role: Database["public"]["Enums"]["studio_booking_artist_role"]
+        }
+        Update: {
+          booking_id?: string
+          character_id?: string
+          daily_cost?: number
+          id?: string
+          role?: Database["public"]["Enums"]["studio_booking_artist_role"]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "studio_booking_artists_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: false
+            referencedRelation: "studio_bookings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "studio_booking_artists_character_id_fkey"
+            columns: ["character_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      studio_booking_slots: {
+        Row: {
+          booking_id: string
+          id: string
+          is_booked: boolean
+          slot: Database["public"]["Enums"]["studio_slot"]
+          slot_date: string
+        }
+        Insert: {
+          booking_id: string
+          id?: string
+          is_booked?: boolean
+          slot: Database["public"]["Enums"]["studio_slot"]
+          slot_date: string
+        }
+        Update: {
+          booking_id?: string
+          id?: string
+          is_booked?: boolean
+          slot?: Database["public"]["Enums"]["studio_slot"]
+          slot_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "studio_booking_slots_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: false
+            referencedRelation: "studio_bookings"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      studio_booking_songs: {
+        Row: {
+          booking_id: string
+          id: string
+          momentum: number
+          progress_end: number
+          progress_start: number
+          song_id: string
+        }
+        Insert: {
+          booking_id: string
+          id?: string
+          momentum?: number
+          progress_end?: number
+          progress_start?: number
+          song_id: string
+        }
+        Update: {
+          booking_id?: string
+          id?: string
+          momentum?: number
+          progress_end?: number
+          progress_start?: number
+          song_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "studio_booking_songs_booking_id_fkey"
+            columns: ["booking_id"]
+            isOneToOne: false
+            referencedRelation: "studio_bookings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "studio_booking_songs_song_id_fkey"
+            columns: ["song_id"]
+            isOneToOne: false
+            referencedRelation: "songs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      studio_bookings: {
+        Row: {
+          band_id: string
+          created_at: string
+          end_date: string
+          id: string
+          mood: Database["public"]["Enums"]["studio_session_mood"]
+          producer_id: string | null
+          start_date: string
+          status: Database["public"]["Enums"]["studio_booking_status"]
+          studio_id: string
+          total_cost: number
+          updated_at: string
+        }
+        Insert: {
+          band_id: string
+          created_at?: string
+          end_date: string
+          id?: string
+          mood: Database["public"]["Enums"]["studio_session_mood"]
+          producer_id?: string | null
+          start_date: string
+          status?: Database["public"]["Enums"]["studio_booking_status"]
+          studio_id: string
+          total_cost?: number
+          updated_at?: string
+        }
+        Update: {
+          band_id?: string
+          created_at?: string
+          end_date?: string
+          id?: string
+          mood?: Database["public"]["Enums"]["studio_session_mood"]
+          producer_id?: string | null
+          start_date?: string
+          status?: Database["public"]["Enums"]["studio_booking_status"]
+          studio_id?: string
+          total_cost?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "studio_bookings_band_id_fkey"
+            columns: ["band_id"]
+            isOneToOne: false
+            referencedRelation: "bands"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "studio_bookings_producer_id_fkey"
+            columns: ["producer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "studio_bookings_studio_id_fkey"
+            columns: ["studio_id"]
+            isOneToOne: false
+            referencedRelation: "studios"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      studios: {
+        Row: {
+          city_id: string
+          cost_per_day: number
+          created_at: string
+          engineer_rating: number
+          equipment_rating: number
+          id: string
+          name: string
+          quality: number
+          updated_at: string
+        }
+        Insert: {
+          city_id: string
+          cost_per_day: number
+          created_at?: string
+          engineer_rating: number
+          equipment_rating: number
+          id?: string
+          name: string
+          quality: number
+          updated_at?: string
+        }
+        Update: {
+          city_id?: string
+          cost_per_day?: number
+          created_at?: string
+          engineer_rating?: number
+          equipment_rating?: number
+          id?: string
+          name?: string
+          quality?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "studios_city_id_fkey"
+            columns: ["city_id"]
+            isOneToOne: false
+            referencedRelation: "cities"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       streaming_platforms: {
         Row: {
           created_at: string | null
@@ -1624,6 +1845,15 @@ export type Database = {
       chat_participant_status: "online" | "offline" | "typing" | "away"
       friendship_status: "pending" | "accepted" | "declined" | "blocked"
       show_type_enum: "concert" | "festival" | "private" | "street"
+      studio_booking_artist_role: "band_member" | "session_musician" | "producer"
+      studio_booking_status:
+        | "pending"
+        | "confirmed"
+        | "in_progress"
+        | "completed"
+        | "cancelled"
+      studio_session_mood: "professional" | "party" | "chilled"
+      studio_slot: "morning" | "evening"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/migrations/20270630100000_create_studio_infrastructure.sql
+++ b/supabase/migrations/20270630100000_create_studio_infrastructure.sql
@@ -1,0 +1,338 @@
+-- Create recording studio core tables and enums
+
+DO $$
+BEGIN
+  CREATE TYPE public.studio_session_mood AS ENUM ('professional', 'party', 'chilled');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.studio_booking_status AS ENUM ('pending', 'confirmed', 'in_progress', 'completed', 'cancelled');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.studio_slot AS ENUM ('morning', 'evening');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.studio_booking_artist_role AS ENUM ('band_member', 'session_musician', 'producer');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.studios (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  quality integer NOT NULL CHECK (quality BETWEEN 1 AND 100),
+  cost_per_day integer NOT NULL CHECK (cost_per_day >= 0),
+  engineer_rating integer NOT NULL CHECK (engineer_rating BETWEEN 1 AND 100),
+  equipment_rating integer NOT NULL CHECK (equipment_rating BETWEEN 1 AND 100),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS studios_city_id_idx ON public.studios (city_id);
+CREATE INDEX IF NOT EXISTS studios_quality_idx ON public.studios (quality DESC);
+
+CREATE TABLE IF NOT EXISTS public.studio_bookings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  studio_id uuid NOT NULL REFERENCES public.studios(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  start_date date NOT NULL,
+  end_date date NOT NULL,
+  mood public.studio_session_mood NOT NULL,
+  producer_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  status public.studio_booking_status NOT NULL DEFAULT 'pending',
+  total_cost integer NOT NULL DEFAULT 0 CHECK (total_cost >= 0),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CHECK (end_date >= start_date)
+);
+
+CREATE INDEX IF NOT EXISTS studio_bookings_band_id_idx ON public.studio_bookings (band_id);
+CREATE INDEX IF NOT EXISTS studio_bookings_studio_id_idx ON public.studio_bookings (studio_id);
+CREATE INDEX IF NOT EXISTS studio_bookings_status_idx ON public.studio_bookings (status);
+
+CREATE TABLE IF NOT EXISTS public.studio_booking_slots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  booking_id uuid NOT NULL REFERENCES public.studio_bookings(id) ON DELETE CASCADE,
+  slot_date date NOT NULL,
+  slot public.studio_slot NOT NULL,
+  is_booked boolean NOT NULL DEFAULT true,
+  UNIQUE (booking_id, slot_date, slot)
+);
+
+CREATE INDEX IF NOT EXISTS studio_booking_slots_booking_idx ON public.studio_booking_slots (booking_id, slot_date);
+CREATE INDEX IF NOT EXISTS studio_booking_slots_slot_idx ON public.studio_booking_slots (slot_date, slot);
+
+CREATE TABLE IF NOT EXISTS public.studio_booking_artists (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  booking_id uuid NOT NULL REFERENCES public.studio_bookings(id) ON DELETE CASCADE,
+  character_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role public.studio_booking_artist_role NOT NULL,
+  daily_cost integer NOT NULL DEFAULT 0 CHECK (daily_cost >= 0),
+  UNIQUE (booking_id, character_id, role)
+);
+
+CREATE INDEX IF NOT EXISTS studio_booking_artists_booking_idx ON public.studio_booking_artists (booking_id);
+CREATE INDEX IF NOT EXISTS studio_booking_artists_character_idx ON public.studio_booking_artists (character_id);
+
+CREATE TABLE IF NOT EXISTS public.studio_booking_songs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  booking_id uuid NOT NULL REFERENCES public.studio_bookings(id) ON DELETE CASCADE,
+  song_id uuid NOT NULL REFERENCES public.songs(id) ON DELETE CASCADE,
+  progress_start numeric(5,2) NOT NULL DEFAULT 0 CHECK (progress_start >= 0 AND progress_start <= 100),
+  progress_end numeric(5,2) NOT NULL DEFAULT 0 CHECK (progress_end >= 0 AND progress_end <= 100),
+  momentum integer NOT NULL DEFAULT 0,
+  UNIQUE (booking_id, song_id)
+);
+
+CREATE INDEX IF NOT EXISTS studio_booking_songs_booking_idx ON public.studio_booking_songs (booking_id);
+CREATE INDEX IF NOT EXISTS studio_booking_songs_song_idx ON public.studio_booking_songs (song_id);
+
+CREATE TRIGGER set_studios_updated_at
+  BEFORE UPDATE ON public.studios
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER set_studio_bookings_updated_at
+  BEFORE UPDATE ON public.studio_bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.studios ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.studio_bookings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.studio_booking_slots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.studio_booking_artists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.studio_booking_songs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Studios are viewable by everyone" ON public.studios;
+CREATE POLICY "Studios are viewable by everyone"
+  ON public.studios
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Studios managed by privileged roles" ON public.studios;
+CREATE POLICY "Studios managed by privileged roles"
+  ON public.studios
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+  );
+
+DROP POLICY IF EXISTS "Studio bookings are viewable by band members" ON public.studio_bookings;
+CREATE POLICY "Studio bookings are viewable by band members"
+  ON public.studio_bookings
+  FOR SELECT
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = studio_bookings.band_id
+        AND b.leader_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = studio_bookings.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band leaders manage studio bookings" ON public.studio_bookings;
+CREATE POLICY "Band leaders manage studio bookings"
+  ON public.studio_bookings
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = studio_bookings.band_id
+        AND b.leader_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = studio_bookings.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio slots follow booking visibility" ON public.studio_booking_slots;
+CREATE POLICY "Studio slots follow booking visibility"
+  ON public.studio_booking_slots
+  FOR SELECT
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_slots.booking_id
+        AND (b.leader_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = sb.band_id
+              AND bm.user_id = auth.uid()
+          ))
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio slots managed by band leaders" ON public.studio_booking_slots;
+CREATE POLICY "Studio slots managed by band leaders"
+  ON public.studio_booking_slots
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_slots.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_slots.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio booking artists viewable to participants" ON public.studio_booking_artists;
+CREATE POLICY "Studio booking artists viewable to participants"
+  ON public.studio_booking_artists
+  FOR SELECT
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_artists.booking_id
+        AND (b.leader_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = sb.band_id
+              AND bm.user_id = auth.uid()
+          ))
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = studio_booking_artists.character_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio booking artists managed by leaders" ON public.studio_booking_artists;
+CREATE POLICY "Studio booking artists managed by leaders"
+  ON public.studio_booking_artists
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_artists.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_artists.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio booking songs viewable to band" ON public.studio_booking_songs;
+CREATE POLICY "Studio booking songs viewable to band"
+  ON public.studio_booking_songs
+  FOR SELECT
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_songs.booking_id
+        AND (b.leader_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = sb.band_id
+              AND bm.user_id = auth.uid()
+          ))
+    )
+  );
+
+DROP POLICY IF EXISTS "Studio booking songs managed by leaders" ON public.studio_booking_songs;
+CREATE POLICY "Studio booking songs managed by leaders"
+  ON public.studio_booking_songs
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_songs.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+    OR EXISTS (
+      SELECT 1
+      FROM public.studio_bookings sb
+      JOIN public.bands b ON b.id = sb.band_id
+      WHERE sb.id = studio_booking_songs.booking_id
+        AND b.leader_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add Supabase migration defining studio infrastructure tables, enums, indexes, and RLS policies
- extend the Supabase TypeScript definitions to cover the new studio booking tables and enums
- document studio booking schema details, status lifecycle, and access control expectations

## Testing
- npm run lint *(fails: existing lint rule about unexpected any in stubTables.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d6688aea7483258aa4e216c300989d