### PR TITLE
Scope songwriting data by user

### DIFF
--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -100,13 +100,15 @@ export const getSongQualityDescriptor = (score: number): SongQualityDescriptor &
   return { ...band, score: normalized };
 };
 
-export const useSongwritingData = () => {
+export const useSongwritingData = (userId?: string | null) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const songThemesTableAvailableRef = useRef(true);
   const chordProgressionsTableAvailableRef = useRef(true);
   const songwritingProjectsTableAvailableRef = useRef(true);
+
+  const activeUserId = typeof userId === "string" && userId.length > 0 ? userId : null;
 
   const isMissingTableError = (error: unknown, tableName: string): boolean => {
     if (!error || typeof error !== "object") {
@@ -230,9 +232,9 @@ export const useSongwritingData = () => {
   });
 
   const { data: projects, isLoading: isLoadingProjects } = useQuery({
-    queryKey: ["songwriting-projects"],
+    queryKey: ["songwriting-projects", activeUserId ?? "anonymous"],
     queryFn: async () => {
-      if (!songwritingProjectsTableAvailableRef.current) {
+      if (!songwritingProjectsTableAvailableRef.current || !activeUserId) {
         return [] as SongwritingProject[];
       }
 
@@ -258,6 +260,7 @@ export const useSongwritingData = () => {
             created_at
           )
         `)
+        .eq("user_id", activeUserId)
         .order("created_at", { ascending: false });
 
       if (error) {

--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -161,7 +161,7 @@ const Songwriting = () => {
     startSession,
     completeSession,
     convertToSong,
-  } = useSongwritingData();
+  } = useSongwritingData(user?.id);
 
   const [songs, setSongs] = useState<Song[]>([]);
   const [statusFilter, setStatusFilter] = useState<string>("all");


### PR DESCRIPTION
## Summary
- scope the songwriting projects query by the active user so the page refreshes when accounts change
- pass the authenticated user id into the songwriting page hook

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da62899ce0832580a979b5a843487a