### PR TITLE
Add smoke/regression tests for auth, profiles, songs, recording, band creation and DB services

### DIFF
--- a/src/components/band/BandCreationForm.test.tsx
+++ b/src/components/band/BandCreationForm.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: [] }) }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock("@/hooks/useActiveProfile", () => ({ useActiveProfile: () => ({ profileId: "profile-1", userId: "user-fallback" }) }));
+
+const { supabase } = await import("@/integrations/supabase/client");
+const { BandCreationForm } = await import("@/components/band/BandCreationForm");
+
+const fromMock = vi.fn();
+const inserts: Array<{ table: string; payload: any }> = [];
+
+const makeQuery = (table: string) => {
+  const query: any = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    limit: vi.fn(async () => ({ data: [], error: null })),
+    delete: vi.fn(() => query),
+    insert: vi.fn((payload) => {
+      inserts.push({ table, payload });
+      return table === "bands"
+        ? { select: vi.fn(() => ({ single: vi.fn(async () => ({ data: { id: "band-1" }, error: null })) })) }
+        : Promise.resolve({ data: payload, error: null });
+    }),
+    single: vi.fn(async () => ({ data: null, error: null })),
+  };
+  return query;
+};
+
+beforeEach(() => {
+  inserts.length = 0;
+  fromMock.mockImplementation(makeQuery);
+  (supabase as any).from = fromMock;
+  (supabase.auth as any).getUser = vi.fn(async () => ({ data: { user: { id: "user-1" } }, error: null }));
+});
+
+describe("band creation smoke tests", () => {
+  it("creates a band row and founder membership from the form", async () => {
+    const onBandCreated = vi.fn();
+    render(<BandCreationForm onBandCreated={onBandCreated} />);
+
+    fireEvent.change(screen.getByLabelText(/band name/i), { target: { value: "The Beta Beats" } });
+    fireEvent.submit(screen.getByRole("button", { name: /create band/i }).closest("form")!);
+
+    await waitFor(() => expect(onBandCreated).toHaveBeenCalled());
+    expect(inserts).toEqual(expect.arrayContaining([
+      { table: "bands", payload: expect.objectContaining({ name: "The Beta Beats", leader_id: "profile-1", max_members: 4, is_solo_artist: false }) },
+      { table: "band_members", payload: expect.objectContaining({ band_id: "band-1", profile_id: "profile-1", user_id: "user-1", role: "Founder" }) },
+    ]));
+  });
+});

--- a/src/hooks/__tests__/auth.smoke.test.tsx
+++ b/src/hooks/__tests__/auth.smoke.test.tsx
@@ -1,0 +1,56 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAuth } from "@/hooks/use-auth-context";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const { supabase } = await import("@/integrations/supabase/client");
+const { AuthProvider } = await import("@/hooks/useAuth");
+
+const Consumer = () => {
+  const { loading, user, signOut } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="user">{user?.id ?? "none"}</span>
+      <button onClick={() => void signOut()}>Sign out</button>
+    </div>
+  );
+};
+
+let authCallback: ((event: string, session: any) => void) | undefined;
+const unsubscribe = vi.fn();
+
+beforeEach(() => {
+  authCallback = undefined;
+  unsubscribe.mockClear();
+  (supabase.auth as any).onAuthStateChange = vi.fn((callback) => {
+    authCallback = callback;
+    return { data: { subscription: { unsubscribe } } };
+  });
+  (supabase.auth as any).getSession = vi.fn(async () => ({ data: { session: { user: { id: "user-1" } } }, error: null }));
+  (supabase.auth as any).signOut = vi.fn(async () => ({ error: null }));
+});
+
+describe("authentication smoke tests", () => {
+  it("hydrates the initial Supabase session", async () => {
+    render(<AuthProvider><Consumer /></AuthProvider>);
+
+    await waitFor(() => expect(screen.getByTestId("loading")).toHaveTextContent("false"));
+    expect(screen.getByTestId("user")).toHaveTextContent("user-1");
+    expect(supabase.auth.getSession).toHaveBeenCalled();
+  });
+
+  it("responds to auth state changes and clears local state on sign out", async () => {
+    render(<AuthProvider><Consumer /></AuthProvider>);
+    await waitFor(() => expect(screen.getByTestId("user")).toHaveTextContent("user-1"));
+
+    act(() => authCallback?.("SIGNED_IN", { user: { id: "user-2" } }));
+    expect(screen.getByTestId("user")).toHaveTextContent("user-2");
+
+    await act(async () => screen.getByRole("button", { name: /sign out/i }).click());
+    expect(supabase.auth.signOut).toHaveBeenCalledWith({ scope: "local" });
+    expect(screen.getByTestId("user")).toHaveTextContent("none");
+  });
+});

--- a/src/lib/api/__tests__/players.smoke.test.ts
+++ b/src/lib/api/__tests__/players.smoke.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const { supabase } = await import("@/integrations/supabase/client");
+const { ensurePlayerProfile, getPlayerProfileForUser, updatePlayerOnboarding } = await import("@/lib/api/players");
+
+const fromMock = vi.fn();
+let query: any;
+let result: any;
+
+beforeEach(() => {
+  result = { data: null, error: null };
+  query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    insert: vi.fn(() => query),
+    update: vi.fn(() => query),
+    single: vi.fn(async () => result),
+    maybeSingle: vi.fn(async () => result),
+  };
+  fromMock.mockReturnValue(query);
+  (supabase as any).from = fromMock;
+  vi.clearAllMocks();
+});
+
+describe("profile loading regressions", () => {
+  it("loads a profile by Supabase user id", async () => {
+    result.data = { id: "profile-1", user_id: "user-1", username: "ace" };
+
+    await expect(getPlayerProfileForUser("user-1")).resolves.toMatchObject({ id: "profile-1" });
+
+    expect(fromMock).toHaveBeenCalledWith("profiles");
+    expect(query.select).toHaveBeenCalledWith("id, user_id, username, display_name, avatar_url, bio");
+    expect(query.eq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(query.maybeSingle).toHaveBeenCalled();
+  });
+
+  it("creates a normalized fallback profile when one does not exist", async () => {
+    query.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    query.single.mockResolvedValueOnce({
+      data: { id: "profile-2", user_id: "user-2", username: "jane-rocker", display_name: "Jane Rocker" },
+      error: null,
+    });
+
+    await ensurePlayerProfile({
+      id: "user-2",
+      email: "Jane Rocker@example.com",
+      phone: undefined,
+      user_metadata: {},
+    } as any);
+
+    expect(query.insert).toHaveBeenCalledWith([
+      expect.objectContaining({ user_id: "user-2", username: "jane-rocker-example-com", display_name: "Jane Rocker@example.com" }),
+    ]);
+  });
+
+  it("trims onboarding updates and stores empty optional values as null", async () => {
+    result.data = { id: "profile-3", display_name: "Nova", avatar_url: null, bio: null };
+
+    await updatePlayerOnboarding("profile-3", { displayName: "  Nova  ", avatarUrl: "   ", bio: "  " });
+
+    expect(query.update).toHaveBeenCalledWith({ display_name: "Nova", avatar_url: null, bio: null });
+    expect(query.eq).toHaveBeenCalledWith("id", "profile-3");
+  });
+});

--- a/src/lib/api/__tests__/tours.database.test.ts
+++ b/src/lib/api/__tests__/tours.database.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const { supabase } = await import("@/integrations/supabase/client");
+const { createTour, deleteTour, getTour, listTours, updateTour } = await import("@/lib/api/tours");
+
+const fromMock = vi.fn();
+let query: any;
+let result: any;
+
+beforeEach(() => {
+  result = { data: [], error: null };
+  query = {
+    select: vi.fn(() => query),
+    order: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    insert: vi.fn(() => query),
+    update: vi.fn(() => query),
+    delete: vi.fn(() => query),
+    single: vi.fn(async () => result),
+    then: (resolve: any) => Promise.resolve(resolve(result)),
+  };
+  fromMock.mockReturnValue(query);
+  (supabase as any).from = fromMock;
+  vi.clearAllMocks();
+});
+
+describe("database service smoke tests", () => {
+  it("lists tours ordered by start date and filters by band", async () => {
+    result.data = [{ id: "tour-1", band_id: "band-1" }];
+
+    await expect(listTours("band-1")).resolves.toHaveLength(1);
+
+    expect(fromMock).toHaveBeenCalledWith("tours");
+    expect(query.order).toHaveBeenCalledWith("start_date", { ascending: true });
+    expect(query.eq).toHaveBeenCalledWith("band_id", "band-1");
+  });
+
+  it("maps a missing tour response to null", async () => {
+    result = { data: null, error: { code: "PGRST116" } };
+
+    await expect(getTour("missing-tour")).resolves.toBeNull();
+  });
+
+  it("creates and updates tours with camelCase API inputs converted to database columns", async () => {
+    query.single.mockResolvedValueOnce({ data: { id: "tour-2" }, error: null });
+    await createTour({ name: "Beta Run", bandId: "band-2", userId: "user-2", startDate: "2026-08-01", endDate: "2026-08-10" } as any);
+    expect(query.insert).toHaveBeenCalledWith([{ name: "Beta Run", band_id: "band-2", user_id: "user-2", start_date: "2026-08-01", end_date: "2026-08-10" }]);
+
+    query.single.mockResolvedValueOnce({ data: { id: "tour-2", name: "Beta Run Deluxe" }, error: null });
+    await updateTour("tour-2", { name: "Beta Run Deluxe", bandId: "band-3" } as any);
+    expect(query.update).toHaveBeenCalledWith({ name: "Beta Run Deluxe", band_id: "band-3" });
+    expect(query.eq).toHaveBeenCalledWith("id", "tour-2");
+  });
+
+  it("deletes a tour by id", async () => {
+    await expect(deleteTour("tour-3")).resolves.toBeUndefined();
+    expect(query.delete).toHaveBeenCalled();
+    expect(query.eq).toHaveBeenCalledWith("id", "tour-3");
+  });
+});

--- a/src/lib/workflows/__tests__/recording.workflow.test.ts
+++ b/src/lib/workflows/__tests__/recording.workflow.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { ensureRecordingStage, ensureRecordingStatus, getNextStage, getRecordingWorkflowState, hasRemainingStages, isValidStatusTransition } from "@/lib/workflows/recording";
+
+describe("recording workflow regressions", () => {
+  it("falls back safely for unknown persisted stage and status values", () => {
+    expect(ensureRecordingStage("bad-stage")).toBe("recording");
+    expect(ensureRecordingStatus("bad-status")).toBe("scheduled");
+  });
+
+  it("keeps allowed status transitions narrow", () => {
+    expect(isValidStatusTransition("scheduled", "in_progress")).toBe(true);
+    expect(isValidStatusTransition("scheduled", "completed")).toBe(false);
+    expect(isValidStatusTransition("completed", "cancelled")).toBe(false);
+  });
+
+  it("marks prior recording stages complete and current mixing work active", () => {
+    const stages = getRecordingWorkflowState("mixing", "in_progress");
+
+    expect(stages.map(stage => stage.progress)).toEqual(["completed", "active", "pending"]);
+    expect(stages[1]?.tasks[0]?.status).toBe("in_progress");
+    expect(stages[1]?.collaborators.every(collaborator => collaborator.status === "active")).toBe(true);
+  });
+
+  it("detects the end of the recording pipeline", () => {
+    expect(getNextStage("recording")).toBe("mixing");
+    expect(hasRemainingStages("mixing")).toBe(true);
+    expect(hasRemainingStages("mastering")).toBe(false);
+  });
+});

--- a/src/utils/__tests__/shared-utilities.smoke.test.ts
+++ b/src/utils/__tests__/shared-utilities.smoke.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { cn } from "@/lib/utils";
+import { clamp, clampPercent, clampScore } from "@/utils/number";
+import { calculateSongQuality, canStartSongwriting, canWriteGenre, getSkillCeiling } from "@/utils/songQuality";
+
+describe("shared utilities smoke tests", () => {
+  it("merges Tailwind classes predictably", () => {
+    expect(cn("px-2 text-sm", false && "hidden", "px-4")).toBe("text-sm px-4");
+  });
+
+  it("clamps common gameplay ranges", () => {
+    expect(clamp(12, 0, 10)).toBe(10);
+    expect(clampPercent(-3)).toBe(0);
+    expect(clampScore(180)).toBe(100);
+  });
+});
+
+describe("song creation quality regressions", () => {
+  it("keeps songwriting availability permissive during beta", () => {
+    expect(canStartSongwriting({})).toBe(true);
+    expect(canWriteGenre("rock", {})).toBe(true);
+  });
+
+  it("raises the quality ceiling when professional or mastery skills are unlocked", () => {
+    expect(getSkillCeiling({})).toBe(500);
+    expect(getSkillCeiling({ songwriting_professional_composing: 10 })).toBe(800);
+    expect(getSkillCeiling({ songwriting_mastery_lyrics: 10 })).toBe(1000);
+  });
+
+  it("calculates a bounded song score with deterministic session luck", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const result = calculateSongQuality({
+      genre: "rock",
+      skillLevels: {
+        songwriting_basic_composing: 40,
+        songwriting_basic_lyrics: 40,
+        songwriting_basic_arrangement: 40,
+        songwriting_basic_record_production: 40,
+        songwriting_basic_rhythm: 40,
+        genre_rock_basic: 50,
+      },
+      attributes: { creative_insight: 600, musical_ability: 600, technical_mastery: 600 },
+      sessionHours: 4,
+      coWriters: 1,
+      aiLyrics: false,
+      songsWritten: 5,
+      sessionsCompleted: 2,
+      instrumentSkills: [{ slug: "guitar", level: 25 }],
+    });
+
+    expect(result.totalQuality).toBeGreaterThan(0);
+    expect(result.totalQuality).toBeLessThanOrEqual(result.skillCeiling);
+    expect(result.sessionLuckLabel).toContain("Normal Session");
+    expect(result.instrumentationBonus).toBeGreaterThan(0);
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,13 @@
 import "@testing-library/jest-dom/vitest";
+
+// Smoke tests use mocked Supabase calls, but the generated client validates
+// env configuration at import time. Provide safe defaults for the test runner.
+const testEnv = import.meta.env as Record<string, string | undefined>;
+
+if (!testEnv.VITE_SUPABASE_URL) {
+  testEnv.VITE_SUPABASE_URL = "https://example.supabase.co";
+}
+
+if (!testEnv.VITE_SUPABASE_PUBLISHABLE_KEY) {
+  testEnv.VITE_SUPABASE_PUBLISHABLE_KEY = "test-key";
+}


### PR DESCRIPTION
### Motivation
- Increase confidence for beta by adding focused smoke and regression tests around critical flows (authentication, profile management, song creation, recording workflow, band creation, and core DB services). 
- Prefer fast, mock-based tests that exercise business logic and database interaction shapes rather than full end-to-end coverage. 
- Provide a safe test runtime environment so tests that import the generated Supabase client can run without real env values.

### Description
- Added smoke and regression tests for authentication in `src/hooks/__tests__/auth.smoke.test.tsx` that cover initial session hydration, auth state changes, and local sign-out clearing. 
- Added profile-loading and onboarding tests in `src/lib/api/__tests__/players.smoke.test.ts` validating Supabase query usage, fallback username/displayName derivation, and trimmed/null onboarding payloads. 
- Added song-creation and shared-utility tests in `src/utils/__tests__/shared-utilities.smoke.test.ts` covering `calculateSongQuality`, songwriting gates and utility clamps. 
- Added recording workflow regression tests in `src/lib/workflows/__tests__/recording.workflow.test.ts` for stage/status normalization, transitions, and workflow state mapping. 
- Added band creation smoke test in `src/components/band/BandCreationForm.test.tsx` to assert band row and founder membership insert behavior. 
- Added database service smoke tests for tours (list/get/create/update/delete) in `src/lib/api/__tests__/tours.database.test.ts`. 
- Added test setup defaults in `vitest.setup.ts` to provide safe `VITE_SUPABASE_*` values so the generated Supabase client can be imported in tests; tests use mocked `supabase` calls (no real network). 

### Testing
- Ran `git diff --check` which reported no lint diffs blocking the change. 
- Attempted to run the test suite with `npm run test` / `npx vitest run` against the new test files, but execution of the test runner was blocked because local dependency installation failed (registry 403 while resolving dependencies), so `vitest` was not available to execute tests in this environment. 
- All added tests are mock-based and designed to run quickly once `node_modules` are available; they have been committed and are ready for CI or a local dev machine with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5e40b800832591a915228992c42f)