### PR TITLE
Move Skills & Education into Character/Progression hub

### DIFF
--- a/src/components/ui/Breadcrumbs.tsx
+++ b/src/components/ui/Breadcrumbs.tsx
@@ -66,6 +66,7 @@ const LABELS: Record<string, string> = {
   finances: "Finances",
   employment: "Jobs",
   education: "Education",
+  skills: "Skills",
   wellness: "Wellness",
   travel: "Travel",
   city: "City",

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -19,7 +19,6 @@ import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/u
 import { DashboardHero } from "@/components/dashboard/DashboardHero";
 import { RecentActivitySection } from "@/components/dashboard/RecentActivitySection";
 import { DaySchedule } from "@/components/schedule/DaySchedule";
-import { SkillsAttributesTab } from "@/components/dashboard/SkillsAttributesTab";
 import { DebtWarningBanner } from "@/components/prison/DebtWarningBanner";
 import { CharacterFameOverview } from "@/components/fame/CharacterFameOverview";
 import { LocationHeader } from "@/components/location/LocationHeader";
@@ -286,8 +285,6 @@ const Dashboard = () => {
   } = useAuth();
   const {
     profile,
-    skillProgress,
-    attributes,
     currentCity
   } = useGameData();
   const { t } = useTranslation();
@@ -361,18 +358,6 @@ const Dashboard = () => {
     enabled: !!profile?.id
   });
 
-  // Filter skills with XP > 0
-  const trainedSkills = skillProgress?.filter(skill => (skill.current_xp || 0) > 0) || [];
-  const getInitials = (name: string) => {
-    return name.split(" ").map(n => n[0]).join("").toUpperCase().slice(0, 2);
-  };
-  const calculateSkillProgress = (currentXp: number, level: number) => {
-    const currentLevelXp = Math.pow(level, 2) * 100;
-    const nextLevelXp = Math.pow(level + 1, 2) * 100;
-    const progressInLevel = currentXp - currentLevelXp;
-    const xpNeededForLevel = nextLevelXp - currentLevelXp;
-    return progressInLevel / xpNeededForLevel * 100;
-  };
 
   return <StandardPageLayout
       title={t('dashboard.title')}
@@ -401,7 +386,7 @@ const Dashboard = () => {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-          <TabsList className="inline-flex w-max sm:grid sm:w-full sm:grid-cols-7 gap-1">
+          <TabsList className="inline-flex w-max sm:grid sm:w-full sm:grid-cols-6 gap-1">
             <TabsTrigger value="profile" className="flex-shrink-0">
               <User className="h-4 w-4 sm:mr-2" />
               <span className="hidden sm:inline">{t('common.profile')}</span>
@@ -417,10 +402,6 @@ const Dashboard = () => {
             <TabsTrigger value="behavior" className="flex-shrink-0">
               <Flame className="h-4 w-4 sm:mr-2" />
               <span className="hidden sm:inline">Lifestyle</span>
-            </TabsTrigger>
-            <TabsTrigger value="skills" className="flex-shrink-0">
-              <Zap className="h-4 w-4 sm:mr-2" />
-              <span className="hidden sm:inline">{t('nav.skills')}</span>
             </TabsTrigger>
             <TabsTrigger value="schedule" className="flex-shrink-0">
               <Calendar className="h-4 w-4 sm:mr-2" />
@@ -520,12 +501,6 @@ const Dashboard = () => {
         <TabsContent value="behavior" className="space-y-4">
           <BehaviorSettingsTab />
         </TabsContent>
-
-        {/* Skills & Attributes Tab */}
-        <TabsContent value="skills" className="space-y-4">
-          <SkillsAttributesTab profile={profile} />
-        </TabsContent>
-
 
         {/* Schedule Tab */}
         <TabsContent value="schedule" className="space-y-4">

--- a/src/pages/Education.tsx
+++ b/src/pages/Education.tsx
@@ -29,8 +29,8 @@ const Education = () => {
       title={t('education.title', 'Build your creative intelligence')}
       subtitle={t('education.subtitle', 'Dive into curated resources, mentor networks, and collaborative learning experiences that keep your artistry growing with every session.')}
       icon={GraduationCap}
-      backTo="/hub/music"
-      backLabel="Back to Music Hub"
+      backTo="/hub/character"
+      backLabel="Back to Character Hub"
     >
 
       <Tabs defaultValue={defaultValue} className="mt-6 sm:mt-8 space-y-6">

--- a/src/pages/hubs/CareerBusinessHub.tsx
+++ b/src/pages/hubs/CareerBusinessHub.tsx
@@ -1,7 +1,7 @@
 import { CategoryHub } from "@/components/CategoryHub";
 import {
   Briefcase, DollarSign, Building2, Handshake, Disc, Sparkles, Megaphone,
-  Building, Headphones, Scissors, ShoppingCart, GraduationCap, BookOpen, Film, Heart, Landmark,
+  Building, Headphones, Scissors, ShoppingCart, BookOpen, Film, Heart, Landmark,
 } from "lucide-react";
 
 export default function CareerBusinessHub() {
@@ -21,10 +21,9 @@ export default function CareerBusinessHub() {
           ],
         },
         {
-          label: "Work & Learn",
+          label: "Work & Teaching",
           tiles: [
             { icon: Briefcase, labelKey: "nav.employment", path: "/employment", imagePrompt: "A job board with music industry positions: producer, roadie, DJ, sound engineer" },
-            { icon: GraduationCap, labelKey: "nav.education", path: "/education", imagePrompt: "A music school classroom with instruments, chalkboard, and students" },
             { icon: BookOpen, labelKey: "nav.teaching", path: "/teaching", imagePrompt: "A music teacher in front of students with a guitar and music theory board" },
           ],
         },

--- a/src/pages/hubs/CharacterHub.tsx
+++ b/src/pages/hubs/CharacterHub.tsx
@@ -1,6 +1,6 @@
 import { CategoryHub } from "@/components/CategoryHub";
 import {
-  User, Users, ShoppingCart, Guitar, HeartPulse, History, BookOpen,
+  User, Users, ShoppingCart, Guitar, HeartPulse, History, BookOpen, GraduationCap, Sparkles,
   Palette, Skull, Crown, Scissors, Package, Home, Car, Heart,
 } from "lucide-react";
 
@@ -18,6 +18,13 @@ export default function CharacterHub() {
             { icon: ShoppingCart, labelKey: "nav.skinStore", path: "/skin-store", imagePrompt: "A colorful shop displaying character skins, outfits, and accessories" },
             { icon: Palette, labelKey: "nav.tattooParlour", path: "/tattoo-parlour", imagePrompt: "A tattoo parlour with flash art on walls and rock-themed designs" },
             { icon: Scissors, labelKey: "nav.clothingShop", path: "/clothing-shop", imagePrompt: "A boutique clothing shop with stage outfits and racks of rock fashion" },
+          ],
+        },
+        {
+          label: "Progression",
+          tiles: [
+            { icon: Sparkles, labelKey: "nav.skills", path: "/skills", imagePrompt: "A personal progression screen with branching music skill trees, XP meters, and practice plans" },
+            { icon: GraduationCap, labelKey: "nav.education", path: "/education", imagePrompt: "A music school classroom with instruments, chalkboard, and students" },
             { icon: HeartPulse, labelKey: "nav.wellness", path: "/wellness", imagePrompt: "A wellness dashboard showing health and energy meters with a spa scene" },
           ],
         },


### PR DESCRIPTION
### Motivation
- Keep the Dashboard focused on today’s briefing, recommendations and schedule by moving persistent character management (Skills/Education) out of the Dashboard and into a more logical Character/Progression area.
- Surface long-term progression tools (Skills, Education, Wellness) under the Character hub so discovery matches mental model for personal development.

### Description
- Removed the full Skills tab from the Dashboard by deleting the `SkillsAttributesTab` import and its `TabsTrigger`/`TabsContent`, and by removing related `skillProgress`/`attributes` destructuring and helper code in `src/pages/Dashboard.tsx`.
- Added a `Progression` tile group in the Character hub that links to `/skills` and `/education`, and kept `wellness` alongside them in `src/pages/hubs/CharacterHub.tsx`.
- Changed the Education page scaffold back navigation to point at the Character hub via `backTo="/hub/character"` in `src/pages/Education.tsx`.
- Removed the Education tile from the Career/Business hub and renamed that group to `Work & Teaching` in `src/pages/hubs/CareerBusinessHub.tsx`.
- Added a breadcrumb label for `skills` to `src/components/ui/Breadcrumbs.tsx` so route context is clearer.

### Testing
- `npx tsc --noEmit` completed successfully (typecheck passed).
- `npm run lint` could not complete because ESLint failed to resolve `@eslint/js` in `node_modules` (dependency missing), so lint was not run to completion.
- `npm run build` could not be executed because `vite` was not available in `node_modules` (build not run).
- `npm install` attempt failed due to registry access issues (received `403 Forbidden` for `@react-three/fiber`), preventing a full dependency install and therefore blocking lint/build steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501ea8d8148325b3c4454836ea9540)