### PR TITLE
Standardize beta form validation

### DIFF
--- a/src/components/band/BandCreationForm.tsx
+++ b/src/components/band/BandCreationForm.tsx
@@ -1,27 +1,40 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import { useActiveProfile } from '@/hooks/useActiveProfile';
-import logger from '@/lib/logger';
-import { Users, User, MapPin } from 'lucide-react';
-import { INSTRUMENT_ROLES, VOCAL_ROLES } from '@/utils/touringMembers';
-import { MUSIC_GENRES } from '@/data/genres';
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import logger from "@/lib/logger";
+import { Users, User, MapPin } from "lucide-react";
+import { INSTRUMENT_ROLES, VOCAL_ROLES } from "@/utils/touringMembers";
+import { MUSIC_GENRES } from "@/data/genres";
+import { getErrorMessage, validateRequired } from "@/utils/formValidation";
 
 interface BandCreationFormProps {
   onBandCreated?: () => void;
 }
 
 const getErrorContext = (error: unknown) => {
-  if (error && typeof error === 'object') {
+  if (error && typeof error === "object") {
     const candidate = error as {
       message?: string;
       code?: string;
@@ -30,7 +43,7 @@ const getErrorContext = (error: unknown) => {
     };
 
     return {
-      message: candidate.message ?? 'Unknown error',
+      message: candidate.message ?? "Unknown error",
       code: candidate.code,
       details: candidate.details,
       hint: candidate.hint,
@@ -38,51 +51,90 @@ const getErrorContext = (error: unknown) => {
   }
 
   return {
-    message: typeof error === 'string' ? error : 'Unknown error',
+    message: typeof error === "string" ? error : "Unknown error",
   };
 };
 
-export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) {
+export function BandCreationForm({
+  onBandCreated,
+}: BandCreationFormProps = {}) {
   const { profileId, userId } = useActiveProfile();
   const { toast } = useToast();
   const navigate = useNavigate();
-  const [creationMode, setCreationMode] = useState<'band' | 'solo'>('band');
-  const [name, setName] = useState('');
-  const [artistName, setArtistName] = useState('');
-  const [genre, setGenre] = useState('Rock');
-  const [description, setDescription] = useState('');
+  const [creationMode, setCreationMode] = useState<"band" | "solo">("band");
+  const [name, setName] = useState("");
+  const [artistName, setArtistName] = useState("");
+  const [genre, setGenre] = useState("Rock");
+  const [description, setDescription] = useState("");
   const [maxMembers, setMaxMembers] = useState(4);
-  const [instrumentRole, setInstrumentRole] = useState('Guitar');
-  const [vocalRole, setVocalRole] = useState('None');
-  const [homeCityId, setHomeCityId] = useState<string>('');
+  const [instrumentRole, setInstrumentRole] = useState("Guitar");
+  const [vocalRole, setVocalRole] = useState("None");
+  const [homeCityId, setHomeCityId] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const [formError, setFormError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Fetch cities for home city selector
   const { data: cities } = useQuery({
-    queryKey: ['creation-cities'],
+    queryKey: ["creation-cities"],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('cities')
-        .select('id, name, country')
-        .order('country')
-        .order('name');
+        .from("cities")
+        .select("id, name, country")
+        .order("country")
+        .order("name");
       if (error) throw error;
       return data ?? [];
     },
   });
 
   // Group cities by country
-  const citiesByCountry = cities?.reduce((acc, city) => {
-    const country = city.country || 'Unknown';
-    if (!acc[country]) acc[country] = [];
-    acc[country].push(city);
-    return acc;
-  }, {} as Record<string, typeof cities>) || {};
+  const citiesByCountry =
+    cities?.reduce(
+      (acc, city) => {
+        const country = city.country || "Unknown";
+        if (!acc[country]) acc[country] = [];
+        acc[country].push(city);
+        return acc;
+      },
+      {} as Record<string, typeof cities>,
+    ) || {};
 
   const sortedCountries = Object.keys(citiesByCountry).sort();
 
+  const validateForm = () => {
+    const errors: Record<string, string> = {};
+    const isSolo = creationMode === "solo";
+    const nameCheck = validateRequired(
+      isSolo ? artistName : name,
+      isSolo ? "Artist name" : "Band name",
+    );
+    if (!nameCheck.valid && nameCheck.message) errors.name = nameCheck.message;
+
+    const genreCheck = validateRequired(genre, "Genre");
+    if (!genreCheck.valid && genreCheck.message)
+      errors.genre = genreCheck.message;
+
+    const instrumentCheck = validateRequired(instrumentRole, "Instrument");
+    if (!instrumentCheck.valid && instrumentCheck.message)
+      errors.instrument = instrumentCheck.message;
+
+    if (
+      !isSolo &&
+      (!Number.isFinite(maxMembers) || maxMembers < 2 || maxMembers > 8)
+    ) {
+      errors.maxMembers = "Max members must be between 2 and 8.";
+    }
+
+    setFieldErrors(errors);
+    setFormError(Object.values(errors)[0] ?? "");
+    return Object.keys(errors).length === 0;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (loading || !validateForm()) return;
 
     setLoading(true);
     let createdBandId: string | null = null;
@@ -100,24 +152,28 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
       const authUserId = user?.id ?? userId;
 
       if (!profileId || !authUserId) {
-        logger.warn('Band creation blocked: missing active profile or auth user', {
-          profileId,
-          userId,
-        });
+        logger.warn(
+          "Band creation blocked: missing active profile or auth user",
+          {
+            profileId,
+            userId,
+          },
+        );
 
         toast({
-          title: 'Session issue',
-          description: 'We could not confirm your active character. Please refresh and try again.',
-          variant: 'destructive',
+          title: "Session issue",
+          description:
+            "We could not confirm your active character. Please refresh and try again.",
+          variant: "destructive",
         });
 
         return;
       }
 
-      const isSolo = creationMode === 'solo';
-      const bandName = isSolo ? (artistName || 'Solo Artist') : name;
+      const isSolo = creationMode === "solo";
+      const bandName = isSolo ? artistName || "Solo Artist" : name;
 
-      logger.info('Starting band creation', {
+      logger.info("Starting band creation", {
         profileId,
         authUserId,
         creationMode,
@@ -128,19 +184,19 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
 
       // Check if this profile is already in an active band
       const { data: existingBands } = await supabase
-        .from('band_members')
-        .select('band_id, is_touring_member, bands!inner(name, status)')
-        .eq('profile_id', profileId)
-        .eq('is_touring_member', false)
-        .eq('bands.status', 'active')
+        .from("band_members")
+        .select("band_id, is_touring_member, bands!inner(name, status)")
+        .eq("profile_id", profileId)
+        .eq("is_touring_member", false)
+        .eq("bands.status", "active")
         .limit(1);
 
       if (existingBands && existingBands.length > 0) {
-        const bandName = (existingBands[0].bands as any)?.name || 'a band';
+        const bandName = (existingBands[0].bands as any)?.name || "a band";
         toast({
-          title: 'Already in a band',
+          title: "Already in a band",
           description: `You're already a member of ${bandName}. Leave your current band first to create a new one.`,
-          variant: 'destructive',
+          variant: "destructive",
         });
         setLoading(false);
         return;
@@ -148,13 +204,13 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
 
       // Clean up any stray non-touring memberships that may have been left behind by old bugs
       const { error: cleanupError } = await supabase
-        .from('band_members')
+        .from("band_members")
         .delete()
-        .eq('profile_id', profileId)
-        .eq('is_touring_member', false);
+        .eq("profile_id", profileId)
+        .eq("is_touring_member", false);
 
       if (cleanupError) {
-        logger.warn('Band creation cleanup skipped', {
+        logger.warn("Band creation cleanup skipped", {
           profileId,
           authUserId,
           code: cleanupError.code,
@@ -165,12 +221,12 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
       }
 
       const { data: band, error: bandError } = await supabase
-        .from('bands')
+        .from("bands")
         .insert({
           name: bandName,
           leader_id: profileId,
           genre,
-          description: description || (isSolo ? 'Solo artist' : 'A new band'),
+          description: description || (isSolo ? "Solo artist" : "A new band"),
           max_members: isSolo ? 1 : maxMembers,
           is_solo_artist: isSolo,
           artist_name: isSolo ? artistName : null,
@@ -181,7 +237,7 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
         .single();
 
       if (bandError) {
-        logger.error('Band row creation failed', {
+        logger.error("Band row creation failed", {
           profileId,
           authUserId,
           bandName,
@@ -196,27 +252,27 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
 
       createdBandId = band.id;
 
-      logger.info('Creating founder membership for band', {
+      logger.info("Creating founder membership for band", {
         createdBandId,
         profileId,
         authUserId,
         instrumentRole,
-        hasVocalRole: vocalRole !== 'None',
+        hasVocalRole: vocalRole !== "None",
       });
 
       const { error: memberError } = await supabase
-        .from('band_members')
+        .from("band_members")
         .insert({
           band_id: band.id,
           user_id: authUserId,
           profile_id: profileId,
-          role: 'Founder',
+          role: "Founder",
           instrument_role: instrumentRole,
-          vocal_role: vocalRole === 'None' ? null : vocalRole,
+          vocal_role: vocalRole === "None" ? null : vocalRole,
         });
 
       if (memberError) {
-        logger.error('Founder membership creation failed', {
+        logger.error("Founder membership creation failed", {
           createdBandId,
           profileId,
           authUserId,
@@ -230,19 +286,21 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
       }
 
       toast({
-        title: isSolo ? 'Solo Artist Profile Created!' : 'Band Created!',
+        title: isSolo ? "Solo Artist Profile Created!" : "Band Created!",
         description: `${bandName} has been created successfully.`,
       });
 
       if (onBandCreated) {
         onBandCreated();
       } else {
-        navigate('/band');
+        navigate("/band");
       }
     } catch (error: any) {
       const errorContext = getErrorContext(error);
+      const friendlyMessage = getErrorMessage(error, "Failed to create band");
+      setFormError(friendlyMessage);
 
-      logger.error('Band creation failed', {
+      logger.error("Band creation failed", {
         profileId,
         userId,
         createdBandId,
@@ -251,9 +309,9 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
       });
 
       toast({
-        title: 'Error',
-        description: errorContext.message || 'Failed to create band',
-        variant: 'destructive',
+        title: "Error",
+        description: friendlyMessage,
+        variant: "destructive",
       });
     } finally {
       setLoading(false);
@@ -270,17 +328,26 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="space-y-4">
             <Label>What would you like to create?</Label>
-            <RadioGroup value={creationMode} onValueChange={(v) => setCreationMode(v as 'band' | 'solo')}>
+            <RadioGroup
+              value={creationMode}
+              onValueChange={(v) => setCreationMode(v as "band" | "solo")}
+            >
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="band" id="band" />
-                <Label htmlFor="band" className="flex items-center gap-2 cursor-pointer">
+                <Label
+                  htmlFor="band"
+                  className="flex items-center gap-2 cursor-pointer"
+                >
                   <Users className="h-4 w-4" />
                   Form a Band
                 </Label>
               </div>
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="solo" id="solo" />
-                <Label htmlFor="solo" className="flex items-center gap-2 cursor-pointer">
+                <Label
+                  htmlFor="solo"
+                  className="flex items-center gap-2 cursor-pointer"
+                >
                   <User className="h-4 w-4" />
                   Become a Solo Artist
                 </Label>
@@ -288,17 +355,29 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
             </RadioGroup>
           </div>
 
-          {creationMode === 'band' ? (
+          {creationMode === "band" ? (
             <>
               <div className="space-y-2">
                 <Label htmlFor="name">Band Name</Label>
                 <Input
                   id="name"
                   value={name}
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    setFieldErrors((prev) => ({ ...prev, name: "" }));
+                  }}
                   placeholder="The Rock Stars"
                   required
+                  aria-invalid={!!fieldErrors.name}
+                  aria-describedby={
+                    fieldErrors.name ? "band-name-error" : undefined
+                  }
                 />
+                {fieldErrors.name && (
+                  <p id="band-name-error" className="text-sm text-destructive">
+                    {fieldErrors.name}
+                  </p>
+                )}
               </div>
               <div className="space-y-2">
                 <Label htmlFor="maxMembers">Max Members</Label>
@@ -308,8 +387,20 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
                   min={2}
                   max={8}
                   value={maxMembers}
-                  onChange={(e) => setMaxMembers(parseInt(e.target.value))}
+                  onChange={(e) => setMaxMembers(Number(e.target.value))}
+                  aria-invalid={!!fieldErrors.maxMembers}
+                  aria-describedby={
+                    fieldErrors.maxMembers ? "max-members-error" : undefined
+                  }
                 />
+                {fieldErrors.maxMembers && (
+                  <p
+                    id="max-members-error"
+                    className="text-sm text-destructive"
+                  >
+                    {fieldErrors.maxMembers}
+                  </p>
+                )}
               </div>
             </>
           ) : (
@@ -318,10 +409,22 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
               <Input
                 id="artistName"
                 value={artistName}
-                onChange={(e) => setArtistName(e.target.value)}
+                onChange={(e) => {
+                  setArtistName(e.target.value);
+                  setFieldErrors((prev) => ({ ...prev, name: "" }));
+                }}
                 placeholder="Your stage name"
                 required
+                aria-invalid={!!fieldErrors.name}
+                aria-describedby={
+                  fieldErrors.name ? "artist-name-error" : undefined
+                }
               />
+              {fieldErrors.name && (
+                <p id="artist-name-error" className="text-sm text-destructive">
+                  {fieldErrors.name}
+                </p>
+              )}
             </div>
           )}
 
@@ -351,12 +454,12 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
                 <SelectValue placeholder="Select your band's home city" />
               </SelectTrigger>
               <SelectContent className="max-h-[300px]">
-                {sortedCountries.map(country => (
+                {sortedCountries.map((country) => (
                   <div key={country}>
                     <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50">
                       {country}
                     </div>
-                    {citiesByCountry[country]?.map(city => (
+                    {citiesByCountry[country]?.map((city) => (
                       <SelectItem key={city.id} value={city.id}>
                         {city.name}
                       </SelectItem>
@@ -365,16 +468,24 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
                 ))}
               </SelectContent>
             </Select>
-            <p className="text-xs text-muted-foreground">This helps with regional rankings and can only be set once</p>
+            <p className="text-xs text-muted-foreground">
+              This helps with regional rankings and can only be set once
+            </p>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="description">{creationMode === 'solo' ? 'Artist Bio' : 'Band Description'}</Label>
+            <Label htmlFor="description">
+              {creationMode === "solo" ? "Artist Bio" : "Band Description"}
+            </Label>
             <Textarea
               id="description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder={creationMode === 'solo' ? 'Tell your story...' : 'Describe your band...'}
+              placeholder={
+                creationMode === "solo"
+                  ? "Tell your story..."
+                  : "Describe your band..."
+              }
               rows={3}
             />
           </div>
@@ -411,8 +522,18 @@ export function BandCreationForm({ onBandCreated }: BandCreationFormProps = {}) 
             </Select>
           </div>
 
+          {formError && (
+            <p className="text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+
           <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? 'Creating...' : (creationMode === 'solo' ? 'Start Solo Career' : 'Create Band')}
+            {loading
+              ? "Creating..."
+              : creationMode === "solo"
+                ? "Start Solo Career"
+                : "Create Band"}
           </Button>
         </form>
       </CardContent>

--- a/src/components/jam-sessions/JamSessionBookingDialog.tsx
+++ b/src/components/jam-sessions/JamSessionBookingDialog.tsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from "react";
 import { useToast } from "@/components/ui/use-toast";
 import {
-  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,16 +15,44 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
-import { CalendarIcon, MapPin, Clock, Music, Users, DollarSign, Loader2 } from "lucide-react";
-import { REHEARSAL_SLOTS, FacilitySlot, getSlotTimeRange } from "@/utils/facilitySlots";
+import {
+  CalendarIcon,
+  MapPin,
+  Clock,
+  Music,
+  Users,
+  DollarSign,
+  Loader2,
+} from "lucide-react";
+import {
+  REHEARSAL_SLOTS,
+  FacilitySlot,
+  getSlotTimeRange,
+} from "@/utils/facilitySlots";
+import {
+  getErrorMessage,
+  validateDurationHours,
+  validateFutureOrTodayDate,
+  validateRequired,
+} from "@/utils/formValidation";
 import { useJamSessionBooking } from "@/hooks/useJamSessionBooking";
 import { MUSIC_GENRES } from "@/data/genres";
 import { useRehearsalRoomAvailability } from "@/hooks/useRehearsalRoomAvailability";
@@ -54,12 +87,17 @@ export const JamSessionBookingDialog = ({
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedSlotId, setSelectedSlotId] = useState("");
   const [durationHours, setDurationHours] = useState(2);
+  const [formError, setFormError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Fetch cities
   const { data: cities = [] } = useQuery({
     queryKey: ["cities"],
     queryFn: async () => {
-      const { data } = await supabase.from("cities").select("id, name, country").order("name");
+      const { data } = await supabase
+        .from("cities")
+        .select("id, name, country")
+        .order("name");
       return data || [];
     },
   });
@@ -82,62 +120,102 @@ export const JamSessionBookingDialog = ({
       const client = supabase as any;
       let query = client
         .from("rehearsal_rooms")
-        .select("id, name, hourly_rate, quality_rating, equipment_quality, capacity, city_id, city:cities(id, name)");
-      
+        .select(
+          "id, name, hourly_rate, quality_rating, equipment_quality, capacity, city_id, city:cities(id, name)",
+        );
+
       if (selectedCityId && selectedCityId !== "all") {
         query = query.eq("city_id", selectedCityId);
       }
-      
+
       const { data, error } = await query;
-      
+
       if (error) throw error;
-      
+
       return (data || []) as RoomWithCity[];
     },
     enabled: open,
   });
 
   // Check slot availability for the selected room and date
-  const { data: slotAvailability, isLoading: loadingSlots } = useRehearsalRoomAvailability(
-    selectedRoomId,
-    selectedDate,
-    undefined, // No band ID for jam sessions
-    !!selectedRoomId
-  );
+  const { data: slotAvailability, isLoading: loadingSlots } =
+    useRehearsalRoomAvailability(
+      selectedRoomId,
+      selectedDate,
+      undefined, // No band ID for jam sessions
+      !!selectedRoomId,
+    );
 
-  const selectedRoom = rooms.find(r => r.id === selectedRoomId);
+  const selectedRoom = rooms.find((r) => r.id === selectedRoomId);
   const totalCost = selectedRoom ? selectedRoom.hourly_rate * durationHours : 0;
   const estimatedCostPerPerson = Math.ceil(totalCost / maxParticipants);
   const canAfford = (profile?.cash || 0) >= totalCost;
 
   // Check if consecutive slots are available for the duration
   const slotsNeeded = Math.ceil(durationHours / 2);
-  
+
   const canBookSlot = (slotId: string): boolean => {
     if (!slotAvailability) return false;
-    
-    const slotIndex = REHEARSAL_SLOTS.findIndex(s => s.id === slotId);
+
+    const slotIndex = REHEARSAL_SLOTS.findIndex((s) => s.id === slotId);
     if (slotIndex === -1) return false;
 
     for (let i = 0; i < slotsNeeded; i++) {
       const checkSlot = REHEARSAL_SLOTS[slotIndex + i];
       if (!checkSlot) return false;
-      
-      const availability = slotAvailability.find(a => a.slot.id === checkSlot.id);
+
+      const availability = slotAvailability.find(
+        (a) => a.slot.id === checkSlot.id,
+      );
       if (!availability?.isAvailable) return false;
     }
     return true;
   };
 
-  const canBook = name.trim() && 
-    genre && 
-    selectedRoomId && 
-    selectedSlotId && 
-    canBookSlot(selectedSlotId) && 
-    canAfford;
+  const validateForm = () => {
+    const errors: Record<string, string> = {};
+    const checks = [
+      ["name", validateRequired(name, "Session name")],
+      ["genre", validateRequired(genre, "Genre")],
+      ["room", validateRequired(selectedRoomId, "Rehearsal room")],
+      ["date", validateFutureOrTodayDate(selectedDate)],
+      ["duration", validateDurationHours(durationHours, 2, 6)],
+      ["slot", validateRequired(selectedSlotId, "Time slot")],
+    ] as const;
+
+    checks.forEach(([key, result]) => {
+      if (!result.valid && result.message) errors[key] = result.message;
+    });
+
+    if (selectedSlotId && !canBookSlot(selectedSlotId)) {
+      errors.slot =
+        "Choose an available future time slot for the full duration.";
+    }
+
+    if (!canAfford) {
+      errors.balance = "You do not have enough cash for this booking.";
+    }
+
+    if (isPrivate && !accessCode.trim()) {
+      errors.accessCode = "Add an access code for private sessions.";
+    }
+
+    setFieldErrors(errors);
+    setFormError(Object.values(errors)[0] ?? "");
+    return Object.keys(errors).length === 0;
+  };
+
+  const canBook =
+    name.trim() &&
+    genre &&
+    selectedRoomId &&
+    selectedSlotId &&
+    canBookSlot(selectedSlotId) &&
+    canAfford &&
+    (!isPrivate || accessCode.trim());
 
   const handleBook = async () => {
-    if (!canBook || !selectedDate) return;
+    if (isBooking || !validateForm()) return;
 
     try {
       const sessionId = await bookJamSession({
@@ -168,14 +246,18 @@ export const JamSessionBookingDialog = ({
       setAccessCode("");
       setSelectedRoomId("");
       setSelectedSlotId("");
-      
+
       onOpenChange(false);
       onSuccess?.(sessionId);
-    } catch (error: any) {
-      console.error("Booking failed:", error);
+    } catch (error: unknown) {
+      const message = getErrorMessage(
+        error,
+        "Something went wrong while booking the jam session.",
+      );
+      setFormError(message);
       toast({
         title: "Booking Failed",
-        description: error.message || "Something went wrong while booking the jam session.",
+        description: message,
         variant: "destructive",
       });
     }
@@ -199,28 +281,48 @@ export const JamSessionBookingDialog = ({
             {/* Session Details */}
             <div className="space-y-4">
               <h3 className="font-semibold">Session Details</h3>
-              
+
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
-                  <Label>Session Name *</Label>
+                  <Label htmlFor="jam-name">Session Name *</Label>
                   <Input
+                    id="jam-name"
                     placeholder="Late Night Groove"
                     value={name}
-                    onChange={(e) => setName(e.target.value)}
+                    onChange={(e) => {
+                      setName(e.target.value);
+                      setFieldErrors((prev) => ({ ...prev, name: "" }));
+                    }}
+                    aria-invalid={!!fieldErrors.name}
+                    aria-describedby={
+                      fieldErrors.name ? "jam-name-error" : undefined
+                    }
                   />
+                  {fieldErrors.name && (
+                    <p id="jam-name-error" className="text-sm text-destructive">
+                      {fieldErrors.name}
+                    </p>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label>Genre *</Label>
                   <Select value={genre} onValueChange={setGenre}>
-                    <SelectTrigger>
+                    <SelectTrigger aria-invalid={!!fieldErrors.genre}>
                       <SelectValue placeholder="Select genre" />
                     </SelectTrigger>
                     <SelectContent>
-                      {MUSIC_GENRES.map(g => (
-                        <SelectItem key={g} value={g}>{g}</SelectItem>
+                      {MUSIC_GENRES.map((g) => (
+                        <SelectItem key={g} value={g}>
+                          {g}
+                        </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
+                  {fieldErrors.genre && (
+                    <p className="text-sm text-destructive">
+                      {fieldErrors.genre}
+                    </p>
+                  )}
                 </div>
               </div>
 
@@ -262,7 +364,9 @@ export const JamSessionBookingDialog = ({
                     min={0}
                     max={100}
                     value={skillRequirement}
-                    onChange={(e) => setSkillRequirement(Number(e.target.value))}
+                    onChange={(e) =>
+                      setSkillRequirement(Number(e.target.value))
+                    }
                   />
                 </div>
               </div>
@@ -270,19 +374,36 @@ export const JamSessionBookingDialog = ({
               <div className="flex items-center justify-between p-3 border rounded-lg">
                 <div>
                   <Label>Private Session</Label>
-                  <p className="text-xs text-muted-foreground">Require access code to join</p>
+                  <p className="text-xs text-muted-foreground">
+                    Require access code to join
+                  </p>
                 </div>
                 <Switch checked={isPrivate} onCheckedChange={setIsPrivate} />
               </div>
 
               {isPrivate && (
                 <div className="space-y-2">
-                  <Label>Access Code</Label>
+                  <Label htmlFor="jam-access-code">Access Code</Label>
                   <Input
+                    id="jam-access-code"
                     placeholder="e.g. GROOVE2025"
                     value={accessCode}
                     onChange={(e) => setAccessCode(e.target.value)}
+                    aria-invalid={!!fieldErrors.accessCode}
+                    aria-describedby={
+                      fieldErrors.accessCode
+                        ? "jam-access-code-error"
+                        : undefined
+                    }
                   />
+                  {fieldErrors.accessCode && (
+                    <p
+                      id="jam-access-code-error"
+                      className="text-sm text-destructive"
+                    >
+                      {fieldErrors.accessCode}
+                    </p>
+                  )}
                 </div>
               )}
             </div>
@@ -296,7 +417,14 @@ export const JamSessionBookingDialog = ({
                   <MapPin className="h-4 w-4" />
                   Filter by City
                 </Label>
-                <Select value={selectedCityId} onValueChange={(v) => { setSelectedCityId(v); setSelectedRoomId(""); setSelectedSlotId(""); }}>
+                <Select
+                  value={selectedCityId}
+                  onValueChange={(v) => {
+                    setSelectedCityId(v);
+                    setSelectedRoomId("");
+                    setSelectedSlotId("");
+                  }}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select a city..." />
                   </SelectTrigger>
@@ -318,22 +446,36 @@ export const JamSessionBookingDialog = ({
                     No rehearsal rooms available.
                   </p>
                 ) : (
-                  <RadioGroup value={selectedRoomId} onValueChange={(v) => { setSelectedRoomId(v); setSelectedSlotId(""); }}>
+                  <RadioGroup
+                    value={selectedRoomId}
+                    onValueChange={(v) => {
+                      setSelectedRoomId(v);
+                      setSelectedSlotId("");
+                    }}
+                  >
                     <div className="grid gap-2">
                       {rooms.slice(0, 6).map((room) => (
                         <div
                           key={room.id}
                           className={cn(
-                            'flex items-start space-x-3 rounded-lg border p-3 transition-colors cursor-pointer',
-                            selectedRoomId === room.id && 'border-primary bg-primary/5'
+                            "flex items-start space-x-3 rounded-lg border p-3 transition-colors cursor-pointer",
+                            selectedRoomId === room.id &&
+                              "border-primary bg-primary/5",
                           )}
-                          onClick={() => { setSelectedRoomId(room.id); setSelectedSlotId(""); }}
+                          onClick={() => {
+                            setSelectedRoomId(room.id);
+                            setSelectedSlotId("");
+                          }}
                         >
                           <RadioGroupItem value={room.id} />
                           <div className="flex-1 space-y-1">
                             <div className="flex items-center justify-between">
-                              <Label className="font-semibold cursor-pointer">{room.name}</Label>
-                              <Badge variant="outline">${room.hourly_rate}/hr</Badge>
+                              <Label className="font-semibold cursor-pointer">
+                                {room.name}
+                              </Label>
+                              <Badge variant="outline">
+                                ${room.hourly_rate}/hr
+                              </Badge>
                             </div>
                             {room.city && (
                               <p className="text-xs text-muted-foreground flex items-center gap-1">
@@ -363,7 +505,10 @@ export const JamSessionBookingDialog = ({
                       </Label>
                       <Popover>
                         <PopoverTrigger asChild>
-                          <Button variant="outline" className="w-full justify-start text-left font-normal">
+                          <Button
+                            variant="outline"
+                            className="w-full justify-start text-left font-normal"
+                          >
                             {format(selectedDate, "PPP")}
                           </Button>
                         </PopoverTrigger>
@@ -383,7 +528,13 @@ export const JamSessionBookingDialog = ({
                         <Clock className="h-4 w-4" />
                         Duration
                       </Label>
-                      <Select value={durationHours.toString()} onValueChange={(v) => { setDurationHours(Number(v)); setSelectedSlotId(""); }}>
+                      <Select
+                        value={durationHours.toString()}
+                        onValueChange={(v) => {
+                          setDurationHours(Number(v));
+                          setSelectedSlotId("");
+                        }}
+                      >
                         <SelectTrigger>
                           <SelectValue />
                         </SelectTrigger>
@@ -407,7 +558,7 @@ export const JamSessionBookingDialog = ({
                         {REHEARSAL_SLOTS.map((slot) => {
                           const available = canBookSlot(slot.id);
                           const isSelected = selectedSlotId === slot.id;
-                          
+
                           return (
                             <Button
                               key={slot.id}
@@ -417,7 +568,7 @@ export const JamSessionBookingDialog = ({
                               onClick={() => setSelectedSlotId(slot.id)}
                               className={cn(
                                 !available && "opacity-50 cursor-not-allowed",
-                                isSelected && "ring-2 ring-primary"
+                                isSelected && "ring-2 ring-primary",
                               )}
                             >
                               {slot.name}
@@ -441,7 +592,9 @@ export const JamSessionBookingDialog = ({
                 <div className="grid gap-2 text-sm">
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Room Rate</span>
-                    <span>${selectedRoom.hourly_rate}/hr × {durationHours}hrs</span>
+                    <span>
+                      ${selectedRoom.hourly_rate}/hr × {durationHours}hrs
+                    </span>
                   </div>
                   <div className="flex justify-between font-semibold">
                     <span>Total Cost</span>
@@ -459,7 +612,8 @@ export const JamSessionBookingDialog = ({
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  You pay the full amount upfront. Cost is split as musicians join.
+                  You pay the full amount upfront. Cost is split as musicians
+                  join.
                 </p>
               </div>
             )}
@@ -467,7 +621,16 @@ export const JamSessionBookingDialog = ({
         </ScrollArea>
 
         <DialogFooter className="flex-shrink-0 pt-4 border-t">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          {formError && (
+            <p className="mr-auto text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isBooking}
+          >
             Cancel
           </Button>
           <Button onClick={handleBook} disabled={!canBook || isBooking}>

--- a/src/components/performance/RehearsalBookingDialog.tsx
+++ b/src/components/performance/RehearsalBookingDialog.tsx
@@ -1,28 +1,68 @@
-import React, { useState, useEffect } from 'react';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Calendar } from '@/components/ui/calendar';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { DollarSign, Clock, TrendingUp, Music2, Zap, AlertCircle, CheckCircle, MapPin, Ban } from 'lucide-react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { format, isSameDay } from 'date-fns';
-import { CalendarIcon } from 'lucide-react';
-import type { Database } from '@/lib/supabase-types';
-import { cn } from '@/lib/utils';
-import { supabase } from '@/integrations/supabase/client';
-import { getRehearsalLevel, formatRehearsalTime } from '@/utils/rehearsalLevels';
-import { REHEARSAL_SLOTS, getSlotTimeRange, FacilitySlot } from '@/utils/facilitySlots';
-import { useRehearsalRoomAvailability } from '@/hooks/useRehearsalRoomAvailability';
-import { isSlotInPast } from '@/utils/timeSlotValidation';
+import React, { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  DollarSign,
+  Clock,
+  TrendingUp,
+  Music2,
+  Zap,
+  AlertCircle,
+  CheckCircle,
+  MapPin,
+  Ban,
+} from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { format, isSameDay } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import type { Database } from "@/lib/supabase-types";
+import { cn } from "@/lib/utils";
+import { supabase } from "@/integrations/supabase/client";
+import {
+  getRehearsalLevel,
+  formatRehearsalTime,
+} from "@/utils/rehearsalLevels";
+import {
+  REHEARSAL_SLOTS,
+  getSlotTimeRange,
+  FacilitySlot,
+} from "@/utils/facilitySlots";
+import { useRehearsalRoomAvailability } from "@/hooks/useRehearsalRoomAvailability";
+import { isSlotInPast } from "@/utils/timeSlotValidation";
+import {
+  getErrorMessage,
+  validateDurationHours,
+  validateFutureOrTodayDate,
+  validateRequired,
+} from "@/utils/formValidation";
 
-type RehearsalRoom = Database['public']['Tables']['rehearsal_rooms']['Row'] & {
+type RehearsalRoom = Database["public"]["Tables"]["rehearsal_rooms"]["Row"] & {
   city?: { id: string; name: string } | null;
 };
-type Band = Database['public']['Tables']['bands']['Row'];
+type Band = Database["public"]["Tables"]["bands"]["Row"];
 type City = { id: string; name: string };
 
 interface RehearsalBookingDialogProps {
@@ -31,47 +71,68 @@ interface RehearsalBookingDialogProps {
   currentCityId: string | null;
   band: Band;
   songs: any[];
-  onConfirm: (roomId: string, duration: number, songId: string | null, setlistId: string | null, scheduledStart: Date) => Promise<string | void>;
+  onConfirm: (
+    roomId: string,
+    duration: number,
+    songId: string | null,
+    setlistId: string | null,
+    scheduledStart: Date,
+  ) => Promise<string | void>;
   onClose: () => void;
 }
 
-export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, songs, onConfirm, onClose }: RehearsalBookingDialogProps) => {
-  const [selectedCityId, setSelectedCityId] = useState<string>(currentCityId || 'all');
-  const [selectedRoomId, setSelectedRoomId] = useState<string>('');
+export const RehearsalBookingDialog = ({
+  rooms,
+  cities,
+  currentCityId,
+  band,
+  songs,
+  onConfirm,
+  onClose,
+}: RehearsalBookingDialogProps) => {
+  const [selectedCityId, setSelectedCityId] = useState<string>(
+    currentCityId || "all",
+  );
+  const [selectedRoomId, setSelectedRoomId] = useState<string>("");
   const [selectedDuration, setSelectedDuration] = useState<number>(2);
-  const [practiceType, setPracticeType] = useState<'song' | 'setlist'>('song');
-  const [selectedSongId, setSelectedSongId] = useState<string>('');
-  const [selectedSetlistId, setSelectedSetlistId] = useState<string>('');
+  const [practiceType, setPracticeType] = useState<"song" | "setlist">("song");
+  const [selectedSongId, setSelectedSongId] = useState<string>("");
+  const [selectedSetlistId, setSelectedSetlistId] = useState<string>("");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [selectedSlotId, setSelectedSlotId] = useState<string>('');
+  const [selectedSlotId, setSelectedSlotId] = useState<string>("");
   const [booking, setBooking] = useState(false);
   const [setlists, setSetlists] = useState<any[]>([]);
-  const [songFamiliarity, setSongFamiliarity] = useState<Record<string, number>>({});
+  const [songFamiliarity, setSongFamiliarity] = useState<
+    Record<string, number>
+  >({});
+  const [formError, setFormError] = useState("");
 
   // Filter rooms by selected city
-  const filteredRooms = selectedCityId === 'all' 
-    ? rooms 
-    : rooms.filter(room => room.city_id === selectedCityId);
+  const filteredRooms =
+    selectedCityId === "all"
+      ? rooms
+      : rooms.filter((room) => room.city_id === selectedCityId);
 
   // Fetch slot availability for the selected room and date
-  const { data: slotAvailability, isLoading: loadingSlots } = useRehearsalRoomAvailability(
-    selectedRoomId,
-    selectedDate,
-    band.id,
-    !!selectedRoomId
-  );
+  const { data: slotAvailability, isLoading: loadingSlots } =
+    useRehearsalRoomAvailability(
+      selectedRoomId,
+      selectedDate,
+      band.id,
+      !!selectedRoomId,
+    );
 
   useEffect(() => {
     const loadSetlists = async () => {
       const { data } = await supabase
-        .from('setlists')
-        .select('id, name')
-        .eq('band_id', band.id)
-        .eq('is_active', true);
-      
+        .from("setlists")
+        .select("id, name")
+        .eq("band_id", band.id)
+        .eq("is_active", true);
+
       setSetlists(data || []);
     };
-    
+
     loadSetlists();
   }, [band.id]);
 
@@ -79,36 +140,42 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
   useEffect(() => {
     const loadFamiliarity = async () => {
       if (!songs.length || !band.id) return;
-      
-      const songIds = songs.map(s => s.id);
+
+      const songIds = songs.map((s) => s.id);
       const { data } = await supabase
-        .from('band_song_familiarity')
-        .select('song_id, familiarity_minutes')
-        .eq('band_id', band.id)
-        .in('song_id', songIds);
-      
+        .from("band_song_familiarity")
+        .select("song_id, familiarity_minutes")
+        .eq("band_id", band.id)
+        .in("song_id", songIds);
+
       const familiarityMap: Record<string, number> = {};
-      data?.forEach(item => {
+      data?.forEach((item) => {
         familiarityMap[item.song_id] = item.familiarity_minutes;
       });
       setSongFamiliarity(familiarityMap);
     };
-    
+
     loadFamiliarity();
   }, [songs, band.id]);
 
   // Calculate how many consecutive slots are needed for the selected duration
   const slotsNeeded = Math.ceil(selectedDuration / 2);
 
-  const selectedRoom = rooms.find(r => r.id === selectedRoomId);
-  const totalCost = selectedRoom ? selectedRoom.hourly_rate * selectedDuration : 0;
-  const chemistryGain = selectedRoom ? Math.floor((selectedRoom.quality_rating / 10) * selectedDuration) : 0;
-  const xpGain = selectedRoom ? Math.floor(75 * selectedDuration * (selectedRoom.equipment_quality / 100)) : 0;
+  const selectedRoom = rooms.find((r) => r.id === selectedRoomId);
+  const totalCost = selectedRoom
+    ? selectedRoom.hourly_rate * selectedDuration
+    : 0;
+  const chemistryGain = selectedRoom
+    ? Math.floor((selectedRoom.quality_rating / 10) * selectedDuration)
+    : 0;
+  const xpGain = selectedRoom
+    ? Math.floor(75 * selectedDuration * (selectedRoom.equipment_quality / 100))
+    : 0;
   const familiarityGain = selectedDuration * 60;
 
   // Check if a slot has passed (for today only)
   const isSlotPast = (slotId: string): boolean => {
-    const slot = REHEARSAL_SLOTS.find(s => s.id === slotId);
+    const slot = REHEARSAL_SLOTS.find((s) => s.id === slotId);
     if (!slot) return false;
     return isSlotInPast(slot, selectedDate);
   };
@@ -116,8 +183,8 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
   // Check if consecutive slots are available for the selected duration
   const canBookSlot = (slotId: string): boolean => {
     if (!slotAvailability) return false;
-    
-    const slotIndex = REHEARSAL_SLOTS.findIndex(s => s.id === slotId);
+
+    const slotIndex = REHEARSAL_SLOTS.findIndex((s) => s.id === slotId);
     if (slotIndex === -1) return false;
 
     // Check if the first slot has already passed
@@ -128,48 +195,79 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
     for (let i = 0; i < slotsNeeded; i++) {
       const checkIndex = slotIndex + i;
       if (checkIndex >= REHEARSAL_SLOTS.length) return false;
-      
+
       const checkSlotId = REHEARSAL_SLOTS[checkIndex].id;
-      const slotData = slotAvailability.find(s => s.slot.id === checkSlotId);
+      const slotData = slotAvailability.find((s) => s.slot.id === checkSlotId);
       if (!slotData || !slotData.isAvailable) return false;
     }
-    
+
     return true;
   };
 
+  const validateForm = () => {
+    const checks = [
+      validateRequired(selectedRoomId, "Rehearsal room"),
+      validateFutureOrTodayDate(selectedDate),
+      validateDurationHours(selectedDuration, 1, 8),
+      validateRequired(selectedSlotId, "Time slot"),
+      practiceType === "song"
+        ? validateRequired(selectedSongId, "Song")
+        : validateRequired(selectedSetlistId, "Setlist"),
+    ];
+
+    const failedCheck = checks.find((check) => !check.valid);
+    if (failedCheck?.message) return failedCheck.message;
+
+    if (!canBookSlot(selectedSlotId)) {
+      return "Choose an available future time slot for the full rehearsal.";
+    }
+
+    if (!canAfford) {
+      return "Your band does not have enough funds for this rehearsal.";
+    }
+
+    return "";
+  };
+
   const handleConfirm = async () => {
-    if (!selectedRoomId || !selectedSlotId) return;
-    if (practiceType === 'song' && !selectedSongId) return;
-    if (practiceType === 'setlist' && !selectedSetlistId) return;
-    
+    if (booking) return;
+
+    const validationMessage = validateForm();
+    setFormError(validationMessage);
+    if (validationMessage) return;
+
     setBooking(true);
     try {
       // Get the slot and calculate start time
-      const slot = REHEARSAL_SLOTS.find(s => s.id === selectedSlotId);
-      if (!slot) throw new Error('Invalid slot');
+      const slot = REHEARSAL_SLOTS.find((s) => s.id === selectedSlotId);
+      if (!slot) throw new Error("Invalid slot");
 
       const { start } = getSlotTimeRange(slot, selectedDate);
-      
+
       await onConfirm(
         selectedRoomId,
         selectedDuration,
-        practiceType === 'song' ? selectedSongId : null,
-        practiceType === 'setlist' ? selectedSetlistId : null,
-        start
+        practiceType === "song" ? selectedSongId : null,
+        practiceType === "setlist" ? selectedSetlistId : null,
+        start,
       );
-      
+
       onClose();
     } catch (error) {
-      console.error('Failed to book rehearsal:', error);
+      setFormError(
+        getErrorMessage(error, "Unable to book rehearsal right now."),
+      );
     } finally {
       setBooking(false);
     }
   };
 
   const canAfford = (band.band_balance || 0) >= totalCost;
-  const canBook = selectedRoomId && 
+  const canBook =
+    selectedRoomId &&
     selectedSlotId &&
-    ((practiceType === 'song' && selectedSongId) || (practiceType === 'setlist' && selectedSetlistId)) &&
+    ((practiceType === "song" && selectedSongId) ||
+      (practiceType === "setlist" && selectedSetlistId)) &&
     canAfford &&
     canBookSlot(selectedSlotId);
 
@@ -190,7 +288,14 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
               <MapPin className="h-4 w-4" />
               Filter by City
             </Label>
-            <Select value={selectedCityId} onValueChange={(v) => { setSelectedCityId(v); setSelectedRoomId(''); setSelectedSlotId(''); }}>
+            <Select
+              value={selectedCityId}
+              onValueChange={(v) => {
+                setSelectedCityId(v);
+                setSelectedRoomId("");
+                setSelectedSlotId("");
+              }}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Select a city..." />
               </SelectTrigger>
@@ -213,20 +318,32 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                 No rehearsal rooms available in this city.
               </p>
             ) : (
-              <RadioGroup value={selectedRoomId} onValueChange={(v) => { setSelectedRoomId(v); setSelectedSlotId(''); }}>
+              <RadioGroup
+                value={selectedRoomId}
+                onValueChange={(v) => {
+                  setSelectedRoomId(v);
+                  setSelectedSlotId("");
+                }}
+              >
                 {filteredRooms.map((room) => (
                   <div
                     key={room.id}
                     className={cn(
-                      'flex items-start space-x-3 rounded-lg border p-4 transition-colors cursor-pointer',
-                      selectedRoomId === room.id && 'border-primary bg-primary/5'
+                      "flex items-start space-x-3 rounded-lg border p-4 transition-colors cursor-pointer",
+                      selectedRoomId === room.id &&
+                        "border-primary bg-primary/5",
                     )}
-                    onClick={() => { setSelectedRoomId(room.id); setSelectedSlotId(''); }}
+                    onClick={() => {
+                      setSelectedRoomId(room.id);
+                      setSelectedSlotId("");
+                    }}
                   >
                     <RadioGroupItem value={room.id} />
                     <div className="flex-1 space-y-2">
                       <div className="flex items-center justify-between">
-                        <Label className="font-semibold cursor-pointer">{room.name}</Label>
+                        <Label className="font-semibold cursor-pointer">
+                          {room.name}
+                        </Label>
                         <Badge variant="outline">${room.hourly_rate}/hr</Badge>
                       </div>
                       {room.city && (
@@ -236,7 +353,9 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                         </p>
                       )}
                       {room.description && (
-                        <p className="text-sm text-muted-foreground">{room.description}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {room.description}
+                        </p>
                       )}
                       <div className="flex gap-3 text-xs text-muted-foreground">
                         <span>Quality: {room.quality_rating}/100</span>
@@ -259,20 +378,31 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                   <Button
                     variant="outline"
                     className={cn(
-                      'w-full justify-start text-left font-normal',
-                      !selectedDate && 'text-muted-foreground'
+                      "w-full justify-start text-left font-normal",
+                      !selectedDate && "text-muted-foreground",
                     )}
                   >
                     <CalendarIcon className="mr-2 h-4 w-4" />
-                    {selectedDate ? format(selectedDate, 'PPP') : <span>Pick a date</span>}
+                    {selectedDate ? (
+                      format(selectedDate, "PPP")
+                    ) : (
+                      <span>Pick a date</span>
+                    )}
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
                   <Calendar
                     mode="single"
                     selected={selectedDate}
-                    onSelect={(date) => { if (date) { setSelectedDate(date); setSelectedSlotId(''); } }}
-                    disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                    onSelect={(date) => {
+                      if (date) {
+                        setSelectedDate(date);
+                        setSelectedSlotId("");
+                      }
+                    }}
+                    disabled={(date) =>
+                      date < new Date(new Date().setHours(0, 0, 0, 0))
+                    }
                     initialFocus
                     className={cn("p-3 pointer-events-auto")}
                   />
@@ -285,7 +415,13 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
           {selectedRoomId && (
             <div className="space-y-2">
               <Label htmlFor="duration">Duration</Label>
-              <Select value={selectedDuration.toString()} onValueChange={(v) => { setSelectedDuration(parseInt(v)); setSelectedSlotId(''); }}>
+              <Select
+                value={selectedDuration.toString()}
+                onValueChange={(v) => {
+                  setSelectedDuration(parseInt(v));
+                  setSelectedSlotId("");
+                }}
+              >
                 <SelectTrigger id="duration">
                   <SelectValue />
                 </SelectTrigger>
@@ -297,7 +433,8 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">
-                Requires {slotsNeeded} consecutive slot{slotsNeeded > 1 ? 's' : ''}
+                Requires {slotsNeeded} consecutive slot
+                {slotsNeeded > 1 ? "s" : ""}
               </p>
             </div>
           )}
@@ -311,10 +448,15 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                   <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-primary" />
                 </div>
               ) : (
-                <RadioGroup value={selectedSlotId} onValueChange={setSelectedSlotId}>
+                <RadioGroup
+                  value={selectedSlotId}
+                  onValueChange={setSelectedSlotId}
+                >
                   <div className="grid grid-cols-2 gap-2">
-                  {REHEARSAL_SLOTS.map((slot) => {
-                      const slotData = slotAvailability?.find(s => s.slot.id === slot.id);
+                    {REHEARSAL_SLOTS.map((slot) => {
+                      const slotData = slotAvailability?.find(
+                        (s) => s.slot.id === slot.id,
+                      );
                       const isBooked = slotData?.isBooked || false;
                       const isYourBooking = slotData?.isYourBooking || false;
                       const bookedBy = slotData?.bookedByBand;
@@ -325,35 +467,59 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                         <div
                           key={slot.id}
                           className={cn(
-                            'flex items-center space-x-2 rounded-lg border p-3 transition-colors',
-                            selectedSlotId === slot.id && 'border-primary bg-primary/5',
-                            isPast && 'bg-muted/50 border-muted opacity-60 cursor-not-allowed',
-                            isBooked && !isYourBooking && !isPast && 'bg-red-500/10 border-red-500/30',
-                            isYourBooking && !isPast && 'bg-blue-500/10 border-blue-500/30',
-                            !canSelect && !isPast && 'opacity-50 cursor-not-allowed',
-                            canSelect && 'cursor-pointer hover:bg-accent/50'
+                            "flex items-center space-x-2 rounded-lg border p-3 transition-colors",
+                            selectedSlotId === slot.id &&
+                              "border-primary bg-primary/5",
+                            isPast &&
+                              "bg-muted/50 border-muted opacity-60 cursor-not-allowed",
+                            isBooked &&
+                              !isYourBooking &&
+                              !isPast &&
+                              "bg-red-500/10 border-red-500/30",
+                            isYourBooking &&
+                              !isPast &&
+                              "bg-blue-500/10 border-blue-500/30",
+                            !canSelect &&
+                              !isPast &&
+                              "opacity-50 cursor-not-allowed",
+                            canSelect && "cursor-pointer hover:bg-accent/50",
                           )}
-                          onClick={() => canSelect && setSelectedSlotId(slot.id)}
+                          onClick={() =>
+                            canSelect && setSelectedSlotId(slot.id)
+                          }
                         >
-                          <RadioGroupItem value={slot.id} disabled={!canSelect} />
+                          <RadioGroupItem
+                            value={slot.id}
+                            disabled={!canSelect}
+                          />
                           <div className="flex-1">
                             <div className="flex items-center justify-between">
-                              <Label className={cn(
-                                "text-sm font-medium",
-                                canSelect && "cursor-pointer",
-                                isPast && "text-muted-foreground"
-                              )}>{slot.name}</Label>
+                              <Label
+                                className={cn(
+                                  "text-sm font-medium",
+                                  canSelect && "cursor-pointer",
+                                  isPast && "text-muted-foreground",
+                                )}
+                              >
+                                {slot.name}
+                              </Label>
                               {isPast ? (
                                 <Badge variant="secondary" className="text-xs">
                                   <Ban className="h-3 w-3 mr-1" />
                                   Passed
                                 </Badge>
                               ) : isBooked ? (
-                                <Badge variant="destructive" className="text-xs">
-                                  {isYourBooking ? 'Your booking' : 'Booked'}
+                                <Badge
+                                  variant="destructive"
+                                  className="text-xs"
+                                >
+                                  {isYourBooking ? "Your booking" : "Booked"}
                                 </Badge>
                               ) : canSelect ? (
-                                <Badge variant="outline" className="text-xs bg-green-500/10 text-green-700 dark:text-green-400">
+                                <Badge
+                                  variant="outline"
+                                  className="text-xs bg-green-500/10 text-green-700 dark:text-green-400"
+                                >
                                   <CheckCircle className="h-3 w-3 mr-1" />
                                   Available
                                 </Badge>
@@ -368,7 +534,9 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                               {slot.startTime} - {slot.endTime}
                             </div>
                             {bookedBy && !isYourBooking && !isPast && (
-                              <p className="text-xs text-destructive mt-1">{bookedBy}</p>
+                              <p className="text-xs text-destructive mt-1">
+                                {bookedBy}
+                              </p>
                             )}
                           </div>
                         </div>
@@ -383,22 +551,29 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
           {/* Practice Type Selection */}
           <div className="space-y-2">
             <Label>What to Practice</Label>
-            <RadioGroup value={practiceType} onValueChange={(v: any) => setPracticeType(v)}>
+            <RadioGroup
+              value={practiceType}
+              onValueChange={(v: any) => setPracticeType(v)}
+            >
               <div className="flex gap-4">
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="song" id="type-song" />
-                  <Label htmlFor="type-song" className="cursor-pointer">Single Song</Label>
+                  <Label htmlFor="type-song" className="cursor-pointer">
+                    Single Song
+                  </Label>
                 </div>
                 <div className="flex items-center space-x-2">
                   <RadioGroupItem value="setlist" id="type-setlist" />
-                  <Label htmlFor="type-setlist" className="cursor-pointer">Entire Setlist</Label>
+                  <Label htmlFor="type-setlist" className="cursor-pointer">
+                    Entire Setlist
+                  </Label>
                 </div>
               </div>
             </RadioGroup>
           </div>
 
           {/* Song/Setlist Selection */}
-          {practiceType === 'song' ? (
+          {practiceType === "song" ? (
             <div className="space-y-2">
               <Label htmlFor="song">Song to Practice</Label>
               <Select value={selectedSongId} onValueChange={setSelectedSongId}>
@@ -415,11 +590,15 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                       const minutes = songFamiliarity[song.id] || 0;
                       const level = getRehearsalLevel(minutes);
                       return (
-                        <SelectItem key={song.id} value={song.id} className="py-2">
+                        <SelectItem
+                          key={song.id}
+                          value={song.id}
+                          className="py-2"
+                        >
                           <div className="flex items-center justify-between gap-3 w-full">
                             <span className="truncate">{song.title}</span>
-                            <Badge 
-                              variant={level.variant} 
+                            <Badge
+                              variant={level.variant}
                               className="text-xs shrink-0 ml-auto"
                             >
                               {level.name}
@@ -435,7 +614,10 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
           ) : (
             <div className="space-y-2">
               <Label htmlFor="setlist">Setlist to Practice</Label>
-              <Select value={selectedSetlistId} onValueChange={setSelectedSetlistId}>
+              <Select
+                value={selectedSetlistId}
+                onValueChange={setSelectedSetlistId}
+              >
                 <SelectTrigger id="setlist">
                   <SelectValue placeholder="Choose a setlist..." />
                 </SelectTrigger>
@@ -471,7 +653,11 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                       Time
                     </span>
                     <span className="font-medium">
-                      {format(selectedDate, 'MMM d')} at {REHEARSAL_SLOTS.find(s => s.id === selectedSlotId)?.startTime}
+                      {format(selectedDate, "MMM d")} at{" "}
+                      {
+                        REHEARSAL_SLOTS.find((s) => s.id === selectedSlotId)
+                          ?.startTime
+                      }
                     </span>
                   </div>
                   <div className="flex justify-between items-center">
@@ -486,14 +672,18 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                       <TrendingUp className="h-4 w-4" />
                       Chemistry Gain
                     </span>
-                    <span className="font-semibold text-green-500">+{chemistryGain}</span>
+                    <span className="font-semibold text-green-500">
+                      +{chemistryGain}
+                    </span>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-muted-foreground flex items-center gap-2">
                       <Zap className="h-4 w-4" />
                       XP Earned
                     </span>
-                    <span className="font-semibold text-blue-500">+{xpGain}</span>
+                    <span className="font-semibold text-blue-500">
+                      +{xpGain}
+                    </span>
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-muted-foreground flex items-center gap-2">
@@ -501,16 +691,18 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
                       Song Familiarity
                     </span>
                     <span className="font-semibold text-purple-500">
-                      +{familiarityGain} min {practiceType === 'song' ? '' : '(total)'}
+                      +{familiarityGain} min{" "}
+                      {practiceType === "song" ? "" : "(total)"}
                     </span>
                   </div>
-                  
+
                   {/* Setlist time-split explanation */}
-                  {practiceType === 'setlist' && selectedSetlistId && (
+                  {practiceType === "setlist" && selectedSetlistId && (
                     <div className="mt-3 pt-3 border-t border-border">
                       <p className="text-xs text-muted-foreground">
-                        <strong>Note:</strong> Time is split across all songs in the setlist. 
-                        A {selectedDuration}h session with multiple songs = less time per song.
+                        <strong>Note:</strong> Time is split across all songs in
+                        the setlist. A {selectedDuration}h session with multiple
+                        songs = less time per song.
                       </p>
                       <p className="text-xs text-primary mt-1">
                         💡 Tip: 6 hours of practice per song = Perfected level
@@ -525,7 +717,9 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
           {/* Band Balance */}
           <div className="flex items-center justify-between rounded-lg bg-muted p-3 text-sm">
             <span>Band Balance:</span>
-            <span className={cn('font-semibold', !canAfford && 'text-destructive')}>
+            <span
+              className={cn("font-semibold", !canAfford && "text-destructive")}
+            >
               ${band.band_balance || 0}
             </span>
           </div>
@@ -533,20 +727,23 @@ export const RehearsalBookingDialog = ({ rooms, cities, currentCityId, band, son
           {!canAfford && (
             <p className="text-sm text-destructive flex items-center gap-2">
               <AlertCircle className="h-4 w-4" />
-              Insufficient funds. Your band needs ${totalCost - (band.band_balance || 0)} more.
+              Insufficient funds. Your band needs $
+              {totalCost - (band.band_balance || 0)} more.
             </p>
           )}
         </div>
 
         <DialogFooter>
+          {formError && (
+            <p className="mr-auto text-sm text-destructive" role="alert">
+              {formError}
+            </p>
+          )}
           <Button variant="outline" onClick={onClose} disabled={booking}>
             Cancel
           </Button>
-          <Button 
-            onClick={handleConfirm} 
-            disabled={!canBook || booking}
-          >
-            {booking ? 'Booking...' : `Book Rehearsal ($${totalCost})`}
+          <Button onClick={handleConfirm} disabled={!canBook || booking}>
+            {booking ? "Booking..." : `Book Rehearsal ($${totalCost})`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/recording/SessionConfigurator.tsx
+++ b/src/components/recording/SessionConfigurator.tsx
@@ -6,21 +6,48 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
-import { Clock, DollarSign, TrendingUp, Music2, Users, Wallet, AlertCircle, CalendarIcon, Sparkles } from "lucide-react";
-import { useCreateRecordingSession, calculateRecordingQuality, ORCHESTRA_OPTIONS, type RecordingProducer } from "@/hooks/useRecordingData";
+import {
+  Clock,
+  DollarSign,
+  TrendingUp,
+  Music2,
+  Users,
+  Wallet,
+  AlertCircle,
+  CalendarIcon,
+  Sparkles,
+} from "lucide-react";
+import {
+  useCreateRecordingSession,
+  calculateRecordingQuality,
+  ORCHESTRA_OPTIONS,
+  type RecordingProducer,
+} from "@/hooks/useRecordingData";
 import { calculateIndependentPenalty } from "./RecordingTypeSelector";
 import { Progress } from "@/components/ui/progress";
 import { supabase } from "@/integrations/supabase/client";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { RehearsalWarningDialog } from "./RehearsalWarningDialog";
 import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { format } from "date-fns";
 import { STUDIO_SLOTS, getSlotTimeRange } from "@/utils/facilitySlots";
 import { useStudioAvailability } from "@/hooks/useStudioAvailability";
 import { isSlotInPast } from "@/utils/timeSlotValidation";
+import {
+  getErrorMessage,
+  validateFutureOrTodayDate,
+  validateRequired,
+} from "@/utils/formValidation";
 import { cn } from "@/lib/utils";
-import { calculateRecordingSkillBonus, type RecordingSkillBonus } from "@/utils/skillRecordingBonus";
+import {
+  calculateRecordingSkillBonus,
+  type RecordingSkillBonus,
+} from "@/utils/skillRecordingBonus";
 import type { SkillProgressEntry } from "@/utils/skillGearPerformance";
 
 interface SessionConfiguratorProps {
@@ -29,92 +56,110 @@ interface SessionConfiguratorProps {
   studio: any;
   song: any;
   producer: RecordingProducer;
-  recordingType: 'demo' | 'professional';
-  recordingVersion?: 'standard' | 'remix' | 'acoustic';
+  recordingType: "demo" | "professional";
+  recordingVersion?: "standard" | "remix" | "acoustic";
   onComplete: () => void;
 }
 
-export const SessionConfigurator = ({ userId, bandId, studio, song, producer, recordingType, recordingVersion, onComplete }: SessionConfiguratorProps) => {
+export const SessionConfigurator = ({
+  userId,
+  bandId,
+  studio,
+  song,
+  producer,
+  recordingType,
+  recordingVersion,
+  onComplete,
+}: SessionConfiguratorProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
-  const [selectedSlotId, setSelectedSlotId] = useState<string>('');
-  const [orchestraSize, setOrchestraSize] = useState<'chamber' | 'small' | 'full' | null>(null);
+  const [selectedSlotId, setSelectedSlotId] = useState<string>("");
+  const [orchestraSize, setOrchestraSize] = useState<
+    "chamber" | "small" | "full" | null
+  >(null);
   const [bandBalance, setBandBalance] = useState<number>(0);
   const [personalCash, setPersonalCash] = useState<number>(0);
   const [bandName, setBandName] = useState<string>("");
   const [rehearsalData, setRehearsalData] = useState<{
     minutes: number;
-    stage: 'unrehearsed' | 'tight' | 'perfect';
+    stage: "unrehearsed" | "tight" | "perfect";
     penalty: number;
   } | null>(null);
   const [showRehearsalWarning, setShowRehearsalWarning] = useState(false);
   const [skillBonus, setSkillBonus] = useState<RecordingSkillBonus>({
     multiplier: 1.0,
     totalBonusPercent: 0,
-    breakdown: { mixing: 0, daw: 0, production: 0, vocalProduction: 0, theory: 0 },
+    breakdown: {
+      mixing: 0,
+      daw: 0,
+      production: 0,
+      vocalProduction: 0,
+      theory: 0,
+    },
   });
   const [isLabelSigned, setIsLabelSigned] = useState(false);
   const [playerFame, setPlayerFame] = useState(0);
   const [playerLevel, setPlayerLevel] = useState(1);
+  const [formError, setFormError] = useState("");
   const createSession = useCreateRecordingSession();
 
   // Fetch slot availability
-  const { data: slotAvailability, isLoading: loadingSlots } = useStudioAvailability(
-    studio.id,
-    selectedDate,
-    bandId,
-    true
-  );
+  const { data: slotAvailability, isLoading: loadingSlots } =
+    useStudioAvailability(studio.id, selectedDate, bandId, true);
 
   // Duration depends on recording type
-  const durationHours = recordingType === 'demo' ? 4 : 8;
+  const durationHours = recordingType === "demo" ? 4 : 8;
 
   // Fetch band balance, personal cash, label status, and rehearsal data
   useEffect(() => {
     const fetchData = async () => {
       if (bandId) {
         const { data: band } = await supabase
-          .from('bands')
-          .select('band_balance, name')
-          .eq('id', bandId)
+          .from("bands")
+          .select("band_balance, name")
+          .eq("id", bandId)
           .single();
-        
+
         setBandBalance(band?.band_balance || 0);
-        setBandName(band?.name || 'Unknown Band');
+        setBandName(band?.name || "Unknown Band");
 
         const { data: familiarity } = await supabase
-          .from('band_song_familiarity')
-          .select('familiarity_minutes, rehearsal_stage')
-          .eq('band_id', bandId)
-          .eq('song_id', song.id)
+          .from("band_song_familiarity")
+          .select("familiarity_minutes, rehearsal_stage")
+          .eq("band_id", bandId)
+          .eq("song_id", song.id)
           .single();
 
         if (familiarity) {
           const minutes = familiarity.familiarity_minutes || 0;
-          const stage = familiarity.rehearsal_stage as 'unrehearsed' | 'tight' | 'perfect';
-          const penalty = stage === 'unrehearsed' ? -20 : stage === 'perfect' ? 10 : 0;
+          const stage = familiarity.rehearsal_stage as
+            | "unrehearsed"
+            | "tight"
+            | "perfect";
+          const penalty =
+            stage === "unrehearsed" ? -20 : stage === "perfect" ? 10 : 0;
           setRehearsalData({ minutes, stage, penalty });
         } else {
-          setRehearsalData({ minutes: 0, stage: 'unrehearsed', penalty: -20 });
+          setRehearsalData({ minutes: 0, stage: "unrehearsed", penalty: -20 });
         }
 
         // Check label contract
         const { data: contract } = await supabase
-          .from('artist_label_contracts')
-          .select('id')
-          .eq('band_id', bandId)
-          .eq('status', 'active')
+          .from("artist_label_contracts")
+          .select("id")
+          .eq("band_id", bandId)
+          .eq("status", "active")
           .limit(1)
           .maybeSingle();
-        
+
         setIsLabelSigned(!!contract);
       }
 
       const { data: profile } = await supabase
-        .from('profiles')
-        .select('cash, id, fame, level')
-        .eq('user_id', userId)
+        .from("profiles")
+        .select("cash, id, fame, level")
+        .eq("user_id", userId)
         .single();
-      
+
       setPersonalCash(profile?.cash || 0);
       setPlayerFame(profile?.fame || 0);
       setPlayerLevel(profile?.level || 1);
@@ -122,12 +167,12 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
       // Fetch player skill progress for recording bonus
       if (profile?.id) {
         const { data: skillData } = await supabase
-          .from('skill_progress')
-          .select('skill_slug, current_level')
-          .eq('profile_id', profile.id);
-        
+          .from("skill_progress")
+          .select("skill_slug, current_level")
+          .eq("profile_id", profile.id);
+
         const bonus = calculateRecordingSkillBonus(
-          (skillData || []) as SkillProgressEntry[]
+          (skillData || []) as SkillProgressEntry[],
         );
         setSkillBonus(bonus);
       }
@@ -135,24 +180,32 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
     fetchData();
   }, [bandId, userId, song.id]);
 
-  const orchestraOption = orchestraSize ? ORCHESTRA_OPTIONS.find(o => o.size === orchestraSize) : undefined;
+  const orchestraOption = orchestraSize
+    ? ORCHESTRA_OPTIONS.find((o) => o.size === orchestraSize)
+    : undefined;
 
   const studioQualityRating = Number(studio?.quality_rating ?? 0);
   const studioHourlyRate = Number(studio?.hourly_rate ?? 0);
   const songQualityScore = Number(song?.quality_score ?? 0);
   const producerQualityBonus = Number((producer as any)?.quality_bonus ?? 0);
   const producerCostPerHour = Number((producer as any)?.cost_per_hour ?? 0);
-  
+
   const rehearsalBonus = bandId && rehearsalData ? rehearsalData.penalty : 0;
 
   // Recording type multipliers
-  const isDemo = recordingType === 'demo';
+  const isDemo = recordingType === "demo";
   const demoQualityMultiplier = isDemo ? 0.7 : 1.0;
   const demoCap = isDemo ? Math.round(studioQualityRating * 0.6) : Infinity;
-  const independentPenalty = (!isDemo && !isLabelSigned) ? calculateIndependentPenalty(playerFame, playerLevel) : 0;
-  const labelBonus = (!isDemo && isLabelSigned) ? 15 : 0;
-  const typeMultiplier = demoQualityMultiplier * (1 - independentPenalty / 100) * (1 + labelBonus / 100);
-  
+  const independentPenalty =
+    !isDemo && !isLabelSigned
+      ? calculateIndependentPenalty(playerFame, playerLevel)
+      : 0;
+  const labelBonus = !isDemo && isLabelSigned ? 15 : 0;
+  const typeMultiplier =
+    demoQualityMultiplier *
+    (1 - independentPenalty / 100) *
+    (1 + labelBonus / 100);
+
   const { finalQuality: rawQuality, breakdown } = calculateRecordingQuality(
     songQualityScore,
     studioQualityRating,
@@ -160,28 +213,60 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
     durationHours,
     orchestraOption?.bonus,
     rehearsalBonus,
-    skillBonus.totalBonusPercent
+    skillBonus.totalBonusPercent,
   );
 
   // Apply type multiplier and demo cap
-  const finalQuality = Math.min(Math.round(rawQuality * typeMultiplier), isDemo ? demoCap : rawQuality * 10);
+  const finalQuality = Math.min(
+    Math.round(rawQuality * typeMultiplier),
+    isDemo ? demoCap : rawQuality * 10,
+  );
 
   // Cost: professional = 2.5x studio rate, label-owned = free
   const isLabelOwnedStudio = !!(studio as any)?.isLabelOwned;
   const costMultiplier = isDemo ? 1 : 2.5;
-  const studioCost = isLabelOwnedStudio ? 0 : studioHourlyRate * durationHours * costMultiplier;
+  const studioCost = isLabelOwnedStudio
+    ? 0
+    : studioHourlyRate * durationHours * costMultiplier;
   const producerCost = producerCostPerHour * durationHours;
   const orchestraCost = orchestraOption?.cost || 0;
   const totalCost = studioCost + producerCost + orchestraCost;
 
   const qualityImprovement = finalQuality - songQualityScore;
-  const qualityImprovementPercent = Math.round((qualityImprovement / (songQualityScore || 1)) * 100);
+  const qualityImprovementPercent = Math.round(
+    (qualityImprovement / (songQualityScore || 1)) * 100,
+  );
 
   const availableBalance = bandId ? bandBalance : personalCash;
   const canAfford = availableBalance >= totalCost;
   const balanceShortfall = totalCost - availableBalance;
 
+  const validateRecordingForm = () => {
+    const dateCheck = validateFutureOrTodayDate(selectedDate);
+    if (!dateCheck.valid)
+      return dateCheck.message ?? "Choose a valid recording date.";
+
+    const slotCheck = validateRequired(selectedSlotId, "Time slot");
+    if (!slotCheck.valid) return slotCheck.message ?? "Choose a time slot.";
+
+    const slot = STUDIO_SLOTS.find((s) => s.id === selectedSlotId);
+    if (!slot || isSlotInPast(slot, selectedDate)) {
+      return "Choose an available future time slot.";
+    }
+
+    if (!canAfford) {
+      return "You do not have enough funds for this recording session.";
+    }
+
+    return "";
+  };
+
   const handleStartRecording = () => {
+    if (createSession.isPending) return;
+    const validationMessage = validateRecordingForm();
+    setFormError(validationMessage);
+    if (validationMessage) return;
+
     if (bandId && rehearsalData) {
       setShowRehearsalWarning(true);
     } else {
@@ -191,28 +276,37 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
 
   const proceedWithRecording = async () => {
     setShowRehearsalWarning(false);
-    
-    const slot = STUDIO_SLOTS.find(s => s.id === selectedSlotId);
+
+    const slot = STUDIO_SLOTS.find((s) => s.id === selectedSlotId);
     if (!slot) {
       return;
     }
     const { start, end } = getSlotTimeRange(slot, selectedDate);
 
-    await createSession.mutateAsync({
-      user_id: userId,
-      band_id: bandId || null,
-      studio_id: studio.id,
-      producer_id: producer.id,
-      song_id: song.id,
-      duration_hours: durationHours,
-      orchestra_size: orchestraSize || undefined,
-      recording_version: recordingVersion,
-      recording_type: recordingType,
-      rehearsal_bonus: rehearsalBonus,
-      scheduled_start: start.toISOString(),
-      scheduled_end: end.toISOString(),
-    });
-    onComplete();
+    try {
+      await createSession.mutateAsync({
+        user_id: userId,
+        band_id: bandId || null,
+        studio_id: studio.id,
+        producer_id: producer.id,
+        song_id: song.id,
+        duration_hours: durationHours,
+        orchestra_size: orchestraSize || undefined,
+        recording_version: recordingVersion,
+        recording_type: recordingType,
+        rehearsal_bonus: rehearsalBonus,
+        scheduled_start: start.toISOString(),
+        scheduled_end: end.toISOString(),
+      });
+      onComplete();
+    } catch (error: unknown) {
+      setFormError(
+        getErrorMessage(
+          error,
+          "Unable to book the recording session right now.",
+        ),
+      );
+    }
   };
 
   const canBook = selectedSlotId && canAfford;
@@ -230,22 +324,27 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
         <CardContent>
           <Popover>
             <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full justify-start text-left">
+              <Button
+                variant="outline"
+                className="w-full justify-start text-left"
+              >
                 <CalendarIcon className="mr-2 h-4 w-4" />
-                {format(selectedDate, 'PPP')}
+                {format(selectedDate, "PPP")}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="start">
               <Calendar
                 mode="single"
                 selected={selectedDate}
-                onSelect={(date) => { 
-                  if (date) { 
-                    setSelectedDate(date); 
-                    setSelectedSlotId(''); 
+                onSelect={(date) => {
+                  if (date) {
+                    setSelectedDate(date);
+                    setSelectedSlotId("");
                   }
                 }}
-                disabled={(date) => date < new Date(new Date().setHours(0,0,0,0))}
+                disabled={(date) =>
+                  date < new Date(new Date().setHours(0, 0, 0, 0))
+                }
                 className="pointer-events-auto"
               />
             </PopoverContent>
@@ -263,26 +362,38 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
         </CardHeader>
         <CardContent>
           {loadingSlots ? (
-            <div className="text-center py-4 text-muted-foreground">Loading availability...</div>
+            <div className="text-center py-4 text-muted-foreground">
+              Loading availability...
+            </div>
           ) : (
-            <RadioGroup value={selectedSlotId} onValueChange={setSelectedSlotId}>
+            <RadioGroup
+              value={selectedSlotId}
+              onValueChange={(value) => {
+                setSelectedSlotId(value);
+                setFormError("");
+              }}
+              aria-invalid={!!formError && !selectedSlotId}
+            >
               <div className="grid grid-cols-2 gap-2">
-                {STUDIO_SLOTS.map(slot => {
-                  const slotData = slotAvailability?.find(s => s.slot.id === slot.id);
+                {STUDIO_SLOTS.map((slot) => {
+                  const slotData = slotAvailability?.find(
+                    (s) => s.slot.id === slot.id,
+                  );
                   const isBooked = slotData?.isBooked || false;
                   const isPast = isSlotInPast(slot, selectedDate);
                   const canSelect = !isBooked && !isPast;
-                  
+
                   return (
-                    <div 
-                      key={slot.id} 
+                    <div
+                      key={slot.id}
                       className={cn(
-                        'flex items-center space-x-2 rounded-lg border p-3 transition-colors',
-                        selectedSlotId === slot.id && 'border-primary bg-primary/5',
-                        isPast && 'opacity-50 cursor-not-allowed',
-                        isBooked && 'bg-destructive/10 border-destructive/30',
-                        canSelect && 'cursor-pointer hover:bg-accent/50'
-                      )} 
+                        "flex items-center space-x-2 rounded-lg border p-3 transition-colors",
+                        selectedSlotId === slot.id &&
+                          "border-primary bg-primary/5",
+                        isPast && "opacity-50 cursor-not-allowed",
+                        isBooked && "bg-destructive/10 border-destructive/30",
+                        canSelect && "cursor-pointer hover:bg-accent/50",
+                      )}
                       onClick={() => canSelect && setSelectedSlotId(slot.id)}
                     >
                       <RadioGroupItem value={slot.id} disabled={!canSelect} />
@@ -292,9 +403,24 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
                           {slot.startTime} - {slot.endTime}
                         </div>
                         <div className="mt-1">
-                          {isBooked && <Badge variant="destructive" className="text-xs">Booked</Badge>}
-                          {isPast && !isBooked && <Badge variant="secondary" className="text-xs">Passed</Badge>}
-                          {canSelect && <Badge variant="outline" className="text-xs bg-green-500/10 text-green-700 border-green-500/30">Available</Badge>}
+                          {isBooked && (
+                            <Badge variant="destructive" className="text-xs">
+                              Booked
+                            </Badge>
+                          )}
+                          {isPast && !isBooked && (
+                            <Badge variant="secondary" className="text-xs">
+                              Passed
+                            </Badge>
+                          )}
+                          {canSelect && (
+                            <Badge
+                              variant="outline"
+                              className="text-xs bg-green-500/10 text-green-700 border-green-500/30"
+                            >
+                              Available
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -316,15 +442,27 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
         </CardHeader>
         <CardContent className="space-y-3">
           {ORCHESTRA_OPTIONS.map((opt) => (
-            <div key={opt.size} className="flex items-start space-x-2 p-3 rounded-lg border hover:bg-accent/50">
+            <div
+              key={opt.size}
+              className="flex items-start space-x-2 p-3 rounded-lg border hover:bg-accent/50"
+            >
               <Checkbox
                 id={`orch-${opt.size}`}
                 checked={orchestraSize === opt.size}
-                onCheckedChange={(checked) => setOrchestraSize(checked ? opt.size : null)}
+                onCheckedChange={(checked) =>
+                  setOrchestraSize(checked ? opt.size : null)
+                }
               />
-              <Label htmlFor={`orch-${opt.size}`} className="flex-1 cursor-pointer">
-                <div className="font-semibold capitalize">{opt.size} Orchestra ({opt.musicians} musicians)</div>
-                <div className="text-sm text-muted-foreground">+{opt.bonus}% quality • ${opt.cost.toLocaleString()}</div>
+              <Label
+                htmlFor={`orch-${opt.size}`}
+                className="flex-1 cursor-pointer"
+              >
+                <div className="font-semibold capitalize">
+                  {opt.size} Orchestra ({opt.musicians} musicians)
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  +{opt.bonus}% quality • ${opt.cost.toLocaleString()}
+                </div>
               </Label>
             </div>
           ))}
@@ -342,28 +480,51 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
         <CardContent className="space-y-3">
           <div className="flex justify-between text-sm">
             <span className="text-muted-foreground">
-              Studio ({durationHours} hrs × ${studioHourlyRate.toLocaleString()}{!isDemo ? ' × 2.5' : ''})
+              Studio ({durationHours} hrs × ${studioHourlyRate.toLocaleString()}
+              {!isDemo ? " × 2.5" : ""})
             </span>
             {isLabelOwnedStudio ? (
               <div className="flex items-center gap-2">
-                <span className="line-through text-muted-foreground text-xs">${(studioHourlyRate * durationHours * costMultiplier).toLocaleString()}</span>
-                <span className="font-semibold text-green-600">FREE (Label Studio)</span>
+                <span className="line-through text-muted-foreground text-xs">
+                  $
+                  {(
+                    studioHourlyRate *
+                    durationHours *
+                    costMultiplier
+                  ).toLocaleString()}
+                </span>
+                <span className="font-semibold text-green-600">
+                  FREE (Label Studio)
+                </span>
               </div>
             ) : (
-              <span className="font-semibold">${studioCost.toLocaleString()}</span>
+              <span className="font-semibold">
+                ${studioCost.toLocaleString()}
+              </span>
             )}
           </div>
           {!isDemo && (
-            <div className="text-xs text-muted-foreground">Professional rate: 2.5× standard</div>
+            <div className="text-xs text-muted-foreground">
+              Professional rate: 2.5× standard
+            </div>
           )}
           <div className="flex justify-between text-sm">
-            <span className="text-muted-foreground">Producer ({durationHours} hrs × ${producerCostPerHour.toLocaleString()})</span>
-            <span className="font-semibold">${producerCost.toLocaleString()}</span>
+            <span className="text-muted-foreground">
+              Producer ({durationHours} hrs × $
+              {producerCostPerHour.toLocaleString()})
+            </span>
+            <span className="font-semibold">
+              ${producerCost.toLocaleString()}
+            </span>
           </div>
           {orchestraOption && (
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Orchestra ({orchestraOption.size})</span>
-              <span className="font-semibold">${orchestraCost.toLocaleString()}</span>
+              <span className="text-muted-foreground">
+                Orchestra ({orchestraOption.size})
+              </span>
+              <span className="font-semibold">
+                ${orchestraCost.toLocaleString()}
+              </span>
             </div>
           )}
           <Separator />
@@ -375,9 +536,11 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground flex items-center gap-2">
                 <Wallet className="h-4 w-4" />
-                {bandId ? `Band Balance (${bandName})` : 'Your Cash'}
+                {bandId ? `Band Balance (${bandName})` : "Your Cash"}
               </span>
-              <span className={`font-semibold ${canAfford ? 'text-green-600' : 'text-red-600'}`}>
+              <span
+                className={`font-semibold ${canAfford ? "text-green-600" : "text-red-600"}`}
+              >
                 ${availableBalance.toLocaleString()}
               </span>
             </div>
@@ -390,8 +553,17 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>
             <div className="font-semibold mb-1">Insufficient funds!</div>
-            <div className="text-sm">Shortfall: ${balanceShortfall.toLocaleString()}</div>
+            <div className="text-sm">
+              Shortfall: ${balanceShortfall.toLocaleString()}
+            </div>
           </AlertDescription>
+        </Alert>
+      )}
+
+      {formError && (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{formError}</AlertDescription>
         </Alert>
       )}
 
@@ -411,29 +583,43 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
             </div>
             <Music2 className="h-8 w-8 text-muted-foreground" />
             <div className="text-right">
-              <div className="text-sm text-muted-foreground">After Recording</div>
-              <div className="text-2xl font-bold text-primary">{finalQuality}</div>
+              <div className="text-sm text-muted-foreground">
+                After Recording
+              </div>
+              <div className="text-2xl font-bold text-primary">
+                {finalQuality}
+              </div>
             </div>
           </div>
           <div className="space-y-2">
             <div className="flex justify-between text-sm">
               <span className="text-muted-foreground">Improvement</span>
-              <Badge variant="default">+{qualityImprovement} ({qualityImprovementPercent}%)</Badge>
+              <Badge variant="default">
+                +{qualityImprovement} ({qualityImprovementPercent}%)
+              </Badge>
             </div>
-            <Progress value={Math.min(100, qualityImprovementPercent)} className="h-2" />
+            <Progress
+              value={Math.min(100, qualityImprovementPercent)}
+              className="h-2"
+            />
           </div>
           {/* Type-specific modifiers */}
           <div className="space-y-1 border-t pt-3">
             <div className="flex justify-between text-xs">
               <span className="text-muted-foreground">Recording Type</span>
-              <Badge variant={isDemo ? 'secondary' : 'default'} className="text-xs">
-                {isDemo ? 'Demo' : 'Professional'}
+              <Badge
+                variant={isDemo ? "secondary" : "default"}
+                className="text-xs"
+              >
+                {isDemo ? "Demo" : "Professional"}
               </Badge>
             </div>
             {isDemo && (
               <div className="flex justify-between text-xs">
                 <span className="text-muted-foreground">Demo quality cap</span>
-                <span className="text-orange-500 font-medium">Max {demoCap}</span>
+                <span className="text-orange-500 font-medium">
+                  Max {demoCap}
+                </span>
               </div>
             )}
             {isDemo && (
@@ -450,8 +636,12 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
             )}
             {!isDemo && !isLabelSigned && independentPenalty > 0 && (
               <div className="flex justify-between text-xs">
-                <span className="text-muted-foreground">Independent penalty</span>
-                <span className="text-orange-500 font-medium">-{independentPenalty}%</span>
+                <span className="text-muted-foreground">
+                  Independent penalty
+                </span>
+                <span className="text-orange-500 font-medium">
+                  -{independentPenalty}%
+                </span>
               </div>
             )}
           </div>
@@ -462,7 +652,7 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
         open={showRehearsalWarning}
         onOpenChange={setShowRehearsalWarning}
         songTitle={song.title}
-        rehearsalStage={rehearsalData?.stage || 'unrehearsed'}
+        rehearsalStage={rehearsalData?.stage || "unrehearsed"}
         familiarityMinutes={rehearsalData?.minutes || 0}
         qualityPenalty={rehearsalBonus}
         onConfirm={proceedWithRecording}
@@ -477,7 +667,9 @@ export const SessionConfigurator = ({ userId, bandId, studio, song, producer, re
           disabled={createSession.isPending || !canBook}
           className="flex-1"
         >
-          {createSession.isPending ? 'Booking...' : `Book Recording ($${totalCost.toLocaleString()})`}
+          {createSession.isPending
+            ? "Booking..."
+            : `Book Recording ($${totalCost.toLocaleString()})`}
         </Button>
       </div>
     </div>

--- a/src/utils/__tests__/formValidation.test.ts
+++ b/src/utils/__tests__/formValidation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  validateDurationHours,
+  validateFutureOrTodayDate,
+  validateRequired,
+  getErrorMessage,
+} from "../formValidation";
+
+describe("form validation helpers", () => {
+  it("validates required strings consistently", () => {
+    expect(validateRequired("Rock Stars", "Band name")).toEqual({
+      valid: true,
+    });
+    expect(validateRequired("   ", "Band name")).toEqual({
+      valid: false,
+      message: "Band name is required.",
+    });
+  });
+
+  it("validates durations with friendly messages", () => {
+    expect(validateDurationHours(2, 1, 6)).toEqual({ valid: true });
+    expect(validateDurationHours(0, 1, 6).message).toBe(
+      "Duration must be at least 1 hour.",
+    );
+    expect(validateDurationHours(8, 1, 6).message).toBe(
+      "Duration cannot be more than 6 hours.",
+    );
+    expect(validateDurationHours("nope").message).toBe(
+      "Choose a valid duration.",
+    );
+  });
+
+  it("validates date selections against past days", () => {
+    vi.setSystemTime(new Date("2026-07-09T12:00:00Z"));
+    expect(validateFutureOrTodayDate(new Date("2026-07-09T00:00:00Z"))).toEqual(
+      { valid: true },
+    );
+    expect(
+      validateFutureOrTodayDate(new Date("2026-07-08T23:00:00Z")).message,
+    ).toBe("Date cannot be in the past.");
+    vi.useRealTimers();
+  });
+
+  it("normalizes API error messages", () => {
+    expect(getErrorMessage({ message: "Supabase failed" })).toBe(
+      "Supabase failed",
+    );
+    expect(getErrorMessage(null, "Fallback")).toBe("Fallback");
+  });
+});

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,0 +1,74 @@
+import { isBefore, isValid, startOfDay } from "date-fns";
+
+export type FormValidationResult = { valid: boolean; message?: string };
+
+export function validateRequired(
+  value: unknown,
+  label: string,
+): FormValidationResult {
+  if (typeof value === "string") {
+    return value.trim()
+      ? { valid: true }
+      : { valid: false, message: `${label} is required.` };
+  }
+
+  return value == null || value === false
+    ? { valid: false, message: `${label} is required.` }
+    : { valid: true };
+}
+
+export function validateFutureOrTodayDate(
+  date: Date | null | undefined,
+  label = "Date",
+): FormValidationResult {
+  if (!date || !isValid(date)) {
+    return { valid: false, message: `Choose a valid ${label.toLowerCase()}.` };
+  }
+
+  if (isBefore(startOfDay(date), startOfDay(new Date()))) {
+    return { valid: false, message: `${label} cannot be in the past.` };
+  }
+
+  return { valid: true };
+}
+
+export function validateDurationHours(
+  duration: unknown,
+  min = 1,
+  max = 24,
+): FormValidationResult {
+  const numericDuration = Number(duration);
+
+  if (!Number.isFinite(numericDuration)) {
+    return { valid: false, message: "Choose a valid duration." };
+  }
+
+  if (numericDuration < min) {
+    return {
+      valid: false,
+      message: `Duration must be at least ${min} hour${min === 1 ? "" : "s"}.`,
+    };
+  }
+
+  if (numericDuration > max) {
+    return {
+      valid: false,
+      message: `Duration cannot be more than ${max} hours.`,
+    };
+  }
+
+  return { valid: true };
+}
+
+export function getErrorMessage(
+  error: unknown,
+  fallback = "Something went wrong. Please try again.",
+): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
+}


### PR DESCRIPTION
### Motivation
- Make player-facing booking and creation flows consistently block invalid input and surface friendly errors before submission to avoid confusing failures during beta.
- Reuse small, shared validation helpers where logic was duplicated so fixes are safe and PR-sized.
- Prevent duplicate submissions and ensure submit controls clearly show saving state and are disabled while a mutation is pending.

### Description
- Added a small shared helper `src/utils/formValidation.ts` exposing `validateRequired`, `validateFutureOrTodayDate`, `validateDurationHours`, and `getErrorMessage` and added tests in `src/utils/__tests__/formValidation.test.ts` to cover those helpers.  
- Hardened the jam session booking flow at `src/components/jam-sessions/JamSessionBookingDialog.tsx` with field-level validation, date/duration checks, availability/funds checks, visible field/form errors, `aria-invalid` usage, and duplicate-submit protection while `isBooking` is true.  
- Hardened rehearsal booking flow at `src/components/performance/RehearsalBookingDialog.tsx` with required room/song/setlist/time-slot validation, date/duration checks, consecutive-slot availability checks, affordability checks, friendly top-level form errors, and submit/cancel disabled while booking.  
- Hardened recording session booking flow at `src/components/recording/SessionConfigurator.tsx` with date/time and funds validation before calling the mutation, visible alert errors, `getErrorMessage` for Supabase/API errors, and protection while the `createSession` mutation is pending.  
- Hardened band/solo creation at `src/components/band/BandCreationForm.tsx` with required name/genre/instrument checks, max-member range validation, field-associated error messages, top-level friendly errors from API failures, and disabled submit while saving.  
- Removed noisy `console.error` uses in updated booking paths and replaced them with user-facing messages; preserved existing mutation behavior and database schema. 

### Testing
- Ran TypeScript check with `npx tsc --noEmit`, which completed successfully.  
- Added unit tests `src/utils/__tests__/formValidation.test.ts` for the shared helpers, but running `npm test` failed in this environment because `vitest` was not available (`vitest: not found`).  
- `npm run lint` could not run due to local missing ESLint package (`@eslint/js`) in this environment.  
- `npm run build` could not run because `vite` was not available in the local install.  
- Attempted `npm install` / `npm install --legacy-peer-deps` to restore test/lint/build tooling, but dependency resolution failed due to registry/access issues in this environment, so automated test/lint/build steps could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5022c2494883259459dc80a816901e)