### PR TITLE
Add awards planning data and navigation entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const PublicRelations = lazyWithRetry(() => import("./pages/PublicRelations"));
 const City = lazyWithRetry(() => import("./pages/City"));
 const WorldMap = lazyWithRetry(() => import("./pages/WorldMap"));
 const Festivals = lazyWithRetry(() => import("./pages/Festivals"));
+const AwardShows = lazyWithRetry(() => import("./pages/AwardShows"));
 const SetlistDesigner = lazyWithRetry(() => import("./pages/SetlistDesigner"));
 const EnhancedEquipmentStore = lazyWithRetry(() => import("./pages/EnhancedEquipmentStore"));
 const EnhancedFanManagement = lazyWithRetry(() => import("./pages/EnhancedFanManagement"));
@@ -110,6 +111,7 @@ function App() {
                     <Route path="pr" element={<PublicRelations />} />
                     <Route path="venues" element={<VenueManagement />} />
                     <Route path="festivals" element={<Festivals />} />
+                    <Route path="awards" element={<AwardShows />} />
                     <Route path="chemistry" element={<BandChemistry />} />
                     <Route path="streaming" element={<StreamingPlatforms />} />
                     <Route path="stage-setup" element={<StageSetup />} />

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -35,6 +35,7 @@ import {
   Megaphone,
   Store,
   Guitar,
+  Award,
 } from "lucide-react";
 
 const Navigation = () => {
@@ -74,6 +75,7 @@ const Navigation = () => {
         { icon: MapPin, label: "Tour Manager", path: "/tours" },
         { icon: ListMusic, label: "Setlist Designer", path: "/setlists" },
         { icon: Calendar, label: "Festivals", path: "/festivals" },
+        { icon: Award, label: "Awards", path: "/awards" },
         { icon: Building2, label: "Venue Management", path: "/venues" },
         { icon: Settings, label: "Stage Setup", path: "/stage-setup" },
         { icon: MapPin, label: "City Overview", path: cityOverviewPath },
@@ -122,6 +124,7 @@ const Navigation = () => {
     { icon: Calendar, label: "Gigs", path: "/gigs" },
     { icon: ListMusic, label: "Setlists", path: "/setlists" },
     { icon: Mic, label: "Busking", path: "/busking" },
+    { icon: Award, label: "Awards", path: "/awards" },
     { icon: Music4, label: "Jams", path: "/jams" },
     { icon: Plane, label: "Travel", path: "/travel" },
     { icon: Megaphone, label: "PR", path: "/pr" },

--- a/src/data/awardShows.ts
+++ b/src/data/awardShows.ts
@@ -1,0 +1,427 @@
+export type NominationFocus = "song" | "album" | "live_show" | "visuals" | "innovation";
+
+export interface AwardCategory {
+  name: string;
+  focus: NominationFocus;
+  nominationSource: string;
+  description: string;
+}
+
+export interface VotingBreakdown {
+  playerWeight: number;
+  npcWeight: number;
+  industryJuryWeight: number;
+  notes: string;
+}
+
+export interface PerformanceSlot {
+  slotLabel: string;
+  stage: string;
+  performer: string;
+  songs: [string, string];
+  notes: string;
+}
+
+export interface AwardSchedule {
+  nominationsOpen: string;
+  shortlistAnnounced: string;
+  votingWindow: string;
+  rehearsalDay: string;
+  ceremony: string;
+}
+
+export interface AwardRewards {
+  attendanceFameBoost: string;
+  winnerFameBoost: string;
+  additionalPerks: string[];
+}
+
+export interface AwardShow {
+  id: string;
+  name: string;
+  year: number;
+  venue: string;
+  district: string;
+  overview: string;
+  schedule: AwardSchedule;
+  categories: AwardCategory[];
+  voting: VotingBreakdown;
+  rewards: AwardRewards;
+  performanceSlots: PerformanceSlot[];
+  broadcastPartners: string[];
+}
+
+export const awardShows: AwardShow[] = [
+  {
+    id: "2025-riverlight",
+    name: "Riverlight Music Laurels",
+    year: 2025,
+    venue: "Royal Festival Hall",
+    district: "Southbank, London",
+    overview:
+      "A spring ceremony centered around narrative-driven performances that mix orchestral pop with immersive visual design. The Riverlight Laurels are where emerging storytellers from London's south bank earn international recognition.",
+    schedule: {
+      nominationsOpen: "Jan 6-24, 2025",
+      shortlistAnnounced: "Feb 10, 2025",
+      votingWindow: "Feb 12-Mar 3, 2025",
+      rehearsalDay: "Mar 18, 2025",
+      ceremony: "Mar 19, 2025 • 19:30 GMT",
+    },
+    categories: [
+      {
+        name: "Story-Driven Single of the Year",
+        focus: "song",
+        nominationSource: "Top streamed originals debuted in London venues Q2-Q4 2024",
+        description:
+          "Highlights singles that paired lyrical storytelling with visual identity, curated from south bank live residencies and underground premieres.",
+      },
+      {
+        name: "Immersive Album Narrative",
+        focus: "album",
+        nominationSource: "Albums released via UK indies with narrative liner activations",
+        description:
+          "Celebrates cohesive album arcs that integrated zines, podcasts, or VR walkthroughs sourced from Rockmundo partner labels.",
+      },
+      {
+        name: "Live Show Cinematics",
+        focus: "live_show",
+        nominationSource: "Fan attendance heatmaps and AR capture ratings from London clubs",
+        description:
+          "Rewards the most cinematic touring moment produced in London, tracked through Rockmundo's live show telemetry feeds.",
+      },
+      {
+        name: "Stagecraft Innovation",
+        focus: "innovation",
+        nominationSource: "Production design submissions from Southbank theatres",
+        description:
+          "Honors teams that experimented with lighting, projection, or stage movement to unlock new audience emotions.",
+      },
+    ],
+    voting: {
+      playerWeight: 0.45,
+      npcWeight: 0.35,
+      industryJuryWeight: 0.2,
+      notes:
+        "Player ballots lean on your Rockmundo influence score. NPC votes aggregate promoter sentiment, while a 9-person jury resolves ties with focus on long-term artistry.",
+    },
+    rewards: {
+      attendanceFameBoost: "+350 fame for verified attendees",
+      winnerFameBoost: "+1,200 fame plus London residency invitations",
+      additionalPerks: [
+        "Exclusive Southbank studio writing camp unlock",
+        "Custom AR stage pack usable in future gigs",
+        "Press amplification across Rockmundo social stories",
+      ],
+    },
+    performanceSlots: [
+      {
+        slotLabel: "Opening Immersion",
+        stage: "Main Hall",
+        performer: "Neon Tidemarks",
+        songs: ["Glass Rivers", "Signal Lanterns"],
+        notes: "Choreographed drone curtain reveals the Thames skyline in real time.",
+      },
+      {
+        slotLabel: "Narrative Spotlight",
+        stage: "Acoustic Atrium",
+        performer: "Aurora Grey",
+        songs: ["Letters to the Tide", "City of Echoes"],
+        notes: "Stripped arrangement with holographic journal entries projected behind the duo.",
+      },
+      {
+        slotLabel: "Player Feature",
+        stage: "Interactive Annex",
+        performer: "Player Spotlight",
+        songs: ["Custom Set Piece", "Second Act Reveal"],
+        notes: "Reserved for the top-ranked player nominee to premiere a new storytelling moment.",
+      },
+      {
+        slotLabel: "Riverlight Finale",
+        stage: "Main Hall",
+        performer: "Saffron City",
+        songs: ["Solar Drift", "Afterglow Lines"],
+        notes: "Finale synced with the Thames lightboats to close the ceremony.",
+      },
+    ],
+    broadcastPartners: ["BBC Music", "Rockmundo Live", "Southbank Streams"],
+  },
+  {
+    id: "2025-northbank",
+    name: "Northbank Vanguard Awards",
+    year: 2025,
+    venue: "Alexandra Palace",
+    district: "North London",
+    overview:
+      "Designed as a high-energy summer broadcast celebrating independent artists who turned crowd-funded experiments into arena-ready spectacles.",
+    schedule: {
+      nominationsOpen: "May 5-26, 2025",
+      shortlistAnnounced: "Jun 9, 2025",
+      votingWindow: "Jun 10-Jul 1, 2025",
+      rehearsalDay: "Jul 21, 2025",
+      ceremony: "Jul 22, 2025 • 20:00 GMT",
+    },
+    categories: [
+      {
+        name: "Breakthrough Anthem",
+        focus: "song",
+        nominationSource: "Crowd-funded singles that crossed 500k Rockmundo streams",
+        description:
+          "Spotlights breakthrough tracks where backers voted on arrangement choices through the Rockmundo studio network.",
+      },
+      {
+        name: "Independent Album Surge",
+        focus: "album",
+        nominationSource: "Albums distributed via player-managed labels with sold-out London release shows",
+        description:
+          "Recognizes DIY albums that translated grassroots momentum into tangible ticket demand across the UK.",
+      },
+      {
+        name: "Arena-Ready Live Moment",
+        focus: "live_show",
+        nominationSource: "Rockmundo show ratings from arenas across the Northbank corridor",
+        description:
+          "Honors the single live moment that received the highest real-time crowd engagement scores during the spring tour block.",
+      },
+      {
+        name: "Immersive Visual Suite",
+        focus: "visuals",
+        nominationSource: "3D stage visual submissions vetted by Rockmundo production guilds",
+        description:
+          "Elevates the visual teams who integrated volumetric capture and AI lighting cues into arena shows.",
+      },
+    ],
+    voting: {
+      playerWeight: 0.4,
+      npcWeight: 0.4,
+      industryJuryWeight: 0.2,
+      notes:
+        "Player and NPC weights are balanced to showcase both scene influence and the promoter guild's read on touring potential.",
+    },
+    rewards: {
+      attendanceFameBoost: "+420 fame for full-ceremony attendance",
+      winnerFameBoost: "+1,500 fame plus a global press day",
+      additionalPerks: [
+        "Arena-ready lighting rig loan for one tour stop",
+        "Professional crew matchmaking with Rockmundo partners",
+        "Placement on the Rockmundo Vanguard editorial playlist",
+      ],
+    },
+    performanceSlots: [
+      {
+        slotLabel: "Skyline Lift-Off",
+        stage: "Great Hall Mainstage",
+        performer: "Pulse Array",
+        songs: ["Northbound", "Signal Fire"],
+        notes: "Opens with a suspended lighting rig that descends over the crowd.",
+      },
+      {
+        slotLabel: "Backer Tribute",
+        stage: "360 Atrium",
+        performer: "The Ember Lights",
+        songs: ["City in Motion", "Anchorlines"],
+        notes: "Fan backers appear via volumetric projections singing the choruses.",
+      },
+      {
+        slotLabel: "Player Vanguard",
+        stage: "Immersion Dome",
+        performer: "Player Showcase",
+        songs: ["Signature Anthem", "New Release"],
+        notes: "Dedicated slot for the player project most upvoted by backers in 2025.",
+      },
+      {
+        slotLabel: "Nightfall Encore",
+        stage: "Great Hall Mainstage",
+        performer: "Novae",
+        songs: ["Light Arcs", "Echo Engines"],
+        notes: "Pyro and drone camera hand-off closes the summer broadcast.",
+      },
+    ],
+    broadcastPartners: ["Channel 4 Music", "Rockmundo Live", "IndieWire Sessions"],
+  },
+  {
+    id: "2026-thames-rising",
+    name: "Thames Rising Honors",
+    year: 2026,
+    venue: "The O2 Arena",
+    district: "Greenwich Peninsula, London",
+    overview:
+      "A winter gala aligning with the Rockmundo Rising talent accelerator, celebrating artists who turned mentorship cohorts into breakout campaigns.",
+    schedule: {
+      nominationsOpen: "Oct 6-24, 2025",
+      shortlistAnnounced: "Nov 17, 2025",
+      votingWindow: "Nov 18-Dec 12, 2025",
+      rehearsalDay: "Jan 14, 2026",
+      ceremony: "Jan 15, 2026 • 19:00 GMT",
+    },
+    categories: [
+      {
+        name: "Mentor Session Single",
+        focus: "song",
+        nominationSource: "Top tracked singles from Rockmundo mentor cohorts",
+        description:
+          "Highlights the songs that best translated mentorship feedback into streaming spikes and narrative growth.",
+      },
+      {
+        name: "Ascendant Album Journey",
+        focus: "album",
+        nominationSource: "Albums released during the Rising accelerator showcase",
+        description:
+          "Awards the albums that delivered the strongest story arc and retained listener engagement end-to-end.",
+      },
+      {
+        name: "Breakout Live Residency",
+        focus: "live_show",
+        nominationSource: "Residency attendance and encore request metrics from London partner venues",
+        description:
+          "Spotlights artists who converted intimate residencies into must-see rituals across the Thames corridor.",
+      },
+      {
+        name: "Immersive Mentor Collab",
+        focus: "innovation",
+        nominationSource: "Cross-mentor performance experiments logged in Rockmundo",
+        description:
+          "Celebrates collaborative performances that fused mentor and mentee artistry in novel formats.",
+      },
+    ],
+    voting: {
+      playerWeight: 0.5,
+      npcWeight: 0.3,
+      industryJuryWeight: 0.2,
+      notes:
+        "Players command half the vote, empowering accelerator cohorts, while venue partners and mentors share the remaining influence.",
+    },
+    rewards: {
+      attendanceFameBoost: "+380 fame for ceremony participation",
+      winnerFameBoost: "+1,350 fame and a European showcase booking",
+      additionalPerks: [
+        "Mentor studio residencies extended for one quarter",
+        "O2 Arena rehearsal capture for tour marketing",
+        "Spotlight feature in Rockmundo Rising documentary",
+      ],
+    },
+    performanceSlots: [
+      {
+        slotLabel: "Mentor Overture",
+        stage: "Main Stage",
+        performer: "Guided Lights Ensemble",
+        songs: ["Arcade Bloom", "Signal Paths"],
+        notes: "Mentors join mentees for a hybrid orchestral-electronic opener.",
+      },
+      {
+        slotLabel: "Residency Replay",
+        stage: "Satellite Stage",
+        performer: "Riverheart",
+        songs: ["Midnight Keepsake", "Golden Wake"],
+        notes: "Recreates the most upvoted residency moment from the accelerator.",
+      },
+      {
+        slotLabel: "Player Rising",
+        stage: "Main Stage",
+        performer: "Player Spotlight",
+        songs: ["Cohort Anthem", "Unreleased Finale"],
+        notes: "Showcases the accelerator participant with the highest mentor synergy score.",
+      },
+      {
+        slotLabel: "O2 Closer",
+        stage: "Main Stage",
+        performer: "Vast Cartography",
+        songs: ["Northern Lights", "Keep the Signal"],
+        notes: "Arena-scale closing moment featuring interactive wristband lighting.",
+      },
+    ],
+    broadcastPartners: ["ITV Music", "Rockmundo Live", "MentorWave"],
+  },
+  {
+    id: "2026-skyline-laurels",
+    name: "Skyline Laurels Showcase",
+    year: 2026,
+    venue: "Roundhouse",
+    district: "Camden, London",
+    overview:
+      "A summer gathering that merges Camden's iconic venues with Rockmundo's AI-driven performance analytics to highlight artists pushing cultural conversations forward.",
+    schedule: {
+      nominationsOpen: "Mar 2-23, 2026",
+      shortlistAnnounced: "Apr 13, 2026",
+      votingWindow: "Apr 15-May 6, 2026",
+      rehearsalDay: "Jun 1, 2026",
+      ceremony: "Jun 2, 2026 • 19:30 GMT",
+    },
+    categories: [
+      {
+        name: "Cultural Pulse Single",
+        focus: "song",
+        nominationSource: "Songs with top cultural sentiment scores across Rockmundo socials",
+        description:
+          "Rewards singles that sparked meaningful conversations and positive sentiment within the community.",
+      },
+      {
+        name: "Conceptual Album Experience",
+        focus: "album",
+        nominationSource: "Albums submitted with multimedia companion drops",
+        description:
+          "Highlights albums that used videos, pop-ups, or zines to extend the narrative and deepen fan immersion.",
+      },
+      {
+        name: "Live Community Catalyst",
+        focus: "live_show",
+        nominationSource: "Camden venue attendance lifts and encore streaks",
+        description:
+          "Honors shows that grew local communities and sustained multi-night energy at the Roundhouse and surrounding clubs.",
+      },
+      {
+        name: "Visual Story Installation",
+        focus: "visuals",
+        nominationSource: "Projection and stage design submissions from Camden collectives",
+        description:
+          "Showcases art teams that transformed venues into narrative installations paired with live performance.",
+      },
+    ],
+    voting: {
+      playerWeight: 0.42,
+      npcWeight: 0.38,
+      industryJuryWeight: 0.2,
+      notes:
+        "NPC votes capture venue owner and promoter sentiment, while the jury introduces cultural critics to balance the narrative.",
+    },
+    rewards: {
+      attendanceFameBoost: "+400 fame for verified attendance",
+      winnerFameBoost: "+1,480 fame and global editorial coverage",
+      additionalPerks: [
+        "Camden residency support package",
+        "AI stage designer beta access",
+        "Featured slot on Rockmundo's Skyline podcast series",
+      ],
+    },
+    performanceSlots: [
+      {
+        slotLabel: "Roundhouse Arrival",
+        stage: "Main Hall",
+        performer: "Signal Fires",
+        songs: ["Lumen", "Paper Planes"],
+        notes: "Combines kinetic lighting with live illustration projection.",
+      },
+      {
+        slotLabel: "Community Cipher",
+        stage: "Circular Stage",
+        performer: "Night Glyph",
+        songs: ["Skyline Verse", "Pulse Theory"],
+        notes: "Features rotating community vocalists chosen via Rockmundo fan polls.",
+      },
+      {
+        slotLabel: "Player Laureate",
+        stage: "Main Hall",
+        performer: "Player Showcase",
+        songs: ["Signature Piece", "Surprise Collaboration"],
+        notes: "Dedicated slot for the player nominee driving the highest community impact metrics.",
+      },
+      {
+        slotLabel: "Skyline Finale",
+        stage: "Main Hall",
+        performer: "Celeste Flux",
+        songs: ["After Midnight", "Skyline Dream"],
+        notes: "Immersive finale with crowd-synced starfield projections.",
+      },
+    ],
+    broadcastPartners: ["Channel 4 Music", "Rockmundo Live", "Skyline Sessions"],
+  },
+];

--- a/src/pages/AwardShows.tsx
+++ b/src/pages/AwardShows.tsx
@@ -1,0 +1,216 @@
+import { awardShows } from "@/data/awardShows";
+import { useGameData } from "@/hooks/useGameData";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Award as AwardIcon, CalendarDays, MapPin, Star, Users } from "lucide-react";
+
+const scheduleLabels: Record<keyof (typeof awardShows)[number]["schedule"], string> = {
+  nominationsOpen: "Nominations",
+  shortlistAnnounced: "Shortlist Reveal",
+  votingWindow: "Voting",
+  rehearsalDay: "Rehearsal",
+  ceremony: "Ceremony",
+};
+
+export default function AwardShows() {
+  const { profile } = useGameData();
+  const stageIdentity =
+    profile?.stage_name || profile?.display_name || profile?.username || "your project";
+
+  return (
+    <div className="container mx-auto space-y-12 px-4 py-10">
+      <header className="space-y-4 text-center md:text-left">
+        <Badge variant="secondary" className="text-sm uppercase tracking-wide">
+          Awards Network Preview
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">London Award Shows</h1>
+          <p className="mx-auto max-w-3xl text-muted-foreground md:mx-0 md:text-base">
+            Rockmundo is mapping the capital&apos;s prestige circuits so {stageIdentity} can plan nomination campaigns,
+            voting pushes, and performance narratives ahead of the live data feeds. Each showcase below outlines
+            rehearsal windows, category sourcing, and the exact fame boosts tied to attendance and wins.
+          </p>
+        </div>
+        <div className="grid gap-4 rounded-lg border border-dashed border-primary/40 bg-muted/10 p-6 md:grid-cols-2">
+          <div className="space-y-2 text-left">
+            <h2 className="flex items-center gap-2 text-lg font-semibold">
+              <AwardIcon className="h-5 w-5 text-primary" />
+              Why prep now?
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Build momentum by aligning release cadences and tour stops with the nomination sourcing windows. These
+              placeholders will later sync to real ticketing, stream deltas, and influencer reach metrics.
+            </p>
+          </div>
+          <div className="space-y-2 text-left">
+            <h2 className="flex items-center gap-2 text-lg font-semibold">
+              <Star className="h-5 w-5 text-primary" />
+              Fame acceleration
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Attendance and wins layer onto your fame ledger. Plan for the ceremonies that best fit your sonic identity
+              and performance capacity to maximize the reputation lift.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid gap-8 lg:grid-cols-2">
+        {awardShows.map((show) => (
+          <Card key={show.id} className="flex flex-col justify-between">
+            <CardHeader className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline" className="uppercase tracking-wide">
+                  {show.year}
+                </Badge>
+                <Badge variant="outline" className="border-dashed">
+                  {show.schedule.ceremony}
+                </Badge>
+              </div>
+              <div className="space-y-2">
+                <CardTitle className="text-2xl">{show.name}</CardTitle>
+                <CardDescription>{show.overview}</CardDescription>
+              </div>
+              <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                <span className="flex items-center gap-2">
+                  <MapPin className="h-4 w-4 text-primary" />
+                  {show.district}
+                </span>
+                <span className="flex items-center gap-2">
+                  <CalendarDays className="h-4 w-4 text-primary" />
+                  {show.schedule.rehearsalDay}
+                </span>
+                <span className="flex items-center gap-2">
+                  <Users className="h-4 w-4 text-primary" />
+                  {show.broadcastPartners.join(" • ")}
+                </span>
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Categories preview
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {show.categories.map((category) => (
+                    <Badge key={`${show.id}-${category.name}`} variant="secondary" className="whitespace-nowrap">
+                      {category.name}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <section className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Timeline windows
+                </h4>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {Object.entries(show.schedule).map(([key, value]) => (
+                    <div
+                      key={`${show.id}-${key}`}
+                      className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground"
+                    >
+                      <p className="font-semibold text-foreground">{scheduleLabels[key as keyof typeof scheduleLabels]}</p>
+                      <p>{value}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Nomination sourcing
+                </h4>
+                <div className="space-y-3 text-sm text-muted-foreground">
+                  {show.categories.map((category) => (
+                    <div key={`${show.id}-${category.name}-source`} className="rounded-lg border border-border/60 p-4">
+                      <p className="text-sm font-semibold text-foreground">{category.name}</p>
+                      <p className="text-xs uppercase tracking-wide text-primary/80">Focus: {category.focus}</p>
+                      <p className="mt-2">{category.nominationSource}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{category.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Voting breakdown
+                </h4>
+                <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 p-4 text-sm text-muted-foreground">
+                  <div className="flex flex-wrap gap-6 text-foreground">
+                    <span className="font-semibold">Player influence: {(show.voting.playerWeight * 100).toFixed(0)}%</span>
+                    <span className="font-semibold">NPC guilds: {(show.voting.npcWeight * 100).toFixed(0)}%</span>
+                    <span className="font-semibold">Industry jury: {(show.voting.industryJuryWeight * 100).toFixed(0)}%</span>
+                  </div>
+                  <p className="mt-2">{show.voting.notes}</p>
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Attendance & winner rewards
+                </h4>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="rounded-lg border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
+                    <p className="text-sm font-semibold text-foreground">Ceremony attendance</p>
+                    <p>{show.rewards.attendanceFameBoost}</p>
+                    <p className="mt-2 text-xs uppercase tracking-wide text-primary/80">Plan: Ensure check-in scans complete.</p>
+                  </div>
+                  <div className="rounded-lg border border-border/60 bg-muted/30 p-4 text-sm text-muted-foreground">
+                    <p className="text-sm font-semibold text-foreground">Award victory</p>
+                    <p>{show.rewards.winnerFameBoost}</p>
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                      {show.rewards.additionalPerks.map((perk) => (
+                        <li key={`${show.id}-${perk}`}>{perk}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  Performance roster (4 slots · 2 songs each)
+                </h4>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Slot</TableHead>
+                      <TableHead>Stage</TableHead>
+                      <TableHead>Performer</TableHead>
+                      <TableHead>Songs</TableHead>
+                      <TableHead className="hidden md:table-cell">Notes</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {show.performanceSlots.map((slot) => (
+                      <TableRow key={`${show.id}-${slot.slotLabel}`}>
+                        <TableCell className="font-medium">{slot.slotLabel}</TableCell>
+                        <TableCell>{slot.stage}</TableCell>
+                        <TableCell>{slot.performer}</TableCell>
+                        <TableCell>{slot.songs.join(" • ")}</TableCell>
+                        <TableCell className="hidden md:table-cell text-muted-foreground">{slot.notes}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                {show.performanceSlots.length !== 4 && (
+                  <p className="text-xs font-semibold uppercase tracking-wide text-destructive">
+                    Placeholder roster must maintain exactly four bands with two-song sets.
+                  </p>
+                )}
+              </section>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <footer className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        These award profiles will evolve as Rockmundo ingests live partner data, unlocking automatic applications,
+        campaign reminders, and real-time voting analytics. Until then, use these scaffolds to map out your London
+        award season strategy and coordinate your crew.
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add structured London award show data with categories, voting breakdowns, rewards, and performance slots
- build Awards page that surfaces show timelines, nomination sources, voting weights, rewards, and roster tables using player profile context
- register the new Awards route and expose navigation entries for desktop and mobile menus

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3c6c3ff483259ffebf38c536ff10