### PR TITLE
Standardize reusable UI components

### DIFF
--- a/src/components/ui/standard-components.tsx
+++ b/src/components/ui/standard-components.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export type Tone = "default" | "success" | "warning" | "danger" | "info" | "muted";
+
+const toneClasses: Record<Tone, string> = {
+  default: "bg-primary/10 text-primary border-primary/20",
+  success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+  warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20",
+  danger: "bg-destructive/10 text-destructive border-destructive/20",
+  info: "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+  muted: "bg-muted text-muted-foreground border-border",
+};
+
+export interface StandardStatusBadgeProps {
+  children: ReactNode;
+  tone?: Tone;
+  icon?: LucideIcon;
+  className?: string;
+}
+
+export function StandardStatusBadge({ children, tone = "default", icon: Icon, className }: StandardStatusBadgeProps) {
+  return (
+    <Badge variant="outline" className={cn("gap-1 text-xs capitalize", toneClasses[tone], className)}>
+      {Icon && <Icon className="h-3 w-3" />}
+      {children}
+    </Badge>
+  );
+}
+
+export interface MetricCardItem {
+  label: ReactNode;
+  value: ReactNode;
+  icon?: LucideIcon;
+  tone?: Tone;
+}
+
+export function MetricCard({ label, value, icon: Icon, tone = "default" }: MetricCardItem) {
+  return (
+    <Card className="bg-card/50 backdrop-blur">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-2">
+          {Icon && <Icon className={cn("h-4 w-4", toneClasses[tone].split(" ").find((c) => c.startsWith("text-")))} />}
+          <span className="text-xs text-muted-foreground">{label}</span>
+        </div>
+        <p className="mt-1 text-2xl font-bold tabular-nums">{value}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MetricCardGrid({ items, className }: { items: MetricCardItem[]; className?: string }) {
+  return (
+    <div className={cn("grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4", className)}>
+      {items.map((item, index) => (
+        <MetricCard key={index} {...item} />
+      ))}
+    </div>
+  );
+}
+
+export interface SectionCardProps {
+  title?: ReactNode;
+  description?: ReactNode;
+  icon?: LucideIcon;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+export function SectionCard({ title, description, icon: Icon, actions, children, className, contentClassName }: SectionCardProps) {
+  return (
+    <Card className={className}>
+      {(title || description || actions) && (
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              {title && (
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  {Icon && <Icon className="h-4 w-4" />}
+                  {title}
+                </CardTitle>
+              )}
+              {description && <CardDescription>{description}</CardDescription>}
+            </div>
+            {actions && <div className="shrink-0">{actions}</div>}
+          </div>
+        </CardHeader>
+      )}
+      <CardContent className={cn(!title && !description && !actions && "pt-6", contentClassName)}>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Employment.tsx
+++ b/src/pages/Employment.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { SectionCard, StandardStatusBadge } from "@/components/ui/standard-components";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
@@ -482,13 +483,7 @@ export default function Employment() {
 
           <TabsContent value="jobs" className="space-y-4 mt-4">
             {/* Filters */}
-            <Card>
-              <CardHeader className="pb-3">
-                <CardTitle className="text-lg flex items-center gap-2">
-                  <Filter className="h-4 w-4" /> Filters
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+            <SectionCard title="Filters" icon={Filter}>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
                   <div className="space-y-2">
                     <Label>City</Label>
@@ -551,8 +546,7 @@ export default function Employment() {
                     </div>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
+            </SectionCard>
 
             {/* Job Results */}
             <div className="flex items-center justify-between">
@@ -573,16 +567,16 @@ export default function Employment() {
                           <CardTitle className="text-lg">{job.title}</CardTitle>
                           <CardDescription className="text-xs">{job.company_name}</CardDescription>
                         </div>
-                        <Badge variant="outline" className="text-xs">
+                        <StandardStatusBadge tone="muted">
                           {job.category?.replace("_", " ")}
-                        </Badge>
+                        </StandardStatusBadge>
                       </div>
                       {job.cities && (
                         <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
                           <MapPin className="h-3 w-3" />
                           {job.cities.name}, {job.cities.country}
                           {job.city_id === currentCityId && (
-                            <Badge variant="secondary" className="ml-1 text-[10px] px-1">Your City</Badge>
+                            <StandardStatusBadge tone="info" className="ml-1 text-[10px] px-1">Your City</StandardStatusBadge>
                           )}
                         </p>
                       )}
@@ -660,7 +654,7 @@ export default function Employment() {
                           <MapPin className="h-3 w-3" />
                           {currentJob.cities.name}, {currentJob.cities.country}
                           {currentJob.city_id !== currentCityId && (
-                            <Badge variant="destructive" className="ml-1 text-[10px]">Not in city!</Badge>
+                            <StandardStatusBadge tone="danger" className="ml-1 text-[10px]">Not in city!</StandardStatusBadge>
                           )}
                         </p>
                       )}
@@ -812,9 +806,9 @@ export default function Employment() {
                         </div>
                         <div className="text-right">
                           <p className="font-semibold text-green-600">${shift.earnings}</p>
-                          <Badge variant={shift.status === "completed" ? "default" : "secondary"} className="text-xs">
+                          <StandardStatusBadge tone={shift.status === "completed" ? "success" : "muted"}>
                             {shift.status}
-                          </Badge>
+                          </StandardStatusBadge>
                         </div>
                       </div>
                     ))}

--- a/src/pages/PublicRelations.tsx
+++ b/src/pages/PublicRelations.tsx
@@ -4,8 +4,9 @@ import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { MetricCardGrid } from "@/components/ui/standard-components";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -151,45 +152,14 @@ export default function PublicRelations() {
     >
       <div className="space-y-6">
         {/* Stats Cards */}
-
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4">
-          <Card className="bg-card/50 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2">
-                <Megaphone className="h-4 w-4 text-primary" />
-                <span className="text-xs text-muted-foreground">Pending Offers</span>
-              </div>
-              <p className="mt-1 text-2xl font-bold">{prStats?.pendingOffers || 0}</p>
-            </CardContent>
-          </Card>
-          <Card className="bg-card/50 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-emerald-500" />
-                <span className="text-xs text-muted-foreground">Fame Gained</span>
-              </div>
-              <p className="mt-1 text-2xl font-bold">{(prStats?.totalFameGained || 0).toLocaleString()}</p>
-            </CardContent>
-          </Card>
-          <Card className="bg-card/50 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-blue-500" />
-                <span className="text-xs text-muted-foreground">Total Reach</span>
-              </div>
-              <p className="mt-1 text-2xl font-bold">{(prStats?.totalReach || 0).toLocaleString()}</p>
-            </CardContent>
-          </Card>
-          <Card className="bg-card/50 backdrop-blur">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-2">
-                <DollarSign className="h-4 w-4 text-amber-500" />
-                <span className="text-xs text-muted-foreground">PR Earnings</span>
-              </div>
-              <p className="mt-1 text-2xl font-bold">${(prStats?.totalEarnings || 0).toLocaleString()}</p>
-            </CardContent>
-          </Card>
-        </div>
+        <MetricCardGrid
+          items={[
+            { label: "Pending Offers", value: prStats?.pendingOffers || 0, icon: Megaphone },
+            { label: "Fame Gained", value: (prStats?.totalFameGained || 0).toLocaleString(), icon: TrendingUp, tone: "success" },
+            { label: "Total Reach", value: (prStats?.totalReach || 0).toLocaleString(), icon: Users, tone: "info" },
+            { label: "PR Earnings", value: `$${(prStats?.totalEarnings || 0).toLocaleString()}`, icon: DollarSign, tone: "warning" },
+          ]}
+        />
 
         {/* Band Stats Bar */}
         <Card className="bg-card/50 backdrop-blur">


### PR DESCRIPTION
### Motivation
- Extract repeated UI patterns (status badges, small metric cards, titled card sections) into shared primitives to reduce duplication and enforce visual consistency.
- Target common elements used across pages (cards, badges, headers, status indicators) while preserving the existing visual design and behavior.

### Description
- Added a new shared file `src/components/ui/standard-components.tsx` with `StandardStatusBadge`, `MetricCard`, `MetricCardGrid`, and `SectionCard` primitives that wrap existing `Card`/`Badge` pieces and re-use the established styling.
- Replaced four repeated stat Card blocks on `src/pages/PublicRelations.tsx` with a `MetricCardGrid` usage to centralize metric-card rendering.
- Replaced the Filters Card on `src/pages/Employment.tsx` with `SectionCard` and swapped repeated `Badge` usages for `StandardStatusBadge` for job category, city status, and shift-status labels to standardize tone/appearance.
- Kept all visual styles and classNames intact so there is no redesign beyond extracting and reusing components.

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which completed successfully.
- Attempted ESLint on the changed files with `npx eslint src/components/ui/standard-components.tsx src/pages/PublicRelations.tsx src/pages/Employment.tsx`, which was blocked by a missing local ESLint dependency (`@eslint/js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5b9456a083258a4afe1d61e93050)