### PR TITLE
Stabilize shared profile Supabase access

### DIFF
--- a/src/hooks/useActiveProfile.ts
+++ b/src/hooks/useActiveProfile.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
+import { getActiveProfile } from "@/services/profileService";
 import { useAuth } from "@/hooks/use-auth-context";
 
 /**
@@ -15,16 +15,7 @@ export function useActiveProfile() {
     queryFn: async () => {
       if (!user?.id) return null;
 
-      const { data, error } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("user_id", user.id)
-        .eq("is_active", true)
-        .is("died_at", null)
-        .maybeSingle();
-
-      if (error) throw error;
-      return data;
+      return getActiveProfile(user.id);
     },
     enabled: !!user?.id,
     staleTime: 60 * 1000, // 1 minute

--- a/src/hooks/useGameData.tsx
+++ b/src/hooks/useGameData.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { getOrActivatePlayableProfile } from "@/services/profileService";
 import type { Database } from "@/lib/supabase-types";
 import { useAuth } from "@/hooks/use-auth-context";
 import {
@@ -1019,80 +1020,7 @@ const useProvideGameData = (): UseGameDataReturn => {
     setError(null);
 
     try {
-      const { data: activeProfileData, error: activeProfileError } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("user_id", user.id)
-        .eq("is_active", true)
-        .is("died_at", null)
-        .maybeSingle();
-
-      if (activeProfileError) {
-        throw activeProfileError;
-      }
-
-      let nextProfile = (activeProfileData as PlayerProfile | null) ?? null;
-
-      if (!nextProfile) {
-        const { data: fallbackProfileData, error: fallbackProfileError } = await supabase
-          .from("profiles")
-          .select("*")
-          .eq("user_id", user.id)
-          .is("died_at", null)
-          .order("slot_number", { ascending: true })
-          .limit(1)
-          .maybeSingle();
-
-        if (fallbackProfileError) {
-          throw fallbackProfileError;
-        }
-
-        nextProfile = (fallbackProfileData as PlayerProfile | null) ?? null;
-
-        if (nextProfile && !nextProfile.is_active) {
-          const { error: switchError } = await supabase.rpc("switch_active_character" as any, {
-            p_profile_id: nextProfile.id,
-          });
-
-          if (switchError) {
-            const isMissingSwitchFunction =
-              switchError.code === "PGRST202" ||
-              switchError.message?.includes("Could not find the function public.switch_active_character");
-
-            if (!isMissingSwitchFunction) {
-              throw switchError;
-            }
-
-            const { error: activateTargetError } = await supabase
-              .from("profiles")
-              .update({ is_active: true })
-              .eq("id", nextProfile.id)
-              .eq("user_id", user.id)
-              .is("died_at", null);
-
-            if (activateTargetError) {
-              throw activateTargetError;
-            }
-
-            const { error: deactivateOthersError } = await supabase
-              .from("profiles")
-              .update({ is_active: false })
-              .eq("user_id", user.id)
-              .neq("id", nextProfile.id)
-              .eq("is_active", true)
-              .is("died_at", null);
-
-            if (deactivateOthersError) {
-              throw deactivateOthersError;
-            }
-          }
-
-          nextProfile = {
-            ...nextProfile,
-            is_active: true,
-          };
-        }
-      }
+      const nextProfile = (await getOrActivatePlayableProfile(user.id)) as PlayerProfile | null;
 
       setProfile(nextProfile);
 

--- a/src/hooks/useUserBand.ts
+++ b/src/hooks/useUserBand.ts
@@ -28,7 +28,11 @@ export function useUserBand() {
         .limit(1)
         .maybeSingle();
 
-      if (memberError || !membership) return null;
+      if (memberError) {
+        throw new Error(`Failed to load active band membership: ${memberError.message}`);
+      }
+
+      if (!membership) return null;
 
       const { data: band, error: bandError } = await supabase
         .from("bands")
@@ -37,7 +41,11 @@ export function useUserBand() {
         .eq("status", "active")
         .single();
 
-      if (bandError || !band) return null;
+      if (bandError) {
+        throw new Error(`Failed to load active band: ${bandError.message}`);
+      }
+
+      if (!band) return null;
 
       return {
         id: band.id,

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,98 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/lib/supabase-types";
+
+export type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+
+const ACTIVE_PROFILE_SELECT = "*";
+
+const isMissingSwitchFunctionError = (error: { code?: string; message?: string }) =>
+  error.code === "PGRST202" ||
+  error.message?.includes("Could not find the function public.switch_active_character");
+
+export async function getActiveProfile(userId: string): Promise<ProfileRow | null> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(ACTIVE_PROFILE_SELECT)
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .is("died_at", null)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load active profile: ${error.message}`);
+  }
+
+  return (data as ProfileRow | null) ?? null;
+}
+
+export async function getFirstLivingProfile(userId: string): Promise<ProfileRow | null> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select(ACTIVE_PROFILE_SELECT)
+    .eq("user_id", userId)
+    .is("died_at", null)
+    .order("slot_number", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load fallback profile: ${error.message}`);
+  }
+
+  return (data as ProfileRow | null) ?? null;
+}
+
+export async function activateProfile(profile: ProfileRow, userId: string): Promise<ProfileRow> {
+  if (profile.is_active) {
+    return profile;
+  }
+
+  const { error: switchError } = await supabase.rpc("switch_active_character" as any, {
+    p_profile_id: profile.id,
+  });
+
+  if (switchError && !isMissingSwitchFunctionError(switchError)) {
+    throw new Error(`Failed to switch active profile: ${switchError.message}`);
+  }
+
+  if (switchError) {
+    const { error: activateTargetError } = await supabase
+      .from("profiles")
+      .update({ is_active: true })
+      .eq("id", profile.id)
+      .eq("user_id", userId)
+      .is("died_at", null);
+
+    if (activateTargetError) {
+      throw new Error(`Failed to activate profile: ${activateTargetError.message}`);
+    }
+
+    const { error: deactivateOthersError } = await supabase
+      .from("profiles")
+      .update({ is_active: false })
+      .eq("user_id", userId)
+      .neq("id", profile.id)
+      .eq("is_active", true)
+      .is("died_at", null);
+
+    if (deactivateOthersError) {
+      throw new Error(`Failed to deactivate previous profiles: ${deactivateOthersError.message}`);
+    }
+  }
+
+  return { ...profile, is_active: true };
+}
+
+export async function getOrActivatePlayableProfile(userId: string): Promise<ProfileRow | null> {
+  const activeProfile = await getActiveProfile(userId);
+  if (activeProfile) {
+    return activeProfile;
+  }
+
+  const fallbackProfile = await getFirstLivingProfile(userId);
+  if (!fallbackProfile) {
+    return null;
+  }
+
+  return activateProfile(fallbackProfile, userId);
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicated `profiles` Supabase queries and make profile lookup/activation predictable, error-aware and null-safe without changing gameplay or schema.

### Description
- Add `src/services/profileService.ts` providing `getActiveProfile`, `getFirstLivingProfile`, `activateProfile`, and `getOrActivatePlayableProfile` with consistent `select`/`maybeSingle`/`order`/`limit` usage and contextual error messages.
- Replace inline active-profile lookup in `useActiveProfile` with `getActiveProfile` so React Query continues to manage loading while using the shared implementation.
- Replace the profile selection/activation block in `useGameData` with `getOrActivatePlayableProfile`, preserving the hook’s loading lifecycle and `finally` cleanup for reliable loading states.
- Improve `useUserBand` to surface Supabase query errors for membership and band reads instead of silently returning `null`, while still returning `null` for legitimate “not found” cases.

### Testing
- Ran `npm install` which failed due to the registry returning `403 Forbidden` for `@react-three/fiber`, preventing dependency installation and blocking further automated checks.
- Attempted `npm run build`, `npm run lint`, and `npx tsc -b`, and each failed because required tools and type packages (`vite`, `@eslint/js`, `react`, `@tanstack/react-query`, etc.) were not available after the blocked install.
- Committed the code changes and verified diffs locally, but full automated build/lint/typecheck/test runs could not complete due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a500bffcca48325bb0d7435e0e7c199)