### PR TITLE
Fix jam session host handling

### DIFF
--- a/src/pages/JamSessions.tsx
+++ b/src/pages/JamSessions.tsx
@@ -153,6 +153,15 @@ const JamSessions = () => {
       return;
     }
 
+    if (!profile?.id) {
+      toast({
+        title: "Profile not ready",
+        description: "We couldn't find your profile information. Please try again shortly.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     if (!formState.name || !formState.genre) {
       toast({
         title: "Missing information",
@@ -172,7 +181,7 @@ const JamSessions = () => {
     setCreatingSession(true);
 
     const payload: Database["public"]["Tables"]["jam_sessions"]["Insert"] = {
-      host_id: user.id,
+      host_id: profile.id,
       name: formState.name.trim(),
       description: formState.description.trim() || null,
       genre: formState.genre,
@@ -457,7 +466,7 @@ const JamSessions = () => {
               </div>
             ) : (
               jamSessions.map((session) => {
-                const isHost = session.host_id === user?.id;
+                const isHost = session.host_id === profile?.id;
                 const alreadyJoined = session.participant_ids?.includes(user?.id ?? "");
                 const isFull = (session.current_participants ?? 0) >= session.max_participants;
 


### PR DESCRIPTION
## Summary
- guard jam session creation so it only proceeds when the player's profile is loaded
- create sessions with the profile id as the host_id to satisfy foreign key and RLS rules
- compare jam session host ids against the profile id when deciding if the current user is the host

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de57cc5c0c832589b209a3a1f3d53c