### PR TITLE
Refactor Supabase queries into shared services

### DIFF
--- a/src/hooks/useRadioContent.ts
+++ b/src/hooks/useRadioContent.ts
@@ -1,61 +1,25 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import {
+  fetchAllRadioContent,
+  fetchPlayableRadioContent,
+  radioContentKeys,
+  type RadioContent,
+} from "@/services/radioContentService";
 
-export interface RadioContent {
-  id: string;
-  content_type: 'jingle' | 'advert';
-  title: string;
-  script: string;
-  audio_url: string | null;
-  audio_status: string;
-  voice_id: string | null;
-  category: string | null;
-  brand_name: string | null;
-  humor_style: string | null;
-  duration_seconds: number | null;
-  play_weight: number;
-  is_active: boolean;
-  created_at: string;
-}
+export type { RadioContent } from "@/services/radioContentService";
 
 export const useRadioContent = () => {
   return useQuery({
-    queryKey: ["rm-radio-content"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("radio_content")
-        .select("*")
-        .eq("is_active", true)
-        .eq("audio_status", "completed")
-        .not("audio_url", "is", null);
-
-      if (error) {
-        console.error("[useRadioContent] Error fetching radio content:", error);
-        return [];
-      }
-
-      return (data || []) as RadioContent[];
-    },
+    queryKey: radioContentKeys.active,
+    queryFn: fetchPlayableRadioContent,
     staleTime: 10 * 60 * 1000, // 10 minutes
   });
 };
 
 export const useAllRadioContent = () => {
   return useQuery({
-    queryKey: ["rm-radio-content-all"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("radio_content")
-        .select("*")
-        .order("created_at", { ascending: false });
-
-      if (error) {
-        console.error("[useAllRadioContent] Error fetching radio content:", error);
-        return [];
-      }
-
-      return (data || []) as RadioContent[];
-    },
+    queryKey: radioContentKeys.all,
+    queryFn: fetchAllRadioContent,
     staleTime: 30 * 1000, // 30 seconds for admin
   });
 };
@@ -73,5 +37,5 @@ export const getRandomContent = (content: RadioContent[]): RadioContent | null =
     }
   }
 
-  return weightedArray[Math.floor(Math.random() * weightedArray.length)];
+  return weightedArray[Math.floor(Math.random() * weightedArray.length)] ?? null;
 };

--- a/src/hooks/useTwaaterTrending.ts
+++ b/src/hooks/useTwaaterTrending.ts
@@ -1,119 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import {
+  extractTrendingTopics,
+  fetchRecentTwaatsForTrending,
+  scoreTrendingTwaats,
+} from "@/services/twaaterTrendingService";
+
+const TWAATER_TRENDING_QUERY_KEY = ["twaater-trending"] as const;
+const TWAATER_TRENDING_REFETCH_MS = 5 * 60 * 1000;
 
 export const useTwaaterTrending = () => {
-  const { data: trendingTwaats = [], isLoading } = useQuery({
-    queryKey: ["twaater-trending"],
+  const { data, isLoading } = useQuery({
+    queryKey: TWAATER_TRENDING_QUERY_KEY,
     queryFn: async () => {
-      // Get twaats from the last 24 hours with high engagement
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
+      const recentTwaats = await fetchRecentTwaatsForTrending();
 
-      const { data, error } = await supabase
-        .from("twaats")
-        .select(`
-          *,
-          account:twaater_accounts!twaats_account_id_fkey(
-            id,
-            handle,
-            display_name,
-            verified,
-            owner_type,
-            fame_score
-          ),
-          metrics:twaat_metrics(
-            likes,
-            retwaats,
-            replies,
-            views
-          )
-        `)
-        .gte("created_at", yesterday.toISOString())
-        .order("created_at", { ascending: false })
-        .limit(100);
-
-      if (error) throw error;
-
-      // Calculate engagement score with time decay
-      const now = Date.now();
-      const scored = (data || []).map((twaat) => {
-        const metricsData = Array.isArray(twaat.metrics) ? twaat.metrics[0] : null;
-        const metrics = metricsData || { likes: 0, retwaats: 0, replies: 0, views: 0 };
-        
-        // Base engagement score
-        const baseScore = 
-          (metrics.likes || 0) * 2 + 
-          (metrics.retwaats || 0) * 3 + 
-          (metrics.replies || 0) * 1.5 +
-          (metrics.views || 0) * 0.1;
-
-        // Time decay: exponential decay over 24 hours
-        const hoursOld = (now - new Date(twaat.created_at).getTime()) / (1000 * 60 * 60);
-        const timeDecay = Math.exp(-hoursOld / 12); // Half-life of ~8.3 hours
-
-        // Verified account boost (1.5x)
-        const verifiedBoost = twaat.account?.verified ? 1.5 : 1;
-
-        // Promoted twaat boost (2x while active)
-        const promotedActive =
-          twaat.is_promoted &&
-          twaat.promoted_until &&
-          new Date(twaat.promoted_until).getTime() > now;
-        const promotedBoost = promotedActive ? 2 : 1;
-
-        const engagementScore = baseScore * timeDecay * verifiedBoost * promotedBoost;
-
-        return {
-          ...twaat,
-          engagementScore,
-        };
-      });
-
-      return scored
-        .filter(t => t.engagementScore > 0.5) // Minimum threshold
-        .sort((a, b) => b.engagementScore - a.engagementScore)
-        .slice(0, 20);
+      return {
+        trendingTwaats: scoreTrendingTwaats(recentTwaats),
+        trendingTopics: extractTrendingTopics(recentTwaats),
+      };
     },
-    refetchInterval: 5 * 60 * 1000, // Refresh every 5 minutes
-  });
-
-  const { data: trendingTopics = [], isLoading: topicsLoading } = useQuery({
-    queryKey: ["twaater-trending-topics"],
-    queryFn: async () => {
-      const yesterday = new Date();
-      yesterday.setDate(yesterday.getDate() - 1);
-
-      const { data, error } = await supabase
-        .from("twaats")
-        .select("body")
-        .gte("created_at", yesterday.toISOString());
-
-      if (error) throw error;
-
-      // Extract hashtags
-      const hashtagCounts = new Map<string, number>();
-      (data || []).forEach((twaat) => {
-        const hashtags = twaat.body?.match(/#[a-zA-Z0-9_]+/g) || [];
-        hashtags.forEach((tag) => {
-          const normalized = tag.toLowerCase();
-          hashtagCounts.set(normalized, (hashtagCounts.get(normalized) || 0) + 1);
-        });
-      });
-
-      // Convert to array and sort
-      const trending = Array.from(hashtagCounts.entries())
-        .map(([tag, count]) => ({ tag, count }))
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 10);
-
-      return trending;
-    },
-    refetchInterval: 5 * 60 * 1000,
+    refetchInterval: TWAATER_TRENDING_REFETCH_MS,
   });
 
   return {
-    trendingTwaats,
-    trendingTopics,
-    isLoading: isLoading || topicsLoading,
+    trendingTwaats: data?.trendingTwaats ?? [],
+    trendingTopics: data?.trendingTopics ?? [],
+    isLoading,
   };
 };

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { fetchSeasonalWeatherPattern } from "@/services/weatherService";
 import { useGameCalendar } from "@/hooks/useGameCalendar";
 import type { WeatherCondition, Weather } from "@/utils/weatherSystem";
 
@@ -35,14 +35,9 @@ export function useWeather(cityId: string | null | undefined) {
         return { condition: "sunny", temperature: 20, emoji: "☀️" };
       }
 
-      const { data, error } = await supabase
-        .from("seasonal_weather_patterns")
-        .select("*")
-        .eq("city_id", cityId)
-        .eq("season", calendar.season)
-        .maybeSingle();
+      const weatherPattern = await fetchSeasonalWeatherPattern(cityId, calendar.season);
 
-      if (error || !data) {
+      if (!weatherPattern?.weather_conditions || weatherPattern.avg_temperature_celsius == null) {
         return { condition: "sunny", temperature: 20, emoji: "☀️" };
       }
 
@@ -55,7 +50,7 @@ export function useWeather(cityId: string | null | undefined) {
 
       const random = seededRandom(Math.abs(seedNum));
 
-      const conditions = data.weather_conditions as Record<WeatherCondition, number>;
+      const conditions = weatherPattern.weather_conditions;
       let cumulative = 0;
       let selectedCondition: WeatherCondition = "sunny";
 
@@ -69,7 +64,7 @@ export function useWeather(cityId: string | null | undefined) {
 
       // Add some temperature variance based on seed
       const tempVariance = seededRandom(Math.abs(seedNum + 1)) * 6 - 3; // ±3°C
-      const temperature = Math.round(data.avg_temperature_celsius + tempVariance);
+      const temperature = Math.round(weatherPattern.avg_temperature_celsius + tempVariance);
 
       return {
         condition: selectedCondition,

--- a/src/services/radioContentService.ts
+++ b/src/services/radioContentService.ts
@@ -1,0 +1,50 @@
+import { supabase } from "@/integrations/supabase/client";
+import { supabaseArrayOrFallback } from "@/services/supabaseQuery";
+
+export interface RadioContent {
+  id: string;
+  content_type: "jingle" | "advert";
+  title: string;
+  script: string;
+  audio_url: string | null;
+  audio_status: string;
+  voice_id: string | null;
+  category: string | null;
+  brand_name: string | null;
+  humor_style: string | null;
+  duration_seconds: number | null;
+  play_weight: number;
+  is_active: boolean;
+  created_at: string;
+}
+
+export const radioContentKeys = {
+  active: ["rm-radio-content"] as const,
+  all: ["rm-radio-content-all"] as const,
+};
+
+export const fetchPlayableRadioContent = async (): Promise<RadioContent[]> => {
+  const { data, error } = await supabase
+    .from("radio_content")
+    .select("*")
+    .eq("is_active", true)
+    .eq("audio_status", "completed")
+    .not("audio_url", "is", null);
+
+  return supabaseArrayOrFallback(data as RadioContent[] | null, error, {
+    scope: "radioContentService",
+    action: "fetch playable radio content",
+  });
+};
+
+export const fetchAllRadioContent = async (): Promise<RadioContent[]> => {
+  const { data, error } = await supabase
+    .from("radio_content")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  return supabaseArrayOrFallback(data as RadioContent[] | null, error, {
+    scope: "radioContentService",
+    action: "fetch all radio content",
+  });
+};

--- a/src/services/supabaseQuery.ts
+++ b/src/services/supabaseQuery.ts
@@ -1,0 +1,71 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+export type SupabaseQueryContext = {
+  scope: string;
+  action: string;
+};
+
+export const describeSupabaseError = (error: PostgrestError | Error | null | undefined): string => {
+  if (!error) return "Unknown Supabase error";
+  if ("message" in error && error.message) return error.message;
+  return String(error);
+};
+
+export const logSupabaseError = (
+  context: SupabaseQueryContext,
+  error: PostgrestError | Error | null | undefined,
+) => {
+  console.error(`[${context.scope}] Failed to ${context.action}: ${describeSupabaseError(error)}`, error);
+};
+
+export const requireSupabaseData = <T>(
+  data: T | null | undefined,
+  context: SupabaseQueryContext,
+): T => {
+  if (data == null) {
+    throw new Error(`[${context.scope}] Failed to ${context.action}: no data returned`);
+  }
+
+  return data;
+};
+
+export const supabaseArrayOrThrow = <T>(
+  data: T[] | null | undefined,
+  error: PostgrestError | Error | null | undefined,
+  context: SupabaseQueryContext,
+): T[] => {
+  if (error) {
+    logSupabaseError(context, error);
+    throw error;
+  }
+
+  return data ?? [];
+};
+
+export const supabaseArrayOrFallback = <T>(
+  data: T[] | null | undefined,
+  error: PostgrestError | Error | null | undefined,
+  context: SupabaseQueryContext,
+  fallback: T[] = [],
+): T[] => {
+  if (error) {
+    logSupabaseError(context, error);
+    return fallback;
+  }
+
+  return data ?? fallback;
+};
+
+export const supabaseSingleOrFallback = <T>(
+  data: T | null | undefined,
+  error: PostgrestError | Error | null | undefined,
+  context: SupabaseQueryContext,
+  fallback: T,
+): T => {
+  if (error) {
+    logSupabaseError(context, error);
+    return fallback;
+  }
+
+  return data ?? fallback;
+};

--- a/src/services/twaaterTrendingService.ts
+++ b/src/services/twaaterTrendingService.ts
@@ -1,0 +1,102 @@
+import { supabase } from "@/integrations/supabase/client";
+import { supabaseArrayOrThrow } from "@/services/supabaseQuery";
+
+export type TrendingTopic = { tag: string; count: number };
+
+type TwaatMetrics = {
+  likes?: number | null;
+  retwaats?: number | null;
+  replies?: number | null;
+  views?: number | null;
+};
+
+type TrendingTwaatRow = {
+  body?: string | null;
+  created_at: string;
+  is_promoted?: boolean | null;
+  promoted_until?: string | null;
+  account?: { verified?: boolean | null } | null;
+  metrics?: TwaatMetrics[] | TwaatMetrics | null;
+};
+
+const getYesterdayIso = () => {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return yesterday.toISOString();
+};
+
+export const fetchRecentTwaatsForTrending = async (): Promise<TrendingTwaatRow[]> => {
+  const { data, error } = await supabase
+    .from("twaats")
+    .select(`
+      *,
+      account:twaater_accounts!twaats_account_id_fkey(
+        id,
+        handle,
+        display_name,
+        verified,
+        owner_type,
+        fame_score
+      ),
+      metrics:twaat_metrics(
+        likes,
+        retwaats,
+        replies,
+        views
+      )
+    `)
+    .gte("created_at", getYesterdayIso())
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  return supabaseArrayOrThrow(data as TrendingTwaatRow[] | null, error, {
+    scope: "twaaterTrendingService",
+    action: "fetch recent twaats for trending calculations",
+  });
+};
+
+export const scoreTrendingTwaats = <T extends TrendingTwaatRow>(twaats: T[]) => {
+  const now = Date.now();
+
+  return twaats
+    .map((twaat) => {
+      const metricsData = Array.isArray(twaat.metrics) ? twaat.metrics[0] : twaat.metrics;
+      const metrics = metricsData || { likes: 0, retwaats: 0, replies: 0, views: 0 };
+      const baseScore =
+        (metrics.likes || 0) * 2 +
+        (metrics.retwaats || 0) * 3 +
+        (metrics.replies || 0) * 1.5 +
+        (metrics.views || 0) * 0.1;
+      const createdAtTime = new Date(twaat.created_at).getTime();
+      const hoursOld = Number.isFinite(createdAtTime) ? (now - createdAtTime) / (1000 * 60 * 60) : 24;
+      const timeDecay = Math.exp(-hoursOld / 12);
+      const verifiedBoost = twaat.account?.verified ? 1.5 : 1;
+      const promotedActive =
+        Boolean(twaat.is_promoted) &&
+        Boolean(twaat.promoted_until) &&
+        new Date(twaat.promoted_until as string).getTime() > now;
+      const promotedBoost = promotedActive ? 2 : 1;
+
+      return { ...twaat, engagementScore: baseScore * timeDecay * verifiedBoost * promotedBoost };
+    })
+    .filter((twaat) => twaat.engagementScore > 0.5)
+    .sort((a, b) => b.engagementScore - a.engagementScore)
+    .slice(0, 20);
+};
+
+export const extractTrendingTopics = (twaats: TrendingTwaatRow[]): TrendingTopic[] => {
+  const hashtagCounts = new Map<string, number>();
+
+  twaats.forEach((twaat) => {
+    const hashtags = twaat.body?.match(/#[a-zA-Z0-9_]+/g) || [];
+    hashtags.forEach((tag) => {
+      const normalized = tag.toLowerCase();
+      hashtagCounts.set(normalized, (hashtagCounts.get(normalized) || 0) + 1);
+    });
+  });
+
+  return Array.from(hashtagCounts.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+};

--- a/src/services/weatherService.ts
+++ b/src/services/weatherService.ts
@@ -1,0 +1,25 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { WeatherCondition } from "@/utils/weatherSystem";
+import { supabaseSingleOrFallback } from "@/services/supabaseQuery";
+
+type SeasonalWeatherPattern = {
+  weather_conditions: Record<WeatherCondition, number> | null;
+  avg_temperature_celsius: number | null;
+};
+
+export const fetchSeasonalWeatherPattern = async (
+  cityId: string,
+  season: string,
+): Promise<SeasonalWeatherPattern | null> => {
+  const { data, error } = await supabase
+    .from("seasonal_weather_patterns")
+    .select("weather_conditions, avg_temperature_celsius")
+    .eq("city_id", cityId)
+    .eq("season", season)
+    .maybeSingle();
+
+  return supabaseSingleOrFallback(data as SeasonalWeatherPattern | null, error, {
+    scope: "weatherService",
+    action: "fetch seasonal weather pattern",
+  }, null);
+};


### PR DESCRIPTION
### Motivation
- Reduce duplicated Supabase query logic across hooks, standardise error handling and loading behaviour, and add missing null checks to improve runtime reliability.
- Centralise commonly-used query patterns so future migrations can use typed service functions instead of repeating raw queries in many hooks.

### Description
- Added shared helpers in `src/services/supabaseQuery.ts` to standardise error description, logging, required-data checks, and array/single fallbacks for Supabase responses.
- Extracted radio content queries into `src/services/radioContentService.ts` with stable query keys and two fetchers (`fetchPlayableRadioContent`, `fetchAllRadioContent`) and updated `useRadioContent` to use them, including a null-safe `getRandomContent` fallback.
- Extracted seasonal weather lookup into `src/services/weatherService.ts` and updated `useWeather` to call `fetchSeasonalWeatherPattern`, narrowed selected columns and added guards for missing `weather_conditions`/`avg_temperature_celsius`.
- Consolidated Twaater trending logic into `src/services/twaaterTrendingService.ts` with `fetchRecentTwaatsForTrending`, `scoreTrendingTwaats`, and `extractTrendingTopics`, and updated `useTwaaterTrending` to derive both trending posts and topics from the same dataset to remove a duplicate `twaats.select("body")` query; also added safer handling for missing metrics, invalid dates, nullable account/promotion fields, and typed return shapes.

### Testing
- `npx tsc --noEmit` — TypeScript type-check completed successfully.
- `git diff --check` — whitespace/format checks passed.
- `npm run lint` — could not run due to missing local dependency `@eslint/js` in this environment so linting was not completed.
- `npm run build` — could not run because `vite` is not installed in the current environment, so a full build was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4c2ebc8883258260c2c6fcd0da48)