### PR TITLE
Add health tab activity locking

### DIFF
--- a/src/pages/MyCharacter.tsx
+++ b/src/pages/MyCharacter.tsx
@@ -117,7 +117,8 @@ const MyCharacter = () => {
     loading,
     error,
     currentCity,
-    awardActionXp,
+    activityStatus,
+    startActivity,
   } = useGameData();
   const { toast } = useToast();
   const [claimingDailyXp, setClaimingDailyXp] = useState(false);
@@ -723,7 +724,12 @@ const MyCharacter = () => {
     </TabsContent>
 
     <TabsContent value="health" className="space-y-6 mt-6">
-      <HealthSection profile={profile} attributes={attributes} awardActionXp={awardActionXp} />
+      <HealthSection
+        profile={profile}
+        attributes={attributes}
+        activityStatus={activityStatus}
+        startActivity={startActivity}
+      />
     </TabsContent>
 
     <TabsContent value="achievements" className="space-y-6 mt-6">


### PR DESCRIPTION
## Summary
- register wellness activities in the health tab as timed profile activities so they lock out other gameplay while active
- surface current busy status and countdown in the health tab while disabling wellness buttons during another activity
- wire the My Character page to provide activity status context to the health section

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors around `any` usage and missing hook dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e6693065c48325bc6d3bc25222b081