### PR TITLE
TopStatusBar: keep core stats visible on smaller screens with compact pips and menu

### DIFF
--- a/src/components/fm/TopStatusBar.tsx
+++ b/src/components/fm/TopStatusBar.tsx
@@ -11,7 +11,14 @@ import { HowToPlayDialog } from "@/components/HowToPlayDialog";
 import { ActivityStatusIndicator } from "@/components/ActivityStatusIndicator";
 import { PrisonStatusIndicator } from "@/components/prison/PrisonStatusIndicator";
 import { Button } from "@/components/ui/button";
-import { DollarSign, Flame, Heart, Zap, LogOut, User } from "lucide-react";
+import { DollarSign, Flame, Heart, Zap, LogOut, User, Gauge } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import logo from "@/assets/rockmundo-new-logo.png";
 
 const StatPip = ({ icon: Icon, label, value, tone = "neutral" }: {
@@ -29,6 +36,52 @@ const StatPip = ({ icon: Icon, label, value, tone = "neutral" }: {
       <Icon className={`h-3.5 w-3.5 ${toneClass}`} />
       <span className="text-[11px] text-fm-fg-muted">{label}</span>
       <span className="text-[12px] font-medium tabular-nums text-fm-fg">{value}</span>
+    </div>
+  );
+};
+
+const CompactStatPip = ({ icon: Icon, label, value, tone = "neutral", className = "" }: {
+  icon: React.ElementType; label: string; value: string | number;
+  tone?: "good" | "warn" | "bad" | "neutral";
+  className?: string;
+}) => {
+  const toneClass = {
+    good: "text-fm-good",
+    warn: "text-fm-warn",
+    bad: "text-fm-bad",
+    neutral: "text-fm-accent",
+  }[tone];
+
+  return (
+    <div
+      className={`flex min-w-0 items-center gap-1 rounded-[7px] border border-fm-border bg-fm-panel-2 px-2 py-1 ${className}`}
+      aria-label={`${label}: ${value}`}
+    >
+      <Icon className={`h-3.5 w-3.5 shrink-0 ${toneClass}`} aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+      <span className="text-[12px] font-medium tabular-nums text-fm-fg">{value}</span>
+    </div>
+  );
+};
+
+const StatusMenuRow = ({ icon: Icon, label, value, tone = "neutral" }: {
+  icon: React.ElementType; label: string; value: string | number;
+  tone?: "good" | "warn" | "bad" | "neutral";
+}) => {
+  const toneClass = {
+    good: "text-fm-good",
+    warn: "text-fm-warn",
+    bad: "text-fm-bad",
+    neutral: "text-fm-accent",
+  }[tone];
+
+  return (
+    <div className="flex items-center justify-between gap-4 px-2 py-1.5">
+      <dt className="flex items-center gap-2 text-sm text-fm-fg-muted">
+        <Icon className={`h-4 w-4 ${toneClass}`} aria-hidden="true" />
+        {label}
+      </dt>
+      <dd className="text-sm font-medium tabular-nums text-fm-fg">{value}</dd>
     </div>
   );
 };
@@ -99,7 +152,7 @@ export const TopStatusBar = () => {
 
       <div className="flex-1" />
 
-      <div className="hidden xl:flex items-center gap-1.5">
+      <div className="hidden xl:flex items-center gap-1.5" role="group" aria-label="Character status">
         <StatPip icon={DollarSign} label="Cash" value={`$${Number(cash).toLocaleString()}`} tone="good" />
         <StatPip icon={Flame} label="Fame" value={Number(fame).toLocaleString()} tone="warn" />
         <StatPip
@@ -114,6 +167,58 @@ export const TopStatusBar = () => {
           value={`${energy}%`}
           tone={energy >= 70 ? "good" : energy >= 40 ? "warn" : "bad"}
         />
+      </div>
+
+      <div className="hidden md:flex xl:hidden items-center gap-1.5" role="group" aria-label="Character status">
+        <CompactStatPip icon={DollarSign} label="Cash" value={`$${Number(cash).toLocaleString()}`} tone="good" className="hidden lg:flex" />
+        <CompactStatPip icon={Flame} label="Fame" value={Number(fame).toLocaleString()} tone="warn" className="hidden lg:flex" />
+        <CompactStatPip
+          icon={Heart}
+          label="Health"
+          value={`${health}%`}
+          tone={health >= 70 ? "good" : health >= 40 ? "warn" : "bad"}
+        />
+        <CompactStatPip
+          icon={Zap}
+          label="Energy"
+          value={`${energy}%`}
+          tone={energy >= 70 ? "good" : energy >= 40 ? "warn" : "bad"}
+        />
+      </div>
+
+      <div className="xl:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label="Open complete character status"
+            >
+              <Gauge className="h-4 w-4 text-fm-accent" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56 border-fm-border bg-fm-panel text-fm-fg">
+            <DropdownMenuLabel>Character status</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <dl aria-label="Character status details">
+              <StatusMenuRow icon={DollarSign} label="Cash" value={`$${Number(cash).toLocaleString()}`} tone="good" />
+              <StatusMenuRow icon={Flame} label="Fame" value={Number(fame).toLocaleString()} tone="warn" />
+              <StatusMenuRow
+                icon={Heart}
+                label="Health"
+                value={`${health}%`}
+                tone={health >= 70 ? "good" : health >= 40 ? "warn" : "bad"}
+              />
+              <StatusMenuRow
+                icon={Zap}
+                label="Energy"
+                value={`${energy}%`}
+                tone={energy >= 70 ? "good" : energy >= 40 ? "warn" : "bad"}
+              />
+            </dl>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       <div className="h-6 w-px bg-fm-border mx-1" />


### PR DESCRIPTION
### Motivation
- Fix an accessibility/regression where Cash, Fame, Health and Energy were hidden below the `xl` breakpoint so core gameplay stats were not available on tablets and common desktop widths.
- Preserve the existing shell visuals and gameplay logic while making key stats visible or reachable at `md`/`lg` breakpoints.

### Description
- Added two small local components `CompactStatPip` and `StatusMenuRow` and a compact dropdown menu to `TopStatusBar` to expose stats at smaller breakpoints while keeping the full `StatPip` layout at `xl` and above (file: `src/components/fm/TopStatusBar.tsx`).
- Responsive behavior: full labeled stats remain visible on `xl` (`hidden xl:flex`), a compact inline row appears for `md`→`xl` (`hidden md:flex xl:hidden`) with Health and Energy always present from `md` up and Cash/Fame appearing from `lg`, and a dropdown status menu is available on narrower screens (`xl:hidden`).
- Accessibility improvements: used `role="group"`, a description-list (`<dl>`) in the menu, `sr-only` text for compact pips, and simplified the menu trigger `aria-label` to avoid duplicate screen-reader announcements.
- Kept changes local to `TopStatusBar` and reused existing `DropdownMenu` primitives from `src/components/ui/dropdown-menu.tsx` and `Button` so shell chrome and gameplay logic were not modified.

### Testing
- Ran static checks: `git diff --check` succeeded and `npm exec -- tsc --noEmit` succeeded.
- Lint/build: `npm run lint` and `npm run build` could not complete in this environment due to local dependency resolution/install problems (`@eslint/js` / `vite` missing in `node_modules`).
- Manual breakpoint review: inspected Tailwind breakpoint classes and verified the intended behavior at `mobile`, `md`, `lg`, and `xl` (menu on mobile, Health/Energy visible from `md`, Cash/Fame compact at `lg`, and full labeled stats at `xl`). All manual checks matched the change intent but full runtime visual verification requires a local build to run the app.
- Files changed: `src/components/fm/TopStatusBar.tsx` (primary change).

Remaining risk: visual verification and automated lint/build require resolving local dependency installation issues before running `npm run lint` and `npm run build` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5005e48c548325a4b064fbdcc16898)