### PR TITLE
Polish application navigation and accessibility

### DIFF
--- a/src/components/CharacterGate.tsx
+++ b/src/components/CharacterGate.tsx
@@ -46,9 +46,9 @@ export const CharacterGate = ({ children }: CharacterGateProps) => {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-stage p-6">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-stage p-6" role="status" aria-live="polite" aria-busy="true">
         <div className="text-center">
-          <div className="mx-auto mb-4 h-24 w-24 animate-spin rounded-full border-b-2 border-primary"></div>
+          <div className="mx-auto mb-4 h-24 w-24 animate-spin rounded-full border-b-2 border-primary" aria-hidden="true"></div>
           <p className="text-lg font-oswald">Loading your profile...</p>
         </div>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -81,9 +81,9 @@ const Layout = () => {
 
   if (authLoading || (dataLoading && user)) {
     return (
-      <div className="flex h-screen items-center justify-center bg-gradient-stage">
+      <div className="flex h-screen items-center justify-center bg-gradient-stage" role="status" aria-live="polite" aria-busy="true">
         <div className="text-center">
-          <div className="mx-auto mb-4 h-32 w-32 animate-spin rounded-full border-b-2 border-primary"></div>
+          <div className="mx-auto mb-4 h-32 w-32 animate-spin rounded-full border-b-2 border-primary" aria-hidden="true"></div>
           <p className="text-lg font-oswald">Loading Rockmundo...</p>
         </div>
       </div>

--- a/src/components/fm/FMShell.tsx
+++ b/src/components/fm/FMShell.tsx
@@ -28,12 +28,18 @@ export const FMShell = ({ children }: { children: ReactNode }) => {
         data-fm-module={mod.id}
         className="fm-shell fm-module-themed flex flex-col h-screen w-screen overflow-hidden bg-fm-bg text-fm-fg"
       >
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[100] focus:rounded-md focus:bg-fm-accent focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-white"
+        >
+          Skip to main content
+        </a>
         <TopStatusBar />
         <ModuleTabs />
         <SubTabs />
         <div className="flex-1 flex min-h-0">
           <FMSidebar />
-          <main className="relative flex-1 overflow-auto bg-fm-bg">
+          <main id="main-content" tabIndex={-1} className="relative flex-1 overflow-auto bg-fm-bg">
             {/* Themed background layer — module-specific, low opacity */}
             <div aria-hidden className="fm-module-bg pointer-events-none absolute inset-0" />
             {/* Brand watermark — barely-there Rockmundo wordmark */}

--- a/src/components/fm/FMSidebar.tsx
+++ b/src/components/fm/FMSidebar.tsx
@@ -43,6 +43,7 @@ export const FMSidebar = () => {
         onClick={() => navigate("/")}
         className="h-11 flex items-center gap-2 px-2.5 border-b border-fm-border hover:bg-fm-panel-2 transition-colors"
         title="Rockmundo home"
+        aria-label="Go to Rockmundo home"
       >
         <img src={logo} alt="Rockmundo" className="h-7 w-7 object-contain shrink-0" />
         {!collapsed && (
@@ -62,6 +63,8 @@ export const FMSidebar = () => {
           onClick={toggleCollapsed}
           className="ml-auto p-1 rounded-[6px] hover:bg-fm-panel-2 text-fm-fg-muted"
           title={collapsed ? "Expand" : "Collapse"}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-expanded={!collapsed}
         >
           {collapsed ? <PanelLeftOpen className="h-3.5 w-3.5" /> : <PanelLeftClose className="h-3.5 w-3.5" />}
         </button>
@@ -75,6 +78,7 @@ export const FMSidebar = () => {
               <button
                 onClick={() => toggleGroup(group.label)}
                 className="w-full flex items-center justify-between px-3 py-1 text-[11px] text-fm-fg-muted hover:text-fm-fg"
+                aria-expanded={!!openGroups[group.label]}
               >
                 <span>{group.label}</span>
                 {openGroups[group.label] ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
@@ -90,6 +94,7 @@ export const FMSidebar = () => {
                       key={item.path}
                       onClick={() => navigate(item.path)}
                       title={collapsed ? item.label : undefined}
+                      aria-current={active ? "page" : undefined}
                       className={cn(
                         "w-full flex items-center gap-2 px-2.5 py-1.5 rounded-[7px] text-[12px] transition-colors",
                         active

--- a/src/components/fm/ModuleTabs.tsx
+++ b/src/components/fm/ModuleTabs.tsx
@@ -24,7 +24,7 @@ export const ModuleTabs = () => {
   };
 
   return (
-    <nav className="h-11 flex items-stretch bg-fm-panel border-b border-fm-border px-2 gap-1">
+    <nav className="h-11 flex items-stretch bg-fm-panel border-b border-fm-border px-2 gap-1 overflow-x-auto fm-scrollbar-thin" aria-label="Primary modules">
       {modules.map((mod) => {
         const Icon = mod.icon;
         const isActive = mod.id === active.id;
@@ -32,8 +32,9 @@ export const ModuleTabs = () => {
           <button
             key={mod.id}
             onClick={() => openModule(mod.id, mod.rootPath)}
+            aria-current={isActive ? "page" : undefined}
             className={cn(
-              "relative my-1.5 px-3 flex items-center gap-2 text-[12px] font-medium tracking-tight transition-colors rounded-[7px]",
+              "relative my-1.5 px-3 flex shrink-0 items-center gap-2 text-[12px] font-medium tracking-tight transition-colors rounded-[7px]",
               isActive
                 ? "text-fm-accent"
                 : "text-fm-fg-muted hover:text-fm-fg",

--- a/src/components/fm/SubTabs.tsx
+++ b/src/components/fm/SubTabs.tsx
@@ -11,7 +11,7 @@ export const SubTabs = () => {
   const isActive = (path: string) => pathname === path || pathname.startsWith(path + "/");
 
   return (
-    <div className="h-10 flex items-stretch bg-fm-panel border-b border-fm-border pl-2 pr-2 gap-1">
+    <nav className="h-10 flex items-stretch bg-fm-panel border-b border-fm-border pl-2 pr-2 gap-1" aria-label={`${mod.label} sections`}>
       <div className="flex items-center overflow-x-auto fm-scrollbar-thin min-w-0 flex-1 gap-1">
         {mod.subTabs.map((tab) => {
           const Icon = tab.icon;
@@ -20,6 +20,7 @@ export const SubTabs = () => {
             <button
               key={tab.path}
               onClick={() => navigate(tab.path)}
+              aria-current={active ? "page" : undefined}
               className={cn(
                 "px-3 h-7 flex items-center gap-1.5 text-[12px] font-medium tracking-tight whitespace-nowrap transition-colors rounded-[7px]",
                 active
@@ -37,9 +38,8 @@ export const SubTabs = () => {
       <div className="flex items-center">
         <FMQuickActions />
       </div>
-    </div>
+    </nav>
   );
 };
 
 export default SubTabs;
-

--- a/src/components/fm/TopStatusBar.tsx
+++ b/src/components/fm/TopStatusBar.tsx
@@ -25,7 +25,7 @@ const StatPip = ({ icon: Icon, label, value, tone = "neutral" }: {
     neutral: "text-fm-accent",
   }[tone];
   return (
-    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-[7px] border border-fm-border bg-fm-panel-2">
+    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-[7px] border border-fm-border bg-fm-panel-2" aria-label={`${label}: ${value}`}>
       <Icon className={`h-3.5 w-3.5 ${toneClass}`} />
       <span className="text-[11px] text-fm-fg-muted">{label}</span>
       <span className="text-[12px] font-medium tabular-nums text-fm-fg">{value}</span>
@@ -61,6 +61,7 @@ export const TopStatusBar = () => {
         onClick={() => navigate("/")}
         className="group flex items-center gap-2.5 pr-1 -ml-1 pl-1 py-1 rounded-md hover:bg-fm-panel-2 transition-colors"
         title="Rockmundo home"
+        aria-label="Go to Rockmundo home"
       >
         <img
           src={logo}
@@ -82,6 +83,7 @@ export const TopStatusBar = () => {
       <button
         className="flex items-center gap-2 px-2 py-1 rounded hover:bg-fm-panel-2 transition-colors"
         onClick={() => navigate("/hub/character")}
+        aria-label={`Open character hub for ${name}`}
       >
         <User className="h-4 w-4 text-fm-accent" />
         <span className="text-sm font-semibold text-fm-fg">{name}</span>
@@ -89,7 +91,7 @@ export const TopStatusBar = () => {
 
       <div className="h-6 w-px bg-fm-border" />
 
-      <div className="text-[12px] text-fm-fg-muted flex items-center gap-2">
+      <div className="hidden md:flex text-[12px] text-fm-fg-muted items-center gap-2" aria-label={`Game date: ${dateStr}`}>
         <span>Game date</span>
         <span className="text-fm-fg font-medium tabular-nums">{dateStr}</span>
       </div>
@@ -97,20 +99,22 @@ export const TopStatusBar = () => {
 
       <div className="flex-1" />
 
-      <StatPip icon={DollarSign} label="Cash" value={`$${Number(cash).toLocaleString()}`} tone="good" />
-      <StatPip icon={Flame} label="Fame" value={Number(fame).toLocaleString()} tone="warn" />
-      <StatPip
-        icon={Heart}
-        label="Health"
-        value={`${health}%`}
-        tone={health >= 70 ? "good" : health >= 40 ? "warn" : "bad"}
-      />
-      <StatPip
-        icon={Zap}
-        label="Energy"
-        value={`${energy}%`}
-        tone={energy >= 70 ? "good" : energy >= 40 ? "warn" : "bad"}
-      />
+      <div className="hidden xl:flex items-center gap-1.5">
+        <StatPip icon={DollarSign} label="Cash" value={`$${Number(cash).toLocaleString()}`} tone="good" />
+        <StatPip icon={Flame} label="Fame" value={Number(fame).toLocaleString()} tone="warn" />
+        <StatPip
+          icon={Heart}
+          label="Health"
+          value={`${health}%`}
+          tone={health >= 70 ? "good" : health >= 40 ? "warn" : "bad"}
+        />
+        <StatPip
+          icon={Zap}
+          label="Energy"
+          value={`${energy}%`}
+          tone={energy >= 70 ? "good" : energy >= 40 ? "warn" : "bad"}
+        />
+      </div>
 
       <div className="h-6 w-px bg-fm-border mx-1" />
 
@@ -122,7 +126,7 @@ export const TopStatusBar = () => {
       <ThemeSwitcher />
       <LanguageSwitcher />
       <HowToPlayDialog />
-      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleLogout} title="Sign out">
+      <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleLogout} title="Sign out" aria-label="Sign out">
         <LogOut className="h-4 w-4" />
       </Button>
     </header>

--- a/src/components/performance/RehearsalsTab.tsx
+++ b/src/components/performance/RehearsalsTab.tsx
@@ -59,7 +59,6 @@ export function RehearsalsTab() {
           throw new Error('Band data not found');
         }
         
-        console.log('Band data loaded:', { name: bandData.name, balance: bandData.band_balance });
         setUserBand(bandData);
 
         // Load scheduled rehearsals

--- a/src/components/ui/PageLayout.tsx
+++ b/src/components/ui/PageLayout.tsx
@@ -13,7 +13,7 @@ interface PageLayoutProps {
  */
 export const PageLayout = ({ children, className }: PageLayoutProps) => {
   return (
-    <div className={cn("w-full px-2 py-3 space-y-4", className)}>
+    <div className={cn("w-full px-2 py-3 sm:px-3 lg:px-4 space-y-4", className)}>
       {children}
     </div>
   );


### PR DESCRIPTION
### Motivation
- Improve navigation polish and accessibility across the FM shell and top-level layout ahead of beta by making keyboard/assistive flows clearer without redesigning UI. 
- Reduce noisy console output and make loading states more explicit for screen readers. 
- Tighten spacing and responsive padding to reduce visual crowding on medium screens.

### Description
- Added a keyboard "Skip to main content" link and made the primary `<main>` region focusable with `id="main-content"` and `tabIndex={-1}` so keyboard users can bypass repeated chrome (`src/components/fm/FMShell.tsx`).
- Improved nav semantics by adding `aria-label` to nav regions, enabling horizontal overflow with `overflow-x-auto` for module tabs, and exposing `aria-current` on active module and subtab buttons (`src/components/fm/ModuleTabs.tsx`, `src/components/fm/SubTabs.tsx`).
- Enhanced sidebar accessibility with `aria-label` on the home button, `aria-expanded` on collapse/group toggles, and `aria-current` on sidebar items to indicate the current page (`src/components/fm/FMSidebar.tsx`).
- Polished top status bar and loading UI by adding `aria-label` to stat pips, labeling brand/character/logout controls, hiding dense stats on smaller viewports, marking spinners as `aria-hidden`, and making loading containers `role="status" aria-live="polite" aria-busy="true"` (`src/components/fm/TopStatusBar.tsx`, `src/components/Layout.tsx`, `src/components/CharacterGate.tsx`).
- Small UX/cleanup changes include responsive page padding (`src/components/ui/PageLayout.tsx`) and removal of a stray `console.log` in the rehearsals loader (`src/components/performance/RehearsalsTab.tsx`).

### Testing
- Ran `git diff --check` to verify there are no whitespace or trivial diff issues and it passed.
- Attempted `npm run lint` but it was blocked by a missing installed dependency (`@eslint/js`) in the environment so ESLint could not run successfully.
- Attempted `npm run build` but it failed because the `vite` binary was not available in the environment.
- Attempted `npm install` to reproduce the environment but it failed due to npm registry access returning `403 Forbidden` for a dependency (`@react-three/fiber`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f64fe84848325b42474c3f3198250)