### PR TITLE
Fix activity lock rollback on health tab errors

### DIFF
--- a/src/components/character/HealthSection.tsx
+++ b/src/components/character/HealthSection.tsx
@@ -51,6 +51,7 @@ interface HealthSectionProps {
       metadata?: Record<string, unknown> | null;
     },
   ) => Promise<ProfileActivityStatus | null>;
+  clearActivityStatus: () => Promise<void>;
 }
 
 export function HealthSection({
@@ -58,6 +59,7 @@ export function HealthSection({
   attributes,
   activityStatus,
   startActivity,
+  clearActivityStatus,
 }: HealthSectionProps) {
   const queryClient = useQueryClient();
 
@@ -140,15 +142,28 @@ export function HealthSection({
 
       const newHealth = Math.min(100, health + 10);
       const newEnergy = Math.min(100, energy + 15);
-      const { error } = await supabase
-        .from("profiles")
-        .update({
-          health: newHealth,
-          energy: newEnergy,
-          last_health_update: new Date().toISOString(),
-        })
-        .eq("id", profile.id);
-      if (error) throw error;
+
+      try {
+        const { error } = await supabase
+          .from("profiles")
+          .update({
+            health: newHealth,
+            energy: newEnergy,
+            last_health_update: new Date().toISOString(),
+          })
+          .eq("id", profile.id);
+        if (error) throw error;
+      } catch (error) {
+        if (statusRecord) {
+          try {
+            await clearActivityStatus();
+          } catch (clearError) {
+            console.error("Failed to clear activity status after rest failure", clearError);
+          }
+        }
+        throw error;
+      }
+
       return { health: newHealth, energy: newEnergy };
     },
     onSuccess: ({ health, energy }) => {
@@ -179,15 +194,28 @@ export function HealthSection({
 
       const newHealth = Math.min(100, health + 8);
       const newEnergy = Math.max(0, energy - 15);
-      const { error } = await supabase
-        .from("profiles")
-        .update({
-          health: newHealth,
-          energy: newEnergy,
-          last_health_update: new Date().toISOString(),
-        })
-        .eq("id", profile.id);
-      if (error) throw error;
+
+      try {
+        const { error } = await supabase
+          .from("profiles")
+          .update({
+            health: newHealth,
+            energy: newEnergy,
+            last_health_update: new Date().toISOString(),
+          })
+          .eq("id", profile.id);
+        if (error) throw error;
+      } catch (error) {
+        if (statusRecord) {
+          try {
+            await clearActivityStatus();
+          } catch (clearError) {
+            console.error("Failed to clear activity status after yoga failure", clearError);
+          }
+        }
+        throw error;
+      }
+
       return { health: newHealth, energy: newEnergy };
     },
     onSuccess: ({ health, energy }) => {
@@ -220,15 +248,28 @@ export function HealthSection({
 
       const newHealth = Math.min(100, health + 12);
       const newEnergy = Math.max(0, energy - 25);
-      const { error } = await supabase
-        .from("profiles")
-        .update({
-          health: newHealth,
-          energy: newEnergy,
-          last_health_update: new Date().toISOString(),
-        })
-        .eq("id", profile.id);
-      if (error) throw error;
+
+      try {
+        const { error } = await supabase
+          .from("profiles")
+          .update({
+            health: newHealth,
+            energy: newEnergy,
+            last_health_update: new Date().toISOString(),
+          })
+          .eq("id", profile.id);
+        if (error) throw error;
+      } catch (error) {
+        if (statusRecord) {
+          try {
+            await clearActivityStatus();
+          } catch (clearError) {
+            console.error("Failed to clear activity status after run failure", clearError);
+          }
+        }
+        throw error;
+      }
+
       return { health: newHealth, energy: newEnergy, duration };
     },
     onSuccess: ({ health, energy, duration }) => {

--- a/src/pages/MyCharacter.tsx
+++ b/src/pages/MyCharacter.tsx
@@ -119,6 +119,7 @@ const MyCharacter = () => {
     currentCity,
     activityStatus,
     startActivity,
+    clearActivityStatus,
   } = useGameData();
   const { toast } = useToast();
   const [claimingDailyXp, setClaimingDailyXp] = useState(false);
@@ -729,6 +730,7 @@ const MyCharacter = () => {
         attributes={attributes}
         activityStatus={activityStatus}
         startActivity={startActivity}
+        clearActivityStatus={clearActivityStatus}
       />
     </TabsContent>
 


### PR DESCRIPTION
## Summary
- add clearActivityStatus support to the health tab so wellness mutations can roll back activity state on failure
- clear the recorded activity status when rest, yoga, or run profile updates throw to avoid leaving players locked out

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors around `any` usage in Supabase shared modules and progression handlers)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c7857c248325b55c89451a5bda78