### PR TITLE
Enhance songwriting schema and analytics

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1370,11 +1370,13 @@ export type Database = {
           cash: number | null
           created_at: string | null
           current_city_id: string | null
+          current_location: string
           display_name: string | null
           experience: number | null
           experience_at_last_weekly_bonus: number | null
           fame: number | null
           fans: number | null
+          health: number | null
           id: string
           last_weekly_bonus_at: string | null
           level: number | null
@@ -1390,11 +1392,13 @@ export type Database = {
           cash?: number | null
           created_at?: string | null
           current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
           experience?: number | null
           experience_at_last_weekly_bonus?: number | null
           fame?: number | null
           fans?: number | null
+          health?: number | null
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
@@ -1410,11 +1414,13 @@ export type Database = {
           cash?: number | null
           created_at?: string | null
           current_city_id?: string | null
+          current_location?: string
           display_name?: string | null
           experience?: number | null
           experience_at_last_weekly_bonus?: number | null
           fame?: number | null
           fans?: number | null
+          health?: number | null
           id?: string
           last_weekly_bonus_at?: string | null
           level?: number | null
@@ -1570,6 +1576,30 @@ export type Database = {
         }
         Relationships: []
       }
+      song_genre_catalog: {
+        Row: {
+          created_at: string
+          description: string | null
+          display_name: string
+          id: string
+          slug: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          display_name: string
+          id?: string
+          slug: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          display_name?: string
+          id?: string
+          slug?: string
+        }
+        Relationships: []
+      }
       song_themes: {
         Row: {
           created_at: string
@@ -1594,20 +1624,83 @@ export type Database = {
         }
         Relationships: []
       }
+      song_purposes: {
+        Row: {
+          created_at: string
+          description: string | null
+          focus_area: string | null
+          id: string
+          label: string
+          slug: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          focus_area?: string | null
+          id?: string
+          label: string
+          slug: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          focus_area?: string | null
+          id?: string
+          label?: string
+          slug?: string
+        }
+        Relationships: []
+      }
+      song_writing_modes: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: string
+          is_collaborative: boolean
+          label: string
+          slug: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_collaborative?: boolean
+          label: string
+          slug: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_collaborative?: boolean
+          label?: string
+          slug?: string
+        }
+        Relationships: []
+      }
       songs: {
         Row: {
+          arrangement_quality: number
           chart_position: number | null
           chord_progression_id: string | null
           created_at: string
           estimated_completion_sessions: number
           genre: string
+          genre_familiarity: number
+          genre_id: string | null
           id: string
           lyrics: string | null
           lyrics_progress: number
+          lyrics_quality: number
+          melody_quality: number
           music_progress: number
+          production_potential: number
           quality_score: number
           release_date: string | null
           revenue: number
+          rhythm_quality: number
+          song_purpose_id: string | null
+          song_rating: number
           songwriting_project_id: string | null
           status: string
           streams: number
@@ -1616,20 +1709,30 @@ export type Database = {
           total_sessions: number
           updated_at: string
           user_id: string
+          writing_mode_id: string | null
         }
         Insert: {
+          arrangement_quality?: number
           chart_position?: number | null
           chord_progression_id?: string | null
           created_at?: string
           estimated_completion_sessions?: number
           genre: string
+          genre_familiarity?: number
+          genre_id?: string | null
           id?: string
           lyrics?: string | null
           lyrics_progress?: number
+          lyrics_quality?: number
+          melody_quality?: number
           music_progress?: number
+          production_potential?: number
           quality_score?: number
           release_date?: string | null
           revenue?: number
+          rhythm_quality?: number
+          song_purpose_id?: string | null
+          song_rating?: number
           songwriting_project_id?: string | null
           status?: string
           streams?: number
@@ -1638,20 +1741,30 @@ export type Database = {
           total_sessions?: number
           updated_at?: string
           user_id: string
+          writing_mode_id?: string | null
         }
         Update: {
+          arrangement_quality?: number
           chart_position?: number | null
           chord_progression_id?: string | null
           created_at?: string
           estimated_completion_sessions?: number
           genre?: string
+          genre_familiarity?: number
+          genre_id?: string | null
           id?: string
           lyrics?: string | null
           lyrics_progress?: number
+          lyrics_quality?: number
+          melody_quality?: number
           music_progress?: number
+          production_potential?: number
           quality_score?: number
           release_date?: string | null
           revenue?: number
+          rhythm_quality?: number
+          song_purpose_id?: string | null
+          song_rating?: number
           songwriting_project_id?: string | null
           status?: string
           streams?: number
@@ -1660,6 +1773,7 @@ export type Database = {
           total_sessions?: number
           updated_at?: string
           user_id?: string
+          writing_mode_id?: string | null
         }
         Relationships: [
           {
@@ -1683,74 +1797,125 @@ export type Database = {
             referencedRelation: "song_themes"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "songs_genre_id_fkey"
+            columns: ["genre_id"]
+            isOneToOne: false
+            referencedRelation: "song_genre_catalog"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songs_song_purpose_id_fkey"
+            columns: ["song_purpose_id"]
+            isOneToOne: false
+            referencedRelation: "song_purposes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songs_writing_mode_id_fkey"
+            columns: ["writing_mode_id"]
+            isOneToOne: false
+            referencedRelation: "song_writing_modes"
+            referencedColumns: ["id"]
+          }
         ]
       }
       songwriting_projects: {
         Row: {
+          arrangement_quality: number
           chord_progression_id: string | null
           created_at: string
           estimated_completion_sessions: number
           estimated_sessions: number | null
+          genre_familiarity: number
+          genre_id: string | null
           id: string
           initial_lyrics: string | null
           is_locked: boolean
           locked_until: string | null
           lyrics: string | null
           lyrics_progress: number
+          lyrics_quality: number
+          melody_quality: number
           music_progress: number
+          production_potential: number
           quality_score: number
-          status: string | null
+          rhythm_quality: number
           song_id: string | null
+          song_purpose_id: string | null
+          song_rating: number
           sessions_completed: number
+          status: string | null
           theme_id: string | null
           title: string
           total_sessions: number
           updated_at: string
           user_id: string
+          writing_mode_id: string | null
         }
         Insert: {
+          arrangement_quality?: number
           chord_progression_id?: string | null
           created_at?: string
           estimated_completion_sessions?: number
           estimated_sessions?: number | null
+          genre_familiarity?: number
+          genre_id?: string | null
           id?: string
           initial_lyrics?: string | null
           is_locked?: boolean
           locked_until?: string | null
           lyrics?: string | null
           lyrics_progress?: number
+          lyrics_quality?: number
+          melody_quality?: number
           music_progress?: number
+          production_potential?: number
           quality_score?: number
-          status?: string | null
+          rhythm_quality?: number
           song_id?: string | null
+          song_purpose_id?: string | null
+          song_rating?: number
           sessions_completed?: number
+          status?: string | null
           theme_id?: string | null
           title: string
           total_sessions?: number
           updated_at?: string
           user_id: string
+          writing_mode_id?: string | null
         }
         Update: {
+          arrangement_quality?: number
           chord_progression_id?: string | null
           created_at?: string
           estimated_completion_sessions?: number
           estimated_sessions?: number | null
+          genre_familiarity?: number
+          genre_id?: string | null
           id?: string
           initial_lyrics?: string | null
           is_locked?: boolean
           locked_until?: string | null
           lyrics?: string | null
           lyrics_progress?: number
+          lyrics_quality?: number
+          melody_quality?: number
           music_progress?: number
+          production_potential?: number
           quality_score?: number
-          status?: string | null
+          rhythm_quality?: number
           song_id?: string | null
+          song_purpose_id?: string | null
+          song_rating?: number
           sessions_completed?: number
+          status?: string | null
           theme_id?: string | null
           title?: string
           total_sessions?: number
           updated_at?: string
           user_id?: string
+          writing_mode_id?: string | null
         }
         Relationships: [
           {
@@ -1774,6 +1939,75 @@ export type Database = {
             referencedRelation: "songs"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "songwriting_projects_genre_id_fkey"
+            columns: ["genre_id"]
+            isOneToOne: false
+            referencedRelation: "song_genre_catalog"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_projects_song_purpose_id_fkey"
+            columns: ["song_purpose_id"]
+            isOneToOne: false
+            referencedRelation: "song_purposes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_projects_writing_mode_id_fkey"
+            columns: ["writing_mode_id"]
+            isOneToOne: false
+            referencedRelation: "song_writing_modes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      songwriting_project_collaborators: {
+        Row: {
+          contribution_scope: string | null
+          created_at: string
+          id: string
+          profile_id: string
+          project_id: string
+          role: string | null
+          royalty_split: number
+          updated_at: string
+        }
+        Insert: {
+          contribution_scope?: string | null
+          created_at?: string
+          id?: string
+          profile_id: string
+          project_id: string
+          role?: string | null
+          royalty_split?: number
+          updated_at?: string
+        }
+        Update: {
+          contribution_scope?: string | null
+          created_at?: string
+          id?: string
+          profile_id?: string
+          project_id?: string
+          role?: string | null
+          royalty_split?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "songwriting_project_collaborators_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_project_collaborators_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "songwriting_projects"
+            referencedColumns: ["id"]
+          }
         ]
       }
       songwriting_sessions: {
@@ -1830,6 +2064,64 @@ export type Database = {
             referencedRelation: "songwriting_projects"
             referencedColumns: ["id"]
           },
+        ]
+      }
+      songwriting_session_contributors: {
+        Row: {
+          created_at: string
+          id: string
+          minutes_participated: number
+          profile_id: string
+          project_id: string
+          role: string | null
+          royalty_split: number
+          session_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          minutes_participated?: number
+          profile_id: string
+          project_id: string
+          role?: string | null
+          royalty_split?: number
+          session_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          minutes_participated?: number
+          profile_id?: string
+          project_id?: string
+          role?: string | null
+          royalty_split?: number
+          session_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "songwriting_session_contributors_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_session_contributors_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "songwriting_projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "songwriting_session_contributors_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "songwriting_sessions"
+            referencedColumns: ["id"]
+          }
         ]
       }
       streaming_platforms: {
@@ -2037,11 +2329,24 @@ export type Database = {
         Args: {
           p_attr_creative_insight: number
           p_attr_musical_ability: number
+          p_attr_rhythm_sense: number
+          p_current_arrangement_quality: number
           p_current_lyrics: number
+          p_current_lyrics_quality: number
+          p_current_melody_quality: number
           p_current_music: number
+          p_current_production_potential: number
+          p_current_rhythm_quality: number
+          p_current_song_rating: number
+          p_genre_familiarity: number
+          p_health: number
+          p_inspiration: number
+          p_mood_state: number
           p_skill_composition: number
           p_skill_creativity: number
+          p_skill_instrumental: number
           p_skill_songwriting: number
+          p_skill_vocals: number
         }
         Returns: Json
       }

--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -52,6 +52,9 @@ interface Song {
   genre: string;
   status: string;
   quality_score: number;
+  song_rating?: number;
+  genre_id?: string | null;
+  genre_familiarity?: number | null;
   streams: number;
   revenue: number;
   release_date: string | null;
@@ -189,7 +192,9 @@ const Songwriting = () => {
     try {
       const { data, error } = await supabase
         .from("songs")
-        .select("id, title, genre, status, quality_score, streams, revenue, release_date")
+        .select(
+          "id, title, genre, status, quality_score, song_rating, genre_id, genre_familiarity, streams, revenue, release_date"
+        )
         .eq("user_id", user.id)
         .order("updated_at", { ascending: false });
 
@@ -777,7 +782,7 @@ const Songwriting = () => {
               (project.music_progress ?? 0) >= MAX_PROGRESS &&
               (project.lyrics_progress ?? 0) >= MAX_PROGRESS &&
               !project.song_id;
-            const qualityDescriptor = getSongQualityDescriptor(project.quality_score ?? 0);
+            const ratingDescriptor = getSongQualityDescriptor(project.song_rating ?? project.quality_score ?? 0);
             const totalSessions = project.total_sessions ?? 0;
             const sessionTarget = Math.max(
               project.estimated_completion_sessions ??
@@ -786,7 +791,7 @@ const Songwriting = () => {
               1
             );
             const linkedSongQuality = linkedSong
-              ? getSongQualityDescriptor(linkedSong.quality_score ?? 0)
+              ? getSongQualityDescriptor(linkedSong.song_rating ?? linkedSong.quality_score ?? 0)
               : null;
 
             return (
@@ -843,9 +848,9 @@ const Songwriting = () => {
                         </p>
                       </div>
                       <div>
-                        <p>Quality</p>
-                        <p className="text-base font-semibold text-foreground">{qualityDescriptor.label}</p>
-                        <p className="text-[11px] text-muted-foreground">{qualityDescriptor.hint}</p>
+                        <p>Rating</p>
+                        <p className="text-base font-semibold text-foreground">{ratingDescriptor.label}</p>
+                        <p className="text-[11px] text-muted-foreground">{ratingDescriptor.hint}</p>
                       </div>
                     </div>
                   </div>
@@ -874,7 +879,7 @@ const Songwriting = () => {
                           <p className="font-semibold text-foreground">{linkedSong.genre}</p>
                         </div>
                         <div>
-                          <p className="text-muted-foreground">Quality</p>
+                          <p className="text-muted-foreground">Rating</p>
                           <p className="font-semibold text-foreground">
                             {linkedSongQuality ? linkedSongQuality.label : "Unknown"}
                           </p>

--- a/src/types/database-fallback.ts
+++ b/src/types/database-fallback.ts
@@ -31,6 +31,9 @@ export interface Database {
           weekly_bonus_metadata?: Json;
           created_at: string;
           updated_at: string;
+          current_city_id?: string | null;
+          current_location?: string;
+          health?: number;
         };
         Insert: {
           id?: string;
@@ -51,6 +54,9 @@ export interface Database {
           weekly_bonus_metadata?: Json;
           created_at?: string;
           updated_at?: string;
+          current_city_id?: string | null;
+          current_location?: string;
+          health?: number;
         };
         Update: {
           id?: string;
@@ -71,6 +77,9 @@ export interface Database {
           weekly_bonus_metadata?: Json;
           created_at?: string;
           updated_at?: string;
+          current_city_id?: string | null;
+          current_location?: string;
+          health?: number;
         };
       };
       profile_activity_statuses: {

--- a/supabase/migrations/20270631100000_enhance_songwriting_dimensions.sql
+++ b/supabase/migrations/20270631100000_enhance_songwriting_dimensions.sql
@@ -1,0 +1,453 @@
+BEGIN;
+
+-- Catalog of supported songwriting genres for richer classification
+CREATE TABLE IF NOT EXISTS public.song_genre_catalog (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text NOT NULL UNIQUE,
+  display_name text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Organized list of song purposes (e.g. single, sync brief, pitch demo)
+CREATE TABLE IF NOT EXISTS public.song_purposes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text NOT NULL UNIQUE,
+  label text NOT NULL,
+  description text,
+  focus_area text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+-- Writing modes help teams coordinate the collaborative flow
+CREATE TABLE IF NOT EXISTS public.song_writing_modes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug text NOT NULL UNIQUE,
+  label text NOT NULL,
+  description text,
+  is_collaborative boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+INSERT INTO public.song_genre_catalog (slug, display_name, description)
+VALUES
+  ('pop', 'Pop', 'Contemporary popular music with broad appeal.'),
+  ('rock', 'Rock', 'Guitar-driven music spanning classic to modern styles.'),
+  ('hip_hop', 'Hip-Hop', 'Rhythmic lyric-driven music and beat production.'),
+  ('edm', 'Electronic / Dance', 'Club-focused electronic production and songwriting.'),
+  ('singer_songwriter', 'Singer-Songwriter', 'Acoustic and storytelling-forward works.'),
+  ('soul_rnb', 'Soul / R&B', 'Groove-led songwriting with vocal focus.')
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO public.song_purposes (slug, label, description, focus_area)
+VALUES
+  ('artist_single', 'Artist Single', 'Lead artist single intended for a wide release.', 'release'),
+  ('sync_pitch', 'Sync Pitch', 'Tailored pitch for film, TV, or advertising briefs.', 'licensing'),
+  ('aandr_showcase', 'A&R Showcase', 'Demo geared toward label and publisher meetings.', 'industry'),
+  ('fan_exclusive', 'Fan Exclusive', 'Exclusive drop for superfans and community supporters.', 'community'),
+  ('writing_camp', 'Writing Camp Deliverable', 'Collaborative deliverable from a writing retreat or camp.', 'collaboration')
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO public.song_writing_modes (slug, label, description, is_collaborative)
+VALUES
+  ('solo_focus', 'Solo Focus', 'Single writer crafting ideas independently.', false),
+  ('co_write', 'Co-Write', 'Two or more writers splitting sections or duties.', true),
+  ('topline_session', 'Topline Session', 'Writer focusing on lyrics and melody over existing track.', true),
+  ('production_lab', 'Production Lab', 'Producer-led experimentation generating hooks and motifs.', true),
+  ('band_room', 'Band Room', 'Live room writing with full band iteration.', true)
+ON CONFLICT (slug) DO NOTHING;
+
+-- New collaborative metadata for songwriting projects
+ALTER TABLE public.songwriting_projects
+  ADD COLUMN IF NOT EXISTS genre_id uuid REFERENCES public.song_genre_catalog(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS genre_familiarity numeric(5,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS song_purpose_id uuid REFERENCES public.song_purposes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS writing_mode_id uuid REFERENCES public.song_writing_modes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS lyrics_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS melody_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rhythm_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS arrangement_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS production_potential integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS song_rating integer NOT NULL DEFAULT 0;
+
+UPDATE public.songwriting_projects
+SET
+  genre_familiarity = COALESCE(genre_familiarity, 0),
+  lyrics_quality = COALESCE(lyrics_quality, 0),
+  melody_quality = COALESCE(melody_quality, 0),
+  rhythm_quality = COALESCE(rhythm_quality, 0),
+  arrangement_quality = COALESCE(arrangement_quality, 0),
+  production_potential = COALESCE(production_potential, 0),
+  song_rating = COALESCE(song_rating, 0);
+
+ALTER TABLE public.songwriting_projects
+  ALTER COLUMN genre_familiarity SET NOT NULL,
+  ALTER COLUMN genre_familiarity SET DEFAULT 0,
+  ADD CONSTRAINT songwriting_projects_genre_familiarity_check
+    CHECK (genre_familiarity >= 0 AND genre_familiarity <= 100),
+  ADD CONSTRAINT songwriting_projects_lyrics_quality_check
+    CHECK (lyrics_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songwriting_projects_melody_quality_check
+    CHECK (melody_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songwriting_projects_rhythm_quality_check
+    CHECK (rhythm_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songwriting_projects_arrangement_quality_check
+    CHECK (arrangement_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songwriting_projects_production_potential_check
+    CHECK (production_potential BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songwriting_projects_song_rating_check
+    CHECK (song_rating BETWEEN 0 AND 1000);
+
+CREATE INDEX IF NOT EXISTS songwriting_projects_genre_id_idx
+  ON public.songwriting_projects (genre_id);
+CREATE INDEX IF NOT EXISTS songwriting_projects_song_purpose_idx
+  ON public.songwriting_projects (song_purpose_id);
+CREATE INDEX IF NOT EXISTS songwriting_projects_writing_mode_idx
+  ON public.songwriting_projects (writing_mode_id);
+
+-- Mirror the new analytics columns on finished songs
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS genre_id uuid REFERENCES public.song_genre_catalog(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS genre_familiarity numeric(5,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS song_purpose_id uuid REFERENCES public.song_purposes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS writing_mode_id uuid REFERENCES public.song_writing_modes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS lyrics_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS melody_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rhythm_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS arrangement_quality integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS production_potential integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS song_rating integer NOT NULL DEFAULT 0;
+
+UPDATE public.songs
+SET
+  genre_familiarity = COALESCE(genre_familiarity, 0),
+  lyrics_quality = COALESCE(lyrics_quality, 0),
+  melody_quality = COALESCE(melody_quality, 0),
+  rhythm_quality = COALESCE(rhythm_quality, 0),
+  arrangement_quality = COALESCE(arrangement_quality, 0),
+  production_potential = COALESCE(production_potential, 0),
+  song_rating = COALESCE(song_rating, 0);
+
+ALTER TABLE public.songs
+  ALTER COLUMN genre_familiarity SET NOT NULL,
+  ALTER COLUMN genre_familiarity SET DEFAULT 0,
+  ADD CONSTRAINT songs_genre_familiarity_check
+    CHECK (genre_familiarity >= 0 AND genre_familiarity <= 100),
+  ADD CONSTRAINT songs_lyrics_quality_check
+    CHECK (lyrics_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songs_melody_quality_check
+    CHECK (melody_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songs_rhythm_quality_check
+    CHECK (rhythm_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songs_arrangement_quality_check
+    CHECK (arrangement_quality BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songs_production_potential_check
+    CHECK (production_potential BETWEEN 0 AND 1000),
+  ADD CONSTRAINT songs_song_rating_check
+    CHECK (song_rating BETWEEN 0 AND 1000);
+
+CREATE INDEX IF NOT EXISTS songs_genre_id_idx
+  ON public.songs (genre_id);
+CREATE INDEX IF NOT EXISTS songs_song_purpose_idx
+  ON public.songs (song_purpose_id);
+CREATE INDEX IF NOT EXISTS songs_writing_mode_idx
+  ON public.songs (writing_mode_id);
+
+-- Track collaborators and session contributors with royalty splits
+CREATE TABLE IF NOT EXISTS public.songwriting_project_collaborators (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id uuid NOT NULL REFERENCES public.songwriting_projects(id) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role text,
+  royalty_split numeric(5,2) NOT NULL DEFAULT 0,
+  contribution_scope text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT songwriting_project_collaborators_split_check
+    CHECK (royalty_split >= 0 AND royalty_split <= 100),
+  CONSTRAINT songwriting_project_collaborators_unique_member
+    UNIQUE (project_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS songwriting_project_collaborators_project_idx
+  ON public.songwriting_project_collaborators (project_id);
+CREATE INDEX IF NOT EXISTS songwriting_project_collaborators_profile_idx
+  ON public.songwriting_project_collaborators (profile_id);
+
+ALTER TABLE public.songwriting_project_collaborators ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Project collaborators readable by owners and members"
+  ON public.songwriting_project_collaborators
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_project_collaborators.project_id
+        AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles pr
+      WHERE pr.id = songwriting_project_collaborators.profile_id
+        AND pr.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Project collaborators manageable by project owner"
+  ON public.songwriting_project_collaborators
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_project_collaborators.project_id
+        AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_project_collaborators.project_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE TABLE IF NOT EXISTS public.songwriting_session_contributors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.songwriting_sessions(id) ON DELETE CASCADE,
+  project_id uuid NOT NULL REFERENCES public.songwriting_projects(id) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role text,
+  royalty_split numeric(5,2) NOT NULL DEFAULT 0,
+  minutes_participated integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT songwriting_session_contributors_split_check
+    CHECK (royalty_split >= 0 AND royalty_split <= 100),
+  CONSTRAINT songwriting_session_contributors_minutes_check
+    CHECK (minutes_participated >= 0),
+  CONSTRAINT songwriting_session_contributors_unique_member
+    UNIQUE (session_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS songwriting_session_contributors_session_idx
+  ON public.songwriting_session_contributors (session_id);
+CREATE INDEX IF NOT EXISTS songwriting_session_contributors_project_idx
+  ON public.songwriting_session_contributors (project_id);
+CREATE INDEX IF NOT EXISTS songwriting_session_contributors_profile_idx
+  ON public.songwriting_session_contributors (profile_id);
+
+ALTER TABLE public.songwriting_session_contributors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Session contributors readable by owners and members"
+  ON public.songwriting_session_contributors
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_session_contributors.project_id
+        AND p.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.profiles pr
+      WHERE pr.id = songwriting_session_contributors.profile_id
+        AND pr.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Session contributors manageable by project owner"
+  ON public.songwriting_session_contributors
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_session_contributors.project_id
+        AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.songwriting_projects p
+      WHERE p.id = songwriting_session_contributors.project_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+-- Richer songwriting progression calculation accounting for the new fields
+CREATE OR REPLACE FUNCTION public.calculate_songwriting_progress(
+  p_skill_songwriting INTEGER,
+  p_skill_creativity INTEGER,
+  p_skill_composition INTEGER,
+  p_skill_vocals INTEGER,
+  p_skill_instrumental INTEGER,
+  p_attr_creative_insight INTEGER,
+  p_attr_musical_ability INTEGER,
+  p_attr_rhythm_sense INTEGER,
+  p_current_music INTEGER,
+  p_current_lyrics INTEGER,
+  p_current_lyrics_quality INTEGER,
+  p_current_melody_quality INTEGER,
+  p_current_rhythm_quality INTEGER,
+  p_current_arrangement_quality INTEGER,
+  p_current_production_potential INTEGER,
+  p_current_song_rating INTEGER,
+  p_genre_familiarity NUMERIC,
+  p_mood_state NUMERIC,
+  p_health INTEGER,
+  p_inspiration NUMERIC
+) RETURNS JSONB AS $$
+DECLARE
+  max_progress CONSTANT INTEGER := 2000;
+  max_quality CONSTANT INTEGER := 1000;
+  base_random NUMERIC := 0.30 + (random() * 0.20);
+  songwriting_skill_avg NUMERIC := (
+    COALESCE(p_skill_songwriting, 1) +
+    COALESCE(p_skill_creativity, 1) +
+    COALESCE(p_skill_composition, 1)
+  ) / 3.0;
+  performance_skill_avg NUMERIC := (
+    COALESCE(p_skill_vocals, 1) +
+    COALESCE(p_skill_instrumental, 1)
+  ) / 2.0;
+  attribute_avg NUMERIC := (
+    COALESCE(p_attr_creative_insight, 10) +
+    COALESCE(p_attr_musical_ability, 10) +
+    COALESCE(p_attr_rhythm_sense, 10)
+  ) / 3.0;
+  health_score NUMERIC := LEAST(100, GREATEST(0, COALESCE(p_health, 70)));
+  mood_value NUMERIC := LEAST(100, GREATEST(0, COALESCE(p_mood_state, 60)));
+  inspiration_value NUMERIC := LEAST(100, GREATEST(0, COALESCE(p_inspiration, 55)));
+  familiarity_value NUMERIC := LEAST(100, GREATEST(0, COALESCE(p_genre_familiarity, 0)));
+  mood_modifier NUMERIC := 0.85 + (mood_value / 100.0) * 0.30;
+  health_modifier NUMERIC := 0.80 + (health_score / 100.0) * 0.40;
+  inspiration_modifier NUMERIC := 0.90 + (inspiration_value / 100.0) * 0.50;
+  familiarity_modifier NUMERIC := 0.80 + (familiarity_value / 100.0) * 0.40;
+  skill_modifier NUMERIC := 1 + (songwriting_skill_avg / 120.0);
+  performance_modifier NUMERIC := 1 + (performance_skill_avg / 150.0);
+  attribute_modifier NUMERIC := 1 + (attribute_avg / 200.0);
+  combined_modifier NUMERIC :=
+    skill_modifier *
+    performance_modifier *
+    attribute_modifier *
+    mood_modifier *
+    health_modifier *
+    inspiration_modifier *
+    familiarity_modifier;
+  remaining_music INTEGER := GREATEST(0, max_progress - COALESCE(p_current_music, 0));
+  remaining_lyrics INTEGER := GREATEST(0, max_progress - COALESCE(p_current_lyrics, 0));
+  total_remaining INTEGER := remaining_music + remaining_lyrics;
+  base_total NUMERIC := 0;
+  total_gain INTEGER := 0;
+  music_share NUMERIC := 0.5;
+  music_gain INTEGER := 0;
+  lyrics_gain INTEGER := 0;
+  quality_base NUMERIC := 0;
+  lyrics_quality_gain INTEGER := 0;
+  melody_quality_gain INTEGER := 0;
+  rhythm_quality_gain INTEGER := 0;
+  arrangement_quality_gain INTEGER := 0;
+  production_potential_gain INTEGER := 0;
+  song_rating_gain INTEGER := 0;
+  xp_earned INTEGER := 0;
+  quality_progress_factor NUMERIC := 0;
+  progress_ratio NUMERIC := 0;
+BEGIN
+  IF total_remaining <= 0 THEN
+    RETURN jsonb_build_object(
+      'music_gain', 0,
+      'lyrics_gain', 0,
+      'lyrics_quality_gain', 0,
+      'melody_quality_gain', 0,
+      'rhythm_quality_gain', 0,
+      'arrangement_quality_gain', 0,
+      'production_potential_gain', 0,
+      'song_rating_gain', 0,
+      'xp_earned', 0,
+      'modifiers', jsonb_build_object(
+        'skill', skill_modifier,
+        'performance', performance_modifier,
+        'attributes', attribute_modifier,
+        'mood', mood_modifier,
+        'health', health_modifier,
+        'inspiration', inspiration_modifier,
+        'familiarity', familiarity_modifier
+      )
+    );
+  END IF;
+
+  base_total := total_remaining * base_random;
+  base_total := base_total * combined_modifier;
+  base_total := GREATEST(60, LEAST(total_remaining, FLOOR(base_total)));
+
+  IF remaining_music = 0 THEN
+    music_share := 0;
+  ELSIF remaining_lyrics = 0 THEN
+    music_share := 1;
+  ELSE
+    music_share := (remaining_music::NUMERIC / total_remaining);
+    music_share := LEAST(0.75, GREATEST(0.25, music_share + ((random() - 0.5) * 0.15)));
+  END IF;
+
+  total_gain := FLOOR(base_total);
+  music_gain := LEAST(remaining_music, FLOOR(total_gain * music_share));
+  lyrics_gain := LEAST(remaining_lyrics, total_gain - music_gain);
+
+  quality_progress_factor := (songwriting_skill_avg + performance_skill_avg + attribute_avg) / 3.0;
+  progress_ratio := LEAST(1.0, (COALESCE(p_current_song_rating, 0)::NUMERIC + 200) / (max_quality + 200));
+  quality_base := GREATEST(8, FLOOR((quality_progress_factor / 8.0) * combined_modifier * (1.1 - progress_ratio)));
+
+  lyrics_quality_gain := LEAST(max_quality - COALESCE(p_current_lyrics_quality, 0), FLOOR(quality_base * 1.10));
+  melody_quality_gain := LEAST(max_quality - COALESCE(p_current_melody_quality, 0), FLOOR(quality_base * 1.05));
+  rhythm_quality_gain := LEAST(max_quality - COALESCE(p_current_rhythm_quality, 0), FLOOR(quality_base));
+  arrangement_quality_gain := LEAST(max_quality - COALESCE(p_current_arrangement_quality, 0), FLOOR(quality_base * 0.95));
+  production_potential_gain := LEAST(max_quality - COALESCE(p_current_production_potential, 0), FLOOR(quality_base * inspiration_modifier));
+
+  song_rating_gain := LEAST(
+    max_quality - COALESCE(p_current_song_rating, 0),
+    FLOOR(
+      (lyrics_quality_gain * 0.25) +
+      (melody_quality_gain * 0.25) +
+      (rhythm_quality_gain * 0.15) +
+      (arrangement_quality_gain * 0.15) +
+      (production_potential_gain * 0.20)
+    )
+  );
+
+  xp_earned := GREATEST(
+    8,
+    FLOOR((music_gain + lyrics_gain) / 18) +
+    FLOOR((lyrics_quality_gain + melody_quality_gain + rhythm_quality_gain + arrangement_quality_gain + production_potential_gain) / 240) +
+    FLOOR(inspiration_modifier * 6)
+  );
+
+  RETURN jsonb_build_object(
+    'music_gain', music_gain,
+    'lyrics_gain', lyrics_gain,
+    'lyrics_quality_gain', lyrics_quality_gain,
+    'melody_quality_gain', melody_quality_gain,
+    'rhythm_quality_gain', rhythm_quality_gain,
+    'arrangement_quality_gain', arrangement_quality_gain,
+    'production_potential_gain', production_potential_gain,
+    'song_rating_gain', song_rating_gain,
+    'xp_earned', xp_earned,
+    'modifiers', jsonb_build_object(
+      'skill', skill_modifier,
+      'performance', performance_modifier,
+      'attributes', attribute_modifier,
+      'mood', mood_modifier,
+      'health', health_modifier,
+      'inspiration', inspiration_modifier,
+      'familiarity', familiarity_modifier
+    )
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;


### PR DESCRIPTION
## Summary
- introduce genre, purpose, and writing mode catalogs plus collaborator tables and royalty policies for songwriting projects
- expand songs and songwriting projects with per-attribute quality metrics, 0-1000 song ratings, and updated calculate_songwriting_progress logic with new modifiers
- regenerate Supabase client types and frontend hooks/pages to surface the richer progression data and rating descriptors

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deea09f9f083258fbe68e4b76882f9