### PR TITLE
Add consistent loading and error states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import { FM_MODULES } from "./config/fmNavigation";
+import ErrorBoundary from "@/components/ui/error-boundary";
+import { PageLoadingState } from "@/components/ui/page-state";
 
 // Redirect component for removed placeholder pages
 const RedirectTo = ({ to }: { to: string }) => {
@@ -391,13 +393,19 @@ function App() {
                       <Sonner />
                       <BrowserRouter>
                         <PageTitle />
-              <Suspense
-                fallback={
-                  <div className="flex h-screen w-full items-center justify-center">
-                    <p className="text-lg font-semibold">Loading page...</p>
-                  </div>
-                }
-              >
+              <ErrorBoundary>
+                <Suspense
+                  fallback={
+                    <div className="min-h-screen w-full bg-background p-4 md:p-8">
+                      <div className="mx-auto max-w-6xl">
+                        <PageLoadingState
+                          title="Loading page"
+                          description="Tuning the amps and loading the latest Rockmundo data..."
+                        />
+                      </div>
+                    </div>
+                  }
+                >
                 <Routes>
                   <Route path="/" element={<Landing />} />
                   <Route path="/auth" element={<Auth />} />
@@ -710,7 +718,8 @@ function App() {
                   </Route>
                   <Route path="*" element={<NotFound />} />
                 </Routes>
-              </Suspense>
+                </Suspense>
+              </ErrorBoundary>
                 </BrowserRouter>
                     </TooltipProvider>
                   </BandCrewCatalogProvider>

--- a/src/components/CategoryHub.tsx
+++ b/src/components/CategoryHub.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "@/hooks/useTranslation";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { PageEmptyState } from "@/components/ui/page-state";
 import {
   FeaturedTile,
   SectionBand,
@@ -54,6 +55,13 @@ export const CategoryHub = ({
 
   return (
     <FMPageScaffold title={title} subtitle={description} eyebrow={featuredEyebrow}>
+      {allGroups.length === 0 && (
+        <PageEmptyState
+          title="Nothing is on the setlist yet"
+          description="This hub is ready, but there are no destinations configured for it right now."
+        />
+      )}
+
       {featuredTile && (
         <div className={hasRealStats ? "grid gap-3 lg:grid-cols-[1fr_280px]" : ""}>
           <FeaturedTile

--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { PageErrorState } from '@/components/ui/page-state';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -38,26 +37,13 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       }
 
       return (
-        <Card className="max-w-md mx-auto mt-8">
-          <CardHeader>
-            <CardTitle>Something went wrong</CardTitle>
-            <CardDescription>
-              An error occurred while rendering this component.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {this.state.error && (
-              <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-md">
-                <p className="text-sm text-destructive">
-                  {this.state.error.message}
-                </p>
-              </div>
-            )}
-            <Button onClick={this.resetError} variant="outline" className="w-full">
-              Try again
-            </Button>
-          </CardContent>
-        </Card>
+        <div className="mx-auto mt-8 max-w-2xl p-4">
+          <PageErrorState
+            title="This page hit a bad note"
+            description={this.state.error?.message || "We couldn't render this page. Try again or refresh the browser."}
+            onRetry={this.resetError}
+          />
+        </div>
       );
     }
 

--- a/src/components/ui/page-state.tsx
+++ b/src/components/ui/page-state.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from "react";
+import { AlertCircle, Inbox, Loader2, RefreshCw } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+type PageStateProps = {
+  title: string;
+  description?: ReactNode;
+  className?: string;
+  action?: ReactNode;
+};
+
+export function PageLoadingState({ title = "Loading", description = "Getting everything ready...", className }: Partial<PageStateProps>) {
+  return (
+    <Card className={cn("overflow-hidden", className)}>
+      <CardContent className="space-y-5 p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin text-primary" />
+          <div>
+            <p className="font-medium text-foreground">{title}</p>
+            {description && <p className="text-sm">{description}</p>}
+          </div>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function PageEmptyState({ title, description, className, action }: PageStateProps) {
+  return (
+    <Card className={className}>
+      <CardContent className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+        <Inbox className="h-10 w-10 text-muted-foreground" />
+        <div className="space-y-1">
+          <p className="font-medium">{title}</p>
+          {description && <p className="max-w-md text-sm text-muted-foreground">{description}</p>}
+        </div>
+        {action}
+      </CardContent>
+    </Card>
+  );
+}
+
+type PageErrorStateProps = PageStateProps & {
+  onRetry?: () => void;
+  retryLabel?: string;
+};
+
+export function PageErrorState({
+  title,
+  description = "Something interrupted the encore. Please try again.",
+  className,
+  action,
+  onRetry,
+  retryLabel = "Try again",
+}: PageErrorStateProps) {
+  return (
+    <Alert variant="destructive" className={cn("bg-destructive/10", className)}>
+      <AlertCircle className="h-4 w-4" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription className="mt-2 flex flex-col gap-3">
+        <span>{description}</span>
+        {(onRetry || action) && (
+          <span className="flex flex-wrap gap-2">
+            {onRetry && (
+              <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                <RefreshCw className="mr-2 h-3.5 w-3.5" />
+                {retryLabel}
+              </Button>
+            )}
+            {action}
+          </span>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/hooks/useFanManagement.ts
+++ b/src/hooks/useFanManagement.ts
@@ -39,7 +39,7 @@ export const useFanManagement = (profileId?: string) => {
   const queryClient = useQueryClient();
 
   // Fetch campaigns
-  const { data: campaigns = [], isLoading: campaignsLoading } = useQuery({
+  const campaignsQuery = useQuery({
     queryKey: ["fan-campaigns", profileId],
     queryFn: async () => {
       if (!profileId) return [];
@@ -57,7 +57,7 @@ export const useFanManagement = (profileId?: string) => {
   });
 
   // Fetch segments
-  const { data: segments = [], isLoading: segmentsLoading } = useQuery({
+  const segmentsQuery = useQuery({
     queryKey: ["fan-segments", profileId],
     queryFn: async () => {
       if (!profileId) return [];
@@ -75,7 +75,7 @@ export const useFanManagement = (profileId?: string) => {
   });
 
   // Fetch interactions
-  const { data: interactions = [], isLoading: interactionsLoading } = useQuery({
+  const interactionsQuery = useQuery({
     queryKey: ["fan-interactions", profileId],
     queryFn: async () => {
       if (!profileId) return [];
@@ -139,11 +139,22 @@ export const useFanManagement = (profileId?: string) => {
     },
   });
 
+  const campaigns = campaignsQuery.data ?? [];
+  const segments = segmentsQuery.data ?? [];
+  const interactions = interactionsQuery.data ?? [];
+
   return {
     campaigns,
     segments,
     interactions,
-    isLoading: campaignsLoading || segmentsLoading || interactionsLoading,
+    isLoading: campaignsQuery.isLoading || segmentsQuery.isLoading || interactionsQuery.isLoading,
+    isError: campaignsQuery.isError || segmentsQuery.isError || interactionsQuery.isError,
+    error: campaignsQuery.error || segmentsQuery.error || interactionsQuery.error,
+    refetch: () => {
+      void campaignsQuery.refetch();
+      void segmentsQuery.refetch();
+      void interactionsQuery.refetch();
+    },
     createCampaign: createCampaign.mutate,
     createSegment: createSegment.mutate,
     isCreatingCampaign: createCampaign.isPending,

--- a/src/hooks/useFestivals.ts
+++ b/src/hooks/useFestivals.ts
@@ -49,7 +49,7 @@ export const useFestivals = (userId?: string, bandId?: string) => {
   const queryClient = useQueryClient();
 
   // Fetch all active festivals
-  const { data: festivals = [], isLoading: festivalsLoading } = useQuery({
+  const festivalsQuery = useQuery({
     queryKey: FESTIVALS_QUERY_KEY,
     queryFn: async () => {
       const { data, error } = await (supabase as any)
@@ -66,7 +66,7 @@ export const useFestivals = (userId?: string, bandId?: string) => {
   });
 
   // Fetch user/band festival participations
-  const { data: participations = [], isLoading: participationsLoading } = useQuery({
+  const participationsQuery = useQuery({
     queryKey: PARTICIPATIONS_QUERY_KEY(userId, bandId),
     queryFn: async () => {
       if (!bandId) return [];
@@ -310,11 +310,18 @@ export const useFestivals = (userId?: string, bandId?: string) => {
     },
   });
 
+  const festivals = festivalsQuery.data ?? [];
+  const participations = participationsQuery.data ?? [];
+
   return {
     festivals,
-    festivalsLoading,
+    festivalsLoading: festivalsQuery.isLoading,
+    festivalsError: festivalsQuery.error,
+    refetchFestivals: festivalsQuery.refetch,
     participations,
-    participationsLoading,
+    participationsLoading: participationsQuery.isLoading,
+    participationsError: participationsQuery.error,
+    refetchParticipations: participationsQuery.refetch,
     fetchFestivalLineup,
     applyToFestival,
     withdrawFromFestival,

--- a/src/pages/FanManagement.tsx
+++ b/src/pages/FanManagement.tsx
@@ -9,12 +9,13 @@ import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { useTranslation } from "@/hooks/useTranslation";
 import { Users, TrendingUp, MessageCircle, Target, Calendar, DollarSign } from "lucide-react";
 import { Progress } from "@/components/ui/progress";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 
 const FanManagement = () => {
   const { profileId } = useActiveProfile();
   const { t } = useTranslation();
 
-  const { campaigns, segments, interactions, isLoading } = useFanManagement(profileId ?? undefined);
+  const { campaigns, segments, interactions, isLoading, isError, error, refetch } = useFanManagement(profileId ?? undefined);
 
   const activeCampaigns = campaigns.filter((c) => c.status === "active");
   const totalReach = campaigns.reduce((sum, c) => sum + c.reach, 0);
@@ -31,8 +32,21 @@ const FanManagement = () => {
       icon={Users}
       backTo="/hub/career"
     >
-
-
+      {!profileId ? (
+        <PageEmptyState
+          title="Choose a character to manage fans"
+          description="Fan campaigns, segments, and interactions will appear once a profile is active."
+        />
+      ) : isError ? (
+        <PageErrorState
+          title="Couldn’t load fan management"
+          description={error instanceof Error ? error.message : "Supabase could not return your fan data."}
+          onRetry={refetch}
+        />
+      ) : isLoading ? (
+        <PageLoadingState title="Loading fan management" description="Pulling campaigns, audience segments, and recent fan activity..." />
+      ) : (
+        <>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
@@ -96,7 +110,7 @@ const FanManagement = () => {
           ) : campaigns.length === 0 ? (
             <Card>
               <CardContent className="p-6">
-                <p className="text-muted-foreground">No campaigns yet.</p>
+                <PageEmptyState title="No campaigns yet" description="Launch your first fan campaign to start building reach and engagement." />
               </CardContent>
             </Card>
           ) : (
@@ -168,7 +182,7 @@ const FanManagement = () => {
           {segments.length === 0 ? (
             <Card>
               <CardContent className="p-6">
-                <p className="text-muted-foreground">No fan segments created yet.</p>
+                <PageEmptyState title="No fan segments yet" description="Create fan segments to target messages by audience behavior." />
               </CardContent>
             </Card>
           ) : (
@@ -201,7 +215,7 @@ const FanManagement = () => {
             </CardHeader>
             <CardContent>
               {interactions.length === 0 ? (
-                <p className="text-muted-foreground">No recent interactions.</p>
+                <PageEmptyState title="No recent interactions" description="Fan replies and engagement events will appear here." />
               ) : (
                 <div className="space-y-3">
                   {interactions.slice(0, 10).map((interaction) => (
@@ -235,6 +249,8 @@ const FanManagement = () => {
           </Card>
         </TabsContent>
       </Tabs>
+        </>
+      )}
     </FMPageScaffold>
   );
 };

--- a/src/pages/FestivalsNew.tsx
+++ b/src/pages/FestivalsNew.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { format, formatDistanceToNow } from "date-fns";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 
 const performanceSlots = [
   { value: "opening", label: "Opening Act (6:00 PM)" },
@@ -353,7 +354,11 @@ export default function Festivals() {
     performAtFestival,
     isApplying,
     isWithdrawing,
-    isPerforming
+    isPerforming,
+    festivalsError,
+    refetchFestivals,
+    participationsError,
+    refetchParticipations
   } = useFestivals(userId, band?.id);
 
   const [activeAction, setActiveAction] = useState<{ type: "apply" | "withdraw" | "perform" | null; id: string | null }>({
@@ -462,13 +467,15 @@ export default function Festivals() {
         {/* Upcoming Festivals Tab */}
         <TabsContent value="upcoming" className="space-y-4">
           {festivalsLoading ? (
-            <div className="text-center py-12 text-muted-foreground">Loading festivals...</div>
+            <PageLoadingState title="Loading festivals" description="Checking upcoming stages, slots, and applications..." />
+          ) : festivalsError ? (
+            <PageErrorState
+              title="Couldn’t load festivals"
+              description={festivalsError instanceof Error ? festivalsError.message : "Supabase could not return upcoming festivals."}
+              onRetry={() => void refetchFestivals()}
+            />
           ) : festivals.length === 0 ? (
-            <Card>
-              <CardContent className="text-center py-12 text-muted-foreground">
-                No upcoming festivals available.
-              </CardContent>
-            </Card>
+            <PageEmptyState title="No upcoming festivals" description="The calendar is quiet right now. Check back soon for new festival slots." />
           ) : (
             <div className="grid gap-4">
               {festivals.map((festival) => {
@@ -503,7 +510,13 @@ export default function Festivals() {
         {/* My Performances Tab */}
         <TabsContent value="my-performances" className="space-y-4">
           {participationsLoading ? (
-            <div className="text-center py-12 text-muted-foreground">Loading performances...</div>
+            <PageLoadingState title="Loading performances" description="Reviewing your festival applications and set times..." />
+          ) : participationsError ? (
+            <PageErrorState
+              title="Couldn’t load your performances"
+              description={participationsError instanceof Error ? participationsError.message : "Supabase could not return your festival registrations."}
+              onRetry={() => void refetchParticipations()}
+            />
           ) : participations.filter(p => p.status !== "withdrawn").length === 0 ? (
             <Card>
               <CardContent className="text-center py-12">


### PR DESCRIPTION
### Motivation
- Provide a consistent, friendly loading and error experience across major pages and hubs. 
- Surface empty dataset states and Supabase failures with actionable retry buttons. 
- Reuse visual primitives and keep the current UI style while adding skeletons and concise messages.

### Description
- Add a reusable page-state component file `src/components/ui/page-state.tsx` that exports `PageLoadingState`, `PageEmptyState`, and `PageErrorState` (skeletons, empty UI, and retryable error UI). 
- Replace the route-level lazy fallback in `src/App.tsx` to show `PageLoadingState` and wrap rendered routes with the existing `ErrorBoundary` so the app shows a consistent loading shell. 
- Update `src/components/ui/error-boundary.tsx` to render `PageErrorState` as a friendly fallback with a retry action when rendering fails. 
- Propagate error/refetch information from `useFanManagement` and `useFestivals` hooks and update `FanManagement` and `FestivalsNew` pages to handle loading, empty, and Supabase error states with retry buttons and the new page states; add hub-level empty state to `CategoryHub`.

### Testing
- Ran type-checking with `npx tsc --noEmit --pretty false`, which completed successfully. 
- Ran `git diff --check` to validate diffs, which reported no issues. 
- `npm run lint -- --max-warnings=0` could not be executed due to a missing environment package (`@eslint/js`) in the test environment. 
- `npm run build` could not be executed in this environment because the `vite` binary is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4a3da1908325b4bc97d9c116034b)