### PR TITLE
Fix inventory page load failure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { lazyWithRetry } from "./utils/lazyWithRetry";
 import WorldPulsePage from "./pages/WorldPulse";
 import MusicStudio from "./pages/MusicStudio";
 import BandManager from "./pages/BandManager";
+import InventoryManager from "./pages/InventoryManager";
 
 const Layout = lazyWithRetry(() => import("./components/Layout"));
 const Index = lazyWithRetry(() => import("./pages/Index"));
@@ -62,7 +63,6 @@ const AdminJobs = lazyWithRetry(() => import("./pages/admin/Jobs"));
 const WorldEnvironment = lazyWithRetry(() => import("./pages/WorldEnvironment"));
 const Employment = lazyWithRetry(() => import("./pages/Employment"));
 const SongManager = lazyWithRetry(() => import("./pages/SongManager"));
-const InventoryManager = lazyWithRetry(() => import("./pages/InventoryManager"));
 const PlayerStatistics = lazyWithRetry(() => import("./pages/PlayerStatistics"));
 const Busking = lazyWithRetry(() => import("./pages/Busking"));
 const JamSessions = lazyWithRetry(() => import("./pages/JamSessions"));

--- a/src/pages/InventoryManager.tsx
+++ b/src/pages/InventoryManager.tsx
@@ -3,8 +3,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Loader2 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
-import { supabase } from "@/integrations/supabase/client";
-import type { Tables } from "@/lib/supabase-types";
 import { useAuth } from "@/hooks/use-auth-context";
 import { fetchPrimaryProfileForUser } from "@/integrations/supabase/friends";
 
@@ -32,9 +30,7 @@ const InventoryManager = () => {
   const [profileId, setProfileId] = useState<string | null>(null);
   const [isLoadingProfile, setIsLoadingProfile] = useState(false);
   const [isLoadingBooks, setIsLoadingBooks] = useState(false);
-  const [bookInventory, setBookInventory] = useState<
-    (PlayerSkillBookRow & { skill_books: SkillBookRow | null })[]
-  >([]);
+  const [bookInventory, setBookInventory] = useState<PlayerSkillBookRow[]>([]);
   const [isBookInventorySupported, setIsBookInventorySupported] = useState(true);
 
   const loadBookInventory = useCallback(


### PR DESCRIPTION
## Summary
- import the inventory manager page synchronously so it no longer relies on a flaky dynamic chunk
- remove unused supabase imports from the inventory manager implementation and simplify its state typing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e66966fab88325a7061e873aa8074f