### PR TITLE
Remove global Continue CTA from bottom action bar

### DIFF
--- a/src/components/fm/BottomActionBar.tsx
+++ b/src/components/fm/BottomActionBar.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Bell, ChevronRight, History, Calendar } from "lucide-react";
+import { Bell, History, Calendar } from "lucide-react";
 import { useUnreadInboxCount } from "@/hooks/useInbox";
 
 export const BottomActionBar = () => {
@@ -52,15 +52,6 @@ export const BottomActionBar = () => {
         </span>
         <span className="text-[10px] text-fm-fg-muted/70">© 2026</span>
       </div>
-
-      <Button
-        size="sm"
-        className="h-8 gap-2 bg-fm-accent hover:bg-fm-accent/90 text-fm-bg font-semibold tracking-wide text-xs"
-        onClick={() => navigate("/gigs")}
-      >
-        Continue
-        <ChevronRight className="h-4 w-4" />
-      </Button>
     </footer>
   );
 };


### PR DESCRIPTION
### Motivation
- Remove the persistent global “Continue” CTA that appears across pages by default so the footer no longer forces a single navigation action.

### Description
- Deleted the footer-level Continue button and removed the now-unused `ChevronRight` import in `src/components/fm/BottomActionBar.tsx`.

### Testing
- Ran `git diff --check` (passed) and attempted `npm run lint`, which was blocked due to a missing dependency (`@eslint/js`) required by `eslint.config.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501f80bdd48325aee76deea961e029)