### PR TITLE
Refactor duplicated number clamping helpers

### DIFF
--- a/src/lib/api/roleplaying.ts
+++ b/src/lib/api/roleplaying.ts
@@ -2,6 +2,7 @@
 
 import { supabase } from "@/integrations/supabase/client";
 import type { Json } from "@/lib/supabase-types";
+import { clampScore } from "@/utils/number";
 import type {
   CharacterOrigin,
   PersonalityTrait,
@@ -194,7 +195,6 @@ export const updatePlayerReputation = async (
   if (!current) throw new Error("Player reputation not found");
 
   // Calculate new values and clamp to -100 to 100
-  const clamp = (val: number) => Math.max(-100, Math.min(100, val));
   
   const updates: Partial<PlayerReputation> = {
     last_updated_at: new Date().toISOString(),
@@ -216,7 +216,7 @@ export const updatePlayerReputation = async (
   for (const change of changes) {
     const currentKey = `${change.axis}_score` as keyof PlayerReputation;
     const currentValue = current[currentKey] as number;
-    const newValue = clamp(currentValue + change.change);
+    const newValue = clampScore(currentValue + change.change);
 
     updates[currentKey as 'authenticity_score' | 'attitude_score' | 'reliability_score' | 'creativity_score'] = newValue;
 
@@ -360,11 +360,9 @@ export const updateNPCRelationship = async (
 
   if (fetchError) throw fetchError;
 
-  const clamp = (val: number) => Math.max(-100, Math.min(100, val));
-
-  const newAffinity = clamp(current.affinity_score + (updates.affinity_change ?? 0));
-  const newTrust = clamp(current.trust_score + (updates.trust_change ?? 0));
-  const newRespect = clamp(current.respect_score + (updates.respect_change ?? 0));
+  const newAffinity = clampScore(current.affinity_score + (updates.affinity_change ?? 0));
+  const newTrust = clampScore(current.trust_score + (updates.trust_change ?? 0));
+  const newRespect = clampScore(current.respect_score + (updates.respect_change ?? 0));
 
   // Determine relationship stage based on affinity
   const determineStage = (affinity: number): string => {

--- a/src/lib/minigames/lyricScramble.ts
+++ b/src/lib/minigames/lyricScramble.ts
@@ -1,7 +1,5 @@
+import { clamp } from "@/utils/number";
 import type { MinigameAttemptResult, MinigameSimulationInput } from "./types";
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(Math.max(value, min), max);
 
 interface LyricPrompt {
   phrase: string;

--- a/src/lib/minigames/rhythmChallenge.ts
+++ b/src/lib/minigames/rhythmChallenge.ts
@@ -1,3 +1,4 @@
+import { clamp } from "@/utils/number";
 import type { MinigameAttemptResult, MinigameSimulationInput } from "./types";
 
 interface RhythmBeat {
@@ -6,8 +7,6 @@ interface RhythmBeat {
   timingWindow: number;
 }
 
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(Math.max(value, min), max);
 
 const BASE_PATTERN_LENGTH = 6;
 const MAX_PATTERN_LENGTH = 16;

--- a/src/lib/minigames/soundcheckMix.ts
+++ b/src/lib/minigames/soundcheckMix.ts
@@ -1,7 +1,5 @@
+import { clamp } from "@/utils/number";
 import type { MinigameAttemptResult, MinigameSimulationInput } from "./types";
-
-const clamp = (value: number, min: number, max: number) =>
-  Math.min(Math.max(value, min), max);
 
 interface MixChannel {
   name: string;

--- a/src/utils/dikcokMetrics.ts
+++ b/src/utils/dikcokMetrics.ts
@@ -1,3 +1,5 @@
+import { clamp } from "@/utils/number";
+
 export interface DikCokOutcomeInput {
   followers: number;
   bandFame: number;
@@ -12,7 +14,6 @@ export interface DikCokOutcome {
   velocity: "Niche" | "Stable" | "Trending" | "Exploding";
 }
 
-const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
 
 export const calculateDikCokOutcome = (
   input: DikCokOutcomeInput,

--- a/src/utils/equipmentDegradation.ts
+++ b/src/utils/equipmentDegradation.ts
@@ -1,3 +1,5 @@
+import { clampPercent } from "@/utils/number";
+
 /**
  * Equipment Degradation System (v1.0.936)
  * Equipment wears down with use, affecting performance quality.
@@ -42,7 +44,7 @@ function getConditionLabel(condition: number): DegradationState["conditionLabel"
  * Get equipment degradation state from current condition.
  */
 export function getEquipmentCondition(condition: number): DegradationState {
-  const clamped = Math.max(0, Math.min(100, condition));
+  const clamped = clampPercent(condition);
   const label = getConditionLabel(clamped);
   const t = clamped / 100;
 

--- a/src/utils/fanSentiment.ts
+++ b/src/utils/fanSentiment.ts
@@ -1,3 +1,5 @@
+import { clampScore } from "@/utils/number";
+
 /**
  * Fan Sentiment System (v1.0.953)
  * Tracks how fans feel about the band beyond raw numbers.
@@ -30,7 +32,7 @@ function getSentimentMood(score: number): FanSentiment["mood"] {
  * Get fan sentiment state from raw score.
  */
 export function getFanSentiment(score: number): FanSentiment {
-  const clamped = Math.max(-100, Math.min(100, score));
+  const clamped = clampScore(score);
   const mood = getSentimentMood(clamped);
   const t = (clamped + 100) / 200; // 0 to 1
 
@@ -83,7 +85,7 @@ export const SENTIMENT_EVENTS: Record<string, number> = {
  */
 export function applySentimentEvent(currentScore: number, eventKey: string): { newScore: number; change: number } {
   const change = SENTIMENT_EVENTS[eventKey] ?? 0;
-  const newScore = Math.max(-100, Math.min(100, currentScore + change));
+  const newScore = clampScore(currentScore + change);
   return { newScore, change };
 }
 
@@ -121,5 +123,5 @@ export function estimateSentimentFromActivity(
   // Scandals
   score -= scandalCount * 15;
   
-  return Math.max(-100, Math.min(100, Math.round(score)));
+  return clampScore(Math.round(score));
 }

--- a/src/utils/healthSystem.ts
+++ b/src/utils/healthSystem.ts
@@ -1,4 +1,5 @@
 import type { Tables } from "@/lib/supabase-types";
+import { clampPercent } from "@/utils/number";
 
 type Profile = Tables<"profiles">;
 
@@ -132,7 +133,7 @@ export function updateProfileHealth(
   healthGain: number = 0
 ): Partial<Profile> {
   const currentHealth = profile.health ?? 100;
-  const newHealth = Math.max(0, Math.min(100, currentHealth - healthDrain + healthGain));
+  const newHealth = clampPercent(currentHealth - healthDrain + healthGain);
   
   return {
     health: newHealth,

--- a/src/utils/mapProjection.ts
+++ b/src/utils/mapProjection.ts
@@ -1,3 +1,4 @@
+import { clamp } from "@/utils/number";
 import type { Coordinates } from "./worldTravel";
 
 export interface MapProjectionOptions {
@@ -6,7 +7,6 @@ export interface MapProjectionOptions {
   padding?: number;
 }
 
-const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
 const normalizeLongitude = (value: number) => {
   if (!Number.isFinite(value)) {

--- a/src/utils/mediaCycle.ts
+++ b/src/utils/mediaCycle.ts
@@ -1,3 +1,5 @@
+import { clampPercent } from "@/utils/number";
+
 /**
  * Media Cycle System (v1.0.936)
  * Media attention follows predictable cycles: hype → peak → decline → dormant.
@@ -52,8 +54,8 @@ function getMediaPhase(intensity: number, fatigue: number): MediaCycleState["pha
  * Get current media cycle state.
  */
 export function getMediaCycleState(intensity: number, fatigue: number): MediaCycleState {
-  const clampedIntensity = Math.max(0, Math.min(100, intensity));
-  const clampedFatigue = Math.max(0, Math.min(100, fatigue));
+  const clampedIntensity = clampPercent(intensity);
+  const clampedFatigue = clampPercent(fatigue);
   const phase = getMediaPhase(clampedIntensity, clampedFatigue);
 
   // Coverage multiplier: high intensity + low fatigue = best coverage
@@ -98,8 +100,8 @@ export function applyMediaEvent(
   const fatigueReduction = currentFatigue > 60 ? 0.5 : currentFatigue > 30 ? 0.75 : 1.0;
   const effectiveIntensityChange = Math.round(event.intensityChange * fatigueReduction);
   
-  const newIntensity = Math.max(0, Math.min(100, currentIntensity + effectiveIntensityChange));
-  const newFatigue = Math.max(0, Math.min(100, currentFatigue + event.fatigueChange));
+  const newIntensity = clampPercent(currentIntensity + effectiveIntensityChange);
+  const newFatigue = clampPercent(currentFatigue + event.fatigueChange);
 
   return { newIntensity, newFatigue, event };
 }

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,20 @@
+/**
+ * Clamp a number to an inclusive range.
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Clamp gameplay percentage/state values that use a 0-100 range.
+ */
+export function clampPercent(value: number): number {
+  return clamp(value, 0, 100);
+}
+
+/**
+ * Clamp reputation-style scores that use a -100 to 100 range.
+ */
+export function clampScore(value: number): number {
+  return clamp(value, -100, 100);
+}

--- a/src/utils/publicImageReputation.ts
+++ b/src/utils/publicImageReputation.ts
@@ -1,3 +1,5 @@
+import { clampScore } from "@/utils/number";
+
 /**
  * Public Image & Reputation System (v1.0.931)
  * A composite reputation score affected by media interactions, scandals, charity, and behavior.
@@ -66,7 +68,7 @@ const TIER_CONFIG: Record<ReputationTier, { label: string; gateMultiplier: numbe
  * Calculate reputation state from a raw score.
  */
 export function getReputationState(score: number): ReputationState {
-  const clamped = Math.max(-100, Math.min(100, score));
+  const clamped = clampScore(score);
   const tier = getTier(clamped);
   const config = TIER_CONFIG[tier];
   return { score: clamped, tier, ...config };
@@ -77,7 +79,7 @@ export function getReputationState(score: number): ReputationState {
  */
 export function applyReputationEvent(currentScore: number, eventKey: string): { newScore: number; change: number } {
   const change = REPUTATION_EVENTS[eventKey] ?? 0;
-  const newScore = Math.max(-100, Math.min(100, currentScore + change));
+  const newScore = clampScore(currentScore + change);
   return { newScore, change };
 }
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated numeric clamping logic scattered across gameplay and API code by introducing a small, well-scoped shared utility. 
- Ensure consistent bounds handling for percent/state values (0–100) and reputation/sentiment scores (-100–100). 
- Keep the abstraction minimal to avoid unnecessary complexity while removing obvious copy/paste code.

### Description

- Added a new shared utility `src/utils/number.ts` that exports `clamp`, `clampPercent`, and `clampScore` for generic, 0–100, and -100–100 ranges respectively. 
- Replaced local `clamp` implementations and inline `Math.max/Math.min` patterns in multiple modules including minigames (`lyricScramble`, `rhythmChallenge`, `soundcheckMix`), metrics (`dikcokMetrics`), map projection (`mapProjection`), media (`mediaCycle`), equipment (`equipmentDegradation`), health (`healthSystem`), fan sentiment (`fanSentiment`), public image (`publicImageReputation`), and roleplaying reputation/NPC relationship updates (`lib/api/roleplaying.ts`) with imports from the new utility. 
- Adjusted imports and replaced occurrences of `Math.max(0, Math.min(100, ...))` and `Math.max(-100, Math.min(100, ...))` with the appropriate `clampPercent`/`clampScore` calls and reused `clamp` where a generic bound was needed. 

### Testing

- `git diff --check` completed successfully with no whitespace or simple-diff issues. 
- `npm run lint` could not be completed due to the local environment missing the `@eslint/js` package, so linting was blocked. 
- `npm install` failed in this environment due to registry access errors (403 for `@react-three/fiber`), preventing full dependency installation. 
- `npm run build` could not be executed because dependencies were not installed (`vite` unavailable), so a production build was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f593a3dcc832598ee250e274f91a4)