### PR TITLE
Use released status for converted songs

### DIFF
--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -1402,7 +1402,7 @@ export const useSongwritingData = (userId?: string | null) => {
           total_sessions: normalizedProject.total_sessions,
           estimated_completion_sessions: estimatedSessions,
           songwriting_project_id: normalizedProject.id,
-          status: 'completed'
+          status: 'released'
         })
         .select()
         .single();


### PR DESCRIPTION
## Summary
- update the convertToSong mutation to persist newly created songs with a released status instead of the unsupported completed value
- confirm the Supabase songs status check constraint already allows the released option

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de68eda8f48325949a07af5a44eebc