### PR TITLE
Persist initial lyrics to songwriting project `lyrics` on create

### DIFF
--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -223,6 +223,9 @@ export const useSongwritingData = (profileId?: string | null) => {
           theme_id: projectData.theme_id || null,
           chord_progression_id: projectData.chord_progression_id || null,
           initial_lyrics: projectData.initial_lyrics || null,
+          // Keep canonical lyrics in sync from first save so convertToSong
+          // uses player-entered lyrics instead of falling back to AI generation.
+          lyrics: projectData.initial_lyrics || null,
           creative_brief: projectData.creative_brief || null,
           genres: projectData.genres || [],
           purpose: projectData.purpose || null,


### PR DESCRIPTION
### Motivation
- Fix AI audio regeneration and song conversion using player-entered lyrics because newly-created songwriting projects only set `initial_lyrics` while downstream flows read the canonical `lyrics` field.

### Description
- Write `lyrics: projectData.initial_lyrics || null` when inserting a new project in `src/hooks/useSongwritingData.tsx` so the canonical `songwriting_projects.lyrics` is populated from first save.

### Testing
- Ran lint check `npm run lint -- src/hooks/useSongwritingData.tsx` but it failed due to missing environment dependency `@eslint/js` referenced in `eslint.config.js`, so no further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd87bf04648325a29467d580919794)