### PR TITLE
Add auto clock-in support to employment workflows

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1693,6 +1693,7 @@ export type Database = {
       }
       player_employment: {
         Row: {
+          auto_clock_in: boolean
           created_at: string | null
           hired_at: string | null
           id: string
@@ -1706,6 +1707,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          auto_clock_in?: boolean
           created_at?: string | null
           hired_at?: string | null
           id?: string
@@ -1719,6 +1721,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          auto_clock_in?: boolean
           created_at?: string | null
           hired_at?: string | null
           id?: string

--- a/supabase/migrations/20290602110000_ensure_auto_clock_in_column.sql
+++ b/supabase/migrations/20290602110000_ensure_auto_clock_in_column.sql
@@ -1,0 +1,8 @@
+-- Ensure player employment supports automatic clock-ins
+ALTER TABLE public.player_employment
+ADD COLUMN IF NOT EXISTS auto_clock_in BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill any existing records that might have null values
+UPDATE public.player_employment
+SET auto_clock_in = false
+WHERE auto_clock_in IS NULL;


### PR DESCRIPTION
## Summary
- add a migration to guarantee the `player_employment` table has the `auto_clock_in` column
- expose the new column in the generated Supabase TypeScript definitions
- tighten the Employment page queries and UI logic to use the typed data instead of loose casts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e664a260bc832590b4b6c2b3cd4288