### PR TITLE
Ensure songwriting page loads linked songs

### DIFF
--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -194,6 +194,15 @@ const Songwriting = () => {
   }, [fetchProjects, user?.id]);
 
   useEffect(() => {
+    if (!user?.id) {
+      setSongs([]);
+      return;
+    }
+
+    void fetchSongs();
+  }, [fetchSongs, user?.id]);
+
+  useEffect(() => {
     void refreshActivityStatus();
   }, [refreshActivityStatus]);
 


### PR DESCRIPTION
## Summary
- trigger the songwriting page to load available songs once a user is present
- reset cached songs when the user context clears to avoid stale linked song references

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da4bc064a48325ad5a1196aa1f5041