### PR TITLE
Harden idempotent XP awards for education videos

### DIFF
--- a/src/features/education/hooks/useWatchVideo.ts
+++ b/src/features/education/hooks/useWatchVideo.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import { awardActionXp } from "@/utils/progression";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 
 const STORAGE_KEY_PREFIX = "video_watch_history_";
@@ -92,10 +93,24 @@ export const useWatchVideo = () => {
         throw new Error("Not authenticated");
       }
       
-      // Get profile
+      const transactionRef = `education-video:${profileId}:${videoId}:${Math.floor(Date.now() / COOLDOWN_MS)}`;
+
+      await awardActionXp({
+        amount: XP_PER_VIDEO,
+        category: "education",
+        actionKey: "youtube_video",
+        uniqueEventId: transactionRef,
+        metadata: {
+          video_id: videoId,
+          video_name: videoName,
+          skill_slug: skillSlug?.toLowerCase() || null,
+        },
+      });
+
+      // Get profile after the authoritative XP transaction succeeds.
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
-        .select("id, experience, user_id")
+        .select("id")
         .eq("id", profileId)
         .single();
       
@@ -103,24 +118,22 @@ export const useWatchVideo = () => {
         throw new Error("Could not load profile");
       }
       
-      // Award general XP to profile
-      await supabase
-        .from("profiles")
-        .update({ experience: (profile.experience || 0) + XP_PER_VIDEO })
-        .eq("id", profile.id);
-      
       // Award skill XP if skill is linked
       if (skillSlug) {
         const validSkills = ["guitar", "bass", "drums", "vocals", "performance", "songwriting"];
         const normalizedSkill = skillSlug.toLowerCase();
         
         if (validSkills.includes(normalizedSkill)) {
-          const { data: existingProgress } = await supabase
+          const { data: existingProgress, error: skillLoadError } = await supabase
             .from("skill_progress")
             .select("id, current_xp, current_level, required_xp")
             .eq("profile_id", profile.id)
             .eq("skill_slug", normalizedSkill)
             .maybeSingle();
+
+          if (skillLoadError) {
+            throw new Error(skillLoadError.message || "Could not load skill progress");
+          }
           
           if (existingProgress) {
             let newXp = existingProgress.current_xp + XP_PER_VIDEO;
@@ -134,7 +147,7 @@ export const useWatchVideo = () => {
               requiredXp = Math.floor(requiredXp * 1.5);
             }
             
-            await supabase
+            const { error: skillUpdateError } = await supabase
               .from("skill_progress")
               .update({
                 current_xp: newXp,
@@ -143,9 +156,13 @@ export const useWatchVideo = () => {
                 last_practiced_at: new Date().toISOString(),
               })
               .eq("id", existingProgress.id);
+
+            if (skillUpdateError) {
+              throw new Error(skillUpdateError.message || "Could not update skill progress");
+            }
           } else {
             // Create new skill progress
-            await supabase.from("skill_progress").insert({
+            const { error: skillInsertError } = await supabase.from("skill_progress").insert({
               profile_id: profile.id,
               skill_slug: normalizedSkill,
               current_xp: XP_PER_VIDEO,
@@ -153,19 +170,13 @@ export const useWatchVideo = () => {
               required_xp: 100,
               last_practiced_at: new Date().toISOString(),
             });
+
+            if (skillInsertError) {
+              throw new Error(skillInsertError.message || "Could not create skill progress");
+            }
           }
         }
       }
-      
-      // Log to experience ledger
-      await supabase.from("experience_ledger").insert({
-        user_id: profile.user_id,
-        profile_id: profile.id,
-        activity_type: "youtube_video",
-        xp_amount: XP_PER_VIDEO,
-        skill_slug: skillSlug?.toLowerCase() || null,
-        metadata: { video_id: videoId, video_name: videoName },
-      });
       
       // Record watch timestamp per profile
       const history = getWatchHistory(profileId);

--- a/src/utils/progression.test.ts
+++ b/src/utils/progression.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    functions: { invoke },
+  },
+}));
+
+import { awardActionXp } from "./progression";
+
+describe("awardActionXp", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue({
+      data: {
+        success: true,
+        action: "award_action_xp",
+        profile: {},
+        wallet: null,
+        attributes: null,
+        cooldowns: {},
+      },
+      error: null,
+    });
+  });
+
+  it("passes a unique event id to the progression edge function for idempotency", async () => {
+    await awardActionXp({
+      amount: 15,
+      category: "education",
+      actionKey: "youtube_video",
+      uniqueEventId: "education-video:profile-1:lesson-1:123",
+      metadata: { video_id: "lesson-1" },
+    });
+
+    expect(invoke).toHaveBeenCalledWith("progression", {
+      body: expect.objectContaining({
+        action: "award_action_xp",
+        amount: 15,
+        category: "education",
+        action_key: "youtube_video",
+        event_id: "education-video:profile-1:lesson-1:123",
+        metadata: { video_id: "lesson-1" },
+      }),
+    });
+  });
+
+  it("surfaces failed authoritative XP awards", async () => {
+    invoke.mockResolvedValueOnce({
+      data: { success: false, message: "Failed to log XP in ledger" },
+      error: null,
+    });
+
+    await expect(
+      awardActionXp({ amount: 15, uniqueEventId: "duplicate-safe-ref" }),
+    ).rejects.toThrow("Failed to log XP in ledger");
+  });
+});

--- a/supabase/functions/progression/handlers.ts
+++ b/supabase/functions/progression/handlers.ts
@@ -564,11 +564,32 @@ export async function handleAwardActionXp(
   category: string = "performance",
   actionKey: string = "gameplay_action",
   metadata: Record<string, unknown> = {},
+  eventId?: string,
 ): Promise<ProfileState> {
   const profileId = profileState.profile.id;
 
   if (amount <= 0) {
     throw new Error("XP amount must be positive");
+  }
+
+  const transactionRef = typeof eventId === "string" && eventId.trim().length > 0 ? eventId.trim() : undefined;
+
+  if (transactionRef) {
+    const { data: existingLedger, error: existingLedgerError } = await client
+      .from("experience_ledger")
+      .select("id")
+      .eq("profile_id", profileId)
+      .eq("activity_type", actionKey)
+      .eq("metadata->>transaction_ref", transactionRef)
+      .maybeSingle();
+
+    if (existingLedgerError && existingLedgerError.code !== "PGRST116") {
+      throw new Error(existingLedgerError.message || "Failed to verify XP transaction");
+    }
+
+    if (existingLedger) {
+      return await fetchProfileState(client, profileId);
+    }
   }
 
   // Calculate health drain if metadata includes duration
@@ -625,12 +646,13 @@ export async function handleAwardActionXp(
         action_key: actionKey,
         health_drain: healthDrain,
         pending_daily_process: true,
+        transaction_ref: transactionRef ?? null,
         ...metadata,
       },
     });
 
   if (ledgerError) {
-    console.error("Failed to log XP in ledger:", ledgerError);
+    throw new Error(ledgerError.message || "Failed to log XP in ledger");
   }
 
   return await fetchProfileState(client, profileId);

--- a/supabase/functions/progression/index.ts
+++ b/supabase/functions/progression/index.ts
@@ -204,6 +204,7 @@ serve(async (req) => {
           params.category,
           params.action_key,
           params.metadata,
+          params.event_id,
         );
         break;
 


### PR DESCRIPTION
### Motivation
- Prevent client-authoritative XP ledger/profile writes for video-watching and make education XP authoritative and idempotent. 
- Reduce duplicate rewards from retries/double-clicks by introducing a transaction reference for replay detection. 
- Surface authoritative ledger failures so the UI does not report success when the server did not record XP.

### Description
- Route video-watch XP through the existing progression Edge Function by calling `awardActionXp(...)` from `useWatchVideo` and remove the direct client `profiles.experience` update and direct `experience_ledger` insert for that flow. 
- Add an idempotency/transaction reference param (`event_id` / `transaction_ref`) guarded check in the progression handler so `handleAwardActionXp` queries `experience_ledger` for an existing `metadata->>transaction_ref` before inserting a duplicate row and returns early if found. 
- Record `transaction_ref` into `experience_ledger` metadata and change ledger write failures from silent logs to thrown errors to ensure upstream callers see failures. 
- Pass `params.event_id` from the progression entry point to `handleAwardActionXp` and add a unit test `src/utils/progression.test.ts` that verifies the client forwards `event_id` and that failures from the progression function are surfaced.

### Testing
- Ran the TypeScript typecheck with `npx tsc --noEmit`, which succeeded. 
- Added a Vitest unit test file `src/utils/progression.test.ts` that covers idempotency payload forwarding and failure surfacing, but attempting to run `vitest` in this environment failed due to missing registry/dependency access. 
- Attempts to run `npm test`, `npm run lint`, `npm run build` and `npm install` were blocked by the execution environment (missing binaries and `403` npm registry responses), so lint/build/test coverage in CI should be run after dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5085127b7883258dca85270da17548)