### PR TITLE
Add auto clock in to player employment types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1693,6 +1693,7 @@ export type Database = {
       }
       player_employment: {
         Row: {
+          auto_clock_in: boolean
           created_at: string | null
           hired_at: string | null
           id: string
@@ -1706,6 +1707,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          auto_clock_in?: boolean
           created_at?: string | null
           hired_at?: string | null
           id?: string
@@ -1719,6 +1721,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          auto_clock_in?: boolean
           created_at?: string | null
           hired_at?: string | null
           id?: string


### PR DESCRIPTION
## Summary
- add the `auto_clock_in` field to the generated Supabase types for `player_employment`
- allow employment components to access the new flag without type errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74e84e55c83258487b72eaaa1e287