### PR TITLE
Ensure skill XP spending returns updated progress

### DIFF
--- a/supabase/functions/progression/handlers.ts
+++ b/supabase/functions/progression/handlers.ts
@@ -4,6 +4,7 @@ import { fetchProfileState, type ProfileState } from "./index.ts";
 
 type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 type WalletRow = Database["public"]["Tables"]["player_xp_wallet"]["Row"];
+type SkillProgressRow = Database["public"]["Tables"]["skill_progress"]["Row"];
 
 export async function handleClaimDailyXp(
   client: SupabaseClient<Database>,
@@ -128,7 +129,7 @@ export async function handleSpendSkillXp(
   skillSlug: string,
   xpAmount: number,
   metadata: Record<string, unknown> = {},
-): Promise<ProfileState> {
+): Promise<{ state: ProfileState; skillProgress: SkillProgressRow }> {
   const profileId = profileState.profile.id;
   const currentBalance = profileState.wallet?.xp_balance ?? 0;
 
@@ -159,6 +160,8 @@ export async function handleSpendSkillXp(
   }
 
   // Update skill progress
+  const newRequiredXp = Math.floor(100 * Math.pow(1.5, newLevel));
+
   const { error: skillError } = await client
     .from("skill_progress")
     .upsert({
@@ -166,13 +169,28 @@ export async function handleSpendSkillXp(
       skill_slug: skillSlug,
       current_xp: remainingXp,
       current_level: newLevel,
-      required_xp: Math.floor(100 * Math.pow(1.5, newLevel)),
+      required_xp: newRequiredXp,
       last_practiced_at: new Date().toISOString(),
       metadata: metadata || {},
     }, { onConflict: "profile_id,skill_slug" });
 
   if (skillError) {
     throw new Error(skillError.message || "Failed to update skill");
+  }
+
+  const { data: updatedSkillProgress, error: fetchSkillError } = await client
+    .from("skill_progress")
+    .select("*")
+    .eq("profile_id", profileId)
+    .eq("skill_slug", skillSlug)
+    .maybeSingle();
+
+  if (fetchSkillError) {
+    throw new Error(fetchSkillError.message || "Failed to fetch updated skill progress");
+  }
+
+  if (!updatedSkillProgress) {
+    throw new Error("Updated skill progress not found");
   }
 
   // Deduct from wallet
@@ -190,5 +208,7 @@ export async function handleSpendSkillXp(
     throw new Error(walletError.message || "Failed to deduct XP");
   }
 
-  return await fetchProfileState(client, profileId);
+  const state = await fetchProfileState(client, profileId);
+
+  return { state, skillProgress: updatedSkillProgress };
 }

--- a/supabase/functions/progression/index.ts
+++ b/supabase/functions/progression/index.ts
@@ -149,6 +149,7 @@ serve(async (req) => {
 
     const profileState = await loadActiveProfile(client, user.id);
     let result: ProfileState;
+    let actionResult: Record<string, unknown> = {};
 
     switch (action) {
       case "claim_daily_xp":
@@ -166,8 +167,8 @@ serve(async (req) => {
         );
         break;
 
-      case "spend_skill_xp":
-        result = await handleSpendSkillXp(
+      case "spend_skill_xp": {
+        const { state, skillProgress } = await handleSpendSkillXp(
           client,
           user.id,
           profileState,
@@ -175,7 +176,10 @@ serve(async (req) => {
           params.xp ?? 25,
           params.metadata,
         );
+        result = state;
+        actionResult = { skill_progress: skillProgress };
         break;
+      }
 
       default:
         throw new Error(`Unknown action: ${action}`);
@@ -189,7 +193,7 @@ serve(async (req) => {
         wallet: result.wallet,
         attributes: result.attributes,
         cooldowns: {},
-        result: {},
+        result: actionResult,
       }),
       {
         headers: { ...corsHeaders, "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- include the updated `skill_progress` row in the spend skill XP edge function response
- fetch the persisted skill progress immediately after the upsert so it can be returned alongside the profile state
- rely on the returned skill progress row in `useGameData.spendSkillXp`, falling back to a manual fetch only when necessary so UI updates immediately

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de61e0ebe48325a80a12ffd7725313