### PR TITLE
Limit mobile bottom navigation options

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -120,13 +120,7 @@ const Navigation = () => {
   const mobileShortcuts = [
     { icon: Home, label: "Dashboard", path: "/dashboard" },
     { icon: Music, label: "Performance", path: "/performance" },
-    { icon: Calendar, label: "Gigs", path: "/gigs" },
-    { icon: ListMusic, label: "Setlists", path: "/setlists" },
-    { icon: Award, label: "Awards", path: "/awards" },
-    { icon: Plane, label: "Travel", path: "/travel" },
-    { icon: Megaphone, label: "PR", path: "/pr" },
     { icon: User, label: "My Character", path: "/my-character" },
-    { icon: DollarSign, label: "Underworld", path: "/underworld" },
   ];
 
   const handleLogout = async () => {


### PR DESCRIPTION
## Summary
- restrict the mobile bottom navigation shortcuts to dashboard, performance, and my character

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e94965d548832580e2ff5fae3393c2