### PR TITLE
Fix BandManager import to avoid chunk load errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,12 @@ import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import WorldPulsePage from "./pages/WorldPulse";
 import MusicStudio from "./pages/MusicStudio";
+import BandManager from "./pages/BandManager";
 
 const Layout = lazyWithRetry(() => import("./components/Layout"));
 const Index = lazyWithRetry(() => import("./pages/Index"));
 const PerformGig = lazyWithRetry(() => import("./pages/PerformGig"));
 const Dashboard = lazyWithRetry(() => import("./pages/Dashboard"));
-const BandManager = lazyWithRetry(() => import("./pages/BandManager"));
 const GigBooking = lazyWithRetry(() => import("./pages/GigBooking"));
 const MyCharacter = lazyWithRetry(() => import("./pages/MyCharacter"));
 const Schedule = lazyWithRetry(() => import("./pages/Schedule"));


### PR DESCRIPTION
## Summary
- load the BandManager route component synchronously so the bundle no longer relies on a failing dynamic chunk

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd1c45c97c8325a80fdc4b007aae74