### PR TITLE
Add warn logging support to shared logger

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,4 +1,4 @@
-export type LogLevel = "info" | "error";
+export type LogLevel = "info" | "warn" | "error";
 
 export type LogContext = Record<string, unknown>;
 
@@ -10,15 +10,22 @@ const log = (level: LogLevel, message: string, context?: LogContext) => {
     ...(context ? { context } : {})
   };
 
-  if (level === "error") {
-    console.error(payload);
-  } else {
-    console.info(payload);
+  switch (level) {
+    case "error":
+      console.error(payload);
+      break;
+    case "warn":
+      console.warn(payload);
+      break;
+    default:
+      console.info(payload);
+      break;
   }
 };
 
 export const logger = {
   info: (message: string, context?: LogContext) => log("info", message, context),
+  warn: (message: string, context?: LogContext) => log("warn", message, context),
   error: (message: string, context?: LogContext) => log("error", message, context)
 };
 


### PR DESCRIPTION
## Summary
- extend the shared logger to include a warn level and route warnings to console.warn so existing call sites can use it

## Testing
- npm run lint *(fails: existing lint errors in stub files)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68da74646ed48325b1366db1e944b992