### PR TITLE
Standardize gameplay loading and error states

### DIFF
--- a/src/components/ui/page-state.tsx
+++ b/src/components/ui/page-state.tsx
@@ -16,7 +16,7 @@ type PageStateProps = {
 
 export function PageLoadingState({ title = "Loading", description = "Getting everything ready...", className }: Partial<PageStateProps>) {
   return (
-    <Card className={cn("overflow-hidden", className)}>
+    <Card className={cn("overflow-hidden", className)} role="status" aria-live="polite" aria-busy="true">
       <CardContent className="space-y-5 p-6">
         <div className="flex items-center gap-3 text-muted-foreground">
           <Loader2 className="h-5 w-5 animate-spin text-primary" />
@@ -69,7 +69,7 @@ export function PageErrorState({
   retryLabel = "Try again",
 }: PageErrorStateProps) {
   return (
-    <Alert variant="destructive" className={cn("bg-destructive/10", className)}>
+    <Alert variant="destructive" className={cn("bg-destructive/10", className)} role="alert">
       <AlertCircle className="h-4 w-4" />
       <AlertTitle>{title}</AlertTitle>
       <AlertDescription className="mt-2 flex flex-col gap-3">

--- a/src/hooks/useRecordingData.tsx
+++ b/src/hooks/useRecordingData.tsx
@@ -86,10 +86,7 @@ export const useRecordingProducers = (genreFilter?: string, tierFilter?: string)
 
       const { data, error } = await query;
       
-      if (error) {
-        console.error('Error fetching producers:', error);
-        throw error;
-      }
+      if (error) throw error;
       return (data || []) as RecordingProducer[];
     },
   });
@@ -110,10 +107,7 @@ export const useRecordingSessions = (profileId: string) => {
         .eq('profile_id', profileId)
         .order('created_at', { ascending: false });
       
-      if (error) {
-        console.error('Error fetching recording sessions:', error);
-        throw error;
-      }
+      if (error) throw error;
       return (data || []) as any as RecordingSession[];
     },
   });

--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -112,7 +112,7 @@ export const useSongwritingData = (profileId?: string | null) => {
   const queryClient = useQueryClient();
 
   // Fetch themes
-  const { data: songThemes = [], isLoading: isLoadingThemes } = useQuery({
+  const { data: songThemes = [], isLoading: isLoadingThemes, error: themesError, refetch: refetchThemes } = useQuery({
     queryKey: ['song-themes'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -126,7 +126,7 @@ export const useSongwritingData = (profileId?: string | null) => {
   });
 
   // Fetch chord progressions
-  const { data: chordProgressions = [], isLoading: isLoadingChordProgressions } = useQuery({
+  const { data: chordProgressions = [], isLoading: isLoadingChordProgressions, error: chordProgressionsError, refetch: refetchChordProgressions } = useQuery({
     queryKey: ['chord-progressions'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -140,7 +140,7 @@ export const useSongwritingData = (profileId?: string | null) => {
   });
 
   // Fetch projects with sessions and auto-unlock expired locks
-  const { data: projects = [], isLoading: isLoadingProjects, refetch: refetchProjects } = useQuery({
+  const { data: projects = [], isLoading: isLoadingProjects, error: projectsError, refetch: refetchProjects } = useQuery({
     queryKey: ['songwriting-projects', profileId],
     enabled: !!profileId,
     queryFn: async () => {
@@ -185,7 +185,7 @@ export const useSongwritingData = (profileId?: string | null) => {
               .update({ is_locked: false, locked_until: null })
               .eq('id', p.id)
           )
-        ).catch(err => console.error('Background unlock failed:', err));
+        ).catch(() => undefined);
       }
       
       // Order sessions by created_at DESC - mark expired locks as unlocked in UI immediately
@@ -681,5 +681,10 @@ export const useSongwritingData = (profileId?: string | null) => {
     completeSession,
     convertToSong,
     refetchProjects,
+    projectsError,
+    themesError,
+    chordProgressionsError,
+    refetchThemes,
+    refetchChordProgressions,
   };
 };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@ import { formatDistanceToNow, addDays, startOfWeek, format as formatDate } from 
 import { User, Trophy, Users, Calendar, Heart, Zap, Coins, MapPin, Clock, ChevronLeft, ChevronRight, CalendarDays, Star, Flame, BarChart3, Activity as ActivityIcon, ChevronDown, Shield, Sparkles } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { StandardPageLayout } from "@/components/ui/StandardPageLayout";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 
 import { DashboardHero } from "@/components/dashboard/DashboardHero";
 import { RecentActivitySection } from "@/components/dashboard/RecentActivitySection";
@@ -100,13 +101,17 @@ const Dashboard = () => {
     enabled: !!profile?.id
   });
   const {
-    data: achievements
+    data: achievements,
+    isLoading: achievementsLoading,
+    error: achievementsError,
+    refetch: refetchAchievements,
   } = useQuery({
     queryKey: ["player-achievements", profile?.id],
     queryFn: async (): Promise<any[]> => {
       if (!profile?.id) return [];
       const client: any = supabase;
       const result = await client.from("player_achievements").select("*, achievements(*)").eq("profile_id", profile.id);
+      if (result.error) throw result.error;
       return result.data || [];
     },
     enabled: !!profile?.id
@@ -404,9 +409,23 @@ const Dashboard = () => {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent className="pt-3">
-              {!achievements || achievements.length === 0 ? <p className="text-sm text-muted-foreground text-center py-8">
-                  {t('dashboard.noAchievements', 'No achievements unlocked yet. Keep playing to earn achievements!')}
-                </p> : <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {achievementsLoading ? (
+                <PageLoadingState
+                  title="Loading achievements"
+                  description="Checking your latest milestones..."
+                />
+              ) : achievementsError ? (
+                <PageErrorState
+                  title="Achievements could not be loaded"
+                  description="Your milestone list is temporarily unavailable."
+                  onRetry={() => void refetchAchievements()}
+                />
+              ) : !achievements || achievements.length === 0 ? (
+                <PageEmptyState
+                  title="No achievements unlocked yet"
+                  description={t('dashboard.noAchievements', 'Keep playing to earn achievements!')}
+                />
+              ) : <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {achievements.map((achievement: any) => <div key={achievement.id} className="border rounded-lg p-4 hover:bg-accent/50 transition-colors">
                       <div className="flex items-start gap-3">
                         <div className="text-3xl">{achievement.achievements?.icon || "🏆"}</div>

--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -105,6 +105,7 @@ import {
 } from "lucide-react";
 import logger from "@/lib/logger";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 
 interface Song {
   id: string;
@@ -550,6 +551,11 @@ const Songwriting = () => {
     completeSession,
     convertToSong,
     refetchProjects,
+    projectsError,
+    themesError,
+    chordProgressionsError,
+    refetchThemes,
+    refetchChordProgressions,
   } = useSongwritingData(profile?.id);
 
   // Map attributes to required format
@@ -1627,9 +1633,27 @@ const Songwriting = () => {
   if (isLoadingProjects && projectsList.length === 0) {
     return (
       <div className="container mx-auto p-6">
-        <div className="flex items-center justify-center h-64">
-          <div className="text-muted-foreground">{t("common.loading")}</div>
-        </div>
+        <PageLoadingState
+          title="Loading songwriting projects"
+          description="Tuning up your ideas, themes, and current writing sessions..."
+        />
+      </div>
+    );
+  }
+
+  if (projectsError || themesError || chordProgressionsError) {
+    return (
+      <div className="container mx-auto p-6">
+        <PageErrorState
+          title="Songwriting could not be loaded"
+          description="We could not load your writing desk. Your songs are safe — retry when the connection settles."
+          onRetry={() => {
+            void refetchProjects();
+            void refetchThemes();
+            void refetchChordProgressions();
+            void fetchSongs();
+          }}
+        />
       </div>
     );
   }
@@ -2498,22 +2522,22 @@ const Songwriting = () => {
       )}
 
       {filteredProjects.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12">
-            <Music className="h-12 w-12 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">
-              No songwriting projects yet
-            </h3>
-            <p className="text-muted-foreground text-center mb-4 max-w-md">
-              Capture a new concept, set creative targets, and let focus sprints
-              carry you to a finished song.
-            </p>
-            <Button onClick={handleOpenCreate}>
-              <Plus className="h-4 w-4 mr-2" />
-              Start your first project
-            </Button>
-          </CardContent>
-        </Card>
+        <PageEmptyState
+          title={projectsList.length === 0 ? "No songwriting projects yet" : "No projects match these filters"}
+          description={
+            projectsList.length === 0
+              ? "Capture a new concept, set creative targets, and let focus sprints carry you to a finished song."
+              : "Clear a filter or switch status views to bring more writing projects back into the setlist."
+          }
+          action={
+            projectsList.length === 0 ? (
+              <Button onClick={handleOpenCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Start your first project
+              </Button>
+            ) : null
+          }
+        />
       ) : (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {filteredProjects.map((project) => {

--- a/src/pages/studio/recording.tsx
+++ b/src/pages/studio/recording.tsx
@@ -39,6 +39,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 import { format, formatDistanceToNow } from "date-fns";
 
 const statusBadgeStyles: Record<RecordingStatus, string> = {
@@ -117,7 +118,7 @@ export default function StudioRecordingDashboard() {
   const { session } = useAuth();
   const userId = session?.user?.id;
   const { profileId } = useActiveProfile();
-  const { data: sessions, isLoading } = useRecordingSessions(profileId || "");
+  const { data: sessions, isLoading, error: sessionsError, refetch: refetchSessions } = useRecordingSessions(profileId || "");
   const queryClient = useQueryClient();
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
 
@@ -141,7 +142,6 @@ export default function StudioRecordingDashboard() {
       queryClient.invalidateQueries({ queryKey: ["recording-sessions", userId] });
     },
     onError: (error: Error) => {
-      console.error("Failed to update recording session status", error);
       toast.error(error.message ?? "Unable to update session status.");
     },
     onSettled: () => setPendingAction(null),
@@ -162,7 +162,6 @@ export default function StudioRecordingDashboard() {
       queryClient.invalidateQueries({ queryKey: ["recording-sessions", userId] });
     },
     onError: (error: Error) => {
-      console.error("Failed to advance recording session stage", error);
       toast.error(error.message ?? "Unable to advance the session stage.");
     },
     onSettled: () => setPendingAction(null),
@@ -352,24 +351,18 @@ export default function StudioRecordingDashboard() {
     >
 
       {isLoading ? (
-        <Card className="border-dashed">
-          <CardContent className="flex items-center gap-3 py-12 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" />
-            Loading your recording sessions...
-          </CardContent>
-        </Card>
+        <PageLoadingState title="Loading recording sessions" description="Checking your studio pipeline and collaborator status..." />
+      ) : sessionsError ? (
+        <PageErrorState
+          title="Recording sessions could not be loaded"
+          description="The studio desk could not reach your recording data. Try again in a moment."
+          onRetry={() => void refetchSessions()}
+        />
       ) : !sessions || sessions.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="space-y-4 py-12 text-center">
-            <Users className="mx-auto h-12 w-12 text-muted-foreground" />
-            <div className="space-y-2">
-              <h2 className="text-xl font-semibold">No recording sessions scheduled yet</h2>
-              <p className="mx-auto max-w-md text-sm text-muted-foreground">
-                Launch a new studio booking from the Recording Studio page to start tracking your production workflow.
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+        <PageEmptyState
+          title="No recording sessions scheduled yet"
+          description="Launch a new studio booking from the Recording Studio page to start tracking your production workflow."
+        />
       ) : (
         <div className="grid gap-6">{sessions.map(renderSessionCard)}</div>
       )}


### PR DESCRIPTION
### Motivation
- Make high-traffic gameplay pages feel stable and production-ready by standardising loading, empty and error UI states.  
- Surface query errors and provide safe retry actions so failures are visible to users rather than only logged to the console.  
- Reduce noisy `console.error` calls and reuse shared page-state components to keep UI patterns consistent and accessible.

### Description
- Added accessible semantics to shared states by updating `PageLoadingState` with `role="status"`, `aria-live="polite"`, and `aria-busy="true"` and `PageErrorState` with `role="alert"` in `src/components/ui/page-state.tsx`.  
- Reused `PageLoadingState`, `PageErrorState`, and `PageEmptyState` across pages and replaced ad-hoc loading/empty cards on Dashboard, Songwriting, and Studio Recording pages to provide consistent states and retry hooks; files updated: `src/pages/Dashboard.tsx`, `src/pages/Songwriting.tsx`, and `src/pages/studio/recording.tsx`.  
- Exposed query errors and `refetch` functions from the songwriting hook so the page can show an error state and provide a retry action, and removed background `console.error` noise when unlocking projects in `src/hooks/useSongwritingData.tsx`.  
- Cleaned up noisy console logging in recording queries/hooks and surfaced `sessionsError`/`refetchSessions` for retryable error UI in `src/hooks/useRecordingData.tsx` and `src/pages/studio/recording.tsx`.

### Testing
- Ran typecheck with `npx tsc --noEmit` which completed successfully.  
- Ran lint with `npm run lint` but it failed because dependencies are not installed and ESLint could not resolve `@eslint/js`.  
- Attempted build with `npm run build` but it failed because dependencies are not installed and `vite` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5009bb096083259a385a946a1ad84a)