### PR TITLE
Improve player notification previews

### DIFF
--- a/src/components/dashboard/TodaysBriefing.tsx
+++ b/src/components/dashboard/TodaysBriefing.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { addDays, format, formatDistanceToNow, isAfter } from "date-fns";
-import { AlertTriangle, Bell, CalendarClock, HeartPulse, Inbox, Music2, Radio, TrendingUp, Users, Zap } from "lucide-react";
+import { AlertTriangle, Bell, CalendarClock, ExternalLink, HeartPulse, Inbox, Music2, Radio, TrendingUp, Users, Zap } from "lucide-react";
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 import { supabase } from "@/integrations/supabase/client";
+import { getNotificationPreview } from "@/lib/notificationModels";
 
 interface TodaysBriefingProps {
   profile: any;
@@ -21,6 +22,8 @@ type BriefingItem = {
   href?: string;
   tone?: "default" | "warning" | "good";
   icon: typeof CalendarClock;
+  meta?: string;
+  actionLabel?: string | null;
 };
 
 const todayIso = () => new Date().toISOString();
@@ -64,9 +67,11 @@ export function TodaysBriefing({ profile, userId }: TodaysBriefingProps) {
           .eq("is_archived", false),
         supabase
           .from("notifications")
-          .select("id", { count: "exact", head: true })
+          .select("id, user_id, profile_id, category, type, title, message, action_path, metadata, read_at, created_at", { count: "exact" })
           .eq("user_id", userId)
-          .is("read_at", null),
+          .is("read_at", null)
+          .order("created_at", { ascending: false })
+          .limit(5),
         supabase
           .from("song_releases")
           .select("id, release_date, release_type, platform_name, total_streams, band_id, user_id")
@@ -101,6 +106,7 @@ export function TodaysBriefing({ profile, userId }: TodaysBriefingProps) {
         activities: activitiesResult.data ?? [],
         unreadInbox: inboxResult.count ?? 0,
         unreadNotifications: notificationsResult.count ?? 0,
+        notificationPreviews: notificationsResult.data ?? [],
         releases: (releasesResult.data ?? []).filter((release: any) =>
           release.user_id === userId || (release.band_id && bandIds.includes(release.band_id))
         ),
@@ -130,7 +136,18 @@ export function TodaysBriefing({ profile, userId }: TodaysBriefingProps) {
     });
 
     if ((data?.unreadInbox ?? 0) > 0) next.push({ id: "inbox", title: "Unread inbox", description: `${data?.unreadInbox} unread message${data?.unreadInbox === 1 ? "" : "s"} waiting.`, href: "/inbox", icon: Inbox });
-    if ((data?.unreadNotifications ?? 0) > 0) next.push({ id: "notifications", title: "New notifications", description: `${data?.unreadNotifications} unread notification${data?.unreadNotifications === 1 ? "" : "s"}.`, href: "/notifications", icon: Bell });
+    getNotificationPreview((data?.notificationPreviews ?? []) as any).forEach((notification) => {
+      next.push({
+        id: `notification-${notification.id}`,
+        title: notification.title,
+        description: notification.body,
+        href: notification.action_path ?? "/inbox",
+        tone: notification.priority === "urgent" || notification.priority === "high" ? "warning" : "default",
+        icon: Bell,
+        meta: `${notification.categoryLabel} · ${notification.priority} · ${formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}`,
+        actionLabel: notification.actionLabel ?? "Open inbox",
+      });
+    });
 
     data?.chartEntries?.slice(0, 2).forEach((entry: any) => {
       const song = Array.isArray(entry.songs) ? entry.songs[0] : entry.songs;
@@ -186,14 +203,14 @@ export function TodaysBriefing({ profile, userId }: TodaysBriefingProps) {
               const Icon = item.icon;
               const row = <div className={`flex h-full items-start gap-3 rounded-md border p-3 transition-colors hover:bg-accent/40 ${item.tone === "warning" ? "border-warning/40 bg-warning/5" : item.tone === "good" ? "border-green-500/30 bg-green-500/5" : "bg-card/50"}`}>
                 <Icon className={`mt-0.5 h-4 w-4 flex-shrink-0 ${item.tone === "warning" ? "text-warning" : item.tone === "good" ? "text-green-500" : "text-primary"}`} />
-                <div className="min-w-0 flex-1"><p className="text-sm font-medium leading-tight">{item.title}</p><p className="mt-1 text-xs text-muted-foreground">{item.description}</p></div>
+                <div className="min-w-0 flex-1"><p className="text-sm font-medium leading-tight">{item.title}</p><p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{item.description}</p>{item.meta && <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">{item.meta}</p>}{item.actionLabel && <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary">{item.actionLabel}<ExternalLink className="h-3 w-3" /></p>}</div>
                 {item.tone === "warning" && <AlertTriangle className="h-3.5 w-3.5 text-warning" />}
               </div>;
               return item.href ? <Link key={item.id} to={item.href}>{row}</Link> : <div key={item.id}>{row}</div>;
             })}
           </div>
         )}
-        {items.length > 0 && <div className="mt-3 flex justify-end"><Button asChild size="sm" variant="outline"><Link to="/schedule">Open schedule</Link></Button></div>}
+        {items.length > 0 && <div className="mt-3 flex justify-end"><Button asChild size="sm" variant="outline"><Link to="/inbox">Open inbox</Link></Button></div>}
       </CardContent>
     </Card>
   );

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Bell, X, CheckCircle, AlertTriangle, Info, Gift } from "lucide-react";
+import { Bell, X, CheckCircle, AlertTriangle, Info, Gift, Loader2, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNotificationsFeed, type PersistedNotification } from "@/hooks/useNotificationsFeed";
+import { normalizeNotification, type NotificationPriority } from "@/lib/notificationModels";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +20,13 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   info: Info,
   achievement: Gift,
   offer: Bell,
+};
+
+const PRIORITY_BADGE: Record<NotificationPriority, string> = {
+  low: "bg-muted text-muted-foreground",
+  normal: "bg-secondary text-secondary-foreground",
+  high: "bg-warning/15 text-warning border-warning/30",
+  urgent: "bg-destructive/15 text-destructive border-destructive/30",
 };
 
 const COLOR_MAP: Record<string, string> = {
@@ -31,7 +39,7 @@ const COLOR_MAP: Record<string, string> = {
 
 export const NotificationBell = () => {
   const navigate = useNavigate();
-  const { notifications, unreadCount, markAllRead, dismiss, clearAll, markRead } =
+  const { notifications, unreadCount, isLoading, error, refetch, markAllRead, dismiss, clearAll, markRead } =
     useNotificationsFeed();
   const [open, setOpen] = useState(false);
 
@@ -75,17 +83,32 @@ export const NotificationBell = () => {
           )}
         </div>
         <ScrollArea className="h-[320px]">
-          {notifications.length === 0 ? (
+          {isLoading ? (
+            <div className="p-8 text-center text-muted-foreground">
+              <Loader2 className="h-8 w-8 mx-auto mb-2 animate-spin opacity-70" />
+              <p className="text-sm font-medium">Loading notifications</p>
+              <p className="text-xs">Checking for new player updates...</p>
+            </div>
+          ) : error ? (
+            <div className="p-8 text-center text-muted-foreground">
+              <AlertTriangle className="h-8 w-8 mx-auto mb-2 text-destructive" />
+              <p className="text-sm font-medium text-foreground">Notifications unavailable</p>
+              <p className="text-xs mb-3">Try refreshing the feed.</p>
+              <Button size="sm" variant="outline" onClick={() => void refetch()}>Retry</Button>
+            </div>
+          ) : notifications.length === 0 ? (
             <div className="p-8 text-center text-muted-foreground">
               <Bell className="h-8 w-8 mx-auto mb-2 opacity-50" />
-              <p className="text-sm">No notifications yet</p>
+              <p className="text-sm font-medium text-foreground">No notifications yet</p>
+              <p className="text-xs">Important gigs, offers, milestones, and social updates will appear here.</p>
             </div>
           ) : (
             <div className="p-2 space-y-2">
               {notifications.map((n) => {
-                const Icon = ICON_MAP[n.type] ?? Info;
-                const colorClass = COLOR_MAP[n.type] ?? "text-blue-500";
-                const isRead = !!n.read_at;
+                const display = normalizeNotification(n);
+                const Icon = ICON_MAP[n.type] ?? ICON_MAP[n.category] ?? Info;
+                const colorClass = COLOR_MAP[n.type] ?? COLOR_MAP[n.category] ?? "text-blue-500";
+                const isRead = display.isRead;
                 return (
                   <div key={n.id}>
                     <div
@@ -97,15 +120,24 @@ export const NotificationBell = () => {
                     >
                       <Icon className={cn("h-5 w-5 mt-0.5 flex-shrink-0", colorClass)} />
                       <div className="flex-1 min-w-0">
-                        <p className="font-medium text-sm">{n.title}</p>
-                        {n.message && (
-                          <p className="text-xs text-muted-foreground mt-0.5 break-words">
-                            {n.message}
-                          </p>
-                        )}
-                        <p className="text-[10px] text-muted-foreground mt-1">
-                          {formatDistanceToNow(new Date(n.created_at), { addSuffix: true })}
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="font-medium text-sm leading-tight">{n.title}</p>
+                          {!isRead && <span className="mt-1 h-2 w-2 rounded-full bg-primary" aria-label="Unread" />}
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-0.5 break-words line-clamp-2">
+                          {display.body}
                         </p>
+                        <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[10px] text-muted-foreground">
+                          <Badge variant="outline" className="h-5 px-1.5 text-[10px]">{display.categoryLabel}</Badge>
+                          <Badge variant="outline" className={cn("h-5 px-1.5 text-[10px] capitalize", PRIORITY_BADGE[display.priority])}>{display.priority}</Badge>
+                          <span>{formatDistanceToNow(new Date(n.created_at), { addSuffix: true })}</span>
+                          <span>{isRead ? "Read" : "Unread"}</span>
+                        </div>
+                        {display.actionLabel && (
+                          <div className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary">
+                            {display.actionLabel}<ExternalLink className="h-3 w-3" />
+                          </div>
+                        )}
                       </div>
                       <Button
                         size="icon"

--- a/src/hooks/useNotificationsFeed.ts
+++ b/src/hooks/useNotificationsFeed.ts
@@ -113,6 +113,8 @@ export function useNotificationsFeed() {
     notifications,
     unreadCount,
     isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
     markRead: markRead.mutate,
     markAllRead: markAllRead.mutate,
     dismiss: dismiss.mutate,

--- a/src/lib/notificationModels.ts
+++ b/src/lib/notificationModels.ts
@@ -1,0 +1,96 @@
+import type { PersistedNotification } from "@/hooks/useNotificationsFeed";
+
+export type NotificationPriority = "low" | "normal" | "high" | "urgent";
+
+export type DisplayNotification = PersistedNotification & {
+  body: string;
+  categoryLabel: string;
+  priority: NotificationPriority;
+  isRead: boolean;
+  actionLabel: string | null;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  achievement: "Achievement",
+  band: "Band",
+  booking: "Booking",
+  business: "Business",
+  chart: "Charts",
+  education: "Education",
+  finance: "Finance",
+  gig: "Gigs",
+  label: "Label",
+  recording: "Recording",
+  relationship: "Social",
+  social: "Social",
+  sponsorship: "Sponsors",
+  store: "Store",
+  system: "System",
+  travel: "Travel",
+};
+
+const TYPE_ACTION_LABELS: Record<string, string> = {
+  achievement: "View achievement",
+  audio_generation: "Open audio",
+  band_invite: "Review invite",
+  blind_box_live: "Open store",
+  chart_entry: "View charts",
+  contract_offer: "Review offer",
+  festival_offer: "View festival",
+  gig_offer: "Review gig",
+  gig_outcome: "View gig results",
+  label_deal: "Review deal",
+  release: "View release",
+  sponsor_offer: "Review sponsor",
+  travel: "View travel",
+};
+
+const PRIORITY_BY_TYPE: Record<string, NotificationPriority> = {
+  warning: "high",
+  error: "urgent",
+  gig_offer: "high",
+  contract_offer: "high",
+  sponsor_offer: "high",
+  festival_offer: "high",
+  band_invite: "high",
+  achievement: "normal",
+  success: "normal",
+  info: "normal",
+};
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const isPriority = (value: unknown): value is NotificationPriority =>
+  value === "low" || value === "normal" || value === "high" || value === "urgent";
+
+export function normalizeNotification(notification: PersistedNotification): DisplayNotification {
+  const metadata = notification.metadata ?? {};
+  const metadataPriority = metadata.priority;
+  const priority = isPriority(metadataPriority)
+    ? metadataPriority
+    : PRIORITY_BY_TYPE[notification.type] ?? PRIORITY_BY_TYPE[notification.category] ?? "normal";
+
+  return {
+    ...notification,
+    body: notification.message?.trim() || "Open this update for more details.",
+    categoryLabel: CATEGORY_LABELS[notification.category] ?? toTitleCase(notification.category || "notification"),
+    priority,
+    isRead: !!notification.read_at,
+    actionLabel: notification.action_path ? TYPE_ACTION_LABELS[notification.type] ?? "Open" : null,
+  };
+}
+
+export function getNotificationPreview(notifications: PersistedNotification[], limit = 3) {
+  return notifications
+    .map(normalizeNotification)
+    .sort((a, b) => {
+      const priorityOrder: Record<NotificationPriority, number> = { urgent: 0, high: 1, normal: 2, low: 3 };
+      const priorityDelta = priorityOrder[a.priority] - priorityOrder[b.priority];
+      if (priorityDelta !== 0) return priorityDelta;
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    })
+    .slice(0, limit);
+}


### PR DESCRIPTION
### Motivation
- Make in-app notifications more useful, readable, and action-oriented while keeping changes UI-focused and low-risk. 
- Standardise how notification data is presented (title, short body, category label, timestamp, priority, read/unread, and an action label) so different notification producers render consistently. 

### Description
- Added a small UI helper at `src/lib/notificationModels.ts` that exposes `normalizeNotification` and `getNotificationPreview` to normalize fields (`body`, `categoryLabel`, `priority`, `isRead`, `actionLabel`) and produce prioritized previews. 
- Updated the bell UI at `src/components/notifications/NotificationBell.tsx` to consume the normalizer, show `loading` / `empty` / `error` states, surface category/priority badges, short preview body, read/unread markers, and an action label when available. 
- Enhanced the dashboard preview in `src/components/dashboard/TodaysBriefing.tsx` to fetch a short unread notification preview list and render actionable, prioritized notification rows with meta and deep-link actions. 
- Exposed `error` and `refetch` from the existing hook `useNotificationsFeed` (`src/hooks/useNotificationsFeed.ts`) so UIs can render a retryable error state without changing backend systems. 
- Notification types improved include `gig_offer`, `contract_offer`, `sponsor_offer`, `festival_offer`, `band_invite`, `achievement`, `chart_entry`, `gig_outcome`, `label_deal`, `release`, `blind_box_live`, `audio_generation`, and `travel`, with graceful fallbacks for unknown categories or types. 

### Testing
- Attempted `npm run typecheck -- --pretty false`, but the repository does not define a `typecheck` script so typechecking was not executed. 
- Attempted `npm run build`, but the environment lacks `vite` so a production build could not be executed. 
- Attempted `npm ci` to run dependency installation, but the run failed due to registry access (`403 Forbidden` for `@react-three/fiber`), preventing a full install and automated build/test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5015a7d1808325bcbd23080372426a)