### PR TITLE
Ensure profiles support avatar uploads

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2188,10 +2188,12 @@ export type Database = {
       profiles: {
         Row: {
           age: number
+          avatar_url: string | null
           bio: string | null
           cash: number | null
           created_at: string | null
           current_city_id: string | null
+          current_location: string | null
           display_name: string | null
           energy: number
           experience: number | null
@@ -2212,10 +2214,12 @@ export type Database = {
         }
         Insert: {
           age?: number
+          avatar_url?: string | null
           bio?: string | null
           cash?: number | null
           created_at?: string | null
           current_city_id?: string | null
+          current_location?: string | null
           display_name?: string | null
           energy?: number
           experience?: number | null
@@ -2236,10 +2240,12 @@ export type Database = {
         }
         Update: {
           age?: number
+          avatar_url?: string | null
           bio?: string | null
           cash?: number | null
           created_at?: string | null
           current_city_id?: string | null
+          current_location?: string | null
           display_name?: string | null
           energy?: number
           experience?: number | null

--- a/supabase/migrations/20290601120000_add_avatar_and_location_to_profiles.sql
+++ b/supabase/migrations/20290601120000_add_avatar_and_location_to_profiles.sql
@@ -1,0 +1,7 @@
+-- Ensure the profiles table has fields required by the frontend
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS avatar_url text,
+  ADD COLUMN IF NOT EXISTS current_location text;
+
+-- Make sure PostgREST picks up the schema change right away
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add a migration that guarantees the `profiles` table exposes the `avatar_url` and `current_location` columns expected by the app
- refresh the generated Supabase profile typings so the new fields are available to the frontend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e656f82f7883258dace966fbb59246