### PR TITLE
Stabilize music creation flow error handling

### DIFF
--- a/src/components/recording/RecordedSongsTab.tsx
+++ b/src/components/recording/RecordedSongsTab.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Music, Calendar, Star, Clock, Disc3, Volume2, Flame, Search, Filter, ArrowUpDown } from "lucide-react";
+import { Music, Calendar, Star, Clock, Disc3, Volume2, Flame, Search, Filter, ArrowUpDown, AlertTriangle } from "lucide-react";
 import { formatDistanceToNow, format } from "date-fns";
 import { SongPlayer } from "@/components/audio/SongPlayer";
 import { SongShareButtons } from "@/components/audio/SongShareButtons";
@@ -22,16 +22,21 @@ export function RecordedSongsTab({ userId, bandId }: RecordedSongsTabProps) {
   const [genreFilter, setGenreFilter] = useState("all");
   const [sortBy, setSortBy] = useState<SortOption>("newest");
 
-  const { data: recordedSongs, isLoading } = useQuery({
+  const { data: recordedSongs, isLoading, error } = useQuery({
     queryKey: ["recorded-songs-list", userId, bandId],
     queryFn: async () => {
       // Get all songs with status = 'recorded' for this user
-      const { data: songs, error: songsError } = await supabase
+      let songsQuery = supabase
         .from("songs")
         .select("*, bands(name, artist_name)")
-        .eq("user_id", userId)
         .eq("status", "recorded")
         .order("updated_at", { ascending: false });
+
+      songsQuery = bandId
+        ? songsQuery.eq("band_id", bandId)
+        : songsQuery.eq("user_id", userId).is("band_id", null);
+
+      const { data: songs, error: songsError } = await songsQuery;
 
       if (songsError) throw songsError;
 
@@ -137,6 +142,18 @@ export function RecordedSongsTab({ userId, bandId }: RecordedSongsTabProps) {
 
   if (isLoading) {
     return <div className="text-center py-8 text-muted-foreground">Loading recorded songs...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12 space-y-4">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto" />
+        <div>
+          <p className="font-medium text-destructive">Could not load recorded songs</p>
+          <p className="text-sm text-muted-foreground mt-2">{error instanceof Error ? error.message : "Please try again from the Recording Studio."}</p>
+        </div>
+      </div>
+    );
   }
 
   if (!recordedSongs || recordedSongs.length === 0) {

--- a/src/components/recording/SongSelector.tsx
+++ b/src/components/recording/SongSelector.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Music, TrendingUp, Disc3, CheckCircle2, Search, Filter } from "lucide-react";
+import { Music, TrendingUp, Disc3, CheckCircle2, Search, Filter, AlertTriangle } from "lucide-react";
 import { getRehearsalLevel, formatRehearsalTime, REHEARSAL_LEVELS } from "@/utils/rehearsalLevels";
 
 interface SongSelectorProps {
@@ -28,7 +28,7 @@ export const SongSelector = ({ userId, bandId, selectedSong, onSelect }: SongSel
   const [recordedFilter, setRecordedFilter] = useState<string>("all");
   const [rehearsalFilter, setRehearsalFilter] = useState<string>("all");
 
-  const { data: songs, isLoading } = useQuery({
+  const { data: songs, isLoading, error } = useQuery({
     queryKey: ['recordable-songs', userId, bandId],
     queryFn: async () => {
       // Get songs with their recording history
@@ -60,11 +60,13 @@ export const SongSelector = ({ userId, bandId, selectedSong, onSelect }: SongSel
       let recordingHistory: Record<string, { count: number; versions: string[] }> = {};
 
       if (songIds.length > 0) {
-        const { data: recordings } = await supabase
+        const { data: recordings, error: recordingsError } = await supabase
           .from('recording_sessions')
           .select('song_id, recording_version, status')
           .in('song_id', songIds)
           .eq('status', 'completed');
+
+        if (recordingsError) throw recordingsError;
 
         if (recordings) {
           for (const rec of recordings) {
@@ -126,6 +128,16 @@ export const SongSelector = ({ userId, bandId, selectedSong, onSelect }: SongSel
 
   if (isLoading) {
     return <div className="text-center py-8 text-muted-foreground">Loading songs...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-12 space-y-3">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto" />
+        <p className="font-medium text-destructive">Could not load songs for recording.</p>
+        <p className="text-sm text-muted-foreground">{error instanceof Error ? error.message : "Please try again before booking a studio session."}</p>
+      </div>
+    );
   }
 
   if (!songs || songs.length === 0) {

--- a/src/components/releases/CreateReleaseDialog.tsx
+++ b/src/components/releases/CreateReleaseDialog.tsx
@@ -53,12 +53,13 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
     queryKey: ["user-active-band", profileId],
     queryFn: async () => {
       if (!profileId) return null;
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("band_members")
         .select("band_id, bands!band_members_band_id_fkey(*)")
         .eq("profile_id", profileId)
         .limit(1)
-        .single();
+        .maybeSingle();
+      if (error) throw error;
       return data?.bands || null;
     },
     enabled: !!profileId,
@@ -69,11 +70,12 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
     queryKey: ["band-home-info", userBand?.id],
     queryFn: async () => {
       if (!userBand?.home_city_id) return null;
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("cities")
         .select("country, region")
         .eq("id", userBand.home_city_id)
-        .single();
+        .maybeSingle();
+      if (error) throw error;
       return data;
     },
     enabled: !!userBand?.home_city_id,
@@ -114,10 +116,7 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
         .limit(1)
         .maybeSingle();
 
-      if (error) {
-        console.error("Error fetching active contract:", error);
-        return null;
-      }
+      if (error) throw error;
       return data;
     },
     enabled: open,
@@ -144,10 +143,7 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
         p_band_id: userBand?.id || null,
         p_user_id: userBand ? null : userId
       });
-      if (error) {
-        console.error("Error checking greatest hits eligibility:", error);
-        return { eligible: false, reason: "Error checking eligibility" };
-      }
+      if (error) throw error;
       return data as { eligible: boolean; released_song_count: number; reason: string | null };
     },
     enabled: !!userId
@@ -184,6 +180,12 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
 
   const createRelease = useMutation({
     mutationFn: async () => {
+      if (!title.trim()) throw new Error("Release title is required");
+      if (!artistName.trim()) throw new Error("Artist name is required");
+      if (selectedSongs.length === 0) throw new Error("Select at least one recorded song before creating a release");
+      if (selectedFormats.length === 0) throw new Error("Select at least one release format");
+      if (selectedTerritories.length === 0) throw new Error("Select at least one release territory");
+
       // Calculate total cost including territory distribution
       const formatCost = selectedFormats.reduce((sum, format) => sum + format.manufacturing_cost, 0);
       const totalCost = formatCost + territoryCost;
@@ -269,8 +271,8 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
           user_id: userBand ? null : userId,
           band_id: userBand?.id || null,
           release_type: releaseType === "greatest_hits" ? "album" : releaseType,
-          title,
-          artist_name: artistName,
+          title: title.trim(),
+          artist_name: artistName.trim(),
           release_status: "manufacturing",
           total_cost: bandPays + labelPays,
           manufacturing_complete_at: manufacturingCompleteAt.toISOString(),
@@ -307,7 +309,7 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
           .insert(territoryInserts);
 
         if (territoryError) {
-          console.error("Error saving territories:", territoryError);
+          throw territoryError;
         }
       }
 
@@ -453,7 +455,7 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
   };
 
   const handleNext = () => {
-    if (step === 1 && (!title || !artistName)) {
+    if (step === 1 && (!title.trim() || !artistName.trim())) {
       toast({ title: "Error", description: "Please fill in all fields", variant: "destructive" });
       return;
     }
@@ -542,7 +544,7 @@ export function CreateReleaseDialog({ open, onOpenChange, userId }: CreateReleas
               )}
             </div>
 
-            <Button onClick={handleNext} className="w-full">Next: Select Songs</Button>
+            <Button onClick={handleNext} disabled={createRelease.isPending} className="w-full">Next: Select Songs</Button>
           </div>
         )}
 

--- a/src/components/releases/SongSelectionStep.tsx
+++ b/src/components/releases/SongSelectionStep.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Music2, Disc3, Album, AlertTriangle, Eye, EyeOff } from "lucide-react";
+import { Music2, Disc3, Album, AlertTriangle, Eye, EyeOff, Loader2 } from "lucide-react";
 import { ReleaseType } from "./ReleaseTypeSelector";
 
 export interface SongSelection {
@@ -73,46 +73,48 @@ export function SongSelectionStep({
         p_band_id: bandId,
         p_user_id: bandId ? null : userId
       });
-      if (error) {
-        console.error("Error fetching songs on releases:", error);
-        return [];
-      }
+      if (error) throw error;
       return data || [];
     }
   });
 
-  const { data: songs } = useQuery({
+  const { data: songs, isLoading, error } = useQuery({
     queryKey: ["available-songs-versions", userId, bandId, releaseType],
     queryFn: async () => {
       let allSongs: any[] = [];
 
       if (bandId) {
         // Get band songs
-        const { data: bandSongs } = await supabase
+        const { data: bandSongs, error: bandSongsError } = await supabase
           .from("songs")
           .select("*")
           .eq("band_id", bandId)
           .eq("status", "recorded")
           .order("created_at", { ascending: false });
         
+        if (bandSongsError) throw bandSongsError;
         allSongs = bandSongs || [];
 
         // Also get songs from band members
-        const { data: bandMembers } = await supabase
+        const { data: bandMembers, error: bandMembersError } = await supabase
           .from("band_members")
           .select("user_id")
           .eq("band_id", bandId);
 
+        if (bandMembersError) throw bandMembersError;
+
         if (bandMembers && bandMembers.length > 0) {
           const memberUserIds = bandMembers.map(m => m.user_id).filter(Boolean);
           if (memberUserIds.length > 0) {
-            const { data: memberSongs } = await supabase
+            const { data: memberSongs, error: memberSongsError } = await supabase
               .from("songs")
               .select("*")
               .in("user_id", memberUserIds)
               .is("band_id", null)
               .eq("status", "recorded")
               .order("created_at", { ascending: false });
+
+            if (memberSongsError) throw memberSongsError;
 
             if (memberSongs) {
               const existingIds = new Set(allSongs.map(s => s.id));
@@ -126,23 +128,26 @@ export function SongSelectionStep({
         }
       } else {
         // Get user's solo songs
-        const { data: userSongs } = await supabase
+        const { data: userSongs, error: userSongsError } = await supabase
           .from("songs")
           .select("*")
           .eq("user_id", userId)
+          .is("band_id", null)
           .eq("status", "recorded")
           .order("created_at", { ascending: false });
         
+        if (userSongsError) throw userSongsError;
         allSongs = userSongs || [];
       }
 
       // For greatest hits, only show songs that have been released
       if (isGreatestHits) {
-        const { data: releasedSongIds } = await supabase
+        const { data: releasedSongIds, error: releasedSongIdsError } = await supabase
           .from("release_songs")
           .select("song_id, releases!release_songs_release_id_fkey!inner(release_status)")
           .eq("releases.release_status", "released");
         
+        if (releasedSongIdsError) throw releasedSongIdsError;
         const releasedIds = new Set(releasedSongIds?.map(rs => rs.song_id) || []);
         allSongs = allSongs.filter(s => releasedIds.has(s.id));
       }
@@ -152,13 +157,14 @@ export function SongSelectionStep({
       let recordingSessions: any[] = [];
 
       if (songIds.length > 0) {
-        const { data: sessions } = await supabase
+        const { data: sessions, error: sessionsError } = await supabase
           .from("recording_sessions")
           .select("id, song_id, recording_version, quality_improvement, completed_at")
           .in("song_id", songIds)
           .eq("status", "completed")
           .order("completed_at", { ascending: false });
 
+        if (sessionsError) throw sessionsError;
         recordingSessions = sessions || [];
       }
 
@@ -329,7 +335,18 @@ export function SongSelectionStep({
           </Alert>
         )}
 
-        {!songs || songs.length === 0 ? (
+        {isLoading ? (
+          <div className="text-center py-8 text-muted-foreground">
+            <Loader2 className="h-8 w-8 mx-auto mb-3 animate-spin" />
+            <p>Loading recorded songs...</p>
+          </div>
+        ) : error ? (
+          <div className="text-center py-8 text-muted-foreground">
+            <AlertTriangle className="h-12 w-12 mx-auto mb-3 text-destructive" />
+            <p className="font-medium text-destructive">Could not load recorded songs</p>
+            <p className="text-sm mt-1">{error instanceof Error ? error.message : "Please try again before creating a release."}</p>
+          </div>
+        ) : !songs || songs.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             <Music2 className="h-12 w-12 mx-auto mb-3 opacity-50" />
             <p className="font-medium">


### PR DESCRIPTION
### Motivation
- Prevent silent Supabase/query failures and 406-like no-row errors from breaking the Songwriting → Recording → Release loop by surfacing errors to players.  
- Make recording and release selection UIs reliable with clear loading, error, and empty states so flows do not hang or fail unclearly.  
- Add minimal validation and duplicate-submission protection to release creation so users receive clear feedback when submissions are invalid or in-flight.

### Description
- Surface Supabase errors and add loading/error/empty states to the recording song picker (`src/components/recording/SongSelector.tsx`) so query failures show a player-facing error instead of disappearing.  
- Tighten recorded-song visibility and solo vs band filtering in `src/components/recording/RecordedSongsTab.tsx` so solo views exclude band songs and band views include band songs; added an error state for recording-session query failures.  
- Harden release song selection in `src/components/releases/SongSelectionStep.tsx` by ensuring solo release queries exclude `band_id` rows, adding loading/error UI, and surfacing Supabase errors from related queries.  
- Make release creation safer in `src/components/releases/CreateReleaseDialog.tsx` by replacing brittle `.single()` calls with `.maybeSingle()` where no-row is valid, throwing Supabase errors instead of logging & continuing, trimming input strings before insert, and adding final validation for title, artist, selected songs, formats, and territories; also disable the next action while the create mutation is pending.  
- Replaced several swallowed `console.error` paths with thrown errors (so React Query can surface them) and ensured insert/update errors for critical steps are thrown back to the UI.

Files changed: `src/components/recording/SongSelector.tsx`, `src/components/recording/RecordedSongsTab.tsx`, `src/components/releases/SongSelectionStep.tsx`, `src/components/releases/CreateReleaseDialog.tsx`.

### Testing
- Ran typecheck with `npx tsc --noEmit`, which completed successfully.  
- Attempted lint with `npm run lint`, which failed due to missing environment dependency `@eslint/js` (environment dependency issue).  
- Attempted build with `npm run build`, which failed because `vite` is not available in the environment.  
- Attempted `npm install` to restore dependencies but it failed due to registry access (403) for `@react-three/fiber`, preventing full local dependency restoration and end-to-end app start.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50248e9d2083259d37be292662e451)