### PR TITLE
Harden beta RLS and admin actions

### DIFF
--- a/supabase/functions/admin-boost-plays/index.ts
+++ b/supabase/functions/admin-boost-plays/index.ts
@@ -81,6 +81,14 @@ Deno.serve(async (req) => {
         });
       }
 
+      await supabaseAdmin.from("admin_action_audit").insert({
+        actor_user_id: user.id,
+        action: "admin_boost_plays",
+        target_table: "song_plays",
+        target_id: songId,
+        metadata: { songId, amount },
+      });
+
       console.log(`Admin ${user.id} boosted song ${songId} with ${amount} plays`);
       return new Response(JSON.stringify({ success: true, added: amount }), {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -386,6 +394,14 @@ Deno.serve(async (req) => {
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }
+
+      await supabaseAdmin.from("admin_action_audit").insert({
+        actor_user_id: user.id,
+        action: "admin_release_pump",
+        target_table: "releases",
+        target_id: releaseId,
+        metadata: { releaseId, amount, saleType, grossRevenue, netRevenue },
+      });
 
       return new Response(JSON.stringify({
         success: true,

--- a/supabase/functions/admin-trigger-event/index.ts
+++ b/supabase/functions/admin-trigger-event/index.ts
@@ -11,10 +11,44 @@ Deno.serve(async (req) => {
   }
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-  const supabase = createClient(supabaseUrl, supabaseKey);
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const authHeader = req.headers.get("Authorization");
+
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: "No authorization header" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabaseUser = createClient(
+    supabaseUrl,
+    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+    { global: { headers: { Authorization: authHeader } } },
+  );
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
 
   try {
+    const { data: { user }, error: authError } = await supabaseUser.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: isAdmin, error: roleError } = await supabaseUser.rpc("has_role", {
+      _user_id: user.id,
+      _role: "admin",
+    });
+
+    if (roleError || isAdmin !== true) {
+      return new Response(JSON.stringify({ error: "Admin access required" }), {
+        status: 403,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     const { userId, eventId, category } = await req.json();
 
     if (!userId) {
@@ -120,7 +154,15 @@ Deno.serve(async (req) => {
       throw insertError;
     }
 
-    console.log(`[admin-trigger-event] Triggered event "${selectedEvent.title}" for user ${userId}`);
+    await supabase.from("admin_action_audit").insert({
+      actor_user_id: user.id,
+      action: "admin_trigger_event",
+      target_table: "player_events",
+      target_id: playerEvent.id,
+      metadata: { userId, eventId: selectedEvent.id, category },
+    });
+
+    console.log(`[admin-trigger-event] Admin ${user.id} triggered event "${selectedEvent.title}" for user ${userId}`);
 
     return new Response(
       JSON.stringify({

--- a/supabase/migrations/20291202090000_beta_rls_hardening.sql
+++ b/supabase/migrations/20291202090000_beta_rls_hardening.sql
@@ -1,0 +1,143 @@
+-- Beta RLS hardening for private player progress, casting workflows, admin assets, and admin audit logs.
+
+-- Private player skill state: catalog metadata stays public, but per-profile progress/unlocks do not.
+DROP POLICY IF EXISTS "Profile skill progress is viewable by everyone" ON public.profile_skill_progress;
+DROP POLICY IF EXISTS "Profile skill unlocks are viewable by everyone" ON public.profile_skill_unlocks;
+
+CREATE POLICY "Users can view their own skill progress"
+  ON public.profile_skill_progress
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_skill_progress.profile_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can view their own skill unlocks"
+  ON public.profile_skill_unlocks
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_skill_unlocks.profile_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+-- Presence is user-private except for admins. Public chat messages remain governed by chat_messages policies.
+DROP POLICY IF EXISTS "Chat participants are viewable by everyone" ON public.chat_participants;
+
+CREATE POLICY "Users can view their own chat presence"
+  ON public.chat_participants
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Casting submissions include resumes, portfolios, and feedback. Limit review access to call owners/admins.
+DROP POLICY IF EXISTS "Reviewers can read all submissions" ON public.casting_submissions;
+DROP POLICY IF EXISTS "Reviewers can read reviews" ON public.casting_reviews;
+DROP POLICY IF EXISTS "Reviewers can insert reviews" ON public.casting_reviews;
+
+CREATE POLICY "Casting call owners can read submissions"
+  ON public.casting_submissions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.casting_calls cc
+      WHERE cc.id = casting_submissions.casting_call_id
+        AND cc.created_by = auth.uid()
+    )
+    OR public.has_role(auth.uid(), 'admin'::public.app_role)
+  );
+
+CREATE POLICY "Submission participants can read reviews"
+  ON public.casting_reviews
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.casting_submissions cs
+      LEFT JOIN public.casting_calls cc ON cc.id = cs.casting_call_id
+      LEFT JOIN public.profiles p ON p.id = cs.talent_profile_id
+      WHERE cs.id = casting_reviews.submission_id
+        AND (
+          p.user_id = auth.uid()
+          OR cc.created_by = auth.uid()
+          OR public.has_role(auth.uid(), 'admin'::public.app_role)
+        )
+    )
+  );
+
+CREATE POLICY "Casting call owners can insert reviews"
+  ON public.casting_reviews
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    reviewer_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM public.casting_submissions cs
+      JOIN public.casting_calls cc ON cc.id = cs.casting_call_id
+      WHERE cs.id = casting_reviews.submission_id
+        AND (cc.created_by = auth.uid() OR public.has_role(auth.uid(), 'admin'::public.app_role))
+    )
+  );
+
+-- Admin-managed public asset buckets: read remains public, writes require server-side admin role.
+DROP POLICY IF EXISTS "Authenticated upload practice tracks" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated update practice tracks" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated delete practice tracks" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can upload POV clips" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can update POV clips" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can upload DikCok thumbnails" ON storage.objects;
+
+CREATE POLICY "Admins can upload practice tracks"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'practice-tracks' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Admins can update practice tracks"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'practice-tracks' AND public.has_role(auth.uid(), 'admin'::public.app_role))
+  WITH CHECK (bucket_id = 'practice-tracks' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Admins can delete practice tracks"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'practice-tracks' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Admins can upload POV clips"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'pov-clips' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Admins can update POV clips"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'pov-clips' AND public.has_role(auth.uid(), 'admin'::public.app_role))
+  WITH CHECK (bucket_id = 'pov-clips' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Admins can upload DikCok thumbnails"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'dikcok-thumbnails' AND public.has_role(auth.uid(), 'admin'::public.app_role));
+
+-- Append-only audit log for sensitive admin actions performed by Edge Functions/RPCs.
+CREATE TABLE IF NOT EXISTS public.admin_action_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  target_table text,
+  target_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.admin_action_audit ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins can read admin action audit"
+  ON public.admin_action_audit
+  FOR SELECT
+  TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'::public.app_role));
+
+CREATE POLICY "Service role can append admin action audit"
+  ON public.admin_action_audit
+  FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
### Motivation
- Close obvious permission gaps so private player and band data are not exposed by broad policies during beta. 
- Prevent client-supplied identifiers and unauthenticated callers from performing admin-level resource changes. 
- Add minimal server-side checks and audit logging for sensitive Edge Functions while preserving intentional public gameplay data.

### Description
- Added a corrective Supabase migration `20291202090000_beta_rls_hardening.sql` that tightens RLS for `profile_skill_progress`, `profile_skill_unlocks`, `chat_participants`, `casting_submissions`, `casting_reviews`, and constrains storage write policies for public buckets to admin-only checks. 
- Created an append-only `public.admin_action_audit` table with RLS that allows admins to read and the service role to append audit rows. 
- Hardened Edge Functions by authenticating callers and checking server-side admin role before using the service-role client, and added audit inserts to `admin-trigger-event` and `admin-boost-plays` for recorded admin actions. 
- Kept intentionally public/catalog data (skill definitions, public media buckets for read, public casting calls/roles) readable while moving per-profile or private records to ownership-based `auth.uid()` checks or admin-only paths.

### Testing
- Type check: `npx tsc --noEmit` completed successfully. 
- Pre-commit checks: `git diff --cached --check` passed before commit and changes were committed as `Harden beta RLS and admin actions`. 
- Lint/build/tests: `npm run lint`, `npm run build`, and `npm test` could not be executed in this environment because local tooling/dependencies (`@eslint/js`, `vite`, `vitest`) are not installed. 
- Supabase CLI validation: could not run because the Supabase CLI is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50888824e48325bb760be682c313b1)