### PR TITLE
Handle missing GameData context gracefully

### DIFF
--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -369,6 +369,9 @@ const mapAttributes = (row: RawAttributes): PlayerAttributes => {
 
 const GameDataContext = createContext<UseGameDataReturn | undefined>(undefined);
 
+export const useOptionalGameData = (): UseGameDataReturn | undefined =>
+  useContext(GameDataContext);
+
 const useProvideGameData = (): UseGameDataReturn => {
   const { user } = useAuth();
   const [profile, setProfile] = useState<PlayerProfile | null>(null);
@@ -1966,7 +1969,7 @@ export const GameDataProvider = ({ children }: GameDataProviderProps) => {
 };
 
 export const useGameData = (): UseGameDataReturn => {
-  const context = useContext(GameDataContext);
+  const context = useOptionalGameData();
 
   if (!context) {
     throw new Error("useGameData must be used within a GameDataProvider");

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,14 +3,17 @@ import { useNavigate } from "react-router-dom";
 import { AlertCircle, Loader2 } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth-context";
-import { useGameData } from "@/hooks/useGameData";
+import { useOptionalGameData } from "@/hooks/useGameData";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 
 const Index = () => {
   const navigate = useNavigate();
   const { user, loading: authLoading } = useAuth();
-  const { profile, loading: dataLoading, error } = useGameData();
+  const gameData = useOptionalGameData();
+  const profile = gameData?.profile ?? null;
+  const dataLoading = gameData?.loading ?? true;
+  const error = gameData?.error;
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -19,12 +22,16 @@ const Index = () => {
   }, [user, authLoading, navigate]);
 
   useEffect(() => {
+    if (!gameData) {
+      return;
+    }
+
     if (!authLoading && !dataLoading && user) {
       navigate(profile ? "/dashboard" : "/my-character");
     }
-  }, [authLoading, dataLoading, user, profile, navigate]);
+  }, [authLoading, dataLoading, gameData, navigate, profile, user]);
 
-  if (authLoading || dataLoading) {
+  if (!gameData || authLoading || dataLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gradient-stage">
         <Loader2 className="h-12 w-12 animate-spin text-primary" />


### PR DESCRIPTION
## Summary
- expose a safe game data hook so consumers can avoid crashing when the provider is absent
- guard the index page against missing game data context and show the existing loading state instead of throwing

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd18b5772883258300efaca33f4cf9