### PR TITLE
Add manager recommendations panel

### DIFF
--- a/src/components/dashboard/ManagerRecommendationsPanel.tsx
+++ b/src/components/dashboard/ManagerRecommendationsPanel.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { AlertTriangle, ArrowRight, ClipboardList, Lightbulb } from "lucide-react";
+import { addDays } from "date-fns";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { supabase } from "@/integrations/supabase/client";
+import { buildManagerRecommendations, type ManagerRecommendationPriority } from "@/lib/managerRecommendations";
+import { cn } from "@/lib/utils";
+
+interface ManagerRecommendationsPanelProps {
+  profile: any;
+  userId?: string;
+}
+
+const priorityLabels: Record<ManagerRecommendationPriority, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const priorityStyles: Record<ManagerRecommendationPriority, string> = {
+  high: "border-destructive/30 bg-destructive/10 text-destructive",
+  medium: "border-warning/30 bg-warning/10 text-warning",
+  low: "border-primary/30 bg-primary/10 text-primary",
+};
+
+const todayIso = () => new Date().toISOString();
+export function ManagerRecommendationsPanel({ profile, userId }: ManagerRecommendationsPanelProps) {
+  const profileId = profile?.id;
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["manager-recommendations", userId, profileId],
+    enabled: !!userId && !!profileId,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const now = new Date();
+      const inSevenDays = addDays(now, 7);
+
+      const bandIdsResult = await supabase
+        .from("band_members")
+        .select("band_id")
+        .eq("profile_id", profileId)
+        .eq("member_status", "active");
+      if (bandIdsResult.error) throw bandIdsResult.error;
+      const bandIds = (bandIdsResult.data ?? []).map((row: any) => row.band_id).filter(Boolean);
+
+      const [songsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult] = await Promise.all([
+        supabase
+          .from("songs")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .eq("status", "completed")
+          .or("archived.is.null,archived.eq.false"),
+        supabase
+          .from("songs")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .eq("status", "recorded")
+          .or("archived.is.null,archived.eq.false"),
+        supabase
+          .from("player_inbox")
+          .select("id", { count: "exact", head: true })
+          .eq("user_id", userId)
+          .eq("is_read", false)
+          .eq("is_archived", false)
+          .in("priority", ["high", "urgent"]),
+        supabase
+          .from("player_scheduled_activities")
+          .select("id, title, activity_type, scheduled_start")
+          .eq("profile_id", profileId)
+          .gte("scheduled_start", todayIso())
+          .lte("scheduled_start", inSevenDays.toISOString())
+          .order("scheduled_start", { ascending: true })
+          .limit(3),
+        bandIds.length > 0
+          ? supabase
+              .from("band_rehearsals")
+              .select("id", { count: "exact", head: true })
+              .in("band_id", bandIds)
+              .eq("status", "scheduled")
+              .gte("scheduled_start", todayIso())
+              .lte("scheduled_start", addDays(now, 14).toISOString())
+          : Promise.resolve({ data: [], count: 0, error: null }),
+      ]);
+
+      const failed = [songsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult].find((result: any) => result.error);
+      if (failed?.error) throw failed.error;
+
+      return {
+        songsReadyToRecord: songsResult.count ?? 0,
+        recordingsReadyToRelease: recordingsResult.count ?? 0,
+        unreadImportantMessages: messagesResult.count ?? 0,
+        upcomingActivities: activitiesResult.data ?? [],
+        needsBandRehearsal: bandIds.length > 0 && (rehearsalsResult.count ?? 0) === 0,
+      };
+    },
+  });
+
+  const recommendations = useMemo(() => buildManagerRecommendations({ profile, ...data }), [data, profile]);
+
+  if (isLoading) {
+    return <PageLoadingState title="Loading manager recommendations" description="Reviewing your vitals, songs, recordings, inbox, rehearsals, and schedule..." />;
+  }
+
+  if (error) {
+    return <PageErrorState title="Manager recommendations could not be loaded" description="Your dashboard is still available, but recommendations could not be refreshed." onRetry={() => void refetch()} />;
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Lightbulb className="h-4 w-4 text-primary" />
+              Manager Recommendations
+            </CardTitle>
+            <CardDescription>Rules-based next actions from your current career data.</CardDescription>
+          </div>
+          {recommendations.length > 0 ? <Badge variant="secondary">{recommendations.length}</Badge> : null}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {recommendations.length === 0 ? (
+          <PageEmptyState title="No recommendations right now" description="Your manager has no urgent next actions. Keep writing, recording, rehearsing, and booking activities." />
+        ) : (
+          <div className="space-y-3">
+            {recommendations.map((recommendation) => {
+              const content = (
+                <div className="flex h-full items-start gap-3 rounded-lg border bg-card/50 p-3 transition-colors hover:bg-accent/40">
+                  <ClipboardList className="mt-0.5 h-4 w-4 flex-shrink-0 text-primary" />
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold leading-tight">{recommendation.title}</p>
+                      <Badge variant="outline" className={cn("text-[10px]", priorityStyles[recommendation.priority])}>
+                        {priorityLabels[recommendation.priority]}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{recommendation.reason}</p>
+                    <p className="text-xs font-medium">{recommendation.suggestedAction}</p>
+                  </div>
+                  {recommendation.priority === "high" ? <AlertTriangle className="h-4 w-4 text-destructive" /> : null}
+                  {recommendation.href ? <ArrowRight className="h-4 w-4 text-muted-foreground" /> : null}
+                </div>
+              );
+
+              return recommendation.href ? <Link key={recommendation.id} to={recommendation.href}>{content}</Link> : <div key={recommendation.id}>{content}</div>;
+            })}
+          </div>
+        )}
+        {recommendations.length > 0 ? (
+          <div className="mt-3 flex justify-end">
+            <Button asChild size="sm" variant="outline"><Link to="/schedule">Review schedule</Link></Button>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/managerRecommendations.test.ts
+++ b/src/lib/managerRecommendations.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildManagerRecommendations } from "./managerRecommendations";
+
+describe("buildManagerRecommendations", () => {
+  it("returns an empty list when no rules match", () => {
+    expect(buildManagerRecommendations({ profile: { health: 100, energy: 100 } })).toEqual([]);
+  });
+
+  it("prioritizes critical vitals and important messages", () => {
+    const recommendations = buildManagerRecommendations({
+      profile: { health: 18, energy: 30 },
+      unreadImportantMessages: 2,
+      songsReadyToRecord: 1,
+    });
+
+    expect(recommendations.map((item) => item.id)).toEqual([
+      "vitals-low",
+      "important-messages",
+      "songs-ready-record",
+    ]);
+    expect(recommendations[0].priority).toBe("high");
+  });
+
+  it("caps output at five reusable recommendations", () => {
+    const recommendations = buildManagerRecommendations({
+      profile: { health: 25, energy: 25 },
+      unreadImportantMessages: 1,
+      recordingsReadyToRelease: 3,
+      songsReadyToRecord: 4,
+      needsBandRehearsal: true,
+      upcomingActivities: [{ id: "activity-1", title: "Club gig" }],
+    });
+
+    expect(recommendations).toHaveLength(5);
+    expect(recommendations.some((item) => item.id === "upcoming-activity")).toBe(false);
+  });
+});

--- a/src/lib/managerRecommendations.ts
+++ b/src/lib/managerRecommendations.ts
@@ -1,0 +1,119 @@
+export type ManagerRecommendationPriority = "high" | "medium" | "low";
+
+export interface ManagerRecommendation {
+  id: string;
+  title: string;
+  reason: string;
+  suggestedAction: string;
+  href?: string;
+  priority: ManagerRecommendationPriority;
+}
+
+export interface ManagerRecommendationInput {
+  profile?: {
+    health?: number | null;
+    energy?: number | null;
+  } | null;
+  songsReadyToRecord?: number;
+  recordingsReadyToRelease?: number;
+  needsBandRehearsal?: boolean;
+  unreadImportantMessages?: number;
+  upcomingActivities?: Array<{
+    id: string;
+    title?: string | null;
+    activity_type?: string | null;
+    scheduled_start?: string | null;
+  }>;
+}
+
+const priorityWeight: Record<ManagerRecommendationPriority, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+const clampPercent = (value: number | null | undefined) => Math.max(0, Math.min(100, value ?? 100));
+
+const pluralize = (count: number, singular: string, plural = `${singular}s`) => `${count} ${count === 1 ? singular : plural}`;
+
+export function buildManagerRecommendations(input: ManagerRecommendationInput): ManagerRecommendation[] {
+  const recommendations: ManagerRecommendation[] = [];
+  const health = clampPercent(input.profile?.health);
+  const energy = clampPercent(input.profile?.energy);
+  const songsReadyToRecord = input.songsReadyToRecord ?? 0;
+  const recordingsReadyToRelease = input.recordingsReadyToRelease ?? 0;
+  const unreadImportantMessages = input.unreadImportantMessages ?? 0;
+  const upcomingActivities = input.upcomingActivities ?? [];
+
+  if (health <= 35 || energy <= 35) {
+    const isCritical = health <= 20 || energy <= 20;
+    recommendations.push({
+      id: "vitals-low",
+      title: isCritical ? "Recover before taking risks" : "Top up your health and energy",
+      reason: `Health is ${health}% and energy is ${energy}%, which can hurt gig, rehearsal, and recording outcomes.`,
+      suggestedAction: "Visit Wellness and choose a recovery activity before booking more work.",
+      href: "/wellness",
+      priority: isCritical ? "high" : "medium",
+    });
+  }
+
+  if (unreadImportantMessages > 0) {
+    recommendations.push({
+      id: "important-messages",
+      title: "Review important messages",
+      reason: `${pluralize(unreadImportantMessages, "high-priority message")} may need a response or decision.`,
+      suggestedAction: "Open your inbox and handle urgent opportunities first.",
+      href: "/inbox",
+      priority: "high",
+    });
+  }
+
+  if (recordingsReadyToRelease > 0) {
+    recommendations.push({
+      id: "recordings-ready-release",
+      title: "Release finished recordings",
+      reason: `${pluralize(recordingsReadyToRelease, "recorded song")} ${recordingsReadyToRelease === 1 ? "is" : "are"} ready to turn into momentum.`,
+      suggestedAction: "Create a single, EP, or album release while the material is fresh.",
+      href: "/releases",
+      priority: "high",
+    });
+  }
+
+  if (songsReadyToRecord > 0) {
+    recommendations.push({
+      id: "songs-ready-record",
+      title: "Record completed songs",
+      reason: `${pluralize(songsReadyToRecord, "completed song")} ${songsReadyToRecord === 1 ? "is" : "are"} written but not recorded yet.`,
+      suggestedAction: "Book studio time and capture your strongest unreleased ideas.",
+      href: "/recording-studio",
+      priority: "medium",
+    });
+  }
+
+  if (input.needsBandRehearsal) {
+    recommendations.push({
+      id: "band-rehearsal-needed",
+      title: "Schedule band rehearsal",
+      reason: "No upcoming rehearsal is on the calendar, so chemistry and set familiarity may stall.",
+      suggestedAction: "Book a rehearsal before your next performance window.",
+      href: "/rehearsals",
+      priority: "medium",
+    });
+  }
+
+  if (upcomingActivities.length > 0) {
+    const nextActivity = upcomingActivities[0];
+    recommendations.push({
+      id: "upcoming-activity",
+      title: "Prepare for your next booking",
+      reason: `${nextActivity.title || nextActivity.activity_type || "An activity"} is coming up soon.`,
+      suggestedAction: "Check your schedule, confirm timing, and make sure your vitals are ready.",
+      href: "/schedule",
+      priority: "low",
+    });
+  }
+
+  return recommendations
+    .sort((a, b) => priorityWeight[b.priority] - priorityWeight[a.priority])
+    .slice(0, 5);
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -35,6 +35,7 @@ import { usePlayerSurvey } from "@/hooks/usePlayerSurvey";
 import { PlayerSurveyModal } from "@/components/survey/PlayerSurveyModal";
 import { CharacterUnreadWidget } from "@/components/dashboard/CharacterUnreadWidget";
 import { TodaysBriefing } from "@/components/dashboard/TodaysBriefing";
+import { ManagerRecommendationsPanel } from "@/components/dashboard/ManagerRecommendationsPanel";
 
 import { Link } from "react-router-dom";
 const Dashboard = () => {
@@ -194,6 +195,7 @@ const Dashboard = () => {
         <TabsContent value="profile" className="space-y-4">
           <DashboardHero profile={profile} userId={user?.id} />
           <TodaysBriefing profile={profile} userId={user?.id} />
+          <ManagerRecommendationsPanel profile={profile} userId={user?.id} />
           <CharacterUnreadWidget />
 
 


### PR DESCRIPTION
### Motivation
- Provide players with clear next actions using only existing client-side game data, without adding AI/chat or new backend services. 
- Surface 3–5 prioritized, rules-based suggestions (vitals, songs to record, recordings to release, rehearsals, unread important messages, upcoming activities) on the dashboard so managers/players know what to do next.

### Description
- Added a small, testable recommendation engine `buildManagerRecommendations` in `src/lib/managerRecommendations.ts` that emits typed recommendations (`id`, `title`, `reason`, `suggestedAction`, optional `href`, `priority`) and sorts/caps results to 5. 
- Implemented `ManagerRecommendationsPanel` in `src/components/dashboard/ManagerRecommendationsPanel.tsx` which queries Supabase for songs, recordings, inbox, scheduled activities, and band rehearsals, then renders loading/error/empty/populated states with priority badges and links. 
- Wired the panel into the dashboard at `src/pages/Dashboard.tsx` below Today’s Briefing so recommendations appear on the profile tab. 
- Added unit tests `src/lib/managerRecommendations.test.ts` covering no-match, prioritization, and max-output behavior. 
- Risks/notes: song/release detection currently uses `songs.status === "recorded"` which may over-recommend releases if release linkage differs, and the band-rehearsal heuristic is intentionally simple (active membership + no scheduled rehearsal in next 14 days).

### Testing
- Type check: `npx tsc --noEmit` completed successfully. 
- Unit tests: added `src/lib/managerRecommendations.test.ts` but running `vitest` in this environment failed due to missing runtime/dependencies and registry access (`vitest` not available / `403 Forbidden`), so tests were not executed here. 
- Lint: running `eslint` failed in this environment because local ESLint dependencies (e.g., `@eslint/js`) are not installed, so lint checks were not completed here. 
- Manual verification: component compiled under `tsc` and the panel was added to the dashboard; integration should be validated in a full dev environment where `vitest` and linter dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5011d0f5e883258c909721d672c9b3)