### PR TITLE
Restrict city management to admins

### DIFF
--- a/supabase/migrations/20270624110000_update_cities_policies.sql
+++ b/supabase/migrations/20270624110000_update_cities_policies.sql
@@ -1,0 +1,22 @@
+-- Tighten city management policies to admin-only while allowing service role access
+alter table public.cities enable row level security;
+
+drop policy if exists "Authenticated users manage cities" on public.cities;
+
+create policy "Admin manage cities"
+  on public.cities
+  for all
+  using (
+    auth.role() = 'service_role'
+    or (
+      auth.role() = 'authenticated'
+      and public.has_role(auth.uid(), 'admin')
+    )
+  )
+  with check (
+    auth.role() = 'service_role'
+    or (
+      auth.role() = 'authenticated'
+      and public.has_role(auth.uid(), 'admin')
+    )
+  );


### PR DESCRIPTION
## Summary
- replace the generic city insert/update/delete policy with an admin-only rule
- allow service role access while ensuring authenticated admins can manage city records

## Testing
- not run (SQL migration change only)

------
https://chatgpt.com/codex/tasks/task_e_68d69d9768c08325b6fb3c11fbf0580e