### PR TITLE
Align mentor focus skills with skill tree

### DIFF
--- a/src/features/education/components/MentorsTab.tsx
+++ b/src/features/education/components/MentorsTab.tsx
@@ -71,7 +71,7 @@ export const MentorsTab = () => {
                 <div className="space-y-2">
                   <div className="flex items-center justify-between text-sm">
                     <span className="text-muted-foreground">Focus Skill</span>
-                    <span className="font-medium">{formatFocusSkill(mentor.focus_skill as any)}</span>
+                    <span className="font-medium">{formatFocusSkill(mentor.focus_skill)}</span>
                   </div>
                   <div className="space-y-1">
                     <div className="flex items-center justify-between text-xs text-muted-foreground">

--- a/src/pages/admin/Mentors.tsx
+++ b/src/pages/admin/Mentors.tsx
@@ -68,7 +68,7 @@ const Mentors = () => {
     resolver: zodResolver(mentorSchema),
     defaultValues: {
       name: "",
-      focusSkill: "guitar",
+      focusSkill: focusSkillOptions[0]?.value ?? "",
       description: "",
       specialty: "",
       cost: 0,


### PR DESCRIPTION
## Summary
- build mentor focus skill options from the skill tree definitions and validate form selections accordingly
- update admin mentor form defaults and focus skill formatter to use the new tree-driven options
- ensure the education mentors tab renders the formatted skill name without casting overrides

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9b4890448325a16c74fb2ee84f6d