### PR TITLE
Re-enable friend management features

### DIFF
--- a/src/components/band/InviteFriendToBand.tsx
+++ b/src/components/band/InviteFriendToBand.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -7,6 +7,8 @@ import { Label } from '@/components/ui/label';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { UserPlus, Loader2 } from 'lucide-react';
+import type { Database } from '@/lib/supabase-types';
+import { fetchPrimaryProfileForUser } from '@/integrations/supabase/friends';
 
 interface InviteFriendToBandProps {
   bandId: string;
@@ -14,12 +16,13 @@ interface InviteFriendToBandProps {
   currentUserId: string;
 }
 
+type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
 interface Friend {
   id: string;
-  user_id: string;
-  friend_user_id: string;
-  friend_profile: {
+  profile: {
     id: string;
+    user_id: string;
     display_name: string;
     username: string;
   };
@@ -37,60 +40,60 @@ export function InviteFriendToBand({ bandId, bandName, currentUserId }: InviteFr
   const [instrumentRole, setInstrumentRole] = useState('Guitar');
   const [vocalRole, setVocalRole] = useState<string | undefined>(undefined);
   const [message, setMessage] = useState('');
+  const [currentProfile, setCurrentProfile] = useState<ProfileRow | null>(null);
   const { toast } = useToast();
 
-  useEffect(() => {
-    if (open) {
-      loadFriends();
-    }
-  }, [open]);
-
-  const loadFriends = async () => {
-    setLoading(true);
+  const loadFriends = useCallback(async (profileId: string) => {
     try {
-      // Get accepted friendships with friend user IDs
       const { data: friendships, error } = await supabase
         .from('friendships')
-        .select('id, user_id, friend_user_id, friend_profile_id')
-        .eq('user_id', currentUserId)
-        .eq('status', 'accepted');
+        .select('id, requester_id, addressee_id, status')
+        .eq('status', 'accepted')
+        .or(`requester_id.eq.${profileId},addressee_id.eq.${profileId}`);
 
       if (error) throw error;
 
       if (!friendships || friendships.length === 0) {
         setFriends([]);
-        setLoading(false);
         return;
       }
 
-      // Get friend profiles separately
-      const profileIds = friendships.map(f => f.friend_profile_id).filter(Boolean);
+      const otherProfileIds = Array.from(new Set(friendships.map(friendship =>
+        friendship.requester_id === profileId ? friendship.addressee_id : friendship.requester_id
+      )));
+
+      if (otherProfileIds.length === 0) {
+        setFriends([]);
+        return;
+      }
+
       const { data: profiles, error: profilesError } = await supabase
         .from('profiles')
         .select('id, display_name, username, user_id')
-        .in('id', profileIds);
+        .in('id', otherProfileIds);
 
       if (profilesError) throw profilesError;
 
-      // Map friendships to friends with profile data
+      const profileMap = new Map((profiles || []).map((profile) => [profile.id, profile]));
+
       const friendsWithProfiles = friendships
         .map(friendship => {
-          const profile = profiles?.find(p => p.id === friendship.friend_profile_id);
+          const otherId = friendship.requester_id === profileId ? friendship.addressee_id : friendship.requester_id;
+          const profile = profileMap.get(otherId);
           if (!profile) return null;
+
           return {
             id: friendship.id,
-            user_id: friendship.user_id,
-            friend_user_id: friendship.friend_user_id,
-            friend_profile: {
+            profile: {
               id: profile.id,
+              user_id: profile.user_id,
               display_name: profile.display_name || 'Unknown',
               username: profile.username || 'unknown',
             },
-          };
+          } satisfies Friend;
         })
         .filter(Boolean) as Friend[];
 
-      // Filter out friends who are already band members or have pending invitations
       const { data: bandMembers } = await supabase
         .from('band_members')
         .select('user_id')
@@ -108,7 +111,7 @@ export function InviteFriendToBand({ bandId, bandName, currentUserId }: InviteFr
       ]);
 
       const availableFriends = friendsWithProfiles.filter(
-        f => !existingUserIds.has(f.friend_user_id)
+        f => !existingUserIds.has(f.profile.user_id)
       );
 
       setFriends(availableFriends);
@@ -119,10 +122,47 @@ export function InviteFriendToBand({ bandId, bandName, currentUserId }: InviteFr
         description: 'Failed to load friends list',
         variant: 'destructive',
       });
-    } finally {
-      setLoading(false);
     }
-  };
+  }, [bandId, toast]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const prepareFriends = async () => {
+      setLoading(true);
+      try {
+        if (!currentProfile) {
+          const profile = await fetchPrimaryProfileForUser(currentUserId);
+          if (!profile) {
+            toast({
+              title: 'Profile required',
+              description: 'Create your character profile to invite friends.',
+              variant: 'destructive',
+            });
+            setFriends([]);
+            return;
+          }
+          setCurrentProfile(profile);
+          return;
+        }
+
+        await loadFriends(currentProfile.id);
+      } catch (error) {
+        console.error('Error preparing friends:', error);
+        toast({
+          title: 'Error',
+          description: 'Failed to load friends list',
+          variant: 'destructive',
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void prepareFriends();
+  }, [open, currentProfile, currentUserId, loadFriends, toast]);
 
   const handleInvite = async () => {
     if (!selectedFriend) {
@@ -208,8 +248,8 @@ export function InviteFriendToBand({ bandId, bandName, currentUserId }: InviteFr
                   </SelectTrigger>
                   <SelectContent className="bg-popover z-50">
                     {friends.map((friend) => (
-                      <SelectItem key={friend.id} value={friend.friend_user_id}>
-                        {friend.friend_profile.display_name} (@{friend.friend_profile.username})
+                      <SelectItem key={friend.id} value={friend.profile.user_id}>
+                        {friend.profile.display_name} (@{friend.profile.username})
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/integrations/supabase/friends.ts
+++ b/src/integrations/supabase/friends.ts
@@ -6,11 +6,8 @@ type FriendshipStatus = Database["public"]["Enums"]["friendship_status"];
 type FriendProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 
 export interface SendFriendRequestParams {
-  senderProfileId: string;
-  senderUserId: string;
-  recipientProfileId: string;
-  recipientUserId: string;
-  message?: string | null;
+  requesterProfileId: string;
+  addresseeProfileId: string;
 }
 
 const PROFILE_SELECTION = "id, user_id, username, display_name, bio, level, fame";
@@ -38,10 +35,8 @@ export const fetchFriendshipsForProfile = async (
 ): Promise<FriendshipRow[]> => {
   const { data, error } = await supabase
     .from("friendships")
-    .select(
-      "id, user_id, friend_user_id, user_profile_id, friend_profile_id, status, created_at, updated_at",
-    )
-    .or(`user_profile_id.eq.${profileId},friend_profile_id.eq.${profileId}`)
+    .select("id, requester_id, addressee_id, status, created_at, updated_at, responded_at")
+    .or(`requester_id.eq.${profileId},addressee_id.eq.${profileId}`)
     .order("created_at", { ascending: false });
 
   if (error) {
@@ -59,9 +54,7 @@ export const updateFriendshipStatus = async (
     .from("friendships")
     .update({ status })
     .eq("id", friendshipId)
-    .select(
-      "id, user_id, friend_user_id, user_profile_id, friend_profile_id, status, created_at, updated_at",
-    )
+    .select("id, requester_id, addressee_id, status, created_at, updated_at, responded_at")
     .single();
 
   if (error) {
@@ -95,23 +88,19 @@ export const fetchProfilesByIds = async (
 };
 
 export const sendFriendRequest = async ({
-  senderProfileId,
-  senderUserId,
-  recipientProfileId,
-  recipientUserId,
+  requesterProfileId,
+  addresseeProfileId,
 }: SendFriendRequestParams): Promise<FriendshipRow> => {
   const payload: Database["public"]["Tables"]["friendships"]["Insert"] = {
-    user_id: senderUserId,
-    friend_user_id: recipientUserId,
-    user_profile_id: senderProfileId,
-    friend_profile_id: recipientProfileId,
+    requester_id: requesterProfileId,
+    addressee_id: addresseeProfileId,
     status: "pending",
   };
 
   const { data, error } = await supabase
     .from("friendships")
     .insert(payload)
-    .select()
+    .select("id, requester_id, addressee_id, status, created_at, updated_at, responded_at")
     .single();
 
   if (error) {
@@ -119,4 +108,37 @@ export const sendFriendRequest = async ({
   }
 
   return data as FriendshipRow;
+};
+
+export const deleteFriendship = async (friendshipId: string): Promise<void> => {
+  const { error } = await supabase.from("friendships").delete().eq("id", friendshipId);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const searchProfilesByQuery = async (
+  query: string,
+  excludeProfileIds: string[] = [],
+): Promise<FriendProfileRow[]> => {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(PROFILE_SELECTION)
+    .or(`username.ilike.%${query}%,display_name.ilike.%${query}%`)
+    .order("username")
+    .limit(20);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data as FriendProfileRow[]) ?? [];
+
+  if (excludeProfileIds.length === 0) {
+    return rows;
+  }
+
+  const exclusionSet = new Set(excludeProfileIds);
+  return rows.filter((row) => !exclusionSet.has(row.id));
 };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1213,36 +1213,48 @@ export type Database = {
       }
       friendships: {
         Row: {
-          created_at: string | null
-          friend_profile_id: string | null
-          friend_user_id: string
+          addressee_id: string
+          created_at: string
           id: string
+          requester_id: string
+          responded_at: string | null
           status: Database["public"]["Enums"]["friendship_status"]
-          updated_at: string | null
-          user_id: string
-          user_profile_id: string | null
+          updated_at: string
         }
         Insert: {
-          created_at?: string | null
-          friend_profile_id?: string | null
-          friend_user_id: string
+          addressee_id: string
+          created_at?: string
           id?: string
+          requester_id: string
+          responded_at?: string | null
           status?: Database["public"]["Enums"]["friendship_status"]
-          updated_at?: string | null
-          user_id: string
-          user_profile_id?: string | null
+          updated_at?: string
         }
         Update: {
-          created_at?: string | null
-          friend_profile_id?: string | null
-          friend_user_id?: string
+          addressee_id?: string
+          created_at?: string
           id?: string
+          requester_id?: string
+          responded_at?: string | null
           status?: Database["public"]["Enums"]["friendship_status"]
-          updated_at?: string | null
-          user_id?: string
-          user_profile_id?: string | null
+          updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "friendships_addressee_id_fkey"
+            columns: ["addressee_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "friendships_requester_id_fkey"
+            columns: ["requester_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       game_events: {
         Row: {

--- a/src/pages/SocialMedia.tsx
+++ b/src/pages/SocialMedia.tsx
@@ -1,7 +1,646 @@
-import { StubComponent } from "@/components/StubComponent";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Search,
+  UserPlus,
+  Users,
+  Loader2,
+  Check,
+  X,
+  UserX,
+  Clock,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/use-toast";
+import { useGameData } from "@/hooks/useGameData";
+import type { Database } from "@/lib/supabase-types";
+import {
+  deleteFriendship,
+  fetchFriendshipsForProfile,
+  fetchProfilesByIds,
+  searchProfilesByQuery,
+  sendFriendRequest,
+  updateFriendshipStatus,
+} from "@/integrations/supabase/friends";
+
+type FriendshipRow = Database["public"]["Tables"]["friendships"]["Row"];
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+
+interface DecoratedFriendship {
+  friendship: FriendshipRow;
+  otherProfile: ProfileRow | null;
+  isRequester: boolean;
+}
+
+const MINIMUM_SEARCH_LENGTH = 2;
 
 const SocialMedia = () => {
-  return <StubComponent message="Social Media features are coming soon!" />;
+  const { profile } = useGameData();
+  const { toast } = useToast();
+  const [loadingFriends, setLoadingFriends] = useState(false);
+  const [friendships, setFriendships] = useState<FriendshipRow[]>([]);
+  const [profilesById, setProfilesById] = useState<Record<string, ProfileRow>>({});
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<ProfileRow[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchPerformed, setSearchPerformed] = useState(false);
+  const [actionTarget, setActionTarget] = useState<string | null>(null);
+
+  const loadFriendships = useCallback(async () => {
+    const profileId = profile?.id;
+    if (!profileId) {
+      return;
+    }
+
+    setLoadingFriends(true);
+    try {
+      const data = await fetchFriendshipsForProfile(profileId);
+      setFriendships(data);
+
+      const relatedProfileIds = new Set<string>();
+      data.forEach((friendship) => {
+        relatedProfileIds.add(friendship.requester_id);
+        relatedProfileIds.add(friendship.addressee_id);
+      });
+      relatedProfileIds.delete(profileId);
+
+      if (relatedProfileIds.size === 0) {
+        setProfilesById({});
+        return;
+      }
+
+      const profileMap = await fetchProfilesByIds(Array.from(relatedProfileIds));
+      setProfilesById(profileMap);
+    } catch (error: any) {
+      console.error("Failed to load friendships", error);
+      toast({
+        title: "Unable to load friends",
+        description: error?.message ?? "Something went wrong while loading your friendships.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingFriends(false);
+    }
+  }, [profile?.id, toast]);
+
+  useEffect(() => {
+    void loadFriendships();
+  }, [loadFriendships]);
+
+  useEffect(() => {
+    if (searchQuery.trim().length === 0) {
+      setSearchResults([]);
+      setSearchPerformed(false);
+    }
+  }, [searchQuery]);
+
+  const existingProfileIds = useMemo(() => {
+    const ids = new Set<string>();
+    friendships.forEach((friendship) => {
+      ids.add(friendship.requester_id);
+      ids.add(friendship.addressee_id);
+    });
+    if (profile?.id) {
+      ids.add(profile.id);
+    }
+    return ids;
+  }, [friendships, profile?.id]);
+
+  const { accepted, incoming, outgoing, declined } = useMemo(() => {
+    const initial = {
+      accepted: [] as DecoratedFriendship[],
+      incoming: [] as DecoratedFriendship[],
+      outgoing: [] as DecoratedFriendship[],
+      declined: [] as DecoratedFriendship[],
+    };
+
+    if (!profile?.id) {
+      return initial;
+    }
+
+    return friendships.reduce((accumulator, friendship) => {
+      const isRequester = friendship.requester_id === profile.id;
+      const otherProfileId = isRequester ? friendship.addressee_id : friendship.requester_id;
+      const otherProfile = profilesById[otherProfileId] ?? null;
+      const decorated: DecoratedFriendship = { friendship, otherProfile, isRequester };
+
+      switch (friendship.status) {
+        case "accepted":
+          accumulator.accepted.push(decorated);
+          break;
+        case "pending":
+          if (isRequester) {
+            accumulator.outgoing.push(decorated);
+          } else {
+            accumulator.incoming.push(decorated);
+          }
+          break;
+        case "declined":
+        case "blocked":
+          accumulator.declined.push(decorated);
+          break;
+      }
+
+      return accumulator;
+    }, initial);
+  }, [friendships, profile?.id, profilesById]);
+
+  const handleSearch = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const query = searchQuery.trim();
+    if (query.length < MINIMUM_SEARCH_LENGTH) {
+      toast({
+        title: "Search term too short",
+        description: `Enter at least ${MINIMUM_SEARCH_LENGTH} characters to search for players.`,
+      });
+      return;
+    }
+
+    if (!profile?.id) {
+      return;
+    }
+
+    setSearching(true);
+    setSearchPerformed(true);
+    try {
+      const exclusions = Array.from(existingProfileIds);
+      const results = await searchProfilesByQuery(query, exclusions);
+      setSearchResults(results);
+    } catch (error: any) {
+      console.error("Friend search failed", error);
+      toast({
+        title: "Search failed",
+        description: error?.message ?? "We couldn't search for players right now.",
+        variant: "destructive",
+      });
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleSendRequest = async (targetProfileId: string) => {
+    if (!profile?.id) {
+      return;
+    }
+
+    setActionTarget(targetProfileId);
+    try {
+      await sendFriendRequest({
+        requesterProfileId: profile.id,
+        addresseeProfileId: targetProfileId,
+      });
+      toast({
+        title: "Friend request sent",
+        description: "We'll let you know when they respond.",
+      });
+      setSearchResults((previous) => previous.filter((result) => result.id !== targetProfileId));
+      await loadFriendships();
+    } catch (error: any) {
+      console.error("Failed to send friend request", error);
+      toast({
+        title: "Couldn't send request",
+        description: error?.message ?? "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setActionTarget(null);
+    }
+  };
+
+  const handleAccept = async (friendshipId: string) => {
+    setActionTarget(friendshipId);
+    try {
+      await updateFriendshipStatus(friendshipId, "accepted");
+      toast({
+        title: "Friend added",
+        description: "You're now connected. Time to jam!",
+      });
+      await loadFriendships();
+    } catch (error: any) {
+      console.error("Failed to accept friend request", error);
+      toast({
+        title: "Unable to accept request",
+        description: error?.message ?? "Please try again shortly.",
+        variant: "destructive",
+      });
+    } finally {
+      setActionTarget(null);
+    }
+  };
+
+  const handleDecline = async (friendshipId: string) => {
+    setActionTarget(friendshipId);
+    try {
+      await updateFriendshipStatus(friendshipId, "declined");
+      toast({
+        title: "Request declined",
+        description: "The player has been notified of your decision.",
+      });
+      await loadFriendships();
+    } catch (error: any) {
+      console.error("Failed to decline friend request", error);
+      toast({
+        title: "Unable to decline",
+        description: error?.message ?? "Please try again shortly.",
+        variant: "destructive",
+      });
+    } finally {
+      setActionTarget(null);
+    }
+  };
+
+  const handleCancel = async (friendshipId: string) => {
+    setActionTarget(friendshipId);
+    try {
+      await deleteFriendship(friendshipId);
+      toast({
+        title: "Request cancelled",
+        description: "You can always send another request later.",
+      });
+      await loadFriendships();
+    } catch (error: any) {
+      console.error("Failed to cancel friend request", error);
+      toast({
+        title: "Unable to cancel",
+        description: error?.message ?? "Please try again shortly.",
+        variant: "destructive",
+      });
+    } finally {
+      setActionTarget(null);
+    }
+  };
+
+  const handleRemove = async (friendshipId: string) => {
+    setActionTarget(friendshipId);
+    try {
+      await deleteFriendship(friendshipId);
+      toast({
+        title: "Friend removed",
+        description: "They're no longer on your friends list.",
+      });
+      await loadFriendships();
+    } catch (error: any) {
+      console.error("Failed to remove friend", error);
+      toast({
+        title: "Unable to remove friend",
+        description: error?.message ?? "Please try again shortly.",
+        variant: "destructive",
+      });
+    } finally {
+      setActionTarget(null);
+    }
+  };
+
+  if (!profile) {
+    return (
+      <div className="container mx-auto space-y-6 py-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Friends</CardTitle>
+            <CardDescription>Create your character profile to access friend features.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground">
+              Once your profile is ready you'll be able to find bandmates, send friend requests, and manage your
+              connections from here.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 py-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Friends</h1>
+          <p className="text-muted-foreground">
+            Find new collaborators, accept jam invites, and keep track of your Rockmundo crew.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Search className="h-5 w-5" />
+            Find new friends
+          </CardTitle>
+          <CardDescription>Search by username or stage name to send friend requests.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form onSubmit={handleSearch} className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search players by username or display name"
+                className="pl-9"
+              />
+            </div>
+            <Button type="submit" disabled={searching || searchQuery.trim().length < MINIMUM_SEARCH_LENGTH}>
+              {searching ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Searching
+                </>
+              ) : (
+                <>
+                  <UserPlus className="mr-2 h-4 w-4" /> Search
+                </>
+              )}
+            </Button>
+          </form>
+
+          {searchResults.length > 0 ? (
+            <div className="grid gap-3">
+              {searchResults.map((result) => (
+                <Card key={result.id} className="border-border/80">
+                  <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold">{result.display_name ?? result.username}</span>
+                        <Badge variant="outline">@{result.username}</Badge>
+                      </div>
+                      {result.bio ? (
+                        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{result.bio}</p>
+                      ) : null}
+                      <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
+                        {typeof result.level === "number" && <span>Level {result.level}</span>}
+                        {typeof result.fame === "number" && <span>Fame {result.fame}</span>}
+                      </div>
+                    </div>
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleSendRequest(result.id)}
+                      disabled={actionTarget === result.id}
+                    >
+                      {actionTarget === result.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <>
+                          <UserPlus className="mr-2 h-4 w-4" /> Send request
+                        </>
+                      )}
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : searchPerformed ? (
+            <p className="text-sm text-muted-foreground">No players matched your search. Try another name or handle.</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Enter at least {MINIMUM_SEARCH_LENGTH} characters to search for other performers.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Tabs defaultValue="friends" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="friends" className="flex items-center gap-2">
+            <Users className="h-4 w-4" /> Friends
+          </TabsTrigger>
+          <TabsTrigger value="requests" className="flex items-center gap-2">
+            <UserPlus className="h-4 w-4" /> Requests
+          </TabsTrigger>
+          <TabsTrigger value="history" className="flex items-center gap-2">
+            <Clock className="h-4 w-4" /> History
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="friends">
+          <Card>
+            <CardHeader>
+              <CardTitle>Current friends</CardTitle>
+              <CardDescription>Accepted friendships appear here. Remove a friend at any time.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingFriends ? (
+                <div className="flex items-center justify-center py-12">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : accepted.length === 0 ? (
+                <div className="rounded-md border border-dashed border-border/70 p-6 text-center text-sm text-muted-foreground">
+                  You haven't accepted any friends yet. Send a few requests to start building your network.
+                </div>
+              ) : (
+                <div className="grid gap-3">
+                  {accepted.map(({ friendship, otherProfile }) => (
+                    <Card key={friendship.id} className="border-border/80">
+                      <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className="font-semibold">
+                              {otherProfile?.display_name ?? otherProfile?.username ?? "Former friend"}
+                            </span>
+                            {otherProfile?.username && (
+                              <Badge variant="outline">@{otherProfile.username}</Badge>
+                            )}
+                          </div>
+                          {otherProfile?.bio ? (
+                            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{otherProfile.bio}</p>
+                          ) : null}
+                          <div className="mt-2 flex gap-4 text-xs text-muted-foreground">
+                            {typeof otherProfile?.level === "number" && <span>Level {otherProfile.level}</span>}
+                            {typeof otherProfile?.fame === "number" && <span>Fame {otherProfile.fame}</span>}
+                          </div>
+                        </div>
+                        <Button
+                          variant="destructive"
+                          onClick={() => handleRemove(friendship.id)}
+                          disabled={actionTarget === friendship.id}
+                        >
+                          {actionTarget === friendship.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <>
+                              <UserX className="mr-2 h-4 w-4" /> Remove friend
+                            </>
+                          )}
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="requests">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Incoming requests</CardTitle>
+                <CardDescription>Accept or decline players who want to connect with you.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {incoming.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    You're all caught up. When someone sends a request it'll appear here.
+                  </p>
+                ) : (
+                  <div className="grid gap-3">
+                    {incoming.map(({ friendship, otherProfile }) => (
+                      <Card key={friendship.id} className="border-border/80">
+                        <CardContent className="flex flex-col gap-3 py-4">
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-semibold">
+                                {otherProfile?.display_name ?? otherProfile?.username ?? "Unknown performer"}
+                              </span>
+                              {otherProfile?.username && (
+                                <Badge variant="outline">@{otherProfile.username}</Badge>
+                              )}
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              Requested {new Date(friendship.created_at).toLocaleDateString()}
+                            </p>
+                          </div>
+                          <div className="flex flex-col gap-2 sm:flex-row sm:gap-3">
+                            <Button
+                              className="flex-1"
+                              onClick={() => handleAccept(friendship.id)}
+                              disabled={actionTarget === friendship.id}
+                            >
+                              {actionTarget === friendship.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <>
+                                  <Check className="mr-2 h-4 w-4" /> Accept
+                                </>
+                              )}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              className="flex-1"
+                              onClick={() => handleDecline(friendship.id)}
+                              disabled={actionTarget === friendship.id}
+                            >
+                              {actionTarget === friendship.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <>
+                                  <X className="mr-2 h-4 w-4" /> Decline
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Outgoing requests</CardTitle>
+                <CardDescription>Requests you've sent that are still pending.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {outgoing.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    You haven't sent any friend requests yet. Search for players to start building your crew.
+                  </p>
+                ) : (
+                  <div className="grid gap-3">
+                    {outgoing.map(({ friendship, otherProfile }) => (
+                      <Card key={friendship.id} className="border-border/80">
+                        <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-semibold">
+                                {otherProfile?.display_name ?? otherProfile?.username ?? "Unknown performer"}
+                              </span>
+                              {otherProfile?.username && (
+                                <Badge variant="outline">@{otherProfile.username}</Badge>
+                              )}
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              Sent {new Date(friendship.created_at).toLocaleDateString()}
+                            </p>
+                          </div>
+                          <Button
+                            variant="outline"
+                            onClick={() => handleCancel(friendship.id)}
+                            disabled={actionTarget === friendship.id}
+                          >
+                            {actionTarget === friendship.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <>
+                                <X className="mr-2 h-4 w-4" /> Cancel request
+                              </>
+                            )}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="history">
+          <Card>
+            <CardHeader>
+              <CardTitle>Request history</CardTitle>
+              <CardDescription>Recently declined or blocked requests are listed for reference.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {declined.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No declined requests at the moment. Keep exploring to meet more performers.
+                </p>
+              ) : (
+                <div className="grid gap-3">
+                  {declined.map(({ friendship, otherProfile, isRequester }) => (
+                    <Card key={friendship.id} className="border-border/80">
+                      <CardContent className="py-4">
+                        <div className="flex flex-col gap-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-semibold">
+                              {otherProfile?.display_name ?? otherProfile?.username ?? "Unknown performer"}
+                            </span>
+                            {otherProfile?.username && (
+                              <Badge variant="outline">@{otherProfile.username}</Badge>
+                            )}
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            {isRequester ? "You" : "They"} closed this request on {new Date(friendship.updated_at).toLocaleDateString()}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Status: {friendship.status === "blocked" ? "Blocked" : "Declined"}
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
 };
 
 export default SocialMedia;


### PR DESCRIPTION
## Summary
- rebuild the Social Media page into a full friends hub with search, requests, and history management
- align Supabase friend schemas and helpers with the requester/addressee structure and add search/delete utilities
- update band invitation flow to resolve profile IDs before listing accepted friends

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68eb8f02d0d883258a7b663b201ce975