### PR TITLE
Add configurable city night clubs and nightlife admin management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ const UniversityDetail = lazyWithRetry(() => import("./pages/UniversityDetail"))
 const AdminCities = lazyWithRetry(() => import("./pages/admin/Cities"));
 const AdminSkillBooks = lazyWithRetry(() => import("./pages/admin/SkillBooks"));
 const AdminStudios = lazyWithRetry(() => import("./pages/admin/Studios"));
+const AdminNightClubs = lazyWithRetry(() => import("./pages/admin/NightClubs"));
 const AdminYoutubeVideos = lazyWithRetry(() => import("./pages/admin/YoutubeVideos"));
 const AdminBandLearning = lazyWithRetry(() => import("./pages/admin/BandLearning"));
 const AdminMentors = lazyWithRetry(() => import("./pages/admin/Mentors"));
@@ -140,6 +141,7 @@ function App() {
                     <Route path="admin/cities" element={<AdminCities />} />
                     <Route path="admin/skill-books" element={<AdminSkillBooks />} />
                     <Route path="admin/studios" element={<AdminStudios />} />
+                    <Route path="admin/night-clubs" element={<AdminNightClubs />} />
                     <Route path="admin/youtube-videos" element={<AdminYoutubeVideos />} />
                     <Route path="admin/band-learning" element={<AdminBandLearning />} />
                     <Route path="admin/mentors" element={<AdminMentors />} />

--- a/src/components/city/CityNightClubsSection.tsx
+++ b/src/components/city/CityNightClubsSection.tsx
@@ -1,0 +1,225 @@
+import { Disc3, GlassWater, Mic2, Sparkles, Users } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CityNightClub } from "@/utils/worldEnvironment";
+
+interface CityNightClubsSectionProps {
+  nightClubs: CityNightClub[];
+}
+
+const QUALITY_LABELS: Record<number, string> = {
+  1: "Underground",
+  2: "Neighborhood",
+  3: "Boutique",
+  4: "Premier",
+  5: "Legendary",
+};
+
+const fameFormatter = new Intl.NumberFormat("en-US");
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+const formatCurrencyValue = (value: number | null | undefined): string | null => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return null;
+  }
+
+  return currencyFormatter.format(value);
+};
+
+const formatSetLength = (value: number | null | undefined): string | null => {
+  if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+    return null;
+  }
+
+  if (value < 60) {
+    return `${value} min set`;
+  }
+
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
+  if (!minutes) {
+    return `${hours} hr set`;
+  }
+
+  return `${hours} hr ${minutes} min set`;
+};
+
+const getQualityLabel = (qualityLevel: number) => QUALITY_LABELS[qualityLevel] ?? `Tier ${qualityLevel}`;
+
+export const CityNightClubsSection = ({ nightClubs }: CityNightClubsSectionProps) => {
+  if (!nightClubs.length) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Disc3 className="h-5 w-5 text-primary" />
+            Night Clubs
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border border-dashed border-border/60 p-6 text-center text-sm text-muted-foreground">
+            Nightlife information will appear here once clubs have been scouted for this city.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Disc3 className="h-5 w-5 text-primary" />
+          Night Clubs & Late Sets
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {nightClubs.map((club) => {
+          const qualityLabel = getQualityLabel(club.qualityLevel);
+          const fameRequirementLabel = fameFormatter.format(Math.max(0, club.djSlot.fameRequirement));
+          const coverChargeLabel = formatCurrencyValue(club.coverCharge);
+          const djPayoutLabel = formatCurrencyValue(club.djSlot.payout ?? null);
+          const setLengthLabel = formatSetLength(club.djSlot.setLengthMinutes ?? null);
+          const liveInteractionsLabel = club.liveInteractionsEnabled ? "Live interactions enabled" : "Live interactions paused";
+
+          return (
+            <div
+              key={club.id}
+              className="space-y-4 rounded-lg border border-border/60 p-4 transition-colors hover:border-primary/50"
+            >
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-lg font-semibold leading-tight">{club.name}</h3>
+                    <Badge variant="secondary">{qualityLabel}</Badge>
+                    <Badge variant={club.liveInteractionsEnabled ? "outline" : "destructive"}>{liveInteractionsLabel}</Badge>
+                  </div>
+                  {club.description && (
+                    <p className="max-w-xl text-sm text-muted-foreground">{club.description}</p>
+                  )}
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      DJ slots require {fameRequirementLabel} fame
+                    </span>
+                    {club.capacity && (
+                      <span>
+                        Capacity {club.capacity.toLocaleString()}
+                      </span>
+                    )}
+                    {coverChargeLabel && <span>Cover {coverChargeLabel}</span>}
+                    {club.djSlot.schedule && <span>Slots {club.djSlot.schedule}</span>}
+                    {djPayoutLabel && <span>Pay {djPayoutLabel}</span>}
+                    {setLengthLabel && <span>{setLengthLabel}</span>}
+                  </div>
+                  {club.djSlot.perks && club.djSlot.perks.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {club.djSlot.perks.map((perk) => (
+                        <Badge key={`${club.id}-perk-${perk}`} variant="outline">
+                          {perk}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 md:items-end">
+                  <Button size="sm" className="w-full md:w-auto" variant="default">
+                    <Mic2 className="mr-2 h-4 w-4" /> Queue for DJ Slot
+                  </Button>
+                  <Button size="sm" variant="outline" className="w-full md:w-auto">
+                    <Sparkles className="mr-2 h-4 w-4" /> Visit as Guest
+                  </Button>
+                </div>
+              </div>
+
+              {club.guestActions.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <Sparkles className="h-4 w-4 text-primary" /> Guest Experiences
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {club.guestActions.map((action) => (
+                      <Badge key={action.id} variant="secondary" className="flex items-center gap-1">
+                        {action.label}
+                        {typeof action.energyCost === "number" && action.energyCost > 0 && (
+                          <span className="text-[11px] text-muted-foreground">-{action.energyCost} energy</span>
+                        )}
+                      </Badge>
+                    ))}
+                  </div>
+                  {club.guestActions.some((action) => action.description) && (
+                    <ul className="list-disc space-y-1 pl-6 text-xs text-muted-foreground">
+                      {club.guestActions
+                        .filter((action) => action.description)
+                        .map((action) => (
+                          <li key={`${action.id}-description`}>{action.description}</li>
+                        ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+
+              {club.drinkMenu.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <GlassWater className="h-4 w-4 text-primary" /> Signature Drinks
+                  </div>
+                  <div className="space-y-2">
+                    {club.drinkMenu.map((drink) => (
+                      <div key={drink.id} className="flex flex-wrap items-center gap-2 text-sm">
+                        <span className="font-medium">{drink.name}</span>
+                        {formatCurrencyValue(drink.price) && (
+                          <Badge variant="outline">{formatCurrencyValue(drink.price)}</Badge>
+                        )}
+                        {drink.effect && (
+                          <span className="text-xs text-muted-foreground">{drink.effect}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {club.npcProfiles.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <Users className="h-4 w-4 text-primary" /> Resident NPCs
+                  </div>
+                  <div className="space-y-2">
+                    {club.npcProfiles.map((npc) => (
+                      <div key={npc.id} className="rounded-md border border-border/40 p-3 text-sm">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium text-foreground">{npc.name}</span>
+                          {npc.role && <Badge variant="outline">{npc.role}</Badge>}
+                          {npc.personality && (
+                            <span className="text-xs text-muted-foreground">{npc.personality}</span>
+                          )}
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                          {npc.availability && <span>On deck: {npc.availability}</span>}
+                          {npc.dialogueHooks && npc.dialogueHooks.length > 0 && (
+                            <span>
+                              Topics: {npc.dialogueHooks.slice(0, 3).join(", ")}
+                              {npc.dialogueHooks.length > 3 ? "…" : ""}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CityNightClubsSection;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,16 @@
-import { AudioLines, Building2, Gift, GraduationCap, NotebookPen, PlaySquare, Sparkles, Users, BookOpen, Briefcase } from "lucide-react";
+import {
+  AudioLines,
+  Building2,
+  Disc3,
+  Gift,
+  GraduationCap,
+  NotebookPen,
+  PlaySquare,
+  Sparkles,
+  Users,
+  BookOpen,
+  Briefcase,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { AdminRoute } from "@/components/AdminRoute";
@@ -40,6 +52,13 @@ const adminSections = [
     href: "/admin/studios",
     action: "Manage studios",
     Icon: AudioLines,
+  },
+  {
+    title: "Night Clubs",
+    description: "Curate nightlife venues, DJ slot requirements, and social actions by city.",
+    href: "/admin/night-clubs",
+    action: "Manage night clubs",
+    Icon: Disc3,
   },
   {
     title: "Skill Books",

--- a/src/pages/City.tsx
+++ b/src/pages/City.tsx
@@ -12,10 +12,12 @@ import {
   fetchCityEnvironmentDetails,
   type City as CityRecord,
   type CityEnvironmentDetails,
+  type CityNightClub,
 } from "@/utils/worldEnvironment";
 import { supabase } from "@/integrations/supabase/client";
 import { CityDistrictsSection } from "@/components/city/CityDistrictsSection";
 import { CityStudiosSection } from "@/components/city/CityStudiosSection";
+import { CityNightClubsSection } from "@/components/city/CityNightClubsSection";
 
 type CityRouteParams = {
   cityId?: string;
@@ -32,6 +34,7 @@ interface CityContentProps {
   districts: any[];
   studios: any[];
   playerCount: number;
+  nightClubs: CityNightClub[];
 }
 
 export interface CityPageLoadResult {
@@ -103,6 +106,7 @@ export const CityContent = ({
   districts,
   studios,
   playerCount,
+  nightClubs,
 }: CityContentProps) => {
   const culturalEvents = useMemo(
     () => (city?.cultural_events ?? []).filter((event) => typeof event === "string" && event.trim().length > 0),
@@ -249,6 +253,8 @@ export const CityContent = ({
       <div className="grid gap-6 lg:grid-cols-2">
         <CityStudiosSection studios={studios} />
 
+        <CityNightClubsSection nightClubs={nightClubs} />
+
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -330,6 +336,7 @@ export default function City() {
   const [districts, setDistricts] = useState<any[]>([]);
   const [studios, setStudios] = useState<any[]>([]);
   const [playerCount, setPlayerCount] = useState<number>(0);
+  const [nightClubs, setNightClubs] = useState<CityNightClub[]>([]);
 
   const loadCity = useCallback(
     async (options: { signal?: { cancelled: boolean } } = {}) => {
@@ -343,6 +350,7 @@ export default function City() {
       setError(null);
       setDetailsError(null);
       setDetailsLoading(false);
+      setNightClubs([]);
 
       try {
         const snapshot = await fetchWorldEnvironmentSnapshot();
@@ -394,9 +402,11 @@ export default function City() {
           
           if (cityDetails.status === "fulfilled") {
             setDetails(cityDetails.value);
+            setNightClubs(cityDetails.value.nightClubs ?? []);
           } else if (cityDetails.status === "rejected") {
             console.error(`Failed to load city environment details for ${matchedCity.name}`, cityDetails.reason);
             setDetailsError("We couldn't load extended city details right now.");
+            setNightClubs([]);
           }
           
           setDetailsLoading(false);
@@ -441,6 +451,7 @@ export default function City() {
       districts={districts}
       studios={studios}
       playerCount={playerCount}
+      nightClubs={nightClubs}
       onRetry={() => {
         void loadCity();
       }}

--- a/src/pages/admin/NightClubs.tsx
+++ b/src/pages/admin/NightClubs.tsx
@@ -1,0 +1,782 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2, Pencil, PlusCircle, Trash2 } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { AdminRoute } from "@/components/AdminRoute";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+
+import { currencyFormatter, formatNumberInput, parseNumberInput } from "./shared";
+
+const QUALITY_LABELS: Record<number, string> = {
+  1: "Underground",
+  2: "Neighborhood",
+  3: "Boutique",
+  4: "Premier",
+  5: "Legendary",
+};
+
+const createQualityLevelField = () =>
+  z
+    .string()
+    .trim()
+    .min(1, "Quality level is required")
+    .refine((value) => {
+      const parsed = Number(value);
+      return Number.isInteger(parsed) && parsed >= 1 && parsed <= 5;
+    }, "Quality level must be an integer between 1 and 5");
+
+const optionalNumberField = (label: string) =>
+  z
+    .string()
+    .trim()
+    .refine((value) => {
+      if (!value) return true;
+      const parsed = Number(value);
+      return Number.isFinite(parsed);
+    }, `${label} must be a valid number`)
+    .optional();
+
+const jsonArrayField = (label: string) =>
+  z
+    .string()
+    .trim()
+    .refine((value) => {
+      if (!value) return true;
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed);
+      } catch (error) {
+        console.error(`Invalid JSON for ${label}`, error);
+        return false;
+      }
+    }, `${label} must be a valid JSON array`);
+
+const jsonObjectField = (label: string) =>
+  z
+    .string()
+    .trim()
+    .refine((value) => {
+      if (!value) return true;
+      try {
+        const parsed = JSON.parse(value);
+        return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+      } catch (error) {
+        console.error(`Invalid JSON for ${label}`, error);
+        return false;
+      }
+    }, `${label} must be a valid JSON object`);
+
+const nightClubSchema = z.object({
+  city_id: z.string().trim().min(1, "City is required"),
+  name: z.string().trim().min(1, "Club name is required"),
+  description: z.string().trim().optional(),
+  quality_level: createQualityLevelField(),
+  capacity: optionalNumberField("Capacity"),
+  cover_charge: optionalNumberField("Cover charge"),
+  guest_actions: jsonArrayField("Guest actions"),
+  drink_menu: jsonArrayField("Drink menu"),
+  npc_profiles: jsonArrayField("NPC profiles"),
+  dj_slot_config: jsonObjectField("DJ slot config"),
+  live_interactions_enabled: z.boolean().default(true),
+});
+
+type NightClubFormValues = z.infer<typeof nightClubSchema>;
+
+type CityOption = {
+  id: string;
+  name: string;
+};
+
+type NightClubRow = {
+  id: string;
+  city_id: string;
+  name: string | null;
+  description: string | null;
+  quality_level: number | null;
+  capacity: number | null;
+  cover_charge: number | null;
+  guest_actions: unknown[] | null;
+  drink_menu: unknown[] | null;
+  npc_profiles: unknown[] | null;
+  dj_slot_config: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string | null;
+  updated_at: string | null;
+  city?: {
+    name: string | null;
+  } | null;
+};
+
+const defaultDjSlotConfig = JSON.stringify(
+  {
+    minimum_fame: 750,
+    payout: 800,
+    set_length_minutes: 60,
+    perks: ["+4% night fan buzz", "Audience energy boost"],
+  },
+  null,
+  2,
+);
+
+const nightClubDefaultValues: NightClubFormValues = {
+  city_id: "",
+  name: "",
+  description: "",
+  quality_level: "3",
+  capacity: "",
+  cover_charge: "",
+  guest_actions: "[]",
+  drink_menu: "[]",
+  npc_profiles: "[]",
+  dj_slot_config: defaultDjSlotConfig,
+  live_interactions_enabled: true,
+};
+
+const formatJsonArray = (value: unknown[] | null | undefined): string => {
+  if (!Array.isArray(value) || value.length === 0) {
+    return "[]";
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (error) {
+    console.error("Failed to format JSON array", error);
+    return "[]";
+  }
+};
+
+const formatJsonObject = (value: Record<string, unknown> | null | undefined): string => {
+  if (!value || typeof value !== "object") {
+    return defaultDjSlotConfig;
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (error) {
+    console.error("Failed to format JSON object", error);
+    return defaultDjSlotConfig;
+  }
+};
+
+const parseJsonArrayInput = (value: string): unknown[] => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("Failed to parse JSON array input", error);
+    return [];
+  }
+};
+
+const parseJsonObjectInput = (value: string): Record<string, unknown> | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch (error) {
+    console.error("Failed to parse JSON object input", error);
+  }
+  return null;
+};
+
+const computeFameRequirement = (club: NightClubRow): number => {
+  const quality = typeof club.quality_level === "number" && Number.isFinite(club.quality_level)
+    ? Math.max(1, Math.min(5, Math.round(club.quality_level)))
+    : 1;
+
+  const fromConfig = club.dj_slot_config?.minimum_fame ?? club.dj_slot_config?.fame_requirement;
+  if (typeof fromConfig === "number" && Number.isFinite(fromConfig)) {
+    return fromConfig;
+  }
+
+  return quality * 250;
+};
+
+const parseLiveInteractionFlag = (club: NightClubRow): boolean => {
+  const value = club.metadata?.live_interactions_enabled ?? club.metadata?.liveInteractionsEnabled;
+  return typeof value === "boolean" ? value : true;
+};
+
+const NightClubsAdmin = () => {
+  const { toast } = useToast();
+  const [cities, setCities] = useState<CityOption[]>([]);
+  const [nightClubs, setNightClubs] = useState<NightClubRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [editingClub, setEditingClub] = useState<NightClubRow | null>(null);
+  const [deletingClubId, setDeletingClubId] = useState<string | null>(null);
+
+  const nightClubForm = useForm<NightClubFormValues>({
+    resolver: zodResolver(nightClubSchema),
+    defaultValues: nightClubDefaultValues,
+    mode: "onBlur",
+  });
+
+  const fetchCities = useCallback(async () => {
+    const { data, error } = await supabase
+      .from("cities")
+      .select("id, name")
+      .order("name", { ascending: true });
+
+    if (error) {
+      console.error("Failed to fetch cities", error);
+      setLoadingError("Unable to load city list. Please try again later.");
+      return;
+    }
+
+    setCities(
+      (data ?? []).map((city) => ({
+        id: city.id,
+        name: city.name ?? "Unnamed city",
+      })),
+    );
+  }, []);
+
+  const fetchNightClubs = useCallback(async () => {
+    setIsLoading(true);
+    setLoadingError(null);
+
+    const { data, error } = await supabase
+      .from<NightClubRow>("city_night_clubs")
+      .select("*, city:cities(name)")
+      .order("quality_level", { ascending: false })
+      .order("name", { ascending: true });
+
+    if (error) {
+      console.error("Failed to fetch night clubs", error);
+      setLoadingError("Unable to load night clubs. Ensure the migration has been applied.");
+      setIsLoading(false);
+      return;
+    }
+
+    setNightClubs(data ?? []);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void fetchCities();
+    void fetchNightClubs();
+  }, [fetchCities, fetchNightClubs]);
+
+  const resetForm = useCallback(() => {
+    setEditingClub(null);
+    nightClubForm.reset(nightClubDefaultValues);
+  }, [nightClubForm]);
+
+  const buildPayload = useCallback(
+    (values: NightClubFormValues): Record<string, unknown> => {
+      const metadataBase = editingClub?.metadata && typeof editingClub.metadata === "object"
+        ? { ...editingClub.metadata }
+        : {};
+
+      metadataBase.live_interactions_enabled = values.live_interactions_enabled;
+
+      return {
+        city_id: values.city_id,
+        name: values.name.trim(),
+        description: values.description?.trim() ? values.description.trim() : null,
+        quality_level: Number(values.quality_level),
+        capacity: parseNumberInput(values.capacity ?? ""),
+        cover_charge: parseNumberInput(values.cover_charge ?? ""),
+        guest_actions: parseJsonArrayInput(values.guest_actions),
+        drink_menu: parseJsonArrayInput(values.drink_menu),
+        npc_profiles: parseJsonArrayInput(values.npc_profiles),
+        dj_slot_config: parseJsonObjectInput(values.dj_slot_config) ?? {},
+        metadata: Object.keys(metadataBase).length ? metadataBase : null,
+      };
+    },
+    [editingClub],
+  );
+
+  const onSubmit = nightClubForm.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+    try {
+      const payload = buildPayload(values);
+      if (editingClub) {
+        const { error } = await supabase
+          .from("city_night_clubs")
+          .update(payload)
+          .eq("id", editingClub.id);
+
+        if (error) throw error;
+        toast({
+          title: "Night club updated",
+          description: `${values.name} has been updated successfully.`,
+        });
+      } else {
+        const { error } = await supabase.from("city_night_clubs").insert(payload);
+        if (error) throw error;
+        toast({
+          title: "Night club created",
+          description: `${values.name} has been added to the city roster.`,
+        });
+      }
+
+      resetForm();
+      await fetchNightClubs();
+    } catch (error) {
+      console.error("Failed to save night club", error);
+      toast({
+        title: "Unable to save night club",
+        description: "Please review the form fields or try again later.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  const handleEdit = useCallback(
+    (club: NightClubRow) => {
+      setEditingClub(club);
+      nightClubForm.reset({
+        city_id: club.city_id,
+        name: club.name ?? "",
+        description: club.description ?? "",
+        quality_level: club.quality_level ? `${club.quality_level}` : "1",
+        capacity: formatNumberInput(club.capacity),
+        cover_charge: formatNumberInput(club.cover_charge),
+        guest_actions: formatJsonArray(club.guest_actions),
+        drink_menu: formatJsonArray(club.drink_menu),
+        npc_profiles: formatJsonArray(club.npc_profiles),
+        dj_slot_config: formatJsonObject(club.dj_slot_config),
+        live_interactions_enabled: parseLiveInteractionFlag(club),
+      });
+    },
+    [nightClubForm],
+  );
+
+  const handleDelete = useCallback(
+    async (clubId: string) => {
+      setDeletingClubId(clubId);
+      try {
+        const { error } = await supabase.from("city_night_clubs").delete().eq("id", clubId);
+        if (error) throw error;
+        toast({
+          title: "Night club removed",
+          description: "The night club has been deleted.",
+        });
+        if (editingClub?.id === clubId) {
+          resetForm();
+        }
+        await fetchNightClubs();
+      } catch (error) {
+        console.error("Failed to delete night club", error);
+        toast({
+          title: "Unable to delete night club",
+          description: "Please try again later.",
+          variant: "destructive",
+        });
+      } finally {
+        setDeletingClubId(null);
+      }
+    },
+    [editingClub?.id, fetchNightClubs, resetForm, toast],
+  );
+
+  const qualityLabel = useCallback((club: NightClubRow) => {
+    if (typeof club.quality_level !== "number") {
+      return "Tier 1";
+    }
+    const tier = Math.max(1, Math.min(5, Math.round(club.quality_level)));
+    return QUALITY_LABELS[tier] ?? `Tier ${tier}`;
+  }, []);
+
+  const sortedCities = useMemo(
+    () => cities.slice().sort((a, b) => a.name.localeCompare(b.name)),
+    [cities],
+  );
+
+  return (
+    <AdminRoute>
+      <div className="container mx-auto space-y-6 p-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Night Clubs</h1>
+          <p className="text-muted-foreground">
+            Configure nightlife venues, DJ slot requirements, and social experiences linked to each city.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr,3fr]">
+          <Card className="h-fit">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <PlusCircle className="h-5 w-5 text-primary" />
+                {editingClub ? "Edit Night Club" : "Add Night Club"}
+              </CardTitle>
+              <CardDescription>
+                {editingClub
+                  ? "Update club details, DJ slot settings, and NPC rosters."
+                  : "Create a new nightlife venue with configurable experiences."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Form {...nightClubForm}>
+                <form onSubmit={onSubmit} className="space-y-6">
+                  <FormField
+                    control={nightClubForm.control}
+                    name="city_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>City</FormLabel>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select a city" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {sortedCities.map((city) => (
+                              <SelectItem key={city.id} value={city.id}>
+                                {city.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Club name</FormLabel>
+                        <FormControl>
+                          <Input {...field} placeholder="Midnight Pulse" />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="description"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Description</FormLabel>
+                        <FormControl>
+                          <Textarea {...field} rows={3} placeholder="Describe the club's vibe, layout, and music policy." />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <FormField
+                      control={nightClubForm.control}
+                      name="quality_level"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Quality tier (1-5)</FormLabel>
+                          <FormControl>
+                            <Input {...field} type="number" min={1} max={5} placeholder="3" />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={nightClubForm.control}
+                      name="capacity"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Capacity</FormLabel>
+                          <FormControl>
+                            <Input {...field} type="number" min={0} placeholder="350" />
+                          </FormControl>
+                          <FormDescription>Optional. Leave blank for unknown capacity.</FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={nightClubForm.control}
+                      name="cover_charge"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Cover charge (USD)</FormLabel>
+                          <FormControl>
+                            <Input {...field} type="number" min={0} step="0.01" placeholder="25" />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="guest_actions"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Guest actions (JSON array)</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            rows={3}
+                            placeholder='[{"label":"Buy signature drink","description":"Boosts social energy"}]'
+                          />
+                        </FormControl>
+                        <FormDescription>Configure activities available to visiting players.</FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="drink_menu"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Drink menu (JSON array)</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            rows={3}
+                            placeholder='[{"name":"Neon Bloom","price":18,"effect":"+10 morale"}]'
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="npc_profiles"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>NPC roster (JSON array)</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            rows={3}
+                            placeholder='[{"name":"DJ Vega","role":"Resident DJ","personality":"Charismatic"}]'
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="dj_slot_config"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>DJ slot configuration (JSON object)</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            rows={5}
+                            placeholder='{"minimum_fame": 750, "payout": 800, "set_length_minutes": 60}'
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          Define fame requirements, payouts, set length, and optional perks.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={nightClubForm.control}
+                    name="live_interactions_enabled"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center justify-between rounded-md border border-border/60 p-3">
+                        <div className="space-y-1">
+                          <FormLabel>Live interactions</FormLabel>
+                          <FormDescription>
+                            Enable real-time chats and matchmaking for this venue.
+                          </FormDescription>
+                        </div>
+                        <FormControl>
+                          <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="submit" disabled={isSubmitting}>
+                      {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      {editingClub ? "Save changes" : "Create night club"}
+                    </Button>
+                    {editingClub && (
+                      <Button type="button" variant="outline" onClick={resetForm} disabled={isSubmitting}>
+                        Cancel edit
+                      </Button>
+                    )}
+                  </div>
+                </form>
+              </Form>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Configured night clubs</CardTitle>
+              <CardDescription>
+                Review nightlife venues across the world. Fame requirements scale with club quality.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="flex items-center justify-center py-10 text-muted-foreground">
+                  <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading night clubs...
+                </div>
+              ) : loadingError ? (
+                <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+                  {loadingError}
+                </div>
+              ) : nightClubs.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border/60 p-6 text-center text-sm text-muted-foreground">
+                  No night clubs have been configured yet. Use the form to create one.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Club</TableHead>
+                      <TableHead>City</TableHead>
+                      <TableHead>Quality</TableHead>
+                      <TableHead>Fame requirement</TableHead>
+                      <TableHead className="hidden xl:table-cell">Guest actions</TableHead>
+                      <TableHead>Live</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {nightClubs.map((club) => {
+                      const fameRequirement = computeFameRequirement(club);
+                      const interactionsEnabled = parseLiveInteractionFlag(club);
+
+                      return (
+                        <TableRow key={club.id} className="align-top">
+                          <TableCell>
+                            <div className="space-y-1">
+                              <div className="font-medium text-foreground">{club.name ?? "Untitled club"}</div>
+                              {club.description && (
+                                <p className="text-xs text-muted-foreground">{club.description}</p>
+                              )}
+                              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                {club.capacity && <span>Cap {club.capacity.toLocaleString()}</span>}
+                                {typeof club.cover_charge === "number" && (
+                                  <span>Cover {currencyFormatter.format(club.cover_charge)}</span>
+                                )}
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>{club.city?.name ?? "Unlinked"}</TableCell>
+                          <TableCell>
+                            <Badge variant="secondary">{qualityLabel(club)}</Badge>
+                          </TableCell>
+                          <TableCell>{fameRequirement.toLocaleString()} fame</TableCell>
+                          <TableCell className="hidden xl:table-cell">
+                            {Array.isArray(club.guest_actions) && club.guest_actions.length > 0 ? (
+                              <div className="flex flex-wrap gap-1">
+                                {club.guest_actions.slice(0, 4).map((action, index) => {
+                                  if (typeof action === "string") {
+                                    return (
+                                      <Badge key={`${club.id}-action-${index}`} variant="outline">
+                                        {action}
+                                      </Badge>
+                                    );
+                                  }
+
+                                  if (action && typeof action === "object" && "label" in action && typeof action.label === "string") {
+                                    return (
+                                      <Badge key={`${club.id}-action-${index}`} variant="outline">
+                                        {action.label}
+                                      </Badge>
+                                    );
+                                  }
+
+                                  return null;
+                                })}
+                                {club.guest_actions.length > 4 && (
+                                  <Badge variant="outline">+{club.guest_actions.length - 4} more</Badge>
+                                )}
+                              </div>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={interactionsEnabled ? "outline" : "destructive"}>
+                              {interactionsEnabled ? "Enabled" : "Disabled"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="flex justify-end gap-2">
+                            <Button size="icon" variant="outline" onClick={() => handleEdit(club)}>
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="text-destructive"
+                              onClick={() => handleDelete(club.id)}
+                              disabled={deletingClubId === club.id}
+                            >
+                              {deletingClubId === club.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="h-4 w-4" />
+                              )}
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </AdminRoute>
+  );
+};
+
+export default NightClubsAdmin;

--- a/src/utils/worldEnvironment.ts
+++ b/src/utils/worldEnvironment.ts
@@ -204,6 +204,52 @@ export interface CityTransportLink {
   distance?: string;
 }
 
+export interface NightClubGuestAction {
+  id: string;
+  label: string;
+  description?: string;
+  energyCost?: number | null;
+}
+
+export interface NightClubDrink {
+  id: string;
+  name: string;
+  price: number | null;
+  effect?: string | null;
+}
+
+export interface NightClubNPCProfile {
+  id: string;
+  name: string;
+  role?: string | null;
+  personality?: string | null;
+  dialogueHooks?: string[];
+  availability?: string | null;
+}
+
+export interface NightClubDjSlotConfig {
+  fameRequirement: number;
+  payout?: number | null;
+  schedule?: string | null;
+  setLengthMinutes?: number | null;
+  perks?: string[];
+}
+
+export interface CityNightClub {
+  id: string;
+  cityId: string;
+  name: string;
+  description?: string | null;
+  qualityLevel: number;
+  capacity?: number | null;
+  coverCharge?: number | null;
+  guestActions: NightClubGuestAction[];
+  drinkMenu: NightClubDrink[];
+  npcProfiles: NightClubNPCProfile[];
+  djSlot: NightClubDjSlotConfig;
+  liveInteractionsEnabled: boolean;
+}
+
 const normalizeDistricts = (value: unknown): CityDistrict[] => {
   if (!Array.isArray(value)) {
     return [];
@@ -461,6 +507,214 @@ const normalizeTransportEntries = (
   return [];
 };
 
+const parseNightClubGuestActions = (value: unknown): NightClubGuestAction[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.reduce<NightClubGuestAction[]>((acc, entry, index) => {
+      if (typeof entry === "string") {
+        acc.push({
+          id: `guest-action-${index}`,
+          label: entry,
+        });
+        return acc;
+      }
+
+      if (!isRecord(entry)) {
+        return acc;
+      }
+
+      const labelRaw = typeof entry.label === "string" ? entry.label : (typeof entry.name === "string" ? entry.name : "Guest action");
+      const descriptionRaw = typeof entry.description === "string" ? entry.description : undefined;
+      const energyCostValue = toNumber(entry.energy_cost ?? entry.energyCost, Number.NaN);
+
+      acc.push({
+        id: String(entry.id ?? `guest-action-${index}`),
+        label: labelRaw,
+        description: descriptionRaw,
+        energyCost: Number.isNaN(energyCostValue) ? null : energyCostValue,
+      });
+      return acc;
+    }, []);
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    return value.split(",").map((entry, index) => ({
+      id: `guest-action-${index}`,
+      label: entry.trim(),
+    }));
+  }
+
+  return [];
+};
+
+const parseNightClubDrinkMenu = (value: unknown): NightClubDrink[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.reduce<NightClubDrink[]>((acc, entry, index) => {
+      if (typeof entry === "string") {
+        acc.push({
+          id: `drink-${index}`,
+          name: entry,
+          price: null,
+        });
+        return acc;
+      }
+
+      if (!isRecord(entry)) {
+        return acc;
+      }
+
+      const nameRaw = typeof entry.name === "string" ? entry.name : (typeof entry.label === "string" ? entry.label : "Signature Drink");
+      const effectRaw = typeof entry.effect === "string" ? entry.effect : (typeof entry.bonus === "string" ? entry.bonus : undefined);
+      const priceValue = toNumber(entry.price ?? entry.cost ?? entry.value, Number.NaN);
+
+      acc.push({
+        id: String(entry.id ?? `drink-${index}`),
+        name: nameRaw,
+        effect: effectRaw ?? null,
+        price: Number.isNaN(priceValue) ? null : priceValue,
+      });
+      return acc;
+    }, []);
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    return value.split(",").map((entry, index) => ({
+      id: `drink-${index}`,
+      name: entry.trim(),
+      price: null,
+    }));
+  }
+
+  return [];
+};
+
+const parseNightClubNpcProfiles = (value: unknown): NightClubNPCProfile[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.reduce<NightClubNPCProfile[]>((acc, entry, index) => {
+      if (typeof entry === "string") {
+        acc.push({
+          id: `npc-${index}`,
+          name: entry,
+        });
+        return acc;
+      }
+
+      if (!isRecord(entry)) {
+        return acc;
+      }
+
+      const nameRaw = typeof entry.name === "string" ? entry.name : (typeof entry.handle === "string" ? entry.handle : "Club NPC");
+      const roleRaw = typeof entry.role === "string" ? entry.role : (typeof entry.title === "string" ? entry.title : undefined);
+      const personalityRaw = typeof entry.personality === "string" ? entry.personality : (typeof entry.vibe === "string" ? entry.vibe : undefined);
+      const availabilityRaw = typeof entry.schedule === "string" ? entry.schedule : (typeof entry.availability === "string" ? entry.availability : undefined);
+      const dialogueHooks = normalizeStringArray(entry.dialogue ?? entry.dialogue_hooks ?? entry.prompts);
+
+      acc.push({
+        id: String(entry.id ?? `npc-${index}`),
+        name: nameRaw,
+        role: roleRaw ?? null,
+        personality: personalityRaw ?? null,
+        availability: availabilityRaw ?? null,
+        dialogueHooks: dialogueHooks,
+      });
+      return acc;
+    }, []);
+  }
+
+  if (typeof value === "string" && value.trim()) {
+    return value.split(",").map((entry, index) => ({
+      id: `npc-${index}`,
+      name: entry.trim(),
+    }));
+  }
+
+  return [];
+};
+
+const parseNightClubDjSlotConfig = (
+  rawConfig: unknown,
+  qualityLevel: number,
+): NightClubDjSlotConfig => {
+  const baseRequirement = Math.max(1, qualityLevel) * 250;
+
+  if (!isRecord(rawConfig)) {
+    return {
+      fameRequirement: baseRequirement,
+    };
+  }
+
+  const perks = normalizeStringArray(
+    rawConfig.perks ?? rawConfig.rewards ?? rawConfig.bonuses ?? rawConfig.set_perks,
+  );
+  const payoutValue = toNumber(
+    rawConfig.payout ?? rawConfig.payment ?? rawConfig.fee ?? rawConfig.reward,
+    Number.NaN,
+  );
+  const setLengthValue = toNumber(
+    rawConfig.set_length_minutes ?? rawConfig.setLength ?? rawConfig.duration_minutes ?? rawConfig.duration,
+    Number.NaN,
+  );
+  const fameRequirementValue = toNumber(
+    rawConfig.minimum_fame ?? rawConfig.fame_requirement ?? rawConfig.requirements?.fame,
+    Number.NaN,
+  );
+  const scheduleRaw = typeof rawConfig.schedule === "string"
+    ? rawConfig.schedule
+    : typeof rawConfig.window === "string"
+      ? rawConfig.window
+      : typeof rawConfig.timeslot === "string"
+        ? rawConfig.timeslot
+        : undefined;
+
+  return {
+    fameRequirement: Number.isNaN(fameRequirementValue) ? baseRequirement : fameRequirementValue,
+    payout: Number.isNaN(payoutValue) ? null : payoutValue,
+    schedule: scheduleRaw ?? null,
+    setLengthMinutes: Number.isNaN(setLengthValue) ? null : setLengthValue,
+    perks,
+  };
+};
+
+const normalizeNightClubRecord = (item: Record<string, unknown>): CityNightClub => {
+  const qualityValue = toNumber(item.quality_level ?? item.quality ?? item.level, 1);
+  const boundedQuality = Number.isNaN(qualityValue) ? 1 : Math.min(5, Math.max(1, Math.round(qualityValue)));
+  const capacityValue = toNumber(item.capacity, Number.NaN);
+  const coverChargeValue = toNumber(item.cover_charge ?? item.cover ?? item.entry_fee, Number.NaN);
+  const metadataRecord = isRecord(item.metadata) ? (item.metadata as Record<string, unknown>) : null;
+  const liveInteractionsValue = metadataRecord?.live_interactions_enabled ?? metadataRecord?.liveInteractionsEnabled;
+
+  const guestActions = parseNightClubGuestActions(item.guest_actions ?? metadataRecord?.guest_actions);
+  const drinkMenu = parseNightClubDrinkMenu(item.drink_menu ?? metadataRecord?.drink_menu);
+  const npcProfiles = parseNightClubNpcProfiles(item.npc_profiles ?? metadataRecord?.npc_profiles);
+  const djSlot = parseNightClubDjSlotConfig(item.dj_slot_config ?? metadataRecord?.dj_slot_config, boundedQuality);
+
+  return {
+    id: String(item.id ?? crypto.randomUUID()),
+    cityId: typeof item.city_id === "string" ? item.city_id : String(item.city_id ?? ""),
+    name: typeof item.name === "string" ? item.name : "Night Club",
+    description: typeof item.description === "string" ? item.description : null,
+    qualityLevel: boundedQuality,
+    capacity: Number.isNaN(capacityValue) ? null : capacityValue,
+    coverCharge: Number.isNaN(coverChargeValue) ? null : coverChargeValue,
+    guestActions,
+    drinkMenu,
+    npcProfiles,
+    djSlot,
+    liveInteractionsEnabled: typeof liveInteractionsValue === "boolean" ? liveInteractionsValue : true,
+  };
+};
+
 export interface WeatherCondition {
   id: string;
   city: string;
@@ -608,6 +862,7 @@ export interface CityEnvironmentDetails {
   travelModes: CityTravelMode[];
   players: CityPlayer[];
   gigs: CityGig[];
+  nightClubs: CityNightClub[];
 }
 
 export interface FetchCityEnvironmentOptions {
@@ -1131,7 +1386,7 @@ export const fetchCityEnvironmentDetails = async (
 ): Promise<CityEnvironmentDetails> => {
   const { cityName, country } = options;
 
-  const [playersResponse, gigsResponse, metadataResponse] = await Promise.all([
+  const [playersResponse, gigsResponse, metadataResponse, nightClubsResponse] = await Promise.all([
     supabase
       .from("profiles")
       .select(
@@ -1150,11 +1405,20 @@ export const fetchCityEnvironmentDetails = async (
       .select("*")
       .eq("city_id", cityId)
       .maybeSingle(),
+    supabase
+      .from<Record<string, unknown>>("city_night_clubs")
+      .select("*")
+      .eq("city_id", cityId)
+      .order("quality_level", { ascending: false })
+      .order("created_at", { ascending: true }),
   ]);
 
   if (playersResponse.error) throw playersResponse.error;
   if (gigsResponse.error) throw gigsResponse.error;
   if (metadataResponse.error) throw metadataResponse.error;
+  if (nightClubsResponse.error && !isSchemaCacheMissingTableError(nightClubsResponse.error, "city_night_clubs")) {
+    throw nightClubsResponse.error;
+  }
 
   const metadataRecord = metadataResponse.data
     ? normalizeCityMetadataRecord((metadataResponse.data as any) as Record<string, unknown>)
@@ -1185,6 +1449,10 @@ export const fetchCityEnvironmentDetails = async (
 
   const locations = metadataRecord?.locations ?? [];
 
+  const nightClubs = nightClubsResponse.error
+    ? []
+    : (nightClubsResponse.data ?? []).map((item: any) => normalizeNightClubRecord(item as Record<string, unknown>));
+
   return {
     cityId,
     cityName,
@@ -1194,6 +1462,7 @@ export const fetchCityEnvironmentDetails = async (
     travelModes,
     players,
     gigs,
+    nightClubs,
   };
 };
 

--- a/supabase/migrations/20261022103000_add_city_night_clubs.sql
+++ b/supabase/migrations/20261022103000_add_city_night_clubs.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.city_night_clubs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  quality_level integer NOT NULL CHECK (quality_level BETWEEN 1 AND 5),
+  capacity integer,
+  cover_charge numeric(10, 2),
+  guest_actions jsonb NOT NULL DEFAULT '[]'::jsonb,
+  drink_menu jsonb NOT NULL DEFAULT '[]'::jsonb,
+  npc_profiles jsonb NOT NULL DEFAULT '[]'::jsonb,
+  dj_slot_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS city_night_clubs_city_id_idx
+  ON public.city_night_clubs (city_id);
+
+ALTER TABLE public.city_night_clubs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Night clubs are viewable by everyone" ON public.city_night_clubs;
+CREATE POLICY "Night clubs are viewable by everyone"
+  ON public.city_night_clubs
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Privileged roles manage night clubs" ON public.city_night_clubs;
+CREATE POLICY "Privileged roles manage night clubs"
+  ON public.city_night_clubs
+  FOR ALL
+  USING (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+  )
+  WITH CHECK (
+    auth.role() = 'service_role'
+    OR public.has_role(auth.uid(), 'admin')
+  );
+
+DROP TRIGGER IF EXISTS update_city_night_clubs_updated_at ON public.city_night_clubs;
+CREATE TRIGGER update_city_night_clubs_updated_at
+  BEFORE UPDATE ON public.city_night_clubs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a Supabase migration to create `city_night_clubs` with RLS policies for configurable nightlife data
- surface normalized night club details in the city page with DJ slot requirements, guest actions, and NPCs
- provide an admin tool and routing to create, edit, and remove night clubs linked to cities

## Testing
- npm run lint *(fails: repository currently has hundreds of pre-existing lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e57bb9164c8325ba9ae16e1689c98d