### PR TITLE
Add PostgREST schema reload notifications to songwriting migrations

### DIFF
--- a/supabase/migrations/20270606100000_add_profile_activity_statuses.sql
+++ b/supabase/migrations/20270606100000_add_profile_activity_statuses.sql
@@ -80,3 +80,5 @@ ALTER TABLE public.activity_feed
 ALTER TABLE public.activity_feed
   ADD CONSTRAINT IF NOT EXISTS activity_feed_duration_check
   CHECK (duration_minutes IS NULL OR duration_minutes >= 0);
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20270607100000_create_songwriting_tables.sql
+++ b/supabase/migrations/20270607100000_create_songwriting_tables.sql
@@ -96,3 +96,5 @@ CREATE POLICY "Songwriting sessions can be deleted by owners"
   ON public.songwriting_sessions
   FOR DELETE
   USING (user_id = auth.uid());
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20270610120000_align_songwriting_schema.sql
+++ b/supabase/migrations/20270610120000_align_songwriting_schema.sql
@@ -69,3 +69,5 @@ CREATE INDEX IF NOT EXISTS songwriting_sessions_started_at_idx
 -- Validate the new check constraint once existing data is in place
 ALTER TABLE public.songwriting_projects
   VALIDATE CONSTRAINT songwriting_projects_sessions_completed_check;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20270630153000_expand_songwriting_and_activity_schema.sql
+++ b/supabase/migrations/20270630153000_expand_songwriting_and_activity_schema.sql
@@ -147,3 +147,5 @@ WHERE
   music_progress IS NULL
   OR lyrics_progress IS NULL
   OR total_sessions IS NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20270630170000_refine_songwriting_schema.sql
+++ b/supabase/migrations/20270630170000_refine_songwriting_schema.sql
@@ -171,4 +171,5 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+NOTIFY pgrst, 'reload schema';
 COMMIT;


### PR DESCRIPTION
## Summary
- add PostgREST schema reload notifications at the end of profile activity status and songwriting migrations
- ensure the songwriting refinement migration notifies before committing so PostgREST refreshes immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3d5564e88325acb4b0c198df2d11