### PR TITLE
Expand songwriting studio workflow

### DIFF
--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -23,6 +23,7 @@ export interface SongwritingProject {
   theme_id: string | null;
   chord_progression_id: string | null;
   initial_lyrics: string | null;
+  lyrics?: string | null;
   music_progress: number;
   lyrics_progress: number;
   total_sessions: number;
@@ -31,10 +32,13 @@ export interface SongwritingProject {
   status: string;
   is_locked: boolean;
   locked_until: string | null;
+  sessions_completed?: number;
+  song_id?: string | null;
   created_at: string;
   updated_at: string;
   song_themes?: SongTheme;
   chord_progressions?: ChordProgression;
+  songwriting_sessions?: SongwritingSession[];
 }
 
 export interface SongwritingSession {
@@ -43,75 +47,140 @@ export interface SongwritingSession {
   user_id: string;
   session_start: string;
   session_end: string | null;
+  started_at?: string;
+  completed_at?: string | null;
+  locked_until?: string | null;
   music_progress_gained: number;
   lyrics_progress_gained: number;
   xp_earned: number;
   notes: string | null;
 }
 
+type CreateProjectInput = {
+  title: string;
+  theme_id: string;
+  chord_progression_id: string;
+  initial_lyrics?: string;
+  estimated_sessions?: number;
+  quality_score?: number;
+  status?: string;
+  song_id?: string | null;
+};
+
+type UpdateProjectInput = {
+  id: string;
+  title?: string;
+  theme_id?: string | null;
+  chord_progression_id?: string | null;
+  estimated_sessions?: number;
+  quality_score?: number;
+  status?: string;
+  initial_lyrics?: string | null;
+  lyrics?: string | null;
+  song_id?: string | null;
+};
+
+type CompleteSessionInput = {
+  sessionId: string;
+  notes?: string;
+};
+
 export const useSongwritingData = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
-  const { data: themes } = useQuery({
-    queryKey: ['song-themes'],
+  const { data: themes, isLoading: isLoadingThemes } = useQuery({
+    queryKey: ["song-themes"],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('song_themes')
-        .select('*')
-        .order('name');
-      
+        .from("song_themes")
+        .select("*")
+        .order("name");
+
       if (error) throw error;
       return data as SongTheme[];
-    }
+    },
   });
 
-  const { data: chordProgressions } = useQuery({
-    queryKey: ['chord-progressions'],
+  const { data: chordProgressions, isLoading: isLoadingChordProgressions } = useQuery({
+    queryKey: ["chord-progressions"],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('chord_progressions')
-        .select('*')
-        .order('difficulty', { ascending: true });
-      
+        .from("chord_progressions")
+        .select("*")
+        .order("difficulty", { ascending: true });
+
       if (error) throw error;
       return data as ChordProgression[];
-    }
+    },
   });
 
-  const { data: projects } = useQuery({
-    queryKey: ['songwriting-projects'],
+  const { data: projects, isLoading: isLoadingProjects } = useQuery({
+    queryKey: ["songwriting-projects"],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('songwriting_projects')
+        .from("songwriting_projects")
         .select(`
           *,
           song_themes (id, name, description, mood),
-          chord_progressions (id, name, progression, difficulty)
+          chord_progressions (id, name, progression, difficulty),
+          songwriting_sessions (
+            id,
+            project_id,
+            user_id,
+            session_start,
+            session_end,
+            started_at,
+            completed_at,
+            locked_until,
+            music_progress_gained,
+            lyrics_progress_gained,
+            xp_earned,
+            notes,
+            created_at
+          )
         `)
-        .order('created_at', { ascending: false });
-      
+        .order("created_at", { ascending: false });
+
       if (error) throw error;
       return data as SongwritingProject[];
-    }
+    },
   });
 
   const createProject = useMutation({
-    mutationFn: async (projectData: {
-      title: string;
-      theme_id: string;
-      chord_progression_id: string;
-      initial_lyrics?: string;
-    }) => {
+    mutationFn: async (projectData: CreateProjectInput) => {
+      const { data: authData, error: authError } = await supabase.auth.getUser();
+
+      if (authError) throw authError;
+
+      const userId = authData.user?.id;
+      if (!userId) {
+        throw new Error("User must be signed in to create a songwriting project");
+      }
+
+      const payload = {
+        user_id: userId,
+        title: projectData.title,
+        theme_id: projectData.theme_id || null,
+        chord_progression_id: projectData.chord_progression_id || null,
+        initial_lyrics: projectData.initial_lyrics ?? null,
+        lyrics: projectData.initial_lyrics ?? null,
+        estimated_sessions: projectData.estimated_sessions ?? 3,
+        quality_score: projectData.quality_score ?? 50,
+        status: projectData.status ?? "writing",
+        song_id: projectData.song_id ?? null,
+        music_progress: 0,
+        lyrics_progress: 0,
+        total_sessions: 0,
+        sessions_completed: 0,
+      };
+
       const { data, error } = await supabase
-        .from('songwriting_projects')
-        .insert({
-          ...projectData,
-          user_id: (await supabase.auth.getUser()).data.user?.id
-        })
+        .from("songwriting_projects")
+        .insert(payload)
         .select()
         .single();
-      
+
       if (error) throw error;
       return data;
     },
@@ -119,7 +188,7 @@ export const useSongwritingData = () => {
       queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
       toast({
         title: "Project Created",
-        description: "Your songwriting project has been created successfully!"
+        description: "Your songwriting project is ready for its first focus sprint!"
       });
     },
     onError: (error) => {
@@ -132,49 +201,132 @@ export const useSongwritingData = () => {
     }
   });
 
+  const updateProject = useMutation({
+    mutationFn: async ({ id, ...updates }: UpdateProjectInput) => {
+      if (!id) {
+        throw new Error("Project id is required to update a songwriting project");
+      }
+
+      const payload: Record<string, unknown> = {
+        updated_at: new Date().toISOString(),
+      };
+
+      (Object.entries(updates) as Array<[keyof UpdateProjectInput, unknown]>).forEach(([key, value]) => {
+        if (value !== undefined) {
+          payload[key] = value;
+        }
+      });
+
+      if (payload.initial_lyrics !== undefined && payload.lyrics === undefined) {
+        payload.lyrics = payload.initial_lyrics;
+      }
+
+      const { error } = await supabase
+        .from("songwriting_projects")
+        .update(payload)
+        .eq("id", id);
+
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      toast({
+        title: "Project Updated",
+        description: "Your songwriting roadmap has been refreshed."
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: "Failed to update songwriting project",
+        variant: "destructive"
+      });
+      console.error("Update project error:", error);
+    }
+  });
+
+  const deleteProject = useMutation({
+    mutationFn: async (projectId: string) => {
+      const { error } = await supabase
+        .from("songwriting_projects")
+        .delete()
+        .eq("id", projectId);
+
+      if (error) throw error;
+      return projectId;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      toast({
+        title: "Project Deleted",
+        description: "The songwriting project has been removed."
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Error",
+        description: "Failed to delete songwriting project",
+        variant: "destructive"
+      });
+      console.error("Delete project error:", error);
+    }
+  });
+
   const startSession = useMutation({
     mutationFn: async (projectId: string) => {
-      // First check if project is locked
       const { data: project, error: projectError } = await supabase
-        .from('songwriting_projects')
-        .select('is_locked, locked_until')
-        .eq('id', projectId)
+        .from("songwriting_projects")
+        .select("is_locked, locked_until")
+        .eq("id", projectId)
         .single();
-      
+
       if (projectError) throw projectError;
-      
-      if (project.is_locked && project.locked_until) {
+
+      if (project?.is_locked && project.locked_until) {
         const lockTime = new Date(project.locked_until);
-        if (lockTime > new Date()) {
-          throw new Error('Project is currently locked. Please wait before starting a new session.');
+        if (!Number.isNaN(lockTime.getTime()) && lockTime > new Date()) {
+          throw new Error("Project is currently locked. Please wait before starting a new session.");
         }
       }
 
-      // Lock the project for 1 hour
-      const lockUntil = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
-      
+      const { data: authData, error: authError } = await supabase.auth.getUser();
+      if (authError) throw authError;
+
+      const userId = authData.user?.id;
+      if (!userId) {
+        throw new Error("User must be signed in to start a songwriting session.");
+      }
+
+      const startedAt = new Date();
+      const lockUntil = new Date(startedAt.getTime() + 60 * 60 * 1000);
+
       const { error: lockError } = await supabase
-        .from('songwriting_projects')
+        .from("songwriting_projects")
         .update({
           is_locked: true,
-          locked_until: lockUntil.toISOString()
+          locked_until: lockUntil.toISOString(),
+          updated_at: startedAt.toISOString(),
         })
-        .eq('id', projectId);
-      
+        .eq("id", projectId);
+
       if (lockError) throw lockError;
 
-      // Create session record
       const { data, error } = await supabase
-        .from('songwriting_sessions')
+        .from("songwriting_sessions")
         .insert({
           project_id: projectId,
-          user_id: (await supabase.auth.getUser()).data.user?.id
+          user_id: userId,
+          session_start: startedAt.toISOString(),
+          started_at: startedAt.toISOString(),
+          locked_until: lockUntil.toISOString(),
+          notes: null,
         })
         .select()
         .single();
-      
+
       if (error) throw error;
-      return data;
+      return data as SongwritingSession;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
@@ -183,98 +335,129 @@ export const useSongwritingData = () => {
         description: "Your songwriting session has begun! You're locked in for 1 hour."
       });
     },
-    onError: (error: any) => {
+    onError: (error) => {
+      const description =
+        error instanceof Error ? error.message : "Failed to start songwriting session";
       toast({
         title: "Error",
-        description: error.message || "Failed to start songwriting session",
+        description,
         variant: "destructive"
       });
     }
   });
 
   const completeSession = useMutation({
-    mutationFn: async (sessionId: string) => {
-      // Get session and project data
+    mutationFn: async ({ sessionId, notes }: CompleteSessionInput) => {
       const { data: session, error: sessionError } = await supabase
-        .from('songwriting_sessions')
-        .select('project_id, user_id')
-        .eq('id', sessionId)
+        .from("songwriting_sessions")
+        .select("project_id, user_id")
+        .eq("id", sessionId)
         .single();
-      
+
       if (sessionError) throw sessionError;
 
-      // Get current project progress and user skills/attributes
       const { data: project, error: projectError } = await supabase
-        .from('songwriting_projects')
-        .select('music_progress, lyrics_progress, total_sessions')
-        .eq('id', session.project_id)
+        .from("songwriting_projects")
+        .select(
+          "music_progress, lyrics_progress, total_sessions, estimated_sessions, quality_score, status, sessions_completed"
+        )
+        .eq("id", session.project_id)
         .single();
-      
+
       if (projectError) throw projectError;
 
-      // Get user skills and attributes for calculation
       const { data: skills } = await supabase
-        .from('player_skills')
-        .select('songwriting, creativity, composition')
-        .eq('user_id', session.user_id)
+        .from("player_skills")
+        .select("songwriting, creativity, composition")
+        .eq("user_id", session.user_id)
         .single();
 
       const { data: attributes } = await supabase
-        .from('player_attributes')
-        .select('creative_insight, musical_ability')
-        .eq('user_id', session.user_id)
+        .from("player_attributes")
+        .select("creative_insight, musical_ability")
+        .eq("user_id", session.user_id)
         .single();
 
-      // Calculate progress using the database function
       const { data: progressCalc, error: calcError } = await supabase
-        .rpc('calculate_songwriting_progress', {
+        .rpc("calculate_songwriting_progress", {
           p_skill_songwriting: skills?.songwriting || 1,
           p_skill_creativity: skills?.creativity || 1,
           p_skill_composition: skills?.composition || 1,
           p_attr_creative_insight: attributes?.creative_insight || 10,
           p_attr_musical_ability: attributes?.musical_ability || 10,
           p_current_music: project.music_progress,
-          p_current_lyrics: project.lyrics_progress
+          p_current_lyrics: project.lyrics_progress,
         });
 
       if (calcError) throw calcError;
 
       const progressResult = (progressCalc ?? {}) as Record<string, unknown>;
-      const coerceNumber = (value: unknown) => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
+      const coerceNumber = (value: unknown) => (typeof value === "number" && Number.isFinite(value) ? value : 0);
 
       const musicGain = coerceNumber(progressResult.music_gain);
       const lyricsGain = coerceNumber(progressResult.lyrics_gain);
       const xpEarned = coerceNumber(progressResult.xp_earned);
 
-      // Update session with results
+      const completedAt = new Date();
+
       const { error: updateSessionError } = await supabase
-        .from('songwriting_sessions')
+        .from("songwriting_sessions")
         .update({
-          session_end: new Date().toISOString(),
+          session_end: completedAt.toISOString(),
+          completed_at: completedAt.toISOString(),
+          locked_until: null,
           music_progress_gained: musicGain,
           lyrics_progress_gained: lyricsGain,
-          xp_earned: xpEarned
+          xp_earned: xpEarned,
+          notes: notes?.trim() ? notes.trim() : null,
         })
-        .eq('id', sessionId);
+        .eq("id", sessionId);
 
       if (updateSessionError) throw updateSessionError;
 
-      // Update project progress
-      const newMusicProgress = Math.min(2000, project.music_progress + musicGain);
-      const newLyricsProgress = Math.min(2000, project.lyrics_progress + lyricsGain);
-      const isComplete = newMusicProgress >= 2000 && newLyricsProgress >= 2000;
+      const maxProgress = 2000;
+      const newMusicProgress = Math.min(maxProgress, (project.music_progress || 0) + musicGain);
+      const newLyricsProgress = Math.min(maxProgress, (project.lyrics_progress || 0) + lyricsGain);
+      const isComplete = newMusicProgress >= maxProgress && newLyricsProgress >= maxProgress;
+
+      const newTotalSessions = (project.total_sessions || 0) + 1;
+      const newSessionsCompleted = (project.sessions_completed || project.total_sessions || 0) + 1;
+      const estimatedSessions = project.estimated_sessions || 0;
+      const completionRatio = estimatedSessions > 0 ? newTotalSessions / estimatedSessions : 0;
+
+      let nextStatus = project.status || "writing";
+      if (isComplete) {
+        nextStatus = "completed";
+      } else if (completionRatio >= 1) {
+        nextStatus = "ready_to_finish";
+      } else if (completionRatio >= 0.66) {
+        nextStatus = "arranging";
+      } else if (!nextStatus || nextStatus === "draft") {
+        nextStatus = "writing";
+      }
+
+      const computedQuality = Math.min(
+        100,
+        Math.max(
+          project.quality_score || 0,
+          Math.round(((newMusicProgress + newLyricsProgress) / (maxProgress * 2)) * 100)
+        )
+      );
 
       const { error: updateProjectError } = await supabase
-        .from('songwriting_projects')
+        .from("songwriting_projects")
         .update({
           music_progress: newMusicProgress,
           lyrics_progress: newLyricsProgress,
-          total_sessions: project.total_sessions + 1,
-          status: isComplete ? 'complete' : 'writing',
+          total_sessions: newTotalSessions,
+          sessions_completed: newSessionsCompleted,
+          status: nextStatus,
           is_locked: false,
-          locked_until: null
+          locked_until: null,
+          quality_score: computedQuality,
+          updated_at: completedAt.toISOString(),
         })
-        .eq('id', session.project_id);
+        .eq("id", session.project_id);
 
       if (updateProjectError) throw updateProjectError;
 
@@ -284,21 +467,22 @@ export const useSongwritingData = () => {
         xpEarned,
         isComplete,
         newMusicProgress,
-        newLyricsProgress
+        newLyricsProgress,
+        qualityScore: computedQuality,
       };
     },
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
-      
+
       if (result.isComplete) {
         toast({
           title: "Song Completed!",
-          description: `Your song is finished! You can now add it to a setlist or record it.`
+          description: "Your project hit 100% on both tracks. Time to release it!"
         });
       } else {
         toast({
           title: "Session Complete",
-          description: `Progress made! Music: +${result.musicGain}, Lyrics: +${result.lyricsGain}, XP: +${result.xpEarned}`
+          description: `Progress made! Music +${result.musicGain}, Lyrics +${result.lyricsGain}, XP +${result.xpEarned}, Quality ${result.qualityScore}%`
         });
       }
     },
@@ -315,26 +499,26 @@ export const useSongwritingData = () => {
   const convertToSong = useMutation({
     mutationFn: async (projectId: string) => {
       const { data: project, error: projectError } = await supabase
-        .from('songwriting_projects')
+        .from("songwriting_projects")
         .select(`
           *,
           song_themes (name),
           chord_progressions (name, progression)
         `)
-        .eq('id', projectId)
+        .eq("id", projectId)
         .single();
-      
+
       if (projectError) throw projectError;
 
       // Create the final song
       const { data, error } = await supabase
-        .from('songs')
+        .from("songs")
         .insert({
           user_id: project.user_id,
           title: project.title,
           genre: project.song_themes?.name || 'Unknown',
-          lyrics: project.initial_lyrics,
-          quality_score: Math.round(project.quality_score / 20), // Convert to 0-100 scale
+          lyrics: project.lyrics || project.initial_lyrics,
+          quality_score: Math.round(project.quality_score ?? 0),
           music_progress: project.music_progress,
           lyrics_progress: project.lyrics_progress,
           theme_id: project.theme_id,
@@ -345,8 +529,18 @@ export const useSongwritingData = () => {
         })
         .select()
         .single();
-      
+
       if (error) throw error;
+      const { error: linkError } = await supabase
+        .from("songwriting_projects")
+        .update({
+          status: 'completed',
+          song_id: data.id,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", projectId);
+
+      if (linkError) throw linkError;
       return data;
     },
     onSuccess: () => {
@@ -370,9 +564,14 @@ export const useSongwritingData = () => {
     themes,
     chordProgressions,
     projects,
+    isLoadingProjects,
+    isLoadingThemes,
+    isLoadingChordProgressions,
     createProject,
+    updateProject,
+    deleteProject,
     startSession,
     completeSession,
-    convertToSong
+    convertToSong,
   };
 };

--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -1,7 +1,14 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
+import { formatDistanceToNowStrict } from "date-fns";
+import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
+import {
+  useSongwritingData,
+  type SongwritingProject,
+  type SongwritingSession,
+} from "@/hooks/useSongwritingData";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -9,12 +16,18 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Progress } from "@/components/ui/progress";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { toast } from "sonner";
 import {
   Music,
   Plus,
@@ -23,43 +36,14 @@ import {
   Play,
   CheckCircle2,
   Clock,
-  ListMusic,
-  BarChart3,
   NotebookPen,
   Trophy,
   Filter,
   History,
+  Sparkles,
+  Wand2,
 } from "lucide-react";
 import logger from "@/lib/logger";
-import { formatDistanceToNowStrict } from "date-fns";
-
-type SongwritingStatus = "draft" | "writing" | "ready_to_finish" | "completed";
-
-interface SongwritingSession {
-  id: string;
-  started_at: string;
-  locked_until: string | null;
-  completed_at: string | null;
-  notes: string | null;
-  legacy_session_start?: string | null;
-  legacy_session_end?: string | null;
-}
-
-interface SongwritingProject {
-  id: string;
-  title: string;
-  lyrics: string | null;
-  status: SongwritingStatus;
-  sessions_completed: number;
-  locked_until: string | null;
-  song_id: string | null;
-  created_at: string;
-  updated_at: string;
-  songwriting_sessions?: SongwritingSession[];
-  legacy_total_sessions?: number;
-  legacy_is_locked?: boolean;
-  legacy_initial_lyrics?: string | null;
-}
 
 interface Song {
   id: string;
@@ -72,198 +56,141 @@ interface Song {
   release_date: string | null;
 }
 
-type StatusConfig = {
-  value: SongwritingStatus;
-  label: string;
-  color: "default" | "secondary" | "destructive" | "outline";
+interface ProjectFormState {
+  title: string;
+  theme_id: string;
+  chord_progression_id: string;
+  estimated_sessions: number;
+  quality_score: number;
+  initial_lyrics: string;
+  status: string;
+  song_id: string;
+}
+
+const MAX_PROGRESS = 2000;
+const SESSION_DURATION_MINUTES = 60;
+
+const DEFAULT_FORM_STATE: ProjectFormState = {
+  title: "",
+  theme_id: "",
+  chord_progression_id: "",
+  estimated_sessions: 3,
+  quality_score: 50,
+  initial_lyrics: "",
+  status: "writing",
+  song_id: "",
 };
 
-const STATUSES: StatusConfig[] = [
-  { value: "draft", label: "Draft", color: "secondary" },
-  { value: "writing", label: "Writing", color: "default" },
-  { value: "ready_to_finish", label: "Ready to Finish", color: "outline" },
-  { value: "completed", label: "Completed", color: "default" }
+const STATUS_METADATA: Record<string, { label: string; badge: "default" | "secondary" | "outline" | "destructive" }> = {
+  idea: { label: "Idea", badge: "secondary" },
+  draft: { label: "Draft", badge: "secondary" },
+  writing: { label: "Writing", badge: "default" },
+  arranging: { label: "Arranging", badge: "outline" },
+  ready_to_finish: { label: "Ready to Finish", badge: "outline" },
+  demo: { label: "Demo", badge: "outline" },
+  complete: { label: "Completed", badge: "default" },
+  completed: { label: "Completed", badge: "default" },
+};
+
+const DEFAULT_STATUS_ORDER = [
+  "idea",
+  "draft",
+  "writing",
+  "arranging",
+  "ready_to_finish",
+  "demo",
+  "completed",
 ];
 
-const SESSION_DURATION_MINUTES = 25;
-const STATUS_THRESHOLDS: Record<Exclude<SongwritingStatus, "draft">, number> = {
-  writing: 1,
-  ready_to_finish: 4,
-  completed: 8
+const READY_STATUSES = new Set(["ready_to_finish", "arranging", "completed", "complete"]);
+
+const formatWordCount = (value: string) => {
+  if (!value.trim()) return "0 words";
+  return `${value.trim().split(/\s+/).length} words`;
 };
 
+const getStatusMeta = (status: string | null | undefined) => {
+  if (!status) {
+    return { label: "Unknown", badge: "secondary" as const };
+  }
+
+  const normalized = status.toLowerCase();
+  return STATUS_METADATA[normalized] ?? {
+    label: status.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()),
+    badge: "secondary" as const,
+  };
+};
+
+const computeLockState = (lockedUntil: string | null | undefined) => {
+  if (!lockedUntil) {
+    return { locked: false, message: "Ready for the next focus sprint." };
+  }
+
+  const target = new Date(lockedUntil);
+  if (Number.isNaN(target.getTime()) || target <= new Date()) {
+    return { locked: false, message: "Ready for the next focus sprint." };
+  }
+
+  const diffMinutes = Math.ceil((target.getTime() - Date.now()) / 60000);
+  return {
+    locked: true,
+    message: `Locked for ${diffMinutes} more minute${diffMinutes === 1 ? "" : "s"}.`,
+  };
+};
+
+const findActiveSession = (sessions?: SongwritingSession[] | null) => {
+  if (!Array.isArray(sessions)) return null;
+  return (
+    sessions.find((session) => !session.session_end && !session.completed_at) ??
+    sessions.find((session) => !session.completed_at)
+  );
+};
+
+const getProgressPercent = (value?: number | null) => {
+  if (!value || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(100, Math.round((value / MAX_PROGRESS) * 100));
+};
 const Songwriting = () => {
   const { user } = useAuth();
   const { activityStatus, startActivity, clearActivityStatus, refreshActivityStatus } = useGameData();
-  const [projects, setProjects] = useState<SongwritingProject[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedProject, setSelectedProject] = useState<SongwritingProject | null>(null);
+  const {
+    themes,
+    chordProgressions,
+    projects,
+    isLoadingProjects,
+    isLoadingThemes,
+    isLoadingChordProgressions,
+    createProject,
+    updateProject,
+    deleteProject,
+    startSession,
+    completeSession,
+    convertToSong,
+  } = useSongwritingData();
+
+  const [songs, setSongs] = useState<Song[]>([]);
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [themeFilter, setThemeFilter] = useState<string>("all");
+  const [showActiveOnly, setShowActiveOnly] = useState(false);
+  const [showLockedOnly, setShowLockedOnly] = useState(false);
+  const [showReadyOnly, setShowReadyOnly] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<SongwritingProject | null>(null);
   const [historyProject, setHistoryProject] = useState<SongwritingProject | null>(null);
-  const [completionDialogOpen, setCompletionDialogOpen] = useState(false);
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [completionProject, setCompletionProject] = useState<SongwritingProject | null>(null);
   const [completionNotes, setCompletionNotes] = useState("");
-  const [songs, setSongs] = useState<Song[]>([]);
-  const [statusFilter, setStatusFilter] = useState<SongwritingStatus | "all">("all");
-  const [showActiveOnly, setShowActiveOnly] = useState(false);
-  const [formData, setFormData] = useState({
-    title: "",
-    lyrics: "",
-    status: "draft" as SongwritingStatus,
-    song_id: ""
-  });
-
-  const songMap = useMemo(() => {
-    return songs.reduce<Record<string, Song>>((accumulator, song) => {
-      accumulator[song.id] = song;
-      return accumulator;
-    }, {});
-  }, [songs]);
-
-  const normalizeSession = useCallback((session: Record<string, unknown>, projectLockedUntil: string | null): SongwritingSession => {
-    const startedAt =
-      (typeof session.started_at === "string" && session.started_at) ||
-      (typeof session.session_start === "string" && session.session_start) ||
-      (typeof session.created_at === "string" && session.created_at) ||
-      new Date().toISOString();
-
-    const completedAt =
-      (typeof session.completed_at === "string" && session.completed_at) ||
-      (typeof session.session_end === "string" && session.session_end) ||
-      null;
-
-    let lockedUntil: string | null =
-      (typeof session.locked_until === "string" && session.locked_until) || null;
-
-    if (!lockedUntil && !completedAt && projectLockedUntil) {
-      lockedUntil = projectLockedUntil;
-    }
-
-    const fallbackId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-
-    return {
-      id: String(session.id ?? fallbackId),
-      started_at: startedAt,
-      locked_until: lockedUntil,
-      completed_at: completedAt,
-      notes: (typeof session.notes === "string" && session.notes) || null,
-      legacy_session_start:
-        (typeof session.session_start === "string" && session.session_start) || null,
-      legacy_session_end:
-        (typeof session.session_end === "string" && session.session_end) || null,
-    };
-  }, []);
-
-  const normalizeProject = useCallback(
-    (project: Record<string, unknown>): SongwritingProject => {
-      const lockedUntil = (typeof project.locked_until === "string" && project.locked_until) || null;
-
-      const sessionsRaw = Array.isArray(project.songwriting_sessions)
-        ? (project.songwriting_sessions as Record<string, unknown>[])
-        : [];
-
-      const normalizedSessions = sessionsRaw.map((session) => normalizeSession(session, lockedUntil));
-
-      const sessionsCompleted = (() => {
-        if (typeof project.sessions_completed === "number") {
-          return project.sessions_completed;
-        }
-
-        if (typeof project.sessions_completed === "string") {
-          const parsed = Number.parseInt(project.sessions_completed, 10);
-          if (Number.isFinite(parsed)) {
-            return parsed;
-          }
-        }
-
-        if (typeof project.total_sessions === "number") {
-          return project.total_sessions;
-        }
-
-        if (typeof project.total_sessions === "string") {
-          const parsed = Number.parseInt(project.total_sessions, 10);
-          if (Number.isFinite(parsed)) {
-            return parsed;
-          }
-        }
-
-        return normalizedSessions.filter((session) => Boolean(session.completed_at)).length;
-      })();
-
-      const fallbackId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-
-      return {
-        id: String(project.id ?? fallbackId),
-        title: String(project.title ?? "Untitled Project"),
-        lyrics:
-          (typeof project.lyrics === "string" && project.lyrics) ||
-          (typeof project.initial_lyrics === "string" && project.initial_lyrics) ||
-          null,
-        status: (project.status as SongwritingStatus) ?? "draft",
-        sessions_completed: sessionsCompleted,
-        locked_until: lockedUntil,
-        song_id: (typeof project.song_id === "string" && project.song_id) || null,
-        created_at: String(project.created_at ?? new Date().toISOString()),
-        updated_at: String(project.updated_at ?? new Date().toISOString()),
-        songwriting_sessions: normalizedSessions,
-        legacy_total_sessions:
-          typeof project.total_sessions === "number"
-            ? project.total_sessions
-            : typeof project.total_sessions === "string"
-              ? Number.parseInt(project.total_sessions, 10)
-              : undefined,
-        legacy_is_locked: typeof project.is_locked === "boolean" ? project.is_locked : undefined,
-        legacy_initial_lyrics:
-          (typeof project.initial_lyrics === "string" && project.initial_lyrics) || null,
-      };
-    }, [normalizeSession]);
-
-  const fetchProjects = useCallback(async () => {
-    if (!user?.id) {
-      return;
-    }
-
-    logger.info("Fetching songwriting projects", {
-      userId: user.id
-    });
-
-    try {
-      const { data, error } = await supabase
-        .from("songwriting_projects")
-        .select("*, songwriting_sessions(*)")
-        .eq("user_id", user.id)
-        .order("updated_at", { ascending: false });
-
-      if (error) throw error;
-      const normalized = Array.isArray(data)
-        ? (data as Record<string, unknown>[]).map(normalizeProject)
-        : [];
-      setProjects(normalized);
-
-      logger.info("Fetched songwriting projects successfully", {
-        userId: user.id,
-        projectCount: data?.length ?? 0,
-      });
-    } catch (error) {
-      logger.error("Error fetching songwriting projects", {
-        userId: user.id,
-        error: error instanceof Error ? error.message : String(error)
-      });
-      toast.error("Failed to load songwriting projects");
-    } finally {
-      setLoading(false);
-    }
-  }, [normalizeProject, user?.id]);
+  const [formState, setFormState] = useState<ProjectFormState>(DEFAULT_FORM_STATE);
 
   const fetchSongs = useCallback(async () => {
     if (!user?.id) {
+      setSongs([]);
       return;
     }
 
-    logger.info("Fetching songs for songwriting linking", {
-      userId: user.id,
-    });
+    logger.info("Fetching songs for songwriting", { userId: user.id });
 
     try {
       const { data, error } = await supabase
@@ -274,11 +201,6 @@ const Songwriting = () => {
 
       if (error) throw error;
       setSongs(Array.isArray(data) ? (data as Song[]) : []);
-
-      logger.info("Fetched songs for songwriting", {
-        userId: user.id,
-        songCount: data?.length ?? 0,
-      });
     } catch (error) {
       logger.error("Error fetching songs for songwriting", {
         userId: user.id,
@@ -289,26 +211,42 @@ const Songwriting = () => {
   }, [user?.id]);
 
   useEffect(() => {
-    if (!user?.id) {
-      return;
-    }
-
-    setLoading(true);
-    fetchProjects();
-  }, [fetchProjects, user?.id]);
-
-  useEffect(() => {
-    if (!user?.id) {
-      setSongs([]);
-      return;
-    }
-
     void fetchSongs();
-  }, [fetchSongs, user?.id]);
+  }, [fetchSongs]);
 
   useEffect(() => {
     void refreshActivityStatus();
   }, [refreshActivityStatus]);
+
+  useEffect(() => {
+    if (convertToSong.isSuccess || createProject.isSuccess || updateProject.isSuccess) {
+      void fetchSongs();
+    }
+  }, [convertToSong.isSuccess, createProject.isSuccess, updateProject.isSuccess, fetchSongs]);
+
+  const projectsList = useMemo(() => projects ?? [], [projects]);
+  const themesList = useMemo(() => themes ?? [], [themes]);
+  const progressionsList = useMemo(() => chordProgressions ?? [], [chordProgressions]);
+
+  const songMap = useMemo(() => {
+    return songs.reduce<Record<string, Song>>((accumulator, song) => {
+      accumulator[song.id] = song;
+      return accumulator;
+    }, {});
+  }, [songs]);
+  const statusOptions = useMemo(() => {
+    const knownStatuses = new Set(DEFAULT_STATUS_ORDER);
+    projectsList.forEach((project) => {
+      if (project.status) {
+        knownStatuses.add(project.status.toLowerCase());
+      }
+    });
+
+    return Array.from(knownStatuses).map((status) => ({
+      value: status,
+      label: getStatusMeta(status).label,
+    }));
+  }, [projectsList]);
 
   const globalActivityLock = useMemo(() => {
     if (!activityStatus || activityStatus.status === "idle") {
@@ -347,378 +285,47 @@ const Songwriting = () => {
     try {
       return formatDistanceToNowStrict(globalActivityLock.endsAt, { addSuffix: true });
     } catch (error) {
-      console.error("Failed to compute activity lock countdown", error);
+      logger.warn("Failed to compute activity countdown", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }, [globalActivityLock]);
 
-  const determineNextStatus = (current: SongwritingStatus, completedSessions: number) => {
-    if (current === "completed") {
-      return current;
-    }
-
-    if (completedSessions >= STATUS_THRESHOLDS.completed) {
-      return "completed";
-    }
-
-    if (completedSessions >= STATUS_THRESHOLDS.ready_to_finish) {
-      return "ready_to_finish";
-    }
-
-    if (completedSessions >= STATUS_THRESHOLDS.writing) {
-      return "writing";
-    }
-
-    return current;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!user) return;
-
-    const action = selectedProject ? "update" : "create";
-    const payload = {
-      title: formData.title,
-      status: formData.status,
-      song_id: formData.song_id || null,
-      lyricsLength: formData.lyrics.length
-    };
-
-    logger.info("Submitting songwriting project", {
-      userId: user.id,
-      action,
-      projectId: selectedProject?.id,
-      payload
-    });
-
-    try {
-      if (selectedProject) {
-        const projectUpdate: Record<string, unknown> = {
-          title: formData.title,
-          lyrics: formData.lyrics,
-          status: formData.status,
-          song_id: formData.song_id || null,
-          updated_at: new Date().toISOString(),
-        };
-
-        if (selectedProject.legacy_initial_lyrics !== undefined) {
-          projectUpdate.initial_lyrics = formData.lyrics;
-        }
-
-        if (typeof selectedProject.legacy_total_sessions === "number") {
-          projectUpdate.total_sessions = selectedProject.legacy_total_sessions;
-        }
-
-        const { error } = await supabase
-          .from("songwriting_projects")
-          .update(projectUpdate)
-          .eq("id", selectedProject.id)
-          .eq("user_id", user.id);
-
-        if (error) throw error;
-        toast.success("Project updated successfully!");
-        logger.info("Songwriting project updated", {
-          userId: user.id,
-          projectId: selectedProject.id,
-          payload
-        });
-      } else {
-        const projectInsert: Record<string, unknown> = {
-          user_id: user.id,
-          title: formData.title,
-          lyrics: formData.lyrics,
-          status: formData.status,
-          song_id: formData.song_id || null,
-          sessions_completed: 0,
-        };
-
-        projectInsert.initial_lyrics = formData.lyrics;
-        projectInsert.total_sessions = 0;
-
-        const { error } = await supabase
-          .from("songwriting_projects")
-          .insert(projectInsert);
-
-        if (error) throw error;
-        toast.success("Project created successfully!");
-        logger.info("Songwriting project created", {
-          userId: user.id,
-          payload
-        });
-      }
-
-      setIsDialogOpen(false);
-      setSelectedProject(null);
-      setFormData({ title: "", lyrics: "", status: "draft", song_id: "" });
-      fetchProjects();
-      fetchSongs();
-    } catch (error) {
-      logger.error("Error saving songwriting project", {
-        userId: user.id,
-        action,
-        projectId: selectedProject?.id,
-        payload,
-        error: error instanceof Error ? error.message : String(error)
-      });
-      toast.error("Failed to save project");
-    }
-  };
-
-  const handleEdit = (project: SongwritingProject) => {
-    setSelectedProject(project);
-    setFormData({
-      title: project.title,
-      lyrics: project.lyrics || "",
-      status: project.status,
-      song_id: project.song_id || ""
-    });
-    setIsDialogOpen(true);
-  };
-
-  const handleDelete = async (projectId: string) => {
-    if (!confirm("Are you sure you want to delete this songwriting project?")) return;
-
-    logger.info("Deleting songwriting project", {
-      userId: user?.id,
-      projectId
-    });
-
-    try {
-      const { error } = await supabase
-        .from("songwriting_projects")
-        .delete()
-        .eq("id", projectId)
-        .eq("user_id", user?.id);
-
-      if (error) throw error;
-      toast.success("Project deleted successfully!");
-      logger.info("Songwriting project deleted", {
-        userId: user?.id,
-        projectId
-      });
-      fetchProjects();
-    } catch (error) {
-      logger.error("Error deleting songwriting project", {
-        userId: user?.id,
-        projectId,
-        error: error instanceof Error ? error.message : String(error)
-      });
-      toast.error("Failed to delete project");
-    }
-  };
-
-  const handleStartSession = async (project: SongwritingProject) => {
-    if (!user) return;
-
-    const activeSession = project.songwriting_sessions?.find((session) => !session.completed_at);
-    if (activeSession) {
-      toast.info("You already have an active session for this project.");
-      return;
-    }
-
-    if (project.locked_until && new Date(project.locked_until) > new Date()) {
-      toast.info("This project is currently locked. Try again soon.");
-      return;
-    }
-
-    if (globalActivityLock.locked) {
-      const statusLabel = globalActivityLock.label ?? "another activity";
-      const countdown = globalActivityCountdown
-        ? `You'll be free ${globalActivityCountdown}.`
-        : "Finish your current activity before starting a new sprint.";
-      toast.info(`You're currently busy with ${statusLabel}. ${countdown}`);
-      return;
-    }
-
-    let statusRegistered = false;
-
-    try {
-      await startActivity({
-        status: "songwriting_session",
-        durationMinutes: SESSION_DURATION_MINUTES,
-        metadata: project.song_id ? { song_id: project.song_id } : undefined,
-      });
-      statusRegistered = true;
-    } catch (statusError) {
-      console.error("Error starting songwriting status:", statusError);
-      toast.info("Session started, but we couldn't update your availability status.");
-    }
-
-    try {
-      const lockedUntil = new Date(Date.now() + SESSION_DURATION_MINUTES * 60 * 1000).toISOString();
-      const sessionStart = new Date().toISOString();
-
-      const sessionInsert: Record<string, unknown> = {
-        project_id: project.id,
-        user_id: user.id,
-        started_at: sessionStart,
-        locked_until: lockedUntil,
-        session_start: sessionStart,
-      };
-
-      const { error: sessionError } = await supabase
-        .from("songwriting_sessions")
-        .insert(sessionInsert);
-
-      if (sessionError) throw sessionError;
-
-      const projectUpdate: Record<string, unknown> = {
-        locked_until: lockedUntil,
-        updated_at: new Date().toISOString(),
-      };
-
-      if (typeof project.legacy_is_locked === "boolean") {
-        projectUpdate.is_locked = true;
-      }
-
-      const { error: projectError } = await supabase
-        .from("songwriting_projects")
-        .update(projectUpdate)
-        .eq("id", project.id)
-        .eq("user_id", user.id);
-
-      if (projectError) throw projectError;
-
-      toast.success("Songwriting session started! Stay focused.");
-      fetchProjects();
-      if (statusRegistered) {
-        void refreshActivityStatus();
-      }
-    } catch (error) {
-      console.error("Error starting songwriting session:", error);
-      toast.error("Failed to start session");
-
-      if (statusRegistered) {
-        try {
-          await clearActivityStatus();
-        } catch (clearError) {
-          console.error("Failed to revert activity status after session error", clearError);
-        } finally {
-          void refreshActivityStatus();
-        }
-      }
-    }
-  };
-
-  const handleCompleteSession = async (project: SongwritingProject, notes?: string) => {
-    if (!user) return;
-
-    const activeSession = project.songwriting_sessions?.find((session) => !session.completed_at);
-    if (!activeSession) {
-      toast.info("No active session to complete for this project.");
-      return;
-    }
-
-    try {
-      const completedAt = new Date().toISOString();
-      const updatedSessions = project.sessions_completed + 1;
-      const nextStatus = determineNextStatus(project.status, updatedSessions);
-
-      const sessionUpdate: Record<string, unknown> = {
-        completed_at: completedAt,
-        notes: notes?.trim() ? notes.trim() : null,
-      };
-
-      if (activeSession.legacy_session_end !== undefined) {
-        sessionUpdate.session_end = completedAt;
-      }
-
-      const { error: sessionError } = await supabase
-        .from("songwriting_sessions")
-        .update(sessionUpdate)
-        .eq("id", activeSession.id)
-        .eq("user_id", user.id);
-
-      if (sessionError) throw sessionError;
-
-      const projectUpdate: Record<string, unknown> = {
-        sessions_completed: updatedSessions,
-        locked_until: null,
-        status: nextStatus,
-        updated_at: new Date().toISOString(),
-      };
-
-      if (typeof project.legacy_total_sessions === "number") {
-        projectUpdate.total_sessions = updatedSessions;
-      }
-
-      if (typeof project.legacy_is_locked === "boolean") {
-        projectUpdate.is_locked = false;
-      }
-
-      const { error: projectError } = await supabase
-        .from("songwriting_projects")
-        .update(projectUpdate)
-        .eq("id", project.id)
-        .eq("user_id", user.id);
-
-      if (projectError) throw projectError;
-
-      toast.success("Great job! Session completed.");
-      fetchProjects();
-      if (activityStatus?.status === "songwriting_session") {
-        try {
-          await clearActivityStatus();
-        } catch (statusError) {
-          console.error("Failed to clear songwriting activity status", statusError);
-        } finally {
-          void refreshActivityStatus();
-        }
-      }
-    } catch (error) {
-      console.error("Error completing songwriting session:", error);
-      toast.error("Failed to complete session");
-    }
-  };
-
-  const getStatusBadgeVariant = (status: string) => {
-    const statusConfig = STATUSES.find((s) => s.value === status);
-    return statusConfig?.color || "secondary";
-  };
-
-  const getLockMessage = (lockedUntil: string | null) => {
-    if (!lockedUntil) {
-      return { locked: false, message: "Ready for the next focus sprint." };
-    }
-
-    const lockedDate = new Date(lockedUntil);
-    const now = new Date();
-
-    if (lockedDate <= now) {
-      return { locked: false, message: "Ready for the next focus sprint." };
-    }
-
-    const diffMs = lockedDate.getTime() - now.getTime();
-    const diffMinutes = Math.ceil(diffMs / (60 * 1000));
-    return {
-      locked: true,
-      message: `Locked for ${diffMinutes} more minute${diffMinutes === 1 ? "" : "s"}.`
-    };
-  };
-
-  const totalProjects = projects.length;
-  const totalSessions = projects.reduce((sum, project) => sum + project.sessions_completed, 0);
-  const activeSprints = projects.filter((project) =>
-    project.songwriting_sessions?.some((session) => !session.completed_at)
+  const totalProjects = projectsList.length;
+  const totalSessions = projectsList.reduce((sum, project) => sum + (project.total_sessions ?? 0), 0);
+  const focusMinutes = totalSessions * SESSION_DURATION_MINUTES;
+  const activeProjects = projectsList.filter((project) => !READY_STATUSES.has((project.status || "").toLowerCase())).length;
+  const completedProjects = projectsList.filter((project) =>
+    READY_STATUSES.has((project.status || "").toLowerCase()) &&
+    (project.music_progress ?? 0) >= MAX_PROGRESS &&
+    (project.lyrics_progress ?? 0) >= MAX_PROGRESS
   ).length;
-  const completedProjects = projects.filter((project) => project.status === "completed").length;
-  const completionRate = totalProjects ? Math.round((completedProjects / totalProjects) * 100) : 0;
-  const totalFocusMinutes = totalSessions * SESSION_DURATION_MINUTES;
+  const readyProjects = projectsList.filter((project) => READY_STATUSES.has((project.status || "").toLowerCase())).length;
+  const averageQuality = totalProjects
+    ? Math.round(
+        projectsList.reduce((sum, project) => sum + (project.quality_score ?? 0), 0) / totalProjects
+      )
+    : 0;
 
   const filteredProjects = useMemo(() => {
-    const byStatus =
-      statusFilter === "all"
-        ? projects
-        : projects.filter((project) => project.status === statusFilter);
+    return projectsList.filter((project) => {
+      const status = (project.status || "").toLowerCase();
+      const matchesStatus =
+        statusFilter === "all" ||
+        status === statusFilter ||
+        (statusFilter === "completed" && status === "complete");
 
-    if (!showActiveOnly) {
-      return byStatus;
-    }
+      const matchesTheme = themeFilter === "all" || project.theme_id === themeFilter;
+      const activeSession = findActiveSession(project.songwriting_sessions);
+      const matchesActive = !showActiveOnly || Boolean(activeSession);
+      const lockState = computeLockState(project.locked_until ?? null);
+      const matchesLocked = !showLockedOnly || lockState.locked;
+      const matchesReady = !showReadyOnly || READY_STATUSES.has(status);
 
-    return byStatus.filter((project) =>
-      project.songwriting_sessions?.some((session) => !session.completed_at)
-    );
-  }, [projects, showActiveOnly, statusFilter]);
+      return matchesStatus && matchesTheme && matchesActive && matchesLocked && matchesReady;
+    });
+  }, [projectsList, statusFilter, themeFilter, showActiveOnly, showLockedOnly, showReadyOnly]);
 
   const formatCurrency = useMemo(
     () =>
@@ -738,31 +345,156 @@ const Songwriting = () => {
     []
   );
 
-  const handleOpenCompletionDialog = (project: SongwritingProject) => {
-    setCompletionProject(project);
-    setCompletionNotes("");
-    setCompletionDialogOpen(true);
+  const resetForm = useCallback(() => {
+    setFormState(DEFAULT_FORM_STATE);
+    setSelectedProject(null);
+  }, []);
+  const handleOpenCreate = () => {
+    resetForm();
+    setIsDialogOpen(true);
   };
 
-  const handleOpenHistoryDialog = (project: SongwritingProject) => {
-    setHistoryProject(project);
-    setIsHistoryOpen(true);
+  const handleEdit = (project: SongwritingProject) => {
+    setSelectedProject(project);
+    setFormState({
+      title: project.title,
+      theme_id: project.theme_id ?? "",
+      chord_progression_id: project.chord_progression_id ?? "",
+      estimated_sessions: project.estimated_sessions ?? project.total_sessions ?? 3,
+      quality_score: project.quality_score ?? 50,
+      initial_lyrics: project.lyrics ?? project.initial_lyrics ?? "",
+      status: project.status ?? "writing",
+      song_id: project.song_id ?? "",
+    });
+    setIsDialogOpen(true);
   };
 
-  const handleCompleteSessionWithNotes = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!completionProject) {
+  const handleDelete = async (project: SongwritingProject) => {
+    if (!confirm(`Delete songwriting project "${project.title}"?`)) {
       return;
     }
 
-    await handleCompleteSession(completionProject, completionNotes);
-    setCompletionDialogOpen(false);
-    setCompletionProject(null);
+    try {
+      await deleteProject.mutateAsync(project.id);
+    } catch (error) {
+      logger.error("Failed to delete songwriting project", {
+        projectId: project.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toast.error("Failed to delete songwriting project");
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const payload = {
+      title: formState.title.trim(),
+      theme_id: formState.theme_id,
+      chord_progression_id: formState.chord_progression_id,
+      estimated_sessions: Number.isFinite(formState.estimated_sessions)
+        ? formState.estimated_sessions
+        : 3,
+      quality_score: Math.min(100, Math.max(0, Math.round(formState.quality_score))),
+      status: formState.status,
+      initial_lyrics: formState.initial_lyrics,
+      song_id: formState.song_id || null,
+    };
+
+    try {
+      if (selectedProject) {
+        await updateProject.mutateAsync({
+          id: selectedProject.id,
+          title: payload.title,
+          theme_id: payload.theme_id || null,
+          chord_progression_id: payload.chord_progression_id || null,
+          estimated_sessions: payload.estimated_sessions,
+          quality_score: payload.quality_score,
+          status: payload.status,
+          initial_lyrics: payload.initial_lyrics ?? null,
+          lyrics: payload.initial_lyrics ?? null,
+          song_id: payload.song_id,
+        });
+      } else {
+        await createProject.mutateAsync(payload);
+      }
+
+      setIsDialogOpen(false);
+      resetForm();
+    } catch (error) {
+      logger.error("Failed to save songwriting project", {
+        projectId: selectedProject?.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toast.error("Failed to save project");
+    }
+  };
+
+  const handleStartSession = async (project: SongwritingProject) => {
+    try {
+      await startSession.mutateAsync(project.id);
+      await startActivity({
+        status: "songwriting_session",
+        durationMinutes: SESSION_DURATION_MINUTES,
+        metadata: { projectId: project.id },
+      });
+      await refreshActivityStatus();
+    } catch (error) {
+      logger.error("Failed to start songwriting session", {
+        projectId: project.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const handleOpenCompletionDialog = (project: SongwritingProject) => {
+    setCompletionProject(project);
     setCompletionNotes("");
   };
 
+  const handleCompleteSessionSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!completionProject) return;
+
+    const activeSession = findActiveSession(completionProject.songwriting_sessions);
+    if (!activeSession) {
+      toast.info("No active session to complete for this project.");
+      return;
+    }
+
+    try {
+      await completeSession.mutateAsync({
+        sessionId: activeSession.id,
+        notes: completionNotes,
+      });
+
+      setCompletionProject(null);
+      setCompletionNotes("");
+      await clearActivityStatus();
+      await refreshActivityStatus();
+    } catch (error) {
+      logger.error("Failed to complete songwriting session", {
+        projectId: completionProject.id,
+        sessionId: activeSession.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toast.error("Failed to complete session");
+    }
+  };
+
+  const handleConvertProject = async (project: SongwritingProject) => {
+    try {
+      await convertToSong.mutateAsync(project.id);
+    } catch (error) {
+      logger.error("Failed to convert songwriting project", {
+        projectId: project.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toast.error("Failed to create song from project");
+    }
+  };
+
   const handleCompletionDialogChange = (open: boolean) => {
-    setCompletionDialogOpen(open);
     if (!open) {
       setCompletionProject(null);
       setCompletionNotes("");
@@ -770,17 +502,15 @@ const Songwriting = () => {
   };
 
   const handleHistoryDialogChange = (open: boolean) => {
-    setIsHistoryOpen(open);
     if (!open) {
       setHistoryProject(null);
     }
   };
-
-  if (loading) {
+  if (isLoadingProjects && projectsList.length === 0) {
     return (
       <div className="container mx-auto p-6">
         <div className="flex items-center justify-center h-64">
-          <div className="text-muted-foreground">Loading songwriting projects...</div>
+          <div className="text-muted-foreground">Loading songwriting studio...</div>
         </div>
       </div>
     );
@@ -788,62 +518,160 @@ const Songwriting = () => {
 
   return (
     <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
           <h1 className="text-3xl font-bold flex items-center gap-2">
             <Music className="h-8 w-8 text-primary" />
             Songwriting Studio
           </h1>
           <p className="text-muted-foreground mt-2">
-            Build focused songwriting projects and track your creative momentum
+            Craft deliberate songwriting sprints, track your progress, and convert finished projects into release-ready songs.
           </p>
-      </div>
-
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogTrigger asChild>
-          <Button
-              onClick={() => {
-                setSelectedProject(null);
-                setFormData({ title: "", lyrics: "", status: "draft", song_id: "" });
-              }}
-            >
-              <Plus className="h-4 w-4 mr-2" />
+        </div>
+        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <DialogTrigger asChild>
+            <Button onClick={handleOpenCreate}>
+              <Plus className="mr-2 h-4 w-4" />
               New Project
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-2xl">
+          <DialogContent className="max-w-3xl">
             <DialogHeader>
-              <DialogTitle>
-                {selectedProject ? "Edit Project" : "Create New Project"}
-              </DialogTitle>
+              <DialogTitle>{selectedProject ? "Edit Songwriting Project" : "Create Songwriting Project"}</DialogTitle>
               <DialogDescription>
-                {selectedProject ? "Update your songwriting plan" : "Start your next hit"}
+                {selectedProject
+                  ? "Update your creative plan, adjust targets, or link the project to an existing song."
+                  : "Define the creative direction for your next hit before jumping into focus sprints."}
               </DialogDescription>
             </DialogHeader>
-
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <Label htmlFor="title">Project Title</Label>
+                  <Label htmlFor="project-title">Project Title</Label>
                   <Input
-                    id="title"
-                    value={formData.title}
-                    onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                    placeholder="Enter project title"
+                    id="project-title"
+                    value={formState.title}
+                    onChange={(event) => setFormState((previous) => ({ ...previous, title: event.target.value }))}
+                    placeholder="anthemic stadium rock banger"
                     required
                   />
                 </div>
-
                 <div className="space-y-2">
-                  <Label htmlFor="song_id">Link to an existing song</Label>
+                  <Label htmlFor="project-status">Status</Label>
                   <Select
-                    value={formData.song_id || "none"}
+                    value={formState.status}
+                    onValueChange={(value) => setFormState((previous) => ({ ...previous, status: value }))}
+                  >
+                    <SelectTrigger id="project-status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {statusOptions.map((status) => (
+                        <SelectItem key={status.value} value={status.value}>
+                          {status.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="project-theme">Song Theme</Label>
+                  <Select
+                    value={formState.theme_id || "none"}
                     onValueChange={(value) =>
-                      setFormData({ ...formData, song_id: value === "none" ? "" : value })
+                      setFormState((previous) => ({ ...previous, theme_id: value === "none" ? "" : value }))
+                    }
+                    disabled={isLoadingThemes && themesList.length === 0}
+                  >
+                    <SelectTrigger id="project-theme">
+                      <SelectValue placeholder="Choose a theme" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">No specific theme</SelectItem>
+                      {themesList.map((theme) => (
+                        <SelectItem key={theme.id} value={theme.id}>
+                          {theme.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-progression">Chord Progression</Label>
+                  <Select
+                    value={formState.chord_progression_id || "none"}
+                    onValueChange={(value) =>
+                      setFormState((previous) => ({
+                        ...previous,
+                        chord_progression_id: value === "none" ? "" : value,
+                      }))
+                    }
+                    disabled={isLoadingChordProgressions && progressionsList.length === 0}
+                  >
+                    <SelectTrigger id="project-progression">
+                      <SelectValue placeholder="Select a progression" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">No progression yet</SelectItem>
+                      {progressionsList.map((progression) => (
+                        <SelectItem key={progression.id} value={progression.id}>
+                          {progression.name} · {progression.progression}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="project-estimate">Estimated Sessions</Label>
+                  <Input
+                    id="project-estimate"
+                    type="number"
+                    min={1}
+                    value={formState.estimated_sessions}
+                    onChange={(event) =>
+                      setFormState((previous) => ({
+                        ...previous,
+                        estimated_sessions: Number.parseInt(event.target.value, 10) || 1,
+                      }))
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Plan how many deep work sessions you expect to invest in this song.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-quality">Quality Target</Label>
+                  <Input
+                    id="project-quality"
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={formState.quality_score}
+                    onChange={(event) =>
+                      setFormState((previous) => ({
+                        ...previous,
+                        quality_score: Number.parseInt(event.target.value, 10) || 0,
+                      }))
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">Set an ambition level for the finished song.</p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project-song">Link to an existing song</Label>
+                  <Select
+                    value={formState.song_id || "none"}
+                    onValueChange={(value) =>
+                      setFormState((previous) => ({ ...previous, song_id: value === "none" ? "" : value }))
                     }
                   >
-                    <SelectTrigger id="song_id">
-                      <SelectValue placeholder="Select a song (optional)" />
+                    <SelectTrigger id="project-song">
+                      <SelectValue placeholder="Optional" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="none">No linked song</SelectItem>
@@ -864,43 +692,24 @@ const Songwriting = () => {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="status">Status</Label>
-                <Select
-                  value={formData.status}
-                  onValueChange={(value) => setFormData({ ...formData, status: value as SongwritingStatus })}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {STATUSES.map((status) => (
-                      <SelectItem key={status.value} value={status.value}>
-                        {status.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="lyrics">Lyrics</Label>
+                <Label htmlFor="project-lyrics">Lyrics & Song Notes</Label>
                 <Textarea
-                  id="lyrics"
-                  value={formData.lyrics}
-                  onChange={(e) => setFormData({ ...formData, lyrics: e.target.value })}
-                  placeholder="Write your lyrics here..."
+                  id="project-lyrics"
+                  value={formState.initial_lyrics}
+                  onChange={(event) =>
+                    setFormState((previous) => ({ ...previous, initial_lyrics: event.target.value }))
+                  }
+                  placeholder="Capture the core concept, lyric fragments, or production notes."
                   className="min-h-32"
                 />
-                <div className="text-xs text-muted-foreground text-right">
-                  {formData.lyrics.trim() ? `${formData.lyrics.trim().split(/\s+/).length} words` : "0 words"}
-                </div>
+                <p className="text-right text-xs text-muted-foreground">{formatWordCount(formState.initial_lyrics)}</p>
               </div>
 
               <div className="flex justify-end gap-2">
                 <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
                   Cancel
                 </Button>
-                <Button type="submit">
+                <Button type="submit" disabled={createProject.isPending || updateProject.isPending}>
                   {selectedProject ? "Update Project" : "Create Project"}
                 </Button>
               </div>
@@ -908,101 +717,253 @@ const Songwriting = () => {
           </DialogContent>
         </Dialog>
       </div>
+      <Card>
+        <CardContent className="py-6">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
+                Active Projects
+                <NotebookPen className="h-4 w-4" />
+              </div>
+              <p className="mt-2 text-2xl font-semibold">{activeProjects}</p>
+              <p className="text-xs text-muted-foreground">Songs currently in writing or arranging phases.</p>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
+                Focus Minutes Logged
+                <Clock className="h-4 w-4" />
+              </div>
+              <p className="mt-2 text-2xl font-semibold">{formatNumber.format(focusMinutes)}</p>
+              <p className="text-xs text-muted-foreground">Cumulative deep work invested across all projects.</p>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
+                Average Quality
+                <Trophy className="h-4 w-4" />
+              </div>
+              <p className="mt-2 text-2xl font-semibold">{averageQuality}%</p>
+              <p className="text-xs text-muted-foreground">Based on progress across music and lyrics goals.</p>
+            </div>
+            <div className="rounded-lg border bg-card p-4">
+              <div className="flex items-center justify-between text-sm text-muted-foreground">
+                Release Ready
+                <Sparkles className="h-4 w-4" />
+              </div>
+              <p className="mt-2 text-2xl font-semibold">{completedProjects}</p>
+              <p className="text-xs text-muted-foreground">Projects that hit 100% on both creative tracks.</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Filter className="h-4 w-4" />
+            Refine your view
+          </CardTitle>
+          <CardDescription>Slice your studio dashboard by status, theme, and sprint readiness.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-2">
+              <Label>Status</Label>
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger>
+                  <SelectValue placeholder="All statuses" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All statuses</SelectItem>
+                  {statusOptions.map((status) => (
+                    <SelectItem key={status.value} value={status.value}>
+                      {status.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Theme</Label>
+              <Select value={themeFilter} onValueChange={setThemeFilter}>
+                <SelectTrigger>
+                  <SelectValue placeholder="All themes" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All themes</SelectItem>
+                  {themesList.map((theme) => (
+                    <SelectItem key={theme.id} value={theme.id}>
+                      {theme.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2 border rounded-md p-3">
+              <Checkbox
+                id="filter-active"
+                checked={showActiveOnly}
+                onCheckedChange={(checked) => setShowActiveOnly(Boolean(checked))}
+              />
+              <Label htmlFor="filter-active" className="text-sm font-medium">
+                Active sprint in progress
+              </Label>
+            </div>
+            <div className="flex items-center gap-2 border rounded-md p-3">
+              <Checkbox
+                id="filter-ready"
+                checked={showReadyOnly}
+                onCheckedChange={(checked) => setShowReadyOnly(Boolean(checked))}
+              />
+              <Label htmlFor="filter-ready" className="text-sm font-medium">
+                Ready for polish or release
+              </Label>
+            </div>
+            <div className="flex items-center gap-2 border rounded-md p-3">
+              <Checkbox
+                id="filter-locked"
+                checked={showLockedOnly}
+                onCheckedChange={(checked) => setShowLockedOnly(Boolean(checked))}
+              />
+              <Label htmlFor="filter-locked" className="text-sm font-medium">
+                Currently locked for recovery
+              </Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
       {globalActivityLock.locked && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
-          You're currently busy with {globalActivityLock.label ?? "another activity"}.{" "}
+          You're currently focused on {globalActivityLock.label ?? "another activity"}.{" "}
           {globalActivityCountdown
             ? `You'll be free ${globalActivityCountdown}.`
             : "Wrap up your current activity to start a new sprint."}
         </div>
       )}
 
-      {projects.length === 0 ? (
+      {filteredProjects.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
             <Music className="h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No projects yet</h3>
-            <p className="text-muted-foreground text-center mb-4">
-              Start your musical journey by creating your first songwriting project
+            <h3 className="text-lg font-semibold mb-2">No songwriting projects yet</h3>
+            <p className="text-muted-foreground text-center mb-4 max-w-md">
+              Capture a new concept, set creative targets, and let focus sprints carry you to a finished song.
             </p>
-            <Button onClick={() => setIsDialogOpen(true)}>
+            <Button onClick={handleOpenCreate}>
               <Plus className="h-4 w-4 mr-2" />
-              Create Your First Project
+              Start your first project
             </Button>
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredProjects.map((project) => {
-            const activeSession = project.songwriting_sessions?.find((session) => !session.completed_at) || null;
-            const { locked, message } = getLockMessage(project.locked_until);
-            const progressTarget = STATUS_THRESHOLDS.completed;
-            const progressValue = Math.min((project.sessions_completed / progressTarget) * 100, 100);
-            const sessionsRemaining = Math.max(progressTarget - project.sessions_completed, 0);
+            const statusMeta = getStatusMeta(project.status);
+            const activeSession = findActiveSession(project.songwriting_sessions);
+            const lockState = computeLockState(project.locked_until ?? null);
             const linkedSong = project.song_id ? songMap[project.song_id] : undefined;
-            const lyricsWordCount = project.lyrics?.trim() ? project.lyrics.trim().split(/\s+/).length : 0;
+            const musicPercent = getProgressPercent(project.music_progress);
+            const lyricsPercent = getProgressPercent(project.lyrics_progress);
+            const canConvert =
+              (project.music_progress ?? 0) >= MAX_PROGRESS &&
+              (project.lyrics_progress ?? 0) >= MAX_PROGRESS &&
+              !project.song_id;
 
             return (
               <Card key={project.id} className="hover:shadow-md transition-shadow">
                 <CardHeader>
-                  <div className="flex items-start justify-between">
+                  <div className="flex items-start justify-between gap-4">
                     <div className="space-y-1">
-                      <CardTitle className="text-lg">{project.title}</CardTitle>
-                      <CardDescription>
-                        {linkedSong ? (
-                          <span className="flex items-center gap-2">
-                            Linked song: <span className="font-medium">{linkedSong.title}</span>
+                      <CardTitle className="text-lg flex flex-wrap items-center gap-2">
+                        {project.title}
+                        {project.song_themes?.name && (
+                          <Badge variant="outline">{project.song_themes.name}</Badge>
+                        )}
+                      </CardTitle>
+                      <CardDescription className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        {project.chord_progressions ? (
+                          <span>
+                            Progression: <span className="font-medium">{project.chord_progressions.name}</span> · {project.chord_progressions.progression}
                           </span>
-                        ) : project.song_id ? (
-                          `Linked song: ${project.song_id}`
                         ) : (
-                          "No linked song"
+                          <span>No chord progression assigned yet</span>
+                        )}
+                        {project.theme_id && project.song_themes?.mood && (
+                          <span>Mood: {project.song_themes.mood}</span>
                         )}
                       </CardDescription>
                     </div>
-                    <Badge variant={getStatusBadgeVariant(project.status)}>
-                      {STATUSES.find((s) => s.value === project.status)?.label || project.status}
-                    </Badge>
+                    <Badge variant={statusMeta.badge}>{statusMeta.label}</Badge>
                   </div>
                 </CardHeader>
-
-                <CardContent className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">Sessions Completed</span>
-                      <span className="font-medium">{project.sessions_completed}</span>
+                <CardContent className="space-y-4 text-sm">
+                  <div className="space-y-3">
+                    <div>
+                      <div className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span>Music Progress</span>
+                        <span>{musicPercent}%</span>
+                      </div>
+                      <Progress value={musicPercent} className="mt-1 h-2" />
                     </div>
-                    <Progress value={progressValue} className="h-2" />
-                    <p className="text-xs text-muted-foreground">
-                      {project.sessions_completed >= progressTarget
-                        ? "This project is sprint-ready for final polish!"
-                        : `Complete ${sessionsRemaining} more session${sessionsRemaining === 1 ? "" : "s"} to reach mastery.`}
-                    </p>
+                    <div>
+                      <div className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span>Lyrics Progress</span>
+                        <span>{lyricsPercent}%</span>
+                      </div>
+                      <Progress value={lyricsPercent} className="mt-1 h-2" />
+                    </div>
+                    <div className="grid grid-cols-2 gap-4 text-xs text-muted-foreground">
+                      <div>
+                        <p>Sessions Logged</p>
+                        <p className="text-base font-semibold text-foreground">
+                          {project.total_sessions ?? 0} / {project.estimated_sessions ?? 3}
+                        </p>
+                      </div>
+                      <div>
+                        <p>Quality</p>
+                        <p className="text-base font-semibold text-foreground">{project.quality_score ?? 0}%</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {project.initial_lyrics && (
+                    <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground space-y-1">
+                      <p className="uppercase font-semibold text-[10px] tracking-wider">Concept notes</p>
+                      <p className="line-clamp-3 text-foreground">{project.initial_lyrics}</p>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Clock className="h-4 w-4" />
+                    <span className={lockState.locked ? "text-amber-600" : "text-emerald-600"}>{lockState.message}</span>
                   </div>
 
                   {linkedSong && (
-                    <div className="rounded-lg border p-3 text-xs space-y-2 bg-muted/40">
+                    <div className="rounded-lg border p-3 text-xs space-y-2 bg-muted/30">
                       <div className="flex items-center justify-between">
-                        <span className="font-medium">{linkedSong.genre}</span>
+                        <span className="font-medium text-foreground">{linkedSong.title}</span>
                         <Badge variant="outline">{linkedSong.status}</Badge>
                       </div>
                       <div className="grid grid-cols-2 gap-2">
                         <div>
+                          <p className="text-muted-foreground">Genre</p>
+                          <p className="font-semibold text-foreground">{linkedSong.genre}</p>
+                        </div>
+                        <div>
                           <p className="text-muted-foreground">Quality</p>
-                          <p className="font-semibold">{linkedSong.quality_score}</p>
+                          <p className="font-semibold text-foreground">{linkedSong.quality_score}</p>
                         </div>
                         <div>
                           <p className="text-muted-foreground">Streams</p>
-                          <p className="font-semibold">{formatNumber.format(linkedSong.streams)}</p>
+                          <p className="font-semibold text-foreground">{formatNumber.format(linkedSong.streams)}</p>
                         </div>
                         <div>
                           <p className="text-muted-foreground">Revenue</p>
-                          <p className="font-semibold">{formatCurrency.format(linkedSong.revenue)}</p>
+                          <p className="font-semibold text-foreground">{formatCurrency.format(linkedSong.revenue)}</p>
                         </div>
-                        <div>
+                        <div className="col-span-2">
                           <p className="text-muted-foreground">Release</p>
-                          <p className="font-semibold">
+                          <p className="font-semibold text-foreground">
                             {linkedSong.release_date
                               ? new Date(linkedSong.release_date).toLocaleDateString()
                               : "TBD"}
@@ -1012,26 +973,7 @@ const Songwriting = () => {
                     </div>
                   )}
 
-                  <div className="flex items-center gap-2 text-sm">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    <span className={locked ? "text-muted-foreground" : "text-emerald-600"}>{message}</span>
-                  </div>
-
-                  {project.lyrics && (
-                    <div className="text-sm">
-                      <span className="text-muted-foreground">Preview:</span>
-                      <p className="text-xs mt-1 line-clamp-2 text-muted-foreground">
-                        {project.lyrics.substring(0, 100)}...
-                      </p>
-                    </div>
-                  )}
-
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>Lyrics snapshot · {lyricsWordCount} words</span>
-                    <span>Created {new Date(project.created_at).toLocaleDateString()}</span>
-                  </div>
-
-                  <Separator className="my-2" />
+                  <Separator />
 
                   <div className="flex flex-col gap-2">
                     <div className="flex gap-2">
@@ -1039,7 +981,12 @@ const Songwriting = () => {
                         size="sm"
                         className="flex-1"
                         onClick={() => handleStartSession(project)}
-                        disabled={locked || !!activeSession || globalActivityLock.locked}
+                        disabled={
+                          lockState.locked ||
+                          Boolean(activeSession) ||
+                          globalActivityLock.locked ||
+                          startSession.isPending
+                        }
                       >
                         <Play className="h-3 w-3 mr-1" />
                         Start Sprint
@@ -1049,45 +996,55 @@ const Songwriting = () => {
                         variant="outline"
                         className="flex-1"
                         onClick={() => handleOpenCompletionDialog(project)}
-                        disabled={!activeSession}
+                        disabled={!activeSession || completeSession.isPending}
                       >
                         <CheckCircle2 className="h-3 w-3 mr-1" />
                         Complete Sprint
                       </Button>
                     </div>
-
                     {activeSession && (
-                      <div className="text-xs text-muted-foreground text-center">
-                        Active sprint started {new Date(activeSession.started_at).toLocaleTimeString()}.
-                      </div>
+                      <p className="text-center text-xs text-muted-foreground">
+                        Active sprint started {new Date(activeSession.started_at ?? activeSession.session_start).toLocaleTimeString()}.
+                      </p>
                     )}
                     {globalActivityLock.locked && (
-                      <div className="text-xs text-muted-foreground text-center">
+                      <p className="text-center text-xs text-muted-foreground">
                         Global focus busy
-                        {globalActivityCountdown ? ` until ${globalActivityCountdown}` : ' with another activity.'}
-                      </div>
+                        {globalActivityCountdown ? ` until ${globalActivityCountdown}` : " with another activity."}
+                      </p>
                     )}
                   </div>
 
-                  <div className="flex justify-between items-center pt-2">
-                    <div className="flex gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
+                    <div className="flex flex-wrap gap-2">
                       <Button size="sm" variant="outline" onClick={() => handleEdit(project)}>
                         <Edit className="h-3 w-3" />
                       </Button>
-                      <Button size="sm" variant="outline" onClick={() => handleDelete(project.id)}>
+                      <Button size="sm" variant="outline" onClick={() => handleDelete(project)}>
                         <Trash2 className="h-3 w-3" />
                       </Button>
                       <Button
                         size="sm"
                         variant="outline"
-                        onClick={() => handleOpenHistoryDialog(project)}
+                        onClick={() => {
+                          setHistoryProject(project);
+                          setIsHistoryOpen(true);
+                        }}
                         disabled={!project.songwriting_sessions?.length}
                       >
                         <History className="h-3 w-3 mr-1" />
                         History
                       </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => handleConvertProject(project)}
+                        disabled={!canConvert || convertToSong.isPending}
+                      >
+                        <Wand2 className="h-3 w-3 mr-1" />
+                        Convert to Song
+                      </Button>
                     </div>
-
                     <div className="text-xs text-muted-foreground">
                       Updated {new Date(project.updated_at).toLocaleDateString()}
                     </div>
@@ -1099,7 +1056,7 @@ const Songwriting = () => {
         </div>
       )}
 
-      <Dialog open={completionDialogOpen} onOpenChange={handleCompletionDialogChange}>
+      <Dialog open={Boolean(completionProject)} onOpenChange={handleCompletionDialogChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Log your sprint notes</DialogTitle>
@@ -1107,7 +1064,7 @@ const Songwriting = () => {
               Capture the breakthroughs from this focus session before marking it complete.
             </DialogDescription>
           </DialogHeader>
-          <form className="space-y-4" onSubmit={handleCompleteSessionWithNotes}>
+          <form className="space-y-4" onSubmit={handleCompleteSessionSubmit}>
             <div className="space-y-2">
               <Label htmlFor="completion-notes">What did you accomplish?</Label>
               <Textarea
@@ -1116,15 +1073,13 @@ const Songwriting = () => {
                 onChange={(event) => setCompletionNotes(event.target.value)}
                 placeholder="Captured a new chorus hook, refined verse lyrics..."
               />
-              <p className="text-xs text-muted-foreground text-right">
-                {completionNotes.trim() ? `${completionNotes.trim().split(/\s+/).length} words` : "0 words"}
-              </p>
+              <p className="text-xs text-muted-foreground text-right">{formatWordCount(completionNotes)}</p>
             </div>
             <div className="flex justify-end gap-2">
-              <Button type="button" variant="outline" onClick={() => setCompletionDialogOpen(false)}>
+              <Button type="button" variant="outline" onClick={() => handleCompletionDialogChange(false)}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={!completionProject}>
+              <Button type="submit" disabled={!completionProject || completeSession.isPending}>
                 Complete Sprint
               </Button>
             </div>
@@ -1139,44 +1094,58 @@ const Songwriting = () => {
               {historyProject ? `Sprint history · ${historyProject.title}` : "Sprint history"}
             </DialogTitle>
             <DialogDescription>
-              Review every focus sprint, including timestamps and notes captured along the way.
+              Review every focus sprint, including timestamps, gains, and notes captured along the way.
             </DialogDescription>
           </DialogHeader>
           <ScrollArea className="h-72 pr-4">
             <div className="space-y-4">
               {historyProject?.songwriting_sessions && historyProject.songwriting_sessions.length > 0 ? (
                 [...historyProject.songwriting_sessions]
-                  .sort(
-                    (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime()
-                  )
-                  .map((session) => (
-                    <div key={session.id} className="rounded-md border p-3 text-sm space-y-2">
-                      <div className="flex items-start justify-between">
-                        <div>
-                          <p className="font-medium">
-                            {new Date(session.started_at).toLocaleString()}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            Locked until {new Date(session.locked_until).toLocaleTimeString()}
-                          </p>
+                  .sort((a, b) => new Date(b.started_at ?? b.session_start).getTime() - new Date(a.started_at ?? a.session_start).getTime())
+                  .map((session) => {
+                    const started = session.started_at ?? session.session_start;
+                    const ended = session.completed_at ?? session.session_end;
+                    return (
+                      <div key={session.id} className="rounded-md border p-3 text-sm space-y-2">
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="font-medium">{new Date(started).toLocaleString()}</p>
+                            {session.locked_until && (
+                              <p className="text-xs text-muted-foreground">
+                                Locked until {new Date(session.locked_until).toLocaleTimeString()}
+                              </p>
+                            )}
+                          </div>
+                          <Badge variant={session.completed_at ? "default" : "secondary"}>
+                            {session.completed_at ? "Completed" : "In progress"}
+                          </Badge>
                         </div>
-                        <Badge variant={session.completed_at ? "default" : "secondary"}>
-                          {session.completed_at ? "Completed" : "In progress"}
-                        </Badge>
+                        {ended && (
+                          <p className="text-xs text-muted-foreground">Completed {new Date(ended).toLocaleString()}</p>
+                        )}
+                        <div className="grid grid-cols-3 gap-2 text-xs text-muted-foreground">
+                          <div>
+                            <p>Music +</p>
+                            <p className="font-semibold text-foreground">{session.music_progress_gained ?? 0}</p>
+                          </div>
+                          <div>
+                            <p>Lyrics +</p>
+                            <p className="font-semibold text-foreground">{session.lyrics_progress_gained ?? 0}</p>
+                          </div>
+                          <div>
+                            <p>XP</p>
+                            <p className="font-semibold text-foreground">{session.xp_earned ?? 0}</p>
+                          </div>
+                        </div>
+                        {session.notes && (
+                          <div className="rounded-md bg-muted/40 p-2">
+                            <p className="text-xs uppercase text-muted-foreground mb-1">Session notes</p>
+                            <p>{session.notes}</p>
+                          </div>
+                        )}
                       </div>
-                      {session.completed_at && (
-                        <p className="text-xs text-muted-foreground">
-                          Completed {new Date(session.completed_at).toLocaleString()}
-                        </p>
-                      )}
-                      {session.notes && (
-                        <div className="rounded-md bg-muted/40 p-2">
-                          <p className="text-xs uppercase text-muted-foreground mb-1">Session notes</p>
-                          <p>{session.notes}</p>
-                        </div>
-                      )}
-                    </div>
-                  ))
+                    );
+                  })
               ) : (
                 <div className="text-sm text-muted-foreground">
                   No sprint history recorded yet. Complete a sprint to see it here.


### PR DESCRIPTION
## Summary
- extend the songwriting data hook to expose themes, chord progressions, session history, and full project lifecycle mutations
- rebuild the songwriting studio page with enhanced project forms, progress tracking, filtering, and conversion flows tied to the new hook

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any errors in Supabase stubs and functions)*

------
https://chatgpt.com/codex/tasks/task_e_68da51275310832592ab2bb5b2a73ca5