### PR TITLE
Secure crypto token trades

### DIFF
--- a/src/hooks/useCryptoTokens.ts
+++ b/src/hooks/useCryptoTokens.ts
@@ -88,87 +88,29 @@ export const useCryptoTokens = (profileId?: string) => {
     mutationFn: async ({
       tokenId,
       quantity,
-      price,
     }: {
       tokenId: string;
       quantity: number;
-      price: number;
+      price?: number;
     }) => {
       if (!profileId) throw new Error("User not authenticated");
-
-      const totalCost = quantity * price;
-
-      // Check user balance via profile
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("cash")
-        .eq("id", profileId)
-        .single();
-
-      if (!profile || profile.cash < totalCost) {
-        throw new Error("Insufficient funds");
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        throw new Error("Invalid quantity");
       }
 
-      // Deduct cash
-      const { error: cashError } = await supabase
-        .from("profiles")
-        .update({ cash: profile.cash - totalCost })
-        .eq("id", profileId);
-
-      if (cashError) throw cashError;
-
-      // Record transaction
-      const { error: txError } = await supabase.from("token_transactions").insert({
-        user_id: userId,
-        token_id: tokenId,
-        transaction_type: "buy",
-        quantity,
-        price_per_token: price,
-        total_amount: totalCost,
+      const { error } = await (supabase as any).rpc("trade_crypto_token", {
+        p_profile_id: profileId,
+        p_token_id: tokenId,
+        p_transaction_type: "buy",
+        p_quantity: quantity,
       });
 
-      if (txError) throw txError;
-
-      // Fetch fresh holding from DB
-      const { data: existingHoldings } = await supabase
-        .from("player_token_holdings")
-        .select("*")
-        .eq("user_id", userId)
-        .eq("token_id", tokenId)
-        .limit(1);
-
-      const existing = existingHoldings?.[0];
-
-      if (existing) {
-        const newQuantity = existing.quantity + quantity;
-        const newAvgPrice = 
-          (existing.average_buy_price * existing.quantity + price * quantity) / newQuantity;
-
-        const { error: holdingError } = await supabase
-          .from("player_token_holdings")
-          .update({
-            quantity: newQuantity,
-            average_buy_price: newAvgPrice,
-          })
-          .eq("id", existing.id);
-
-        if (holdingError) throw holdingError;
-      } else {
-        const { error: holdingError } = await supabase
-          .from("player_token_holdings")
-          .insert({
-            user_id: userId,
-            token_id: tokenId,
-            quantity,
-            average_buy_price: price,
-          });
-
-        if (holdingError) throw holdingError;
-      }
+      if (error) throw error;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["token-holdings", profileId] });
       queryClient.invalidateQueries({ queryKey: ["token-transactions", profileId] });
+      queryClient.invalidateQueries({ queryKey: ["active-profile"] });
       toast.success("Token purchased successfully");
     },
     onError: (error: any) => {
@@ -181,79 +123,29 @@ export const useCryptoTokens = (profileId?: string) => {
     mutationFn: async ({
       tokenId,
       quantity,
-      price,
     }: {
       tokenId: string;
       quantity: number;
-      price: number;
+      price?: number;
     }) => {
       if (!profileId) throw new Error("User not authenticated");
-
-      // Fetch fresh holding from DB
-      const { data: freshHoldings } = await supabase
-        .from("player_token_holdings")
-        .select("*")
-        .eq("user_id", userId)
-        .eq("token_id", tokenId)
-        .limit(1);
-
-      const holding = freshHoldings?.[0];
-      if (!holding || holding.quantity < quantity) {
-        throw new Error("Insufficient token balance");
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        throw new Error("Invalid quantity");
       }
 
-      const totalRevenue = quantity * price;
-
-      // Add cash to profile
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("cash")
-        .eq("id", profileId)
-        .single();
-
-      if (!profile) throw new Error("Profile not found");
-
-      const { error: cashError } = await supabase
-        .from("profiles")
-        .update({ cash: profile.cash + totalRevenue })
-        .eq("id", profileId);
-
-      if (cashError) throw cashError;
-
-      // Record transaction
-      const { error: txError } = await supabase.from("token_transactions").insert({
-        user_id: profileId,
-        token_id: tokenId,
-        transaction_type: "sell",
-        quantity,
-        price_per_token: price,
-        total_amount: totalRevenue,
+      const { error } = await (supabase as any).rpc("trade_crypto_token", {
+        p_profile_id: profileId,
+        p_token_id: tokenId,
+        p_transaction_type: "sell",
+        p_quantity: quantity,
       });
 
-      if (txError) throw txError;
-
-      // Update holding
-      const newQuantity = holding.quantity - quantity;
-      
-      if (newQuantity > 0) {
-        const { error: holdingError } = await supabase
-          .from("player_token_holdings")
-          .update({ quantity: newQuantity })
-          .eq("id", holding.id);
-
-        if (holdingError) throw holdingError;
-      } else {
-        const { error: holdingError } = await supabase
-          .from("player_token_holdings")
-          .delete()
-          .eq("id", holding.id);
-
-        if (holdingError) throw holdingError;
-      }
+      if (error) throw error;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["token-holdings", profileId] });
       queryClient.invalidateQueries({ queryKey: ["token-transactions", profileId] });
+      queryClient.invalidateQueries({ queryKey: ["active-profile"] });
       toast.success("Token sold successfully");
     },
     onError: (error: any) => {

--- a/supabase/migrations/20260709120000_secure_crypto_token_trades.sql
+++ b/supabase/migrations/20260709120000_secure_crypto_token_trades.sql
@@ -1,0 +1,169 @@
+-- Secure crypto token trading behind an atomic server-side RPC.
+-- Clients may read their portfolio, but cannot mint cash/tokens by directly
+-- updating holdings or by supplying arbitrary trade prices.
+
+DROP POLICY IF EXISTS "Users can manage their own holdings" ON public.player_token_holdings;
+DROP POLICY IF EXISTS "Users can create their own transactions" ON public.token_transactions;
+
+CREATE POLICY "Admins can manage token holdings"
+  ON public.player_token_holdings FOR ALL
+  USING (public.has_role(auth.uid(), 'admin'::app_role))
+  WITH CHECK (public.has_role(auth.uid(), 'admin'::app_role));
+
+CREATE POLICY "Admins can create token transactions"
+  ON public.token_transactions FOR INSERT
+  WITH CHECK (public.has_role(auth.uid(), 'admin'::app_role));
+
+CREATE OR REPLACE FUNCTION public.trade_crypto_token(
+  p_profile_id uuid,
+  p_token_id uuid,
+  p_transaction_type text,
+  p_quantity numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_price numeric(12, 2);
+  v_total numeric(15, 2);
+  v_cash numeric;
+  v_holding public.player_token_holdings%ROWTYPE;
+  v_new_quantity numeric(18, 8);
+  v_new_avg_price numeric(12, 2);
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_transaction_type NOT IN ('buy', 'sell') THEN
+    RAISE EXCEPTION 'Invalid transaction type';
+  END IF;
+
+  IF p_quantity IS NULL OR p_quantity <= 0 OR p_quantity > 100000000 THEN
+    RAISE EXCEPTION 'Invalid quantity';
+  END IF;
+
+  -- Keep quantity precision bounded so clients cannot exploit rounding dust.
+  IF p_quantity != round(p_quantity, 8) THEN
+    RAISE EXCEPTION 'Quantity supports up to 8 decimal places';
+  END IF;
+
+  SELECT current_price
+    INTO v_price
+  FROM public.crypto_tokens
+  WHERE id = p_token_id
+    AND is_active = true
+    AND is_rugged = false
+  FOR UPDATE;
+
+  IF v_price IS NULL OR v_price <= 0 THEN
+    RAISE EXCEPTION 'Token is not tradable';
+  END IF;
+
+  v_total := round(p_quantity * v_price, 2);
+  IF v_total <= 0 THEN
+    RAISE EXCEPTION 'Trade amount is too small';
+  END IF;
+
+  SELECT cash
+    INTO v_cash
+  FROM public.profiles
+  WHERE id = p_profile_id
+    AND user_id = v_user_id
+  FOR UPDATE;
+
+  IF v_cash IS NULL THEN
+    RAISE EXCEPTION 'Profile not found';
+  END IF;
+
+  SELECT *
+    INTO v_holding
+  FROM public.player_token_holdings
+  WHERE user_id = v_user_id
+    AND token_id = p_token_id
+  FOR UPDATE;
+
+  IF p_transaction_type = 'buy' THEN
+    IF v_cash < v_total THEN
+      RAISE EXCEPTION 'Insufficient funds';
+    END IF;
+
+    UPDATE public.profiles
+    SET cash = cash - v_total
+    WHERE id = p_profile_id
+      AND user_id = v_user_id;
+
+    IF v_holding.id IS NULL THEN
+      INSERT INTO public.player_token_holdings (user_id, token_id, quantity, average_buy_price)
+      VALUES (v_user_id, p_token_id, p_quantity, v_price);
+      v_new_quantity := p_quantity;
+      v_new_avg_price := v_price;
+    ELSE
+      v_new_quantity := v_holding.quantity + p_quantity;
+      v_new_avg_price := round(
+        ((coalesce(v_holding.average_buy_price, 0) * v_holding.quantity) + (v_price * p_quantity)) / v_new_quantity,
+        2
+      );
+
+      UPDATE public.player_token_holdings
+      SET quantity = v_new_quantity,
+          average_buy_price = v_new_avg_price
+      WHERE id = v_holding.id;
+    END IF;
+  ELSE
+    IF v_holding.id IS NULL OR v_holding.quantity < p_quantity THEN
+      RAISE EXCEPTION 'Insufficient token balance';
+    END IF;
+
+    UPDATE public.profiles
+    SET cash = cash + v_total
+    WHERE id = p_profile_id
+      AND user_id = v_user_id;
+
+    v_new_quantity := v_holding.quantity - p_quantity;
+    v_new_avg_price := v_holding.average_buy_price;
+
+    IF v_new_quantity > 0 THEN
+      UPDATE public.player_token_holdings
+      SET quantity = v_new_quantity
+      WHERE id = v_holding.id;
+    ELSE
+      DELETE FROM public.player_token_holdings
+      WHERE id = v_holding.id;
+      v_new_quantity := 0;
+    END IF;
+  END IF;
+
+  INSERT INTO public.token_transactions (
+    user_id,
+    token_id,
+    transaction_type,
+    quantity,
+    price_per_token,
+    total_amount
+  ) VALUES (
+    v_user_id,
+    p_token_id,
+    p_transaction_type,
+    p_quantity,
+    v_price,
+    v_total
+  );
+
+  RETURN jsonb_build_object(
+    'transaction_type', p_transaction_type,
+    'token_id', p_token_id,
+    'quantity', p_quantity,
+    'price_per_token', v_price,
+    'total_amount', v_total,
+    'holding_quantity', v_new_quantity,
+    'average_buy_price', v_new_avg_price
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.trade_crypto_token(uuid, uuid, text, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.trade_crypto_token(uuid, uuid, text, numeric) TO authenticated;


### PR DESCRIPTION
### Motivation
- Prevent client-side economy exploits where a modified client could set arbitrary buy/sell prices, mint tokens, or forge transaction history by directly updating `profiles`, `player_token_holdings`, or `token_transactions`.
- Ensure atomic, server-side validation of crypto trades so cash and holdings updates cannot be raced or bypassed.
- Reduce attack surface by restricting direct player writes to sensitive economy tables and centralizing business logic in a validated RPC.

### Description
- Added a migration `supabase/migrations/20260709120000_secure_crypto_token_trades.sql` that drops player-write policies for holdings/transactions and replaces them with admin-only write policies, and creates a `SECURITY DEFINER` RPC `public.trade_crypto_token(...)` which performs validated, atomic buy/sell execution and inserts canonical transactions.
- The RPC validates authentication, profile ownership, transaction type, quantity bounds and precision, token tradability (`is_active`/`is_rugged`), available cash, and token balance, and uses `FOR UPDATE` locks to avoid race conditions.
- Updated the client hook `src/hooks/useCryptoTokens.ts` to stop mutating `profiles`, `player_token_holdings`, and `token_transactions` directly and instead call the `trade_crypto_token` RPC for buys and sells, adding client-side input validation for `quantity`.
- Added server-side guards to revoke public execute on the function and grant `EXECUTE` only to `authenticated` role, and limited direct write policies so only admins may perform free-form writes to holdings/transactions.

### Testing
- `git diff --check` passed in the environment where changes were prepared. 
- `npm run build` could not complete because `vite` was not available in the environment, so frontend build verification did not run. 
- `bun install` failed to fetch dependencies due to npm registry `403` errors, so dependency installation and full test suite were not executed.
- No runtime failures were observed from the code edits themselves when lint-style checks (`git diff --check`) were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f61f31f888325aa8c7f3b9681915b)