### PR TITLE
Handle undefined university enrollment price values

### DIFF
--- a/src/components/university/EnrollmentProgressCard.tsx
+++ b/src/components/university/EnrollmentProgressCard.tsx
@@ -48,6 +48,10 @@ export function EnrollmentProgressCard({ enrollment, onDropCourse }: EnrollmentP
   const totalDays = enrollment.university_courses.base_duration_days;
   const daysAttended = enrollment.days_attended;
   const progressPercentage = (daysAttended / totalDays) * 100;
+  const paymentAmount =
+    typeof enrollment.payment_amount === "number" && !Number.isNaN(enrollment.payment_amount)
+      ? enrollment.payment_amount
+      : 0;
   
   // Validate scheduled_end_date before using it
   const endDate = enrollment.scheduled_end_date ? new Date(enrollment.scheduled_end_date) : null;
@@ -148,7 +152,7 @@ export function EnrollmentProgressCard({ enrollment, onDropCourse }: EnrollmentP
               <DollarSign className="h-4 w-4" />
               <span className="text-xs font-medium">Amount Paid</span>
             </div>
-            <p className="text-2xl font-bold">${enrollment.payment_amount.toLocaleString()}</p>
+            <p className="text-2xl font-bold">${paymentAmount.toLocaleString()}</p>
             <p className="text-xs text-muted-foreground">Course fee</p>
           </div>
         </div>

--- a/src/pages/UniversityDetail.tsx
+++ b/src/pages/UniversityDetail.tsx
@@ -216,9 +216,10 @@ export default function UniversityDetail() {
     return Math.ceil(baseDays * durationMultiplier);
   };
 
-  const calculatePrice = (basePrice: number) => {
-    if (!university) return basePrice;
-    return Math.floor(basePrice * (university.course_cost_modifier || 1.0));
+  const calculatePrice = (basePrice?: number | null) => {
+    const normalizedPrice = typeof basePrice === "number" && !Number.isNaN(basePrice) ? basePrice : 0;
+    if (!university) return normalizedPrice;
+    return Math.floor(normalizedPrice * (university.course_cost_modifier || 1.0));
   };
 
   const getSkillLevel = (skillSlug: string) => {


### PR DESCRIPTION
## Summary
- guard against missing enrollment payment amounts before formatting currency in the progress card
- normalize course pricing inputs before applying university modifiers to prevent undefined currency formatting

## Testing
- `npm run lint` *(fails: existing lint violations throughout the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e75948ccec832582203066acbccd0d