### PR TITLE
Stabilize activity booking time validation

### DIFF
--- a/src/components/busking/BuskingScheduleDialog.tsx
+++ b/src/components/busking/BuskingScheduleDialog.tsx
@@ -6,6 +6,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { createScheduledActivity } from "@/hooks/useActivityBooking";
 import { toast } from "sonner";
+import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 interface BuskingScheduleDialogProps {
   open: boolean;
@@ -28,11 +29,13 @@ export function BuskingScheduleDialog({
       return;
     }
 
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(parseInt(hour), 0, 0, 0);
-
-    const scheduledEnd = new Date(scheduledStart);
-    scheduledEnd.setHours(scheduledStart.getHours() + parseInt(duration));
+    const scheduledStart = buildScheduledDateTime(date, parseInt(hour));
+    const scheduledEnd = addDurationHours(scheduledStart, Number(duration));
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast.error(bookingError);
+      return;
+    }
 
     try {
       await createScheduledActivity({
@@ -66,7 +69,7 @@ export function BuskingScheduleDialog({
               mode="single"
               selected={date}
               onSelect={setDate}
-              disabled={(date) => date < new Date()}
+              disabled={(day) => day < new Date(new Date().setHours(0, 0, 0, 0))}
               className="rounded-md border"
             />
           </div>

--- a/src/components/recording/RecordingScheduleDialog.tsx
+++ b/src/components/recording/RecordingScheduleDialog.tsx
@@ -6,6 +6,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { createScheduledActivity } from "@/hooks/useActivityBooking";
 import { toast } from "sonner";
+import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 interface RecordingScheduleDialogProps {
   open: boolean;
@@ -30,11 +31,13 @@ export function RecordingScheduleDialog({
       return;
     }
 
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(parseInt(hour), 0, 0, 0);
-
-    const scheduledEnd = new Date(scheduledStart);
-    scheduledEnd.setHours(scheduledStart.getHours() + parseInt(duration));
+    const scheduledStart = buildScheduledDateTime(date, parseInt(hour));
+    const scheduledEnd = addDurationHours(scheduledStart, Number(duration));
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast.error(bookingError);
+      return;
+    }
 
     try {
       await createScheduledActivity({
@@ -68,7 +71,7 @@ export function RecordingScheduleDialog({
               mode="single"
               selected={date}
               onSelect={setDate}
-              disabled={(date) => date < new Date()}
+              disabled={(day) => day < new Date(new Date().setHours(0, 0, 0, 0))}
               className="rounded-md border"
             />
           </div>

--- a/src/components/schedule/DaySchedule.tsx
+++ b/src/components/schedule/DaySchedule.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { format, differenceInMinutes } from "date-fns";
+import { format } from "date-fns";
 import {
   Clock, ExternalLink, Music, Guitar, Headphones, Briefcase, GraduationCap,
   BookOpen, Users, Video, Heart, MapPin, Target, Mic, Star, Clapperboard
@@ -10,6 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useScheduledActivities, type ActivityType, type ScheduledActivity } from "@/hooks/useScheduledActivities";
 import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { formatDurationMinutes, getDisplayDurationMinutes } from "@/utils/activityBookingTime";
 
 interface DayScheduleProps {
   date: Date;
@@ -38,6 +39,7 @@ const ACTIVITY_ICONS: Record<ActivityType, typeof Music> = {
   release_manufacturing: Headphones,
   release_promo: Star,
   teaching: GraduationCap,
+  jam_session: Users,
   other: Clock,
 };
 
@@ -63,6 +65,7 @@ const ACTIVITY_COLORS: Record<ActivityType, string> = {
   release_manufacturing: "bg-sky-500/10 border-sky-500/30 text-sky-700 dark:text-sky-300",
   release_promo: "bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-300",
   teaching: "bg-indigo-500/10 border-indigo-500/30 text-indigo-700 dark:text-indigo-300",
+  jam_session: "bg-violet-500/10 border-violet-500/30 text-violet-700 dark:text-violet-300",
   other: "bg-slate-500/10 border-slate-500/30 text-slate-700 dark:text-slate-300",
 };
 
@@ -71,7 +74,7 @@ const TYPE_LABELS: Record<ActivityType, string> = {
   travel: "Travel", work: "Work", university: "Education", reading: "Reading", mentorship: "Mentorship",
   youtube_video: "Video", health: "Health", skill_practice: "Practice", open_mic: "Open mic",
   pr_appearance: "PR", film_production: "Film", festival_attendance: "Festival", festival_performance: "Festival gig",
-  release_manufacturing: "Release", release_promo: "Promotion", teaching: "Teaching", other: "Other",
+  release_manufacturing: "Release", release_promo: "Promotion", teaching: "Teaching", jam_session: "Jam session", other: "Other",
 };
 
 function getDetailHref(activity: ScheduledActivity) {
@@ -85,14 +88,7 @@ function getDetailHref(activity: ScheduledActivity) {
 }
 
 function formatDuration(activity: ScheduledActivity) {
-  if (activity.duration_minutes) return `${activity.duration_minutes} min`;
-  if (!activity.scheduled_end) return null;
-  const minutes = differenceInMinutes(new Date(activity.scheduled_end), new Date(activity.scheduled_start));
-  if (minutes <= 0) return null;
-  if (minutes < 60) return `${minutes} min`;
-  const hours = Math.floor(minutes / 60);
-  const remainder = minutes % 60;
-  return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+  return formatDurationMinutes(getDisplayDurationMinutes(activity));
 }
 
 export function DaySchedule({ date, userId }: DayScheduleProps) {

--- a/src/components/schedule/ScheduleActivityDialog.tsx
+++ b/src/components/schedule/ScheduleActivityDialog.tsx
@@ -35,6 +35,7 @@ const ACTIVITY_ROUTES: Record<ActivityType, { path: string; icon: any; label: st
   release_manufacturing: { path: '/release-manager', icon: Headphones, label: 'Release Manufacturing', description: 'Your release is being manufactured' },
   release_promo: { path: '/release-manager', icon: Star, label: 'Release Promo', description: 'Promotional tour for a release' },
   teaching: { path: '/teaching', icon: GraduationCap, label: 'Teaching Session', description: 'Teach a skill to a friend for bonus XP' },
+  jam_session: { path: '/jam-sessions', icon: Users, label: 'Jam Session', description: 'Book a collaborative jam session' },
   other: { path: '/schedule', icon: Calendar, label: 'Other Activity', description: 'Schedule a custom activity' },
 };
 

--- a/src/components/skills/SchedulePracticeDialog.tsx
+++ b/src/components/skills/SchedulePracticeDialog.tsx
@@ -11,7 +11,9 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Calendar } from "@/components/ui/calendar";
 import { usePracticeSkill } from "@/hooks/useSkillPractice";
-import { addHours, setHours, setMinutes, setSeconds, setMilliseconds } from "date-fns";
+import { setHours, setMinutes, setSeconds, setMilliseconds } from "date-fns";
+import { validateFutureBooking } from "@/utils/activityBookingTime";
+import { toast } from "sonner";
 
 interface SchedulePracticeDialogProps {
   open: boolean;
@@ -36,6 +38,12 @@ export function SchedulePracticeDialog({
     practiceDate = setMinutes(practiceDate, 0);
     practiceDate = setSeconds(practiceDate, 0);
     practiceDate = setMilliseconds(practiceDate, 0);
+
+    const bookingError = validateFutureBooking(practiceDate);
+    if (bookingError) {
+      toast.error(bookingError);
+      return;
+    }
 
     practiceSkill.mutate(
       {
@@ -71,7 +79,7 @@ export function SchedulePracticeDialog({
               mode="single"
               selected={selectedDate}
               onSelect={(date) => date && setSelectedDate(date)}
-              disabled={(date) => date < new Date()}
+              disabled={(day) => day < new Date(new Date().setHours(0, 0, 0, 0))}
               className="rounded-md border"
             />
           </div>

--- a/src/components/songwriting/SongwritingScheduleDialog.tsx
+++ b/src/components/songwriting/SongwritingScheduleDialog.tsx
@@ -6,7 +6,7 @@ import { Calendar } from "@/components/ui/calendar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { createScheduledActivity } from "@/hooks/useActivityBooking";
 import { toast } from "sonner";
-import { format } from "date-fns";
+import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 interface SongwritingScheduleDialogProps {
   open: boolean;
@@ -31,11 +31,13 @@ export function SongwritingScheduleDialog({
       return;
     }
 
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(parseInt(hour), 0, 0, 0);
-
-    const scheduledEnd = new Date(scheduledStart);
-    scheduledEnd.setHours(scheduledStart.getHours() + parseInt(duration));
+    const scheduledStart = buildScheduledDateTime(date, parseInt(hour));
+    const scheduledEnd = addDurationHours(scheduledStart, Number(duration));
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast.error(bookingError);
+      return;
+    }
 
     try {
       await createScheduledActivity({
@@ -68,7 +70,7 @@ export function SongwritingScheduleDialog({
               mode="single"
               selected={date}
               onSelect={setDate}
-              disabled={(date) => date < new Date()}
+              disabled={(day) => day < new Date(new Date().setHours(0, 0, 0, 0))}
               className="rounded-md border"
             />
           </div>

--- a/src/hooks/useActivityBooking.ts
+++ b/src/hooks/useActivityBooking.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { evaluateGate } from "@/lib/api/wellnessActivities";
 import type { ActivityType } from "./useScheduledActivities";
+import { getDurationMinutes, validateBookingWindow } from "@/utils/activityBookingTime";
 
 // Map our ActivityType union → the wellness gate's activity_type vocabulary.
 // `null` = intentionally bypass the gate (wellness/recovery actions themselves,
@@ -31,6 +32,7 @@ const WELLNESS_GATE_MAP: Record<ActivityType, string | null> = {
   release_manufacturing: null,
   release_promo: null,
   teaching: null,
+  jam_session: "jam",
   other: null,
 };
 
@@ -133,10 +135,9 @@ export async function checkTimeSlotAvailable(
  * Create a scheduled activity entry
  */
 export async function createScheduledActivity(params: BookingParams): Promise<string> {
-  // Validate that the scheduled start is in the future
-  const now = new Date();
-  if (params.scheduledStart <= now) {
-    throw new Error('Cannot book activities in the past. Please select a future time slot.');
+  const bookingError = validateBookingWindow(params.scheduledStart, params.scheduledEnd);
+  if (bookingError) {
+    throw new Error(bookingError);
   }
 
   let userId = params.userId;
@@ -185,6 +186,7 @@ export async function createScheduledActivity(params: BookingParams): Promise<st
       activity_type: params.activityType,
       scheduled_start: params.scheduledStart.toISOString(),
       scheduled_end: params.scheduledEnd.toISOString(),
+      duration_minutes: getDurationMinutes(params.scheduledStart, params.scheduledEnd),
       title: params.title,
       description: params.description,
       location: params.location,

--- a/src/hooks/useJamSessionBooking.ts
+++ b/src/hooks/useJamSessionBooking.ts
@@ -4,6 +4,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { REHEARSAL_SLOTS, getSlotTimeRange } from "@/utils/facilitySlots";
+import { getDurationMinutes, validateBookingWindow } from "@/utils/activityBookingTime";
 
 export interface BookJamSessionParams {
   name: string;
@@ -97,7 +98,7 @@ export const useJamSessionBooking = () => {
       activity_type: "jam_session",
       scheduled_start: scheduledStart.toISOString(),
       scheduled_end: scheduledEnd.toISOString(),
-      duration_minutes: Math.round((scheduledEnd.getTime() - scheduledStart.getTime()) / 60000),
+      duration_minutes: getDurationMinutes(scheduledStart, scheduledEnd),
       status: "scheduled",
       title: `Jam Session: ${sessionName}`,
       location: cityName || "Rehearsal Room",
@@ -137,6 +138,8 @@ export const useJamSessionBooking = () => {
 
       const { start: scheduledStart } = getSlotTimeRange(slot, params.selectedDate);
       const scheduledEnd = new Date(scheduledStart.getTime() + params.durationHours * 60 * 60 * 1000);
+      const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+      if (bookingError) throw new Error(bookingError);
 
       // Check for activity conflicts
       const { hasConflict, conflictTitle } = await checkActivityConflict(

--- a/src/hooks/useScheduledActivities.ts
+++ b/src/hooks/useScheduledActivities.ts
@@ -2,13 +2,14 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { startOfDay, endOfDay, addDays } from "date-fns";
+import { getDurationMinutes, validateBookingWindow } from "@/utils/activityBookingTime";
 
 export type ActivityType = 
   | 'songwriting' | 'gig' | 'rehearsal' | 'busking' | 'recording' 
   | 'travel' | 'work' | 'university' | 'reading' | 'mentorship' 
   | 'youtube_video' | 'health' | 'skill_practice' | 'open_mic' 
   | 'pr_appearance' | 'film_production' | 'festival_attendance' | 'festival_performance' 
-  | 'release_manufacturing' | 'release_promo' | 'teaching' | 'other';
+  | 'release_manufacturing' | 'release_promo' | 'teaching' | 'jam_session' | 'other';
 
 export type ActivityStatus = 'scheduled' | 'in_progress' | 'completed' | 'cancelled' | 'missed';
 
@@ -334,6 +335,9 @@ export function useCreateScheduledActivity() {
 
       if (!profile) throw new Error('Profile not found');
 
+      const bookingError = validateBookingWindow(data.scheduled_start, data.scheduled_end);
+      if (bookingError) throw new Error(bookingError);
+
       // Check for conflicts
       const { data: hasConflict } = await (supabase as any).rpc('check_scheduling_conflict', {
         p_user_id: user.id,
@@ -353,6 +357,7 @@ export function useCreateScheduledActivity() {
           activity_type: data.activity_type,
           scheduled_start: data.scheduled_start.toISOString(),
           scheduled_end: data.scheduled_end.toISOString(),
+          duration_minutes: getDurationMinutes(data.scheduled_start, data.scheduled_end),
           title: data.title,
           description: data.description,
           location: data.location,

--- a/src/pages/booking/EducationBooking.tsx
+++ b/src/pages/booking/EducationBooking.tsx
@@ -15,6 +15,7 @@ import { createScheduledActivity } from "@/hooks/useActivityBooking";
 import { useScheduleConflictCheck } from "@/hooks/useScheduleConflictCheck";
 import { ScheduleConflictAlert } from "@/components/ScheduleConflictAlert";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 export default function EducationBooking() {
   const navigate = useNavigate();
@@ -69,9 +70,13 @@ export default function EducationBooking() {
     }
 
     const [hours] = timeSlot.split(":").map(Number);
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(hours, 0, 0, 0);
-    const scheduledEnd = new Date(scheduledStart.getTime() + 60 * 60 * 1000);
+    const scheduledStart = buildScheduledDateTime(date, hours);
+    const scheduledEnd = addDurationHours(scheduledStart, 1);
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast({ title: "Choose a Future Time", description: bookingError, variant: "destructive" });
+      return;
+    }
 
     // Check for conflicts
     const conflict = await checkConflicts(scheduledStart, scheduledEnd);

--- a/src/pages/booking/PerformanceBooking.tsx
+++ b/src/pages/booking/PerformanceBooking.tsx
@@ -18,6 +18,7 @@ import { useScheduleConflictCheck } from "@/hooks/useScheduleConflictCheck";
 import { ScheduleConflictAlert } from "@/components/ScheduleConflictAlert";
 import { assertWellnessAllows } from "@/hooks/useActivityBooking";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { addDurationHours, buildScheduledDateTime, getDurationMinutes, validateBookingWindow } from "@/utils/activityBookingTime";
 
 export default function PerformanceBooking() {
   const navigate = useNavigate();
@@ -167,10 +168,14 @@ export default function PerformanceBooking() {
     }
 
     const [hours] = timeSlot.split(":").map(Number);
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(hours, 0, 0, 0);
     const durationHours = parseInt(duration);
-    const scheduledEnd = new Date(scheduledStart.getTime() + durationHours * 60 * 60 * 1000);
+    const scheduledStart = buildScheduledDateTime(date, hours);
+    const scheduledEnd = addDurationHours(scheduledStart, durationHours);
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast({ title: "Choose a Future Time", description: bookingError, variant: "destructive" });
+      return;
+    }
 
     // Check for conflicts
     const conflict = await checkConflicts(scheduledStart, scheduledEnd);
@@ -223,6 +228,7 @@ export default function PerformanceBooking() {
           activity_type: "rehearsal",
           scheduled_start: scheduledStart.toISOString(),
           scheduled_end: scheduledEnd.toISOString(),
+          duration_minutes: getDurationMinutes(scheduledStart, scheduledEnd),
           status: "scheduled",
           title: "Band Rehearsal",
           metadata: {
@@ -273,10 +279,14 @@ export default function PerformanceBooking() {
     }
 
     const [hours] = timeSlot.split(":").map(Number);
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(hours, 0, 0, 0);
     const durationHours = parseInt(duration);
-    const scheduledEnd = new Date(scheduledStart.getTime() + durationHours * 60 * 60 * 1000);
+    const scheduledStart = buildScheduledDateTime(date, hours);
+    const scheduledEnd = addDurationHours(scheduledStart, durationHours);
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast({ title: "Choose a Future Time", description: bookingError, variant: "destructive" });
+      return;
+    }
 
     // Check for conflicts
     const conflict = await checkConflicts(scheduledStart, scheduledEnd);
@@ -301,6 +311,7 @@ export default function PerformanceBooking() {
       activity_type: activityType,
       scheduled_start: scheduledStart.toISOString(),
       scheduled_end: scheduledEnd.toISOString(),
+      duration_minutes: getDurationMinutes(scheduledStart, scheduledEnd),
       status: "scheduled",
       title: `${activityType === "gig" ? "Gig" : activityType === "busking" ? "Busking" : "Songwriting"}`,
       metadata,

--- a/src/pages/booking/SongwritingBooking.tsx
+++ b/src/pages/booking/SongwritingBooking.tsx
@@ -13,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 export default function SongwritingBooking() {
   const navigate = useNavigate();
@@ -69,9 +70,13 @@ export default function SongwritingBooking() {
     }
 
     const [hours] = timeSlot.split(":").map(Number);
-    const scheduledStart = new Date(date);
-    scheduledStart.setHours(hours, 0, 0, 0);
-    const scheduledEnd = new Date(scheduledStart.getTime() + 60 * 60 * 1000); // 1 hour
+    const scheduledStart = buildScheduledDateTime(date, hours);
+    const scheduledEnd = addDurationHours(scheduledStart, 1);
+    const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
+    if (bookingError) {
+      toast({ title: "Choose a Future Time", description: bookingError, variant: "destructive" });
+      return;
+    }
 
     // Get project details
     const project = projects.find(p => p.id === selectedProjectId);

--- a/src/utils/__tests__/activityBookingTime.test.ts
+++ b/src/utils/__tests__/activityBookingTime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScheduledDateTime,
+  addDurationHours,
+  getDisplayDurationMinutes,
+  formatDurationMinutes,
+  validateBookingWindow,
+} from "../activityBookingTime";
+
+describe("activity booking time helpers", () => {
+  it("builds local scheduled times and adds multi-hour durations", () => {
+    const start = buildScheduledDateTime(new Date("2026-07-10T00:00:00.000Z"), 14);
+    const end = addDurationHours(start, 4);
+
+    expect(start.getHours()).toBe(14);
+    expect(getDisplayDurationMinutes({ scheduled_start: start.toISOString(), scheduled_end: end.toISOString(), duration_minutes: 60 })).toBe(240);
+  });
+
+  it("formats hour and partial-hour durations", () => {
+    expect(formatDurationMinutes(60)).toBe("1h");
+    expect(formatDurationMinutes(120)).toBe("2h");
+    expect(formatDurationMinutes(90)).toBe("1h 30m");
+  });
+
+  it("blocks past starts and allows future starts", () => {
+    const now = new Date("2026-07-09T12:00:00.000Z");
+    expect(validateBookingWindow(new Date("2026-07-09T11:00:00.000Z"), new Date("2026-07-09T12:00:00.000Z"), now)).toContain("future time");
+    expect(validateBookingWindow(new Date("2026-07-10T11:00:00.000Z"), new Date("2026-07-10T15:00:00.000Z"), now)).toBeNull();
+  });
+});

--- a/src/utils/activityBookingTime.ts
+++ b/src/utils/activityBookingTime.ts
@@ -1,0 +1,57 @@
+import { differenceInMinutes } from "date-fns";
+
+const MIN_DURATION_MINUTES = 1;
+
+export function buildScheduledDateTime(date: Date, hour: number, minute = 0): Date {
+  const scheduled = new Date(date);
+  scheduled.setHours(hour, minute, 0, 0);
+  return scheduled;
+}
+
+export function addDurationHours(start: Date, durationHours: number): Date {
+  return new Date(start.getTime() + durationHours * 60 * 60 * 1000);
+}
+
+export function getDurationMinutes(start: Date | string, end: Date | string): number {
+  const minutes = differenceInMinutes(new Date(end), new Date(start));
+  return Number.isFinite(minutes) ? minutes : 0;
+}
+
+export function getDisplayDurationMinutes(activity: {
+  scheduled_start: string;
+  scheduled_end?: string | null;
+  duration_minutes?: number | null;
+}): number | null {
+  const calculated = activity.scheduled_end
+    ? getDurationMinutes(activity.scheduled_start, activity.scheduled_end)
+    : 0;
+
+  if (calculated >= MIN_DURATION_MINUTES) return calculated;
+  if (typeof activity.duration_minutes === "number" && activity.duration_minutes >= MIN_DURATION_MINUTES) {
+    return activity.duration_minutes;
+  }
+  return null;
+}
+
+export function formatDurationMinutes(minutes: number | null): string | null {
+  if (!minutes || minutes < MIN_DURATION_MINUTES) return null;
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+}
+
+export function validateFutureBooking(start: Date, now = new Date()): string | null {
+  if (Number.isNaN(start.getTime())) return "Please choose a valid date and time.";
+  if (start <= now) return "Please choose a future time. Activities cannot be booked in the past.";
+  return null;
+}
+
+export function validateBookingWindow(start: Date, end: Date, now = new Date()): string | null {
+  const futureError = validateFutureBooking(start, now);
+  if (futureError) return futureError;
+  if (Number.isNaN(end.getTime()) || end <= start) {
+    return "Please choose a valid duration for this activity.";
+  }
+  return null;
+}


### PR DESCRIPTION
### Motivation
- Prevent users from booking activities in the past and ensure booking duration is saved and displayed consistently across booking flows and the schedule UI.
- Make date/time handling defensive and centralised to avoid duplicated logic and timezone-related mismatches between dashboard preview and full schedule.
- Apply consistent validation across rehearsals, jam sessions, recording sessions, lessons/education, songwriting, busking, gigs, and general scheduled-activity creation without changing database schema or UI.

### Description
- Added a small shared helper `src/utils/activityBookingTime.ts` with `buildScheduledDateTime`, `addDurationHours`, `getDurationMinutes`, `getDisplayDurationMinutes`, `formatDurationMinutes`, `validateFutureBooking`, and `validateBookingWindow` for consistent construction, validation, and formatting of schedule times and durations.
- Persisted calculated `duration_minutes` on scheduled activity inserts and applied `validateBookingWindow` in the canonical booking helper `createScheduledActivity` (`src/hooks/useActivityBooking.ts`) and the React Query mutation `useCreateScheduledActivity` (`src/hooks/useScheduledActivities.ts`).
- Wired defensive validation and helper usage into direct booking flows and dialogs (recording, songwriting, busking, rehearsals/performance flows, education/mentorship, jam session booking, and skill practice) so submissions are blocked early with clear messages; updated affected files to use `buildScheduledDateTime`, `addDurationHours`, and `validateBookingWindow` (examples: `src/pages/booking/PerformanceBooking.tsx`, `src/components/recording/RecordingScheduleDialog.tsx`, `src/components/songwriting/SongwritingScheduleDialog.tsx`, `src/components/busking/BuskingScheduleDialog.tsx`, `src/pages/booking/EducationBooking.tsx`, `src/hooks/useJamSessionBooking.ts`, `src/components/skills/SchedulePracticeDialog.tsx`).
- Updated schedule display logic in `src/components/schedule/DaySchedule.tsx` to prefer calculating duration from `scheduled_start`/`scheduled_end` and use the new formatter so multi-hour bookings render correctly instead of incorrectly showing 1 hour when a stale value existed; added `jam_session` into activity unions/routes where relevant.
- Added unit tests for the helpers at `src/utils/__tests__/activityBookingTime.test.ts` to cover local scheduled time construction, multi-hour duration computation/display, formatting, and past/future validation.

### Testing
- Added unit test file `src/utils/__tests__/activityBookingTime.test.ts` that exercises `buildScheduledDateTime`, `addDurationHours`, `getDisplayDurationMinutes`, `formatDurationMinutes`, and `validateBookingWindow` (test added but not executed due to environment constraints).
- Attempted to run the unit test with `npm run test -- src/utils/__tests__/activityBookingTime.test.ts --run`, but `vitest` was not available in the current checkout so the test run failed in this environment.
- Attempted `tsc`/`typecheck`, `eslint` and `vite build` but they could not be executed because project dependencies were not installed/available in this environment, so typecheck/lint/build steps could not be completed here.
- Low-level sanity check `git diff --check` (repository checks) passed locally in the change set; functional verification of booking flows and full CI should be run in the normal dev environment (with `npm install`) before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5021ff898483259dfc93ecac5f15ce)