### PR TITLE
Stabilize band activity scheduling and visibility

### DIFF
--- a/src/components/band/BandSongsSection.tsx
+++ b/src/components/band/BandSongsSection.tsx
@@ -24,7 +24,7 @@ interface BandSong {
 }
 
 export function BandSongsSection({ bandId, bandName }: BandSongsSectionProps) {
-  const { data: songs, isLoading } = useQuery({
+  const { data: songs, isLoading, error } = useQuery({
     queryKey: ["band-songs", bandId],
     queryFn: async () => {
       // Get songs with play counts
@@ -79,6 +79,24 @@ export function BandSongsSection({ bandId, bandName }: BandSongsSectionProps) {
           {[1, 2, 3].map(i => (
             <Skeleton key={i} className="h-20 w-full" />
           ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Music className="h-5 w-5" />
+            Songs
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-destructive text-center py-8">
+            Failed to load band songs: {error instanceof Error ? error.message : "Unknown error"}
+          </p>
         </CardContent>
       </Card>
     );

--- a/src/hooks/useJamSessionBooking.ts
+++ b/src/hooks/useJamSessionBooking.ts
@@ -51,14 +51,16 @@ export const useJamSessionBooking = () => {
     startTime: Date,
     endTime: Date
   ): Promise<{ hasConflict: boolean; conflictTitle?: string }> => {
-    const { data: conflicts } = await supabase
+    const { data: conflicts, error } = await supabase
       .from("player_scheduled_activities")
       .select("title")
       .eq("profile_id", userId)
       .in("status", ["scheduled", "in_progress"])
-      .lte("scheduled_start", endTime.toISOString())
-      .gte("scheduled_end", startTime.toISOString())
+      .lt("scheduled_start", endTime.toISOString())
+      .gt("scheduled_end", startTime.toISOString())
       .limit(1);
+
+    if (error) throw new Error(error.message || "Failed to check schedule conflicts");
 
     if (conflicts && conflicts.length > 0) {
       return { hasConflict: true, conflictTitle: conflicts[0].title };
@@ -92,7 +94,7 @@ export const useJamSessionBooking = () => {
     scheduledEnd: Date,
     cityName?: string
   ) => {
-    await (supabase as any).from("player_scheduled_activities").insert({
+    const { error } = await (supabase as any).from("player_scheduled_activities").insert({
       user_id: userId,
       profile_id: profileId,
       activity_type: "jam_session",
@@ -105,6 +107,8 @@ export const useJamSessionBooking = () => {
       linked_jam_session_id: sessionId,
       metadata: { jam_session_id: sessionId },
     });
+
+    if (error) throw new Error(error.message || "Failed to add jam session to schedule");
   };
 
   // Check jam session availability for a room and date
@@ -127,7 +131,7 @@ export const useJamSessionBooking = () => {
 
   const bookJamSession = async (params: BookJamSessionParams): Promise<string> => {
     if (!profile) throw new Error("Profile not found");
-    if (!profile) throw new Error("Profile not found");
+    if (isBooking) throw new Error("Booking already in progress");
 
     setIsBooking(true);
 
@@ -254,7 +258,6 @@ export const useJamSessionBooking = () => {
 
   const joinJamSession = async (sessionId: string): Promise<void> => {
     if (!profile) throw new Error("Profile not found");
-    if (!profile) throw new Error("Profile not found");
 
     // Get session details with city info
     const { data: session } = await supabase
@@ -368,7 +371,6 @@ export const useJamSessionBooking = () => {
   };
 
   const leaveJamSession = async (sessionId: string): Promise<void> => {
-    if (!profile) throw new Error("Profile not found");
     if (!profile) throw new Error("Profile not found");
 
     // Get session details

--- a/src/hooks/useRecordingData.tsx
+++ b/src/hooks/useRecordingData.tsx
@@ -96,20 +96,36 @@ export const useRecordingSessions = (profileId: string) => {
   return useQuery({
     queryKey: ['recording-sessions', profileId],
     queryFn: async () => {
-      const { data, error } = await supabase
+      if (!profileId) return [];
+
+      const { data: membershipRows, error: membershipError } = await supabase
+        .from('band_members')
+        .select('band_id')
+        .eq('profile_id', profileId)
+        .eq('member_status', 'active');
+
+      if (membershipError) throw membershipError;
+
+      const bandIds = (membershipRows || []).map(row => row.band_id).filter(Boolean);
+      let query = supabase
         .from('recording_sessions')
         .select(`
           *,
           city_studios (name, quality_rating),
           recording_producers (name, tier),
           songs (title, genre)
-        `)
-        .eq('profile_id', profileId)
-        .order('created_at', { ascending: false });
+        `);
+
+      query = bandIds.length > 0
+        ? query.or(`profile_id.eq.${profileId},band_id.in.(${bandIds.join(',')})`)
+        : query.eq('profile_id', profileId);
+
+      const { data, error } = await query.order('created_at', { ascending: false });
       
       if (error) throw error;
       return (data || []) as any as RecordingSession[];
     },
+    enabled: !!profileId,
   });
 };
 
@@ -271,8 +287,7 @@ export const useCreateRecordingSession = () => {
       const orchestraCost = orchestraOption?.cost || 0;
       const totalCost = studioCost + producerCost + orchestraCost;
 
-      const scheduledEnd = new Date();
-      scheduledEnd.setHours(scheduledEnd.getHours() + input.duration_hours);
+      const sessionScheduledEnd = sessionEnd;
 
       // If band_id is provided, check band balance and insert earnings (trigger handles balance)
       if (input.band_id) {
@@ -345,8 +360,9 @@ export const useCreateRecordingSession = () => {
           duration_hours: input.duration_hours,
           total_cost: totalCost,
           quality_improvement: finalQuality - song.quality_score,
-          status: 'in_progress',
-          scheduled_end: scheduledEnd.toISOString(),
+          status: input.scheduled_start ? 'scheduled' : 'in_progress',
+          scheduled_start: now.toISOString(),
+          scheduled_end: sessionScheduledEnd.toISOString(),
           city_id: studioInfo?.city_id || null,
         } as any)
         .select()

--- a/src/hooks/useScheduledActivities.ts
+++ b/src/hooks/useScheduledActivities.ts
@@ -3,6 +3,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { startOfDay, endOfDay, addDays } from "date-fns";
 import { getDurationMinutes, validateBookingWindow } from "@/utils/activityBookingTime";
+import { withoutDuplicateBandScheduleActivities } from "@/utils/bandActivityScheduling";
 
 export type ActivityType = 
   | 'songwriting' | 'gig' | 'rehearsal' | 'busking' | 'recording' 
@@ -271,7 +272,7 @@ export function useScheduledActivities(date: Date, userId?: string) {
         (ws: any) => !existingWorkIds.has(ws.metadata?.shift_history_id)
       );
       
-      const allActivities = [...activities, ...uniqueWorkShifts];
+      const allActivities = withoutDuplicateBandScheduleActivities([...activities, ...uniqueWorkShifts]);
 
       return allActivities.sort((a, b) => new Date(a.scheduled_start).getTime() - new Date(b.scheduled_start).getTime());
     },

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,2 +1,7 @@
+import { vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
 // @ts-ignore -- local stub package
 import "@testing-library/jest-dom/vitest";

--- a/src/utils/__tests__/bandActivityScheduling.test.ts
+++ b/src/utils/__tests__/bandActivityScheduling.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { withoutDuplicateBandScheduleActivities } from "../bandActivityScheduling";
+
+describe("band activity schedule helpers", () => {
+  it("keeps one visible schedule item for the same linked rehearsal", () => {
+    const activities = withoutDuplicateBandScheduleActivities([
+      { id: "scheduled-row", activity_type: "rehearsal", linked_rehearsal_id: "reh-1" },
+      { id: "canonical-rehearsal", activity_type: "rehearsal", linked_rehearsal_id: "reh-1" },
+      { id: "solo-practice", activity_type: "skill_practice" },
+    ]);
+
+    expect(activities.map(activity => activity.id)).toEqual(["scheduled-row", "solo-practice"]);
+  });
+
+  it("does not collapse unrelated solo and band activities", () => {
+    const activities = withoutDuplicateBandScheduleActivities([
+      { id: "solo-recording", activity_type: "recording", linked_recording_id: null, metadata: { sessionId: "solo-1" } },
+      { id: "band-recording", activity_type: "recording", linked_recording_id: "rec-1" },
+      { id: "band-recording-duplicate", activity_type: "recording", metadata: { sessionId: "rec-1" } },
+    ]);
+
+    expect(activities.map(activity => activity.id)).toEqual(["solo-recording", "band-recording"]);
+  });
+});

--- a/src/utils/bandActivityScheduling.ts
+++ b/src/utils/bandActivityScheduling.ts
@@ -30,6 +30,34 @@ interface ConflictInfo {
   activityTitle: string;
 }
 
+export interface ScheduleLikeActivity {
+  id: string;
+  activity_type?: string | null;
+  linked_rehearsal_id?: string | null;
+  linked_recording_id?: string | null;
+  metadata?: Record<string, any> | null;
+}
+
+function getBandActivityKey(activity: ScheduleLikeActivity): string | null {
+  if (activity.linked_rehearsal_id) return `rehearsal:${activity.linked_rehearsal_id}`;
+  if (activity.linked_recording_id) return `recording:${activity.linked_recording_id}`;
+  const metadata = activity.metadata || {};
+  if (metadata.rehearsalId) return `rehearsal:${metadata.rehearsalId}`;
+  if (metadata.sessionId && activity.activity_type === 'recording') return `recording:${metadata.sessionId}`;
+  return null;
+}
+
+export function withoutDuplicateBandScheduleActivities<T extends ScheduleLikeActivity>(activities: T[]): T[] {
+  const seen = new Set<string>();
+  return activities.filter((activity) => {
+    const key = getBandActivityKey(activity);
+    if (!key) return true;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 /**
  * Get all active REAL band member user IDs (players only, not touring/hired members)
  * Only includes members with user_id (real players) - excludes NPC touring members
@@ -202,9 +230,40 @@ export async function createBandScheduledActivities(params: BandActivityParams):
     console.warn('No valid profiles found for band members');
     return [];
   }
+
+  let existingQuery = supabase
+    .from('player_scheduled_activities' as any)
+    .select('user_id')
+    .in('user_id', validMembers)
+    .eq('activity_type', params.activityType)
+    .neq('status', 'cancelled');
+
+  if (params.linkedRehearsalId) {
+    existingQuery = existingQuery.eq('linked_rehearsal_id', params.linkedRehearsalId);
+  } else if (params.linkedRecordingId) {
+    existingQuery = existingQuery.eq('linked_recording_id', params.linkedRecordingId);
+  } else {
+    existingQuery = existingQuery
+      .eq('scheduled_start', params.scheduledStart.toISOString())
+      .eq('scheduled_end', params.scheduledEnd.toISOString())
+      .contains('metadata', { band_id: params.bandId });
+  }
+
+  const { data: existingActivities, error: existingError } = await existingQuery;
+  if (existingError) {
+    console.error('Failed to check existing band scheduled activities:', existingError);
+    throw new Error('Failed to verify existing band schedule entries');
+  }
+
+  const alreadyScheduled = new Set((existingActivities || []).map((activity: any) => activity.user_id));
+  const membersToSchedule = validMembers.filter(userId => !alreadyScheduled.has(userId));
+
+  if (membersToSchedule.length === 0) {
+    return [];
+  }
   
   // Create activity for each band member
-  const insertData = validMembers.map(userId => ({
+  const insertData = membersToSchedule.map(userId => ({
     user_id: userId,
     profile_id: profileMap.get(userId),
     activity_type: params.activityType,


### PR DESCRIPTION
### Motivation

- Fix unreliable band activity behavior seen as duplicate/orphan schedule rows, inconsistent song/recording visibility for members, and weak conflict checks when booking rehearsals/jams/recordings.
- Keep changes small, avoid schema/UI changes, and ensure band-created songs/recordings and band bookings appear correctly in member schedules.

### Description

- Add a de-duplication helper `withoutDuplicateBandScheduleActivities` to collapse duplicate linked band activities at schedule aggregation time. (`src/utils/bandActivityScheduling.ts`, `src/hooks/useScheduledActivities.ts`)
- Make `createBandScheduledActivities` idempotent by checking existing non-cancelled per-member schedule rows for the same linked rehearsal/recording (skip already-created rows). (`src/utils/bandActivityScheduling.ts`)
- Expand `useRecordingSessions` to include recording sessions for bands the active profile is currently an active member of, and preserve `scheduled_start`/`scheduled_end` and `status` for scheduled recordings. (`src/hooks/useRecordingData.tsx`)
- Deduplicate aggregated schedule items in `useScheduledActivities` using the new helper so band activities render cleanly for members. (`src/hooks/useScheduledActivities.ts`)
- Harden jam-session booking: use strict overlap checks, surface Supabase errors, ensure scheduled-activity inserts report failures, and prevent duplicate bookings while a request is already in progress. (`src/hooks/useJamSessionBooking.ts`)
- Surface Supabase/API errors in the band songs panel by showing an error state when the query fails. (`src/components/band/BandSongsSection.tsx`)
- Add focused unit tests for schedule de-duplication behavior and add test env stubs to initialize Supabase-env-backed helpers in Vitest. (`src/utils/__tests__/bandActivityScheduling.test.ts`, `src/setupTests.ts`)

### Testing

- Ran TypeScript check with `npx tsc --noEmit`, which passed. 
- Ran `git diff --check`, which passed with no whitespace issues. 
- Added unit tests (`src/utils/__tests__/bandActivityScheduling.test.ts`) but could not run them because test tooling installation failed in this environment; `vitest` is not available and `npm install` is blocked by registry 403 for some dependencies. 
- Lint and build could not be executed in this environment due to missing dev dependencies (`@eslint/js`, `vite`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5083b179b08325abff2b8de0866d22)