### PR TITLE
Add Getting Started dashboard and first-session recommendations for new players

### DIFF
--- a/src/components/dashboard/GettingStartedPanel.tsx
+++ b/src/components/dashboard/GettingStartedPanel.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { CheckCircle2, Circle, Compass, Music2 } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { supabase } from "@/integrations/supabase/client";
+import { cn } from "@/lib/utils";
+
+interface GettingStartedPanelProps {
+  profile: any;
+  userId?: string | null;
+}
+
+interface OnboardingSnapshot {
+  skillRows: number;
+  songCount: number;
+  recordingCount: number;
+  activityCount: number;
+  bandCount: number;
+}
+
+interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+  completed: boolean;
+  optional?: boolean;
+}
+
+function buildSteps(profile: any, snapshot: OnboardingSnapshot): OnboardingStep[] {
+  const hasProfileBasics = Boolean(profile?.display_name || profile?.username) && Boolean(profile?.age || profile?.gender || profile?.city_id);
+  const hasSkills = snapshot.skillRows > 0;
+  const hasSong = snapshot.songCount > 0;
+  const hasBookedActivity = snapshot.activityCount > 0;
+  const hasBand = snapshot.bandCount > 0;
+  const hasRecording = snapshot.recordingCount > 0;
+
+  const steps: OnboardingStep[] = [
+    {
+      id: "profile",
+      title: "Confirm your character setup",
+      description: "Make sure your artist name, identity, and home city are ready before you start making music.",
+      href: "/characters",
+      cta: "Review character",
+      completed: hasProfileBasics,
+    },
+    {
+      id: "skills",
+      title: "Review your starter skills",
+      description: "Check which musical skills you already have, then choose what to practise or learn first.",
+      href: "/skills",
+      cta: "Open skills",
+      completed: hasSkills,
+    },
+    {
+      id: "song",
+      title: "Write your first song",
+      description: "Start a songwriting session so your career has material to rehearse, record, and release.",
+      href: "/booking/songwriting",
+      cta: "Start songwriting",
+      completed: hasSong,
+    },
+    {
+      id: "activity",
+      title: "Book your first activity",
+      description: "Add a lesson, practice session, work shift, or music activity to your schedule so time has a clear next step.",
+      href: "/schedule",
+      cta: "Open schedule",
+      completed: hasBookedActivity,
+    },
+  ];
+
+  if (hasBand || hasSong) {
+    steps.push({
+      id: hasRecording ? "release" : "band",
+      title: hasRecording ? "Prepare your first release" : "Join or create a band",
+      description: hasRecording
+        ? "You have recorded music. Move it toward a release when you are ready."
+        : "A band is optional early on, but it unlocks rehearsals, gigs, and collaboration.",
+      href: hasRecording ? "/release-manager" : "/band",
+      cta: hasRecording ? "Open releases" : "Open band page",
+      completed: hasRecording ? false : hasBand,
+      optional: !hasRecording,
+    });
+  }
+
+  return steps;
+}
+
+export function GettingStartedPanel({ profile, userId }: GettingStartedPanelProps) {
+  const profileId = profile?.id;
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["getting-started", userId, profileId],
+    enabled: !!userId && !!profileId,
+    staleTime: 30_000,
+    queryFn: async (): Promise<OnboardingSnapshot> => {
+      const [skillsResult, songsResult, recordingsResult, activitiesResult, bandsResult] = await Promise.all([
+        (supabase as any).from("player_skills").select("id", { count: "exact", head: true }).eq("user_id", userId),
+        (supabase as any).from("songs").select("id", { count: "exact", head: true }).eq("profile_id", profileId).or("archived.is.null,archived.eq.false"),
+        (supabase as any).from("songs").select("id", { count: "exact", head: true }).eq("profile_id", profileId).in("status", ["recorded", "released"]).or("archived.is.null,archived.eq.false"),
+        (supabase as any).from("player_scheduled_activities").select("id", { count: "exact", head: true }).eq("profile_id", profileId),
+        (supabase as any).from("band_members").select("band_id", { count: "exact", head: true }).eq("profile_id", profileId).eq("member_status", "active"),
+      ]);
+      const failed = [skillsResult, songsResult, recordingsResult, activitiesResult, bandsResult].find((result: any) => result.error);
+      if (failed?.error) throw failed.error;
+      return {
+        skillRows: skillsResult.count ?? 0,
+        songCount: songsResult.count ?? 0,
+        recordingCount: recordingsResult.count ?? 0,
+        activityCount: activitiesResult.count ?? 0,
+        bandCount: bandsResult.count ?? 0,
+      };
+    },
+  });
+
+  const steps = useMemo(() => buildSteps(profile, data ?? { skillRows: 0, songCount: 0, recordingCount: 0, activityCount: 0, bandCount: 0 }), [data, profile]);
+  const requiredSteps = steps.filter((step) => !step.optional);
+  const completedRequired = requiredSteps.filter((step) => step.completed).length;
+  const isEstablished = (profile?.level ?? 1) >= 4 || (profile?.fame ?? 0) >= 100;
+  const isComplete = completedRequired === requiredSteps.length && (data?.songCount ?? 0) > 0 && ((data?.activityCount ?? 0) > 0 || isEstablished);
+
+  if (!profileId || isComplete || (isEstablished && (data?.songCount ?? 0) > 0)) return null;
+  if (isLoading) return <PageLoadingState title="Loading first steps" description="Checking your character, skills, songs, band, and schedule progress..." />;
+  if (error) return <PageErrorState title="First steps could not be loaded" description="You can still start with skills, songwriting, or the schedule from the dashboard links." onRetry={() => void refetch()} />;
+
+  const progress = Math.round((completedRequired / Math.max(1, requiredSteps.length)) * 100);
+  const nextStep = steps.find((step) => !step.completed) ?? steps[0];
+
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Compass className="h-4 w-4 text-primary" />
+            Getting Started
+          </CardTitle>
+          <CardDescription>Follow these first steps to get from character setup to your first meaningful music action.</CardDescription>
+        </div>
+        <Button asChild size="sm"><Link to={nextStep.href}>{nextStep.cta}</Link></Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div aria-label="Getting started progress" aria-valuemin={0} aria-valuemax={requiredSteps.length} aria-valuenow={completedRequired} role="progressbar">
+          <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+            <span>{completedRequired} of {requiredSteps.length} required steps complete</span>
+            <span>{progress}%</span>
+          </div>
+          <Progress value={progress} className="h-2" />
+        </div>
+        <ol className="space-y-2">
+          {steps.map((step, index) => {
+            const Icon = step.completed ? CheckCircle2 : step.id === "song" ? Music2 : Circle;
+            return (
+              <li key={step.id} className={cn("rounded-lg border bg-card/70 p-3", step.completed && "opacity-75")}>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex min-w-0 gap-3">
+                    <Icon className={cn("mt-0.5 h-4 w-4 flex-shrink-0", step.completed ? "text-emerald-500" : "text-primary")} />
+                    <div>
+                      <h3 className="text-sm font-semibold">{index + 1}. {step.title}{step.optional ? " (optional)" : ""}</h3>
+                      <p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
+                    </div>
+                  </div>
+                  <Button asChild size="sm" variant={step.completed ? "outline" : "default"} className="shrink-0"><Link to={step.href}>{step.completed ? "Review" : step.cta}</Link></Button>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/ManagerRecommendationsPanel.tsx
+++ b/src/components/dashboard/ManagerRecommendationsPanel.tsx
@@ -48,7 +48,7 @@ export function ManagerRecommendationsPanel({ profile, userId }: ManagerRecommen
       if (bandIdsResult.error) throw bandIdsResult.error;
       const bandIds = (bandIdsResult.data ?? []).map((row: any) => row.band_id).filter(Boolean);
 
-      const [songsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult] = await Promise.all([
+      const [completedSongsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult, totalSongsResult] = await Promise.all([
         supabase
           .from("songs")
           .select("id", { count: "exact", head: true })
@@ -85,16 +85,23 @@ export function ManagerRecommendationsPanel({ profile, userId }: ManagerRecommen
               .gte("scheduled_start", todayIso())
               .lte("scheduled_start", addDays(now, 14).toISOString())
           : Promise.resolve({ data: [], count: 0, error: null }),
+        supabase
+          .from("songs")
+          .select("id", { count: "exact", head: true })
+          .eq("profile_id", profileId)
+          .or("archived.is.null,archived.eq.false"),
       ]);
 
-      const failed = [songsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult].find((result: any) => result.error);
+      const failed = [completedSongsResult, recordingsResult, messagesResult, activitiesResult, rehearsalsResult, totalSongsResult].find((result: any) => result.error);
       if (failed?.error) throw failed.error;
 
       return {
-        songsReadyToRecord: songsResult.count ?? 0,
+        songsReadyToRecord: completedSongsResult.count ?? 0,
         recordingsReadyToRelease: recordingsResult.count ?? 0,
         unreadImportantMessages: messagesResult.count ?? 0,
         upcomingActivities: activitiesResult.data ?? [],
+        upcomingActivitiesCount: activitiesResult.count ?? activitiesResult.data?.length ?? 0,
+        totalSongs: totalSongsResult.count ?? 0,
         needsBandRehearsal: bandIds.length > 0 && (rehearsalsResult.count ?? 0) === 0,
       };
     },

--- a/src/lib/managerRecommendations.ts
+++ b/src/lib/managerRecommendations.ts
@@ -16,6 +16,8 @@ export interface ManagerRecommendationInput {
   } | null;
   songsReadyToRecord?: number;
   recordingsReadyToRelease?: number;
+  totalSongs?: number;
+  upcomingActivitiesCount?: number;
   needsBandRehearsal?: boolean;
   unreadImportantMessages?: number;
   upcomingActivities?: Array<{
@@ -44,6 +46,30 @@ export function buildManagerRecommendations(input: ManagerRecommendationInput): 
   const recordingsReadyToRelease = input.recordingsReadyToRelease ?? 0;
   const unreadImportantMessages = input.unreadImportantMessages ?? 0;
   const upcomingActivities = input.upcomingActivities ?? [];
+  const totalSongs = input.totalSongs ?? songsReadyToRecord + recordingsReadyToRelease;
+  const upcomingActivitiesCount = input.upcomingActivitiesCount ?? upcomingActivities.length;
+
+  if (totalSongs === 0) {
+    recommendations.push({
+      id: "first-song",
+      title: "Write your first song",
+      reason: "You need original material before recording, releases, setlists, and many gig opportunities become useful.",
+      suggestedAction: "Start a songwriting booking and create your first draft.",
+      href: "/booking/songwriting",
+      priority: "high",
+    });
+  }
+
+  if (totalSongs > 0 && upcomingActivitiesCount === 0) {
+    recommendations.push({
+      id: "first-activity",
+      title: "Book your next activity",
+      reason: "Your schedule has no upcoming activity, so there is no clear next time-based action.",
+      suggestedAction: "Open the schedule and book practice, education, work, rehearsal, or recording when eligible.",
+      href: "/schedule",
+      priority: "medium",
+    });
+  }
 
   if (health <= 35 || energy <= 35) {
     const isCritical = health <= 20 || energy <= 20;
@@ -74,7 +100,7 @@ export function buildManagerRecommendations(input: ManagerRecommendationInput): 
       title: "Release finished recordings",
       reason: `${pluralize(recordingsReadyToRelease, "recorded song")} ${recordingsReadyToRelease === 1 ? "is" : "are"} ready to turn into momentum.`,
       suggestedAction: "Create a single, EP, or album release while the material is fresh.",
-      href: "/releases",
+      href: "/release-manager",
       priority: "high",
     });
   }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -34,6 +34,7 @@ import { PlayerSurveyModal } from "@/components/survey/PlayerSurveyModal";
 import { CharacterUnreadWidget } from "@/components/dashboard/CharacterUnreadWidget";
 import { TodaysBriefing } from "@/components/dashboard/TodaysBriefing";
 import { ManagerRecommendationsPanel } from "@/components/dashboard/ManagerRecommendationsPanel";
+import { GettingStartedPanel } from "@/components/dashboard/GettingStartedPanel";
 import { WorldNewsList } from "@/components/world/WorldNewsList";
 
 import { Link } from "react-router-dom";
@@ -180,7 +181,7 @@ const GoalsProgressPanel = ({ profile, userId }: { profile: any; userId?: string
         ) : error ? (
           <PageErrorState title="Goals could not be loaded" description="Your dashboard is still available while goals refresh." onRetry={() => void refetch()} />
         ) : goals.length === 0 ? (
-          <PageEmptyState title="No goals available" description="Play a little more and your next goals will appear here." />
+          <PageEmptyState title="Start your first music goal" description="Write a song or book an activity and your dashboard goals will update around that progress." action={<Button asChild size="sm"><Link to="/booking/songwriting">Start songwriting</Link></Button>} />
         ) : goals.map((goal) => {
           const pct = Math.min(100, Math.round((goal.current / goal.target) * 100));
           return (
@@ -417,6 +418,7 @@ const Dashboard = () => {
         {/* Profile Tab — identity only */}
         <TabsContent value="profile" className="space-y-4">
           <DashboardHero profile={profile} userId={user?.id} />
+          <GettingStartedPanel profile={profile} userId={user?.id} />
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)]">
             <div className="space-y-4">
               <TodaysBriefing profile={profile} userId={user?.id} />

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -184,7 +184,10 @@ const SkillsPage = () => {
                 <div className="text-center py-8 text-muted-foreground">
                   <Target className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <p>No skills available to practice yet.</p>
-                  <p className="text-sm mt-2">Train via education, gigs, or activities to reach level 1.</p>
+                  <p className="text-sm mt-2">Start with education or a music activity to unlock a level 1 skill.</p>
+                  <Button asChild size="sm" className="mt-4">
+                    <a href="/education">Find starter lessons</a>
+                  </Button>
                 </div>
               ) : (
                 <div className="space-y-4">


### PR DESCRIPTION
### Motivation
- Reduce new-player confusion by giving a clear, actionable path from account/character creation to the first music action without redesigning the app shell. 
- Surface 3–5 ordered onboarding steps and make the primary recommendation immediately actionable using only existing systems and data.
- Keep changes incremental and beta-focused, avoiding DB migrations or gameplay-balance edits.

### Description
- Added a new `GettingStartedPanel` component (src/components/dashboard/GettingStartedPanel.tsx) that detects early-stage players via existing data (`player_skills`, `songs`, recorded/released songs, `player_scheduled_activities`, `band_members`, and profile basics) and shows a 3–5 step, progress-tracked checklist linking to valid pages (`/characters`, `/skills`, `/booking/songwriting`, `/schedule`, optional `/band` or `/release-manager`).
- Inserted the panel under the existing `DashboardHero` in `src/pages/Dashboard.tsx` so the panel is additive to the dashboard layout and hides itself for established or completed players.
- Extended manager recommendation logic to include two newcomer-focused rules in `src/lib/managerRecommendations.ts` (recommend `Write your first song` and `Book your next activity`), and updated `ManagerRecommendationsPanel` to fetch a `totalSongs` and `upcomingActivitiesCount` snapshot so recommendations are actionable and context-aware (src/components/dashboard/ManagerRecommendationsPanel.tsx).
- Improved empty states: replaced the goals empty copy with a CTA to start songwriting (Dashboard) and added a starter lessons CTA to the skills practice empty state (SkillsPage), all linking to existing routes; no schema changes were made.

### Testing
- Type checking: ran `npx tsc --noEmit` which completed successfully for the modified files.
- Lint: `npm run lint` could not be completed in this environment due to missing installed dependencies; ESLint failed to resolve `@eslint/js` so lint checks were not run to completion.
- Build/test: `npm run build` and `npm run test` (Vitest) could not be executed because dev dependencies and the toolchain (`vite`, `vitest`) were not available in this environment, and `npm ci` failed due to registry access (403) while installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508a55f6188325b2996a54f408b2ff)