### PR TITLE
Improve database interaction reliability and RLS-aware error handling

### DIFF
--- a/docs/database-interaction-audit.md
+++ b/docs/database-interaction-audit.md
@@ -1,0 +1,24 @@
+# Database interaction audit
+
+## Issues fixed
+
+- Replaced a `.single()` fetch in the personal loadout detail path with `.maybeSingle()` so an absent or RLS-hidden loadout no longer surfaces as a PostgREST 406/PGRST116 exception.
+- Added required string validation before personal loadout, loadout item, pedal slot, sponsorship offer, contract, and band-scoped queries reach Supabase.
+- Added database error wrapping that includes operation, table, filters, PostgREST code/details/hints, and an RLS-specific troubleshooting hint.
+- Added explicit foreign-key context to loadout child inserts and sponsorship contract/payment inserts so FK failures identify the parent and child IDs involved.
+- Stopped ignoring failures when accepting sponsorship offers and terminating contracts; follow-up status/payment updates now throw contextual errors instead of silently leaving partial state.
+- Added status and numeric validation before accepting sponsorship offers, preventing invalid payment schedules from unsafe assumptions about `term_weeks` and `total_value`.
+
+## Potential schema improvements
+
+- Add or verify unique constraints that match `.maybeSingle()` assumptions, especially one active/pending sponsorship workflow row per relevant business key where the UI expects one row.
+- Consider database constraints for positive sponsorship `term_weeks`, non-negative `total_value`, and valid status transitions.
+- Consider `ON DELETE` behavior for loadout child tables and sponsorship payments so parent deletion/cleanup is predictable.
+- Consider RPC wrappers for multi-step writes such as accepting a sponsorship offer so contract creation, payment creation, and offer status updates are atomic.
+
+## Remaining risks
+
+- This pass targeted high-risk client-side interactions found during review; many other `.single()` calls remain across hooks, pages, utilities, and Edge Functions and should be migrated when the row is optional.
+- RLS cannot be fully proven from client code alone. A null result from `.maybeSingle()` can still mean either genuinely missing data or data hidden by RLS.
+- Multi-step client workflows can still partially complete if later operations fail; schema redesign was avoided, so atomicity remains a risk until these flows move into database functions or Edge Functions.
+- Embedded relationship selects assume Supabase can resolve the intended foreign keys. Ambiguous or missing FK relationships will still fail at runtime and should be covered by integration tests against the live schema.

--- a/src/lib/api/sponsorships.ts
+++ b/src/lib/api/sponsorships.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
+import { assertNonEmptyString, throwDbError } from "@/lib/db-errors";
 
 export interface SponsorshipBrand {
   id: string;
@@ -66,73 +67,70 @@ export async function fetchSponsorshipBrands(): Promise<SponsorshipBrand[]> {
     .select('*')
     .eq('is_active', true)
     .order('wealth_tier', { ascending: false });
-  
-  if (error) throw error;
+
+  if (error) throwDbError(error, { operation: 'list', table: 'sponsorship_brands' });
   return data || [];
 }
 
 export async function fetchSponsorshipOffers(bandId: string): Promise<SponsorshipOffer[]> {
+  const validBandId = assertNonEmptyString(bandId, 'bandId');
   const { data, error } = await supabase
     .from('sponsorship_offers')
-    .select(`
-      *,
-      brand:sponsorship_brands(*)
-    `)
-    .eq('band_id', bandId)
+    .select(`*, brand:sponsorship_brands(*)`)
+    .eq('band_id', validBandId)
     .order('created_at', { ascending: false });
-  
-  if (error) throw error;
+
+  if (error) throwDbError(error, { operation: 'list', table: 'sponsorship_offers', filters: { bandId: validBandId }, rlsHint: 'Verify offer RLS is scoped to the selected band.' });
   return data || [];
 }
 
 export async function fetchSponsorshipContracts(bandId: string): Promise<SponsorshipContract[]> {
+  const validBandId = assertNonEmptyString(bandId, 'bandId');
   const { data, error } = await supabase
     .from('sponsorship_contracts')
-    .select(`
-      *,
-      brand:sponsorship_brands(*)
-    `)
-    .eq('band_id', bandId)
+    .select(`*, brand:sponsorship_brands(*)`)
+    .eq('band_id', validBandId)
     .order('created_at', { ascending: false });
-  
-  if (error) throw error;
+
+  if (error) throwDbError(error, { operation: 'list', table: 'sponsorship_contracts', filters: { bandId: validBandId }, rlsHint: 'Verify contract RLS is scoped to the selected band.' });
   return data || [];
 }
 
 export async function fetchContractPayments(contractId: string): Promise<SponsorshipPayment[]> {
+  const validContractId = assertNonEmptyString(contractId, 'contractId');
   const { data, error } = await supabase
     .from('sponsorship_payments')
     .select('*')
-    .eq('contract_id', contractId)
+    .eq('contract_id', validContractId)
     .order('week_number', { ascending: true });
-  
-  if (error) throw error;
+
+  if (error) throwDbError(error, { operation: 'list', table: 'sponsorship_payments', filters: { contractId: validContractId }, rlsHint: 'Verify payment RLS follows the parent contract ownership.' });
   return data || [];
 }
 
 export async function acceptOffer(offerId: string): Promise<SponsorshipContract> {
-  // Get the offer
+  const validOfferId = assertNonEmptyString(offerId, "offerId");
   const { data: offer, error: offerError } = await supabase
     .from('sponsorship_offers')
     .select('*')
-    .eq('id', offerId)
-    .single();
-  
-  if (offerError || !offer) throw offerError || new Error('Offer not found');
-  
-  // Calculate weekly payment
+    .eq('id', validOfferId)
+    .maybeSingle();
+
+  if (offerError) throwDbError(offerError, { operation: 'fetch', table: 'sponsorship_offers', filters: { offerId: validOfferId }, rlsHint: 'A null row can mean not found or hidden by RLS.' });
+  if (!offer) throw new Error(`Sponsorship offer ${validOfferId} was not found or is not visible`);
+  if (offer.status !== 'pending') throw new Error(`Sponsorship offer ${validOfferId} is ${offer.status}, not pending`);
+  if (!Number.isFinite(offer.term_weeks) || offer.term_weeks <= 0) throw new Error(`Sponsorship offer ${validOfferId} has invalid term_weeks`);
+  if (!Number.isFinite(offer.total_value) || offer.total_value < 0) throw new Error(`Sponsorship offer ${validOfferId} has invalid total_value`);
+
   const weeklyPayment = Math.floor(offer.total_value / offer.term_weeks);
-  
-  // Calculate dates
   const startDate = new Date();
   const endDate = new Date();
   endDate.setDate(endDate.getDate() + (offer.term_weeks * 7));
-  
-  // Create the contract
+
   const { data: contract, error: contractError } = await supabase
     .from('sponsorship_contracts')
     .insert({
-      offer_id: offerId,
+      offer_id: validOfferId,
       brand_id: offer.brand_id,
       band_id: offer.band_id,
       total_value: offer.total_value,
@@ -149,61 +147,41 @@ export async function acceptOffer(offerId: string): Promise<SponsorshipContract>
     })
     .select()
     .single();
-  
-  if (contractError) throw contractError;
-  
-  // Create payment schedule
+
+  if (contractError) throwDbError(contractError, { operation: 'insert', table: 'sponsorship_contracts', filters: { offerId: validOfferId, bandId: offer.band_id, brandId: offer.brand_id }, rlsHint: 'Verify offer_id, brand_id, and band_id FKs exist and contract insert RLS permits this band.' });
+
   const payments = [];
   for (let week = 1; week <= offer.term_weeks; week++) {
     const scheduledDate = new Date(startDate);
     scheduledDate.setDate(scheduledDate.getDate() + (week * 7));
-    
-    payments.push({
-      contract_id: contract.id,
-      band_id: offer.band_id,
-      amount: weeklyPayment,
-      week_number: week,
-      status: 'scheduled',
-      scheduled_at: scheduledDate.toISOString(),
-    });
+    payments.push({ contract_id: contract.id, band_id: offer.band_id, amount: weeklyPayment, week_number: week, status: 'scheduled', scheduled_at: scheduledDate.toISOString() });
   }
-  
-  const { error: paymentsError } = await supabase
-    .from('sponsorship_payments')
-    .insert(payments);
-  
-  if (paymentsError) throw paymentsError;
-  
-  // Update offer status
-  await supabase
-    .from('sponsorship_offers')
-    .update({ status: 'accepted' })
-    .eq('id', offerId);
-  
+
+  const { error: paymentsError } = await supabase.from('sponsorship_payments').insert(payments);
+  if (paymentsError) throwDbError(paymentsError, { operation: 'insert', table: 'sponsorship_payments', filters: { contractId: contract.id, bandId: offer.band_id }, rlsHint: 'Verify sponsorship_payments contract_id and band_id FKs are valid.' });
+
+  const { error: updateOfferError } = await supabase.from('sponsorship_offers').update({ status: 'accepted' }).eq('id', validOfferId);
+  if (updateOfferError) throwDbError(updateOfferError, { operation: 'update', table: 'sponsorship_offers', filters: { offerId: validOfferId }, rlsHint: 'Contract exists but offer status update failed; check offer update RLS.' });
+
   return contract;
 }
 
 export async function rejectOffer(offerId: string): Promise<void> {
-  const { error } = await supabase
-    .from('sponsorship_offers')
-    .update({ status: 'declined' })
-    .eq('id', offerId);
-  
-  if (error) throw error;
+  const validOfferId = assertNonEmptyString(offerId, "offerId");
+  const { error } = await supabase.from('sponsorship_offers').update({ status: 'declined' }).eq('id', validOfferId);
+  if (error) throwDbError(error, { operation: 'update', table: 'sponsorship_offers', filters: { offerId: validOfferId }, rlsHint: 'Verify the current user can update this offer through RLS.' });
 }
 
 export async function terminateContract(contractId: string): Promise<void> {
-  const { error } = await supabase
-    .from('sponsorship_contracts')
-    .update({ status: 'terminated' })
-    .eq('id', contractId);
-  
-  if (error) throw error;
-  
-  // Cancel pending payments
-  await supabase
+  const validContractId = assertNonEmptyString(contractId, "contractId");
+  const { error } = await supabase.from('sponsorship_contracts').update({ status: 'terminated' }).eq('id', validContractId);
+  if (error) throwDbError(error, { operation: 'update', table: 'sponsorship_contracts', filters: { contractId: validContractId }, rlsHint: 'Verify contract ownership RLS permits termination.' });
+
+  const { error: cancelPaymentsError } = await supabase
     .from('sponsorship_payments')
     .update({ status: 'cancelled' })
-    .eq('contract_id', contractId)
+    .eq('contract_id', validContractId)
     .eq('status', 'scheduled');
+
+  if (cancelPaymentsError) throwDbError(cancelPaymentsError, { operation: 'update', table: 'sponsorship_payments', filters: { contractId: validContractId, status: 'scheduled' }, rlsHint: 'Contract was terminated but scheduled payment cancellation failed; check child-row RLS.' });
 }

--- a/src/lib/db-errors.ts
+++ b/src/lib/db-errors.ts
@@ -1,0 +1,47 @@
+export interface DbErrorContext {
+  operation: string;
+  table: string;
+  filters?: Record<string, unknown>;
+  rlsHint?: string;
+}
+
+export const isMissingSingleRowError = (error: unknown): boolean => {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: string }).code === "PGRST116"
+  );
+};
+
+export const assertNonEmptyString = (value: string, fieldName: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${fieldName} is required`);
+  }
+  return trimmed;
+};
+
+export const formatDbError = (error: unknown, context: DbErrorContext): Error => {
+  const code = error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code) : "unknown";
+  const message = error && typeof error === "object" && "message" in error ? String((error as { message?: unknown }).message) : String(error);
+  const detail = error && typeof error === "object" && "details" in error ? (error as { details?: unknown }).details : undefined;
+  const hint = error && typeof error === "object" && "hint" in error ? (error as { hint?: unknown }).hint : undefined;
+
+  const filterSummary = context.filters
+    ? ` filters=${JSON.stringify(context.filters)}`
+    : "";
+  const rlsSummary = context.rlsHint ? ` ${context.rlsHint}` : "";
+  const detailSummary = detail ? ` details=${JSON.stringify(detail)}` : "";
+  const hintSummary = hint ? ` hint=${JSON.stringify(hint)}` : "";
+
+  const wrapped = new Error(
+    `Database ${context.operation} failed on ${context.table} (code=${code}): ${message}${filterSummary}${detailSummary}${hintSummary}${rlsSummary}`
+  );
+  wrapped.cause = error;
+  return wrapped;
+};
+
+export const throwDbError = (error: unknown, context: DbErrorContext): never => {
+  throw formatDbError(error, context);
+};

--- a/src/lib/personal-loadouts.ts
+++ b/src/lib/personal-loadouts.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
+import { assertNonEmptyString, throwDbError } from "@/lib/db-errors";
 
 const db = supabase as any;
 
@@ -66,6 +67,8 @@ const mapLoadout = (row: PersonalLoadoutQueryRow): PersonalLoadoutWithGear => ({
 export const listPersonalLoadoutsByCharacter = async (
   characterId: string
 ): Promise<PersonalLoadoutWithGear[]> => {
+  const validCharacterId = assertNonEmptyString(characterId, "characterId");
+
   const { data, error } = await db
     .from("personal_loadouts")
     .select(
@@ -73,11 +76,11 @@ export const listPersonalLoadoutsByCharacter = async (
         items:personal_loadout_items (*, gear:gear_items (*)),
         pedal_slots:personal_loadout_pedal_slots (*, gear:gear_items (*))`
     )
-    .eq("character_id", characterId)
+    .eq("character_id", validCharacterId)
     .order("created_at", { ascending: true });
 
   if (error) {
-    throw error;
+    throwDbError(error, { operation: "list", table: "personal_loadouts", filters: { characterId: validCharacterId }, rlsHint: "Verify RLS allows the current user to read this character." });
   }
 
   return (data as PersonalLoadoutQueryRow[] | null)?.map(mapLoadout) ?? [];
@@ -86,6 +89,8 @@ export const listPersonalLoadoutsByCharacter = async (
 const fetchPersonalLoadoutById = async (
   loadoutId: string
 ): Promise<PersonalLoadoutWithGear | null> => {
+  const validLoadoutId = assertNonEmptyString(loadoutId, "loadoutId");
+
   const { data, error } = await db
     .from("personal_loadouts")
     .select(
@@ -93,11 +98,11 @@ const fetchPersonalLoadoutById = async (
         items:personal_loadout_items (*, gear:gear_items (*)),
         pedal_slots:personal_loadout_pedal_slots (*, gear:gear_items (*))`
     )
-    .eq("id", loadoutId)
-    .single();
+    .eq("id", validLoadoutId)
+    .maybeSingle();
 
-  if (error && error.code !== "PGRST116") {
-    throw error;
+  if (error) {
+    throwDbError(error, { operation: "fetch", table: "personal_loadouts", filters: { loadoutId: validLoadoutId }, rlsHint: "A null row can mean not found or hidden by RLS." });
   }
 
   if (!data) {
@@ -115,10 +120,11 @@ const insertLoadoutItems = async (
     return;
   }
 
+  const validLoadoutId = assertNonEmptyString(loadoutId, "loadoutId");
   const payload = items.map((item) => ({
-    loadout_id: loadoutId,
-    gear_item_id: item.gearItemId,
-    slot_kind: item.slotKind,
+    loadout_id: validLoadoutId,
+    gear_item_id: assertNonEmptyString(item.gearItemId, "items[].gearItemId"),
+    slot_kind: assertNonEmptyString(item.slotKind, "items[].slotKind"),
     notes: item.notes ?? null,
   }));
 
@@ -127,7 +133,7 @@ const insertLoadoutItems = async (
     .insert(payload);
 
   if (error) {
-    throw error;
+    throwDbError(error, { operation: "insert", table: "personal_loadout_items", filters: { loadoutId: validLoadoutId }, rlsHint: "Verify loadout_id and gear_item_id foreign keys are visible and valid." });
   }
 };
 
@@ -139,10 +145,11 @@ const insertPedalSlots = async (
     return;
   }
 
+  const validLoadoutId = assertNonEmptyString(loadoutId, "loadoutId");
   const payload = pedalSlots.map((slot) => ({
-    loadout_id: loadoutId,
+    loadout_id: validLoadoutId,
     slot_number: slot.slotNumber,
-    slot_type: slot.slotType,
+    slot_type: assertNonEmptyString(slot.slotType, "pedalSlots[].slotType"),
     gear_item_id: slot.gearItemId ?? null,
     notes: slot.notes ?? null,
   }));
@@ -152,7 +159,7 @@ const insertPedalSlots = async (
     .insert(payload);
 
   if (error) {
-    throw error;
+    throwDbError(error, { operation: "insert", table: "personal_loadout_pedal_slots", filters: { loadoutId: validLoadoutId }, rlsHint: "Verify loadout_id and optional gear_item_id foreign keys are visible and valid." });
   }
 };
 
@@ -175,8 +182,8 @@ export const createPersonalLoadout = async (
     .from("personal_loadouts")
     .insert([
       {
-        character_id: characterId,
-        name,
+        character_id: assertNonEmptyString(characterId, "characterId"),
+        name: assertNonEmptyString(name, "name"),
         role: role ?? null,
         scenario: scenario ?? null,
         primary_instrument: primaryInstrument ?? null,
@@ -188,7 +195,7 @@ export const createPersonalLoadout = async (
     .single();
 
   if (error) {
-    throw error;
+    throwDbError(error, { operation: "insert", table: "personal_loadouts", filters: { characterId }, rlsHint: "Verify RLS allows inserts for this character and required FKs exist." });
   }
 
   const loadoutId = (data as PersonalLoadoutRecord).id;
@@ -208,10 +215,12 @@ export const updatePersonalLoadout = async (
   input: UpdatePersonalLoadoutInput
 ): Promise<PersonalLoadoutWithGear | null> => {
   const { characterId, loadoutId, changes, items, pedalSlots } = input;
+  const validCharacterId = assertNonEmptyString(characterId, "characterId");
+  const validLoadoutId = assertNonEmptyString(loadoutId, "loadoutId");
 
   const updatePayload: Record<string, unknown> = {};
   if (changes) {
-    if (changes.name !== undefined) updatePayload.name = changes.name;
+    if (changes.name !== undefined) updatePayload.name = assertNonEmptyString(changes.name, "changes.name");
     if (changes.role !== undefined) updatePayload.role = changes.role ?? null;
     if (changes.scenario !== undefined) updatePayload.scenario = changes.scenario ?? null;
     if (changes.primaryInstrument !== undefined) updatePayload.primary_instrument = changes.primaryInstrument ?? null;
@@ -223,11 +232,11 @@ export const updatePersonalLoadout = async (
     const { error } = await db
       .from("personal_loadouts")
       .update(updatePayload)
-      .eq("id", loadoutId)
-      .eq("character_id", characterId);
+      .eq("id", validLoadoutId)
+      .eq("character_id", validCharacterId);
 
     if (error) {
-      throw error;
+      throwDbError(error, { operation: "update", table: "personal_loadouts", filters: { loadoutId: validLoadoutId, characterId: validCharacterId }, rlsHint: "A zero-row update can indicate RLS or ownership mismatch." });
     }
   }
 
@@ -235,10 +244,10 @@ export const updatePersonalLoadout = async (
     const { error: deleteError } = await db
       .from("personal_loadout_items")
       .delete()
-      .eq("loadout_id", loadoutId);
+      .eq("loadout_id", validLoadoutId);
 
     if (deleteError) {
-      throw deleteError;
+      throwDbError(deleteError, { operation: "delete", table: "personal_loadout_items", filters: { loadoutId: validLoadoutId }, rlsHint: "Verify child rows are covered by loadout ownership RLS." });
     }
 
     await insertLoadoutItems(loadoutId, items);
@@ -248,14 +257,14 @@ export const updatePersonalLoadout = async (
     const { error: deleteError } = await db
       .from("personal_loadout_pedal_slots")
       .delete()
-      .eq("loadout_id", loadoutId);
+      .eq("loadout_id", validLoadoutId);
 
     if (deleteError) {
-      throw deleteError;
+      throwDbError(deleteError, { operation: "delete", table: "personal_loadout_pedal_slots", filters: { loadoutId: validLoadoutId }, rlsHint: "Verify child rows are covered by loadout ownership RLS." });
     }
 
     await insertPedalSlots(loadoutId, pedalSlots);
   }
 
-  return fetchPersonalLoadoutById(loadoutId);
+  return fetchPersonalLoadoutById(validLoadoutId);
 };


### PR DESCRIPTION
### Motivation
- Fix PostgREST 406 / `PGRST116` errors caused by unsafe `.single()` usage and make optional row reads resilient to RLS hiding. 
- Prevent invalid writes by validating inputs before they reach the database and removing unsafe assumptions about numeric fields and foreign keys. 
- Make database errors actionable by including operation/table/filters and RLS-specific hints in error messages. 
- Reduce silent partial failures in multi-step client flows by surfacing follow-up update/insert errors.

### Description
- Add a shared helper `src/lib/db-errors.ts` exposing `assertNonEmptyString`, `isMissingSingleRowError`, `formatDbError`, and `throwDbError` to centralize input validation and contextual DB error wrapping. 
- Harden `src/lib/personal-loadouts.ts` by validating `characterId`/`loadoutId`/names, validating child item fields, switching the detail fetch from `.single()` to `.maybeSingle()`, and replacing raw throws with `throwDbError` that includes FK/RLS hints. 
- Harden `src/lib/api/sponsorships.ts` by validating `bandId`/`offerId`/`contractId`, using `.maybeSingle()` for offer lookup, enforcing offer `status`, `term_weeks` and `total_value` checks, and wrapping contract/payment/offer-update errors with contextual messages and RLS troubleshooting hints. 
- Add documentation `docs/database-interaction-audit.md` summarising issues fixed, suggested schema improvements, and remaining risks.

### Testing
- Ran `npx tsc --noEmit` which succeeded with no TypeScript errors. 
- Ran `git diff --check` which reported no whitespace/merge-conflict issues. 
- Ran `npm run lint` which was blocked due to a missing local dependency (`@eslint/js`), so linting could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f525efe00832595a95f2a16706bab)