### PR TITLE
Fix Filter icon import on Employment page

### DIFF
--- a/src/pages/Employment.tsx
+++ b/src/pages/Employment.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
-import { Briefcase, Clock, DollarSign, Heart, Star, Zap, Calendar, TrendingUp, AlertCircle, CalendarCheck } from "lucide-react";
+import { Briefcase, Clock, DollarSign, Heart, Star, Zap, Calendar, TrendingUp, AlertCircle, CalendarCheck, Filter } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";


### PR DESCRIPTION
## Summary
- import the missing Filter icon from lucide-react on the Employment page

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e664a260bc832590b4b6c2b3cd4288