### PR TITLE
Add beta admin support tooling

### DIFF
--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -58,6 +58,15 @@ const AdminDashboard = () => {
     },
   });
 
+  const { data: betaHealth, isLoading: betaHealthLoading, error: betaHealthError } = useQuery({
+    queryKey: ["admin-beta-health-overview"],
+    queryFn: async () => {
+      const { data, error } = await (supabase as any).rpc("admin_get_beta_health_overview");
+      if (error) throw error;
+      return data as any;
+    },
+  });
+
   const { data: cronJobs } = useQuery({
     queryKey: ["admin-cron-status"],
     queryFn: async () => {
@@ -162,6 +171,68 @@ const AdminDashboard = () => {
               />
               <Label htmlFor="nav-style-toggle" className="text-sm">Horizontal</Label>
             </div>
+          </CardContent>
+        </Card>
+
+        {/* Beta Health Overview */}
+        <Card className="border-primary/20">
+          <CardHeader>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Gauge className="h-5 w-5 text-primary" />
+              Beta Health Overview
+            </CardTitle>
+            <CardDescription>Lightweight support signals from existing logs, activity statuses, economy totals, and cron runs.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {betaHealthError ? (
+              <p className="text-sm text-destructive">{(betaHealthError as Error).message}</p>
+            ) : (
+              <>
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  {[
+                    ["Active players 24h", betaHealth?.active_players_24h],
+                    ["New profiles 24h", betaHealth?.new_profiles_24h],
+                    ["Stuck activities", betaHealth?.stuck_activity_statuses],
+                    ["Failed cron 24h", betaHealth?.failed_recent_cron_jobs],
+                    ["Recent errors", betaHealth?.recent_activity_errors],
+                    ["Active activities", betaHealth?.active_activity_statuses],
+                    ["Admin actions 24h", betaHealth?.recent_admin_actions],
+                    ["Total cash", betaHealth?.total_cash != null ? `$${Number(betaHealth.total_cash).toLocaleString()}` : undefined],
+                  ].map(([label, value]) => (
+                    <div key={String(label)} className="rounded-lg border p-3">
+                      <p className="text-xs text-muted-foreground">{label}</p>
+                      {betaHealthLoading ? <Skeleton className="mt-2 h-6 w-16" /> : <p className="text-xl font-semibold">{value ?? 0}</p>}
+                    </div>
+                  ))}
+                </div>
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <h3 className="mb-2 text-sm font-semibold">Latest error-like events</h3>
+                    <div className="space-y-2 max-h-48 overflow-y-auto">
+                      {betaHealth?.latest_errors?.length ? betaHealth.latest_errors.map((event: any) => (
+                        <div key={event.id} className="rounded border p-2 text-xs">
+                          <div className="font-medium">{event.activity_category}/{event.activity_type}</div>
+                          <div className="text-muted-foreground">{event.description}</div>
+                          <div className="text-muted-foreground">{new Date(event.created_at).toLocaleString()} · user {event.user_id ?? "—"}</div>
+                        </div>
+                      )) : <p className="text-sm text-muted-foreground">No recent error-like events.</p>}
+                    </div>
+                  </div>
+                  <div>
+                    <h3 className="mb-2 text-sm font-semibold">Latest cron/job status</h3>
+                    <div className="space-y-2 max-h-48 overflow-y-auto">
+                      {betaHealth?.latest_cron_jobs?.length ? betaHealth.latest_cron_jobs.map((job: any) => (
+                        <div key={job.id} className="rounded border p-2 text-xs">
+                          <div className="flex items-center justify-between gap-2"><span className="font-medium">{job.job_name}</span><Badge variant={job.status === "success" ? "default" : "destructive"}>{job.status}</Badge></div>
+                          <div className="text-muted-foreground">{new Date(job.started_at).toLocaleString()}</div>
+                          {job.error_message ? <div className="text-destructive">{job.error_message}</div> : null}
+                        </div>
+                      )) : <p className="text-sm text-muted-foreground">No cron/job rows available.</p>}
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
 

--- a/src/pages/admin/PlayerManagement.tsx
+++ b/src/pages/admin/PlayerManagement.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import { AdminRoute } from "@/components/AdminRoute";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,312 +9,264 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
-import { Plus, Edit, Trash2, Users, Search, Gift } from "lucide-react";
+import { Activity, AlertCircle, Banknote, HeartPulse, Search, ShieldAlert, UserRound, Users } from "lucide-react";
 import { format } from "date-fns";
+
+type PlayerSearchResult = {
+  profile_id: string;
+  user_id: string;
+  display_name: string | null;
+  username: string | null;
+  level: number | null;
+  cash: number | null;
+  fame: number | null;
+  fans: number | null;
+  current_city_name?: string | null;
+  band_id?: string | null;
+  band_name?: string | null;
+  band_role?: string | null;
+  created_at?: string | null;
+};
+
+type SupportSummary = {
+  profile?: Record<string, any>;
+  city?: Record<string, any> | null;
+  band_memberships?: Array<Record<string, any>>;
+  activity_status?: Record<string, any> | null;
+  recent_songs?: Array<Record<string, any>>;
+  recent_releases?: Array<Record<string, any>>;
+  recent_activity_logs?: Array<Record<string, any>>;
+  recent_audit_actions?: Array<Record<string, any>>;
+};
+
+const asArray = (value: unknown) => (Array.isArray(value) ? value : []);
+const formatDate = (value?: string | null) => value ? format(new Date(value), "MMM d, yyyy HH:mm") : "—";
 
 export default function PlayerManagement() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedPlayer, setSelectedPlayer] = useState<any>(null);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [submittedQuery, setSubmittedQuery] = useState("");
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
+  const [cashDialogOpen, setCashDialogOpen] = useState(false);
+  const [cashAmount, setCashAmount] = useState("");
+  const [actionReason, setActionReason] = useState("");
 
-  const { data: players = [], isLoading } = useQuery({
-    queryKey: ["admin-players"],
+  const search = useQuery({
+    queryKey: ["admin-player-support-search", submittedQuery],
+    enabled: submittedQuery.trim().length >= 2,
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
-        .from("profiles")
-        .select(`
-          *,
-          band_members!inner(
-            bands(name, genre)
-          )
-        `)
-        .order("created_at", { ascending: false })
-        .limit(100);
+      const { data, error } = await (supabase as any).rpc("admin_search_players", {
+        p_query: submittedQuery.trim(),
+        p_limit: 25,
+      });
+      if (error) throw error;
+      return asArray(data) as PlayerSearchResult[];
+    },
+  });
+
+  const summary = useQuery({
+    queryKey: ["admin-player-support-summary", selectedProfileId],
+    enabled: Boolean(selectedProfileId),
+    queryFn: async () => {
+      const { data, error } = await (supabase as any).rpc("admin_get_player_support_summary", {
+        p_profile_id: selectedProfileId,
+      });
+      if (error) throw error;
+      return (data ?? {}) as SupportSummary;
+    },
+  });
+
+  const selectedResult = useMemo(
+    () => search.data?.find((player) => player.profile_id === selectedProfileId) ?? null,
+    [search.data, selectedProfileId],
+  );
+
+  const adjustCash = useMutation({
+    mutationFn: async () => {
+      if (!selectedProfileId) throw new Error("Select a player first");
+      const amount = Number(cashAmount);
+      if (!Number.isInteger(amount) || amount === 0) throw new Error("Enter a non-zero whole dollar amount");
+      const { data, error } = await (supabase as any).rpc("admin_adjust_player_cash", {
+        p_profile_id: selectedProfileId,
+        p_amount: amount,
+        p_reason: actionReason,
+      });
       if (error) throw error;
       return data;
     },
+    onSuccess: () => {
+      toast({ title: "Cash adjustment recorded", description: "The audited support action completed successfully." });
+      setCashDialogOpen(false);
+      setCashAmount("");
+      setActionReason("");
+      queryClient.invalidateQueries({ queryKey: ["admin-player-support-summary", selectedProfileId] });
+      queryClient.invalidateQueries({ queryKey: ["admin-player-support-search"] });
+    },
+    onError: (error: Error) => toast({ title: "Cash adjustment failed", description: error.message, variant: "destructive" }),
   });
 
-  const updatePlayerMutation = useMutation({
-    mutationFn: async ({ userId, updates }: { userId: string; updates: any }) => {
-      const { error } = await supabase
-        .from("profiles")
-        .update(updates)
-        .eq("user_id", userId);
+  const cancelActivity = useMutation({
+    mutationFn: async ({ statusId, reason }: { statusId: string; reason: string }) => {
+      const { data, error } = await (supabase as any).rpc("admin_cancel_profile_activity", {
+        p_status_id: statusId,
+        p_reason: reason,
+      });
       if (error) throw error;
+      return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin-players"] });
-      toast({ title: "Player updated successfully" });
-      setIsDialogOpen(false);
+      toast({ title: "Activity cancelled", description: "The stuck activity was removed and audited." });
+      queryClient.invalidateQueries({ queryKey: ["admin-player-support-summary", selectedProfileId] });
     },
+    onError: (error: Error) => toast({ title: "Cancel activity failed", description: error.message, variant: "destructive" }),
   });
 
-  const grantCashMutation = useMutation({
-    mutationFn: async ({ userId, amount }: { userId: string; amount: number }) => {
-      const player = players.find(p => p.user_id === userId);
-      if (!player) throw new Error("Player not found");
-      
-      const { error } = await supabase
-        .from("profiles")
-        .update({ cash: (player.cash || 0) + amount })
-        .eq("user_id", userId);
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin-players"] });
-      toast({ title: "Cash granted successfully" });
-    },
-  });
-
-  const giftSlotMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      // Check current slots
-      const { data: existing } = await supabase
-        .from("character_slots")
-        .select("*")
-        .eq("user_id", userId)
-        .maybeSingle();
-
-      const currentExtra = existing?.extra_slots_purchased ?? 0;
-      const currentMax = Math.min(2 + currentExtra, 5);
-
-      if (currentMax >= 5) {
-        throw new Error("Player already has the maximum 5 character slots");
-      }
-
-      if (existing) {
-        const { error } = await supabase
-          .from("character_slots")
-          .update({
-            extra_slots_purchased: currentExtra + 1,
-            max_slots: Math.min(currentMax + 1, 5),
-            updated_at: new Date().toISOString(),
-          })
-          .eq("user_id", userId);
-        if (error) throw error;
-      } else {
-        const { error } = await supabase
-          .from("character_slots")
-          .insert({
-            user_id: userId,
-            extra_slots_purchased: 1,
-            max_slots: 3,
-          });
-        if (error) throw error;
-      }
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin-players"] });
-      toast({ title: "Character slot gifted!", description: "Player now has an additional character slot." });
-    },
-    onError: (err: Error) => {
-      toast({ title: "Failed to gift slot", description: err.message, variant: "destructive" });
-    },
-  });
-
-  const filteredPlayers = players.filter(player =>
-    player.display_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    player.user_id.toLowerCase().includes(searchQuery.toLowerCase())
-  );
-
-  const handleGrantCash = (userId: string) => {
-    const amount = prompt("Enter amount to grant:");
-    if (amount && !isNaN(Number(amount))) {
-      grantCashMutation.mutate({ userId, amount: Number(amount) });
-    }
+  const runSearch = (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmittedQuery(searchQuery.trim());
+    setSelectedProfileId(null);
   };
 
-  const handleUpdatePlayer = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!selectedPlayer) return;
-
-    const formData = new FormData(e.currentTarget);
-    const updates = {
-      cash: Number(formData.get("cash")),
-      fame: Number(formData.get("fame")),
-      level: Number(formData.get("level")),
-      experience: Number(formData.get("experience")),
-    };
-
-    updatePlayerMutation.mutate({ userId: selectedPlayer.user_id, updates });
-  };
+  const playerName = selectedResult?.display_name || summary.data?.profile?.display_name || "Selected player";
+  const profile = summary.data?.profile;
+  const currentActivity = summary.data?.activity_status;
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
+    <AdminRoute>
+      <div className="container mx-auto p-6 space-y-6">
         <div>
-          <h1 className="text-3xl font-bold flex items-center gap-2">
-            <Users className="h-8 w-8" />
-            Player Management
-          </h1>
-          <p className="text-muted-foreground">View and manage player accounts</p>
+          <h1 className="text-3xl font-bold flex items-center gap-2"><Users className="h-8 w-8" /> Player Support</h1>
+          <p className="text-muted-foreground">Search players, inspect read-only support state, and run audited beta corrections.</p>
         </div>
-      </div>
 
-      <div className="flex gap-4">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search by name or ID..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-10"
-          />
-        </div>
-      </div>
+        <Alert>
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>Server-authoritative support tools</AlertTitle>
+          <AlertDescription>Searches and corrections are performed through admin-only RPCs. Sensitive values such as auth secrets and raw credentials are not shown.</AlertDescription>
+        </Alert>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Active Players</CardTitle>
-          <CardDescription>{filteredPlayers.length} players found</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Player</TableHead>
-                <TableHead>Level</TableHead>
-                <TableHead>Cash</TableHead>
-                <TableHead>Fame</TableHead>
-                <TableHead>Band</TableHead>
-                <TableHead>Joined</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredPlayers.map((player) => (
-                <TableRow key={player.user_id}>
-                  <TableCell>
-                    <div>
-                      <p className="font-medium">{player.display_name || "Unknown"}</p>
-                      <p className="text-xs text-muted-foreground">{player.user_id}</p>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge>Lvl {player.level || 1}</Badge>
-                  </TableCell>
-                  <TableCell>${player.cash || 0}</TableCell>
-                  <TableCell>{player.fame || 0}</TableCell>
-                  <TableCell>
-                    {(player.band_members as any)?.[0]?.bands?.name || "No band"}
-                  </TableCell>
-                  <TableCell>
-                    {player.created_at ? format(new Date(player.created_at), "MMM d, yyyy") : "N/A"}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex gap-2 justify-end">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          setSelectedPlayer(player);
-                          setIsDialogOpen(true);
-                        }}
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => handleGrantCash(player.user_id)}
-                      >
-                        Grant Cash
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="text-primary border-primary/30 hover:bg-primary/10"
-                        onClick={() => {
-                          if (confirm(`Gift an extra character slot to ${player.display_name || player.user_id}?`)) {
-                            giftSlotMutation.mutate(player.user_id);
-                          }
-                        }}
-                        disabled={giftSlotMutation.isPending}
-                      >
-                        <Gift className="h-4 w-4 mr-1" />
-                        Gift Slot
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Edit Player</DialogTitle>
-            <DialogDescription>
-              Modify player stats and resources
-            </DialogDescription>
-          </DialogHeader>
-
-          {selectedPlayer && (
-            <form onSubmit={handleUpdatePlayer} className="space-y-4">
-              <div className="space-y-2">
-                <Label>Player: {selectedPlayer.display_name}</Label>
+        <Card>
+          <CardHeader>
+            <CardTitle>Player lookup</CardTitle>
+            <CardDescription>Search by display name, username, profile ID, user ID, or band name. Email search is intentionally omitted unless a secure admin API provides it.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={runSearch} className="flex gap-3">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input className="pl-10" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Search player, ID, character, or band..." />
               </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="cash">Cash</Label>
-                  <Input
-                    id="cash"
-                    name="cash"
-                    type="number"
-                    defaultValue={selectedPlayer.cash || 0}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="fame">Fame</Label>
-                  <Input
-                    id="fame"
-                    name="fame"
-                    type="number"
-                    defaultValue={selectedPlayer.fame || 0}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="level">Level</Label>
-                  <Input
-                    id="level"
-                    name="level"
-                    type="number"
-                    defaultValue={selectedPlayer.level || 1}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="experience">Experience</Label>
-                  <Input
-                    id="experience"
-                    name="experience"
-                    type="number"
-                    defaultValue={selectedPlayer.experience || 0}
-                  />
-                </div>
-              </div>
-
-              <div className="flex justify-end gap-2">
-                <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)}>
-                  Cancel
-                </Button>
-                <Button type="submit">Update Player</Button>
-              </div>
+              <Button type="submit" disabled={searchQuery.trim().length < 2 || search.isFetching}>Search</Button>
             </form>
-          )}
-        </DialogContent>
-      </Dialog>
-    </div>
+            {search.isError && <p className="mt-3 text-sm text-destructive">{(search.error as Error).message}</p>}
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(360px,0.9fr)_minmax(0,1.4fr)]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Results</CardTitle>
+              <CardDescription>{search.isFetching ? "Loading..." : `${search.data?.length ?? 0} players found`}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!submittedQuery ? <p className="text-sm text-muted-foreground">Enter a search above to begin.</p> : null}
+              {submittedQuery && !search.isFetching && search.data?.length === 0 ? <p className="text-sm text-muted-foreground">No matching players found.</p> : null}
+              {search.data?.length ? (
+                <Table>
+                  <TableHeader><TableRow><TableHead>Player</TableHead><TableHead>State</TableHead><TableHead /></TableRow></TableHeader>
+                  <TableBody>
+                    {search.data.map((player) => (
+                      <TableRow key={player.profile_id} className={player.profile_id === selectedProfileId ? "bg-muted/60" : undefined}>
+                        <TableCell>
+                          <div className="font-medium">{player.display_name || player.username || "Unnamed"}</div>
+                          <div className="text-xs text-muted-foreground">{player.user_id}</div>
+                          <div className="text-xs text-muted-foreground">Band: {player.band_name || "None"}</div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">Lvl {player.level ?? 1}</Badge>
+                          <div className="mt-1 text-xs text-muted-foreground">${(player.cash ?? 0).toLocaleString()} · {player.current_city_name || "Unknown city"}</div>
+                        </TableCell>
+                        <TableCell className="text-right"><Button size="sm" variant="outline" onClick={() => setSelectedProfileId(player.profile_id)}>Inspect</Button></TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2"><UserRound className="h-5 w-5" /> Support summary</CardTitle>
+              <CardDescription>{selectedProfileId ? `Read-only snapshot for ${playerName}` : "Select a player to view details."}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {summary.isFetching ? <p className="text-sm text-muted-foreground">Loading player support data...</p> : null}
+              {summary.isError ? <p className="text-sm text-destructive">{(summary.error as Error).message}</p> : null}
+              {profile ? (
+                <>
+                  <div className="grid gap-3 md:grid-cols-4">
+                    <Metric icon={Banknote} label="Cash" value={`$${(profile.cash ?? 0).toLocaleString()}`} />
+                    <Metric icon={Activity} label="Progress" value={`Lvl ${profile.level ?? 1} · XP ${profile.experience ?? 0}`} />
+                    <Metric icon={Users} label="Audience" value={`${profile.fame ?? 0} fame · ${profile.fans ?? 0} fans`} />
+                    <Metric icon={HeartPulse} label="Vitals" value={`${profile.health ?? "—"} HP · ${profile.energy ?? "—"} energy`} />
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant="outline" onClick={() => setCashDialogOpen(true)}>Audited cash adjustment</Button>
+                    {currentActivity?.id ? (
+                      <Button variant="destructive" disabled={cancelActivity.isPending} onClick={() => {
+                        const reason = window.prompt("Reason for cancelling this activity (required, min 8 chars):");
+                        if (reason) cancelActivity.mutate({ statusId: currentActivity.id, reason });
+                      }}>Cancel current activity</Button>
+                    ) : null}
+                  </div>
+
+                  <Separator />
+                  <Section title="Profile and location">
+                    <InfoGrid rows={[
+                      ["Profile ID", profile.id], ["User ID", profile.user_id], ["Display name", profile.display_name || "—"], ["City", summary.data?.city?.name || profile.current_city_id || "—"], ["Joined", formatDate(profile.created_at)], ["Updated", formatDate(profile.updated_at)],
+                    ]} />
+                  </Section>
+                  <Section title="Band membership"><SimpleList rows={summary.data?.band_memberships} empty="No band memberships." render={(band) => `${band.band_name} · ${band.role || "member"} · ${band.genre || "unknown genre"}`} /></Section>
+                  <Section title="Current and upcoming activity">{currentActivity ? <pre className="overflow-auto rounded bg-muted p-3 text-xs">{JSON.stringify(currentActivity, null, 2)}</pre> : <p className="text-sm text-muted-foreground">No current activity status found.</p>}</Section>
+                  <Section title="Recent songs"><SimpleList rows={summary.data?.recent_songs} empty="No recent songs." render={(song) => `${song.title} · ${song.status || "unknown"} · streams ${song.streams ?? 0} · ${formatDate(song.created_at)}`} /></Section>
+                  <Section title="Recent releases"><SimpleList rows={summary.data?.recent_releases} empty="No recent releases." render={(release) => `${release.title} · ${release.release_status || "unknown"} · ${formatDate(release.created_at)}`} /></Section>
+                  <Section title="Recent transactions, errors, and events"><SimpleList rows={summary.data?.recent_activity_logs} empty="No recent activity logs." render={(log) => `${formatDate(log.created_at)} · ${log.activity_category}/${log.activity_type}: ${log.description}`} /></Section>
+                  <Section title="Moderation / support audit"><SimpleList rows={summary.data?.recent_audit_actions} empty="No recent admin audit actions for this player." render={(audit) => `${formatDate(audit.created_at)} · ${audit.action} · ${audit.metadata?.reason || "no reason recorded"}`} /></Section>
+                </>
+              ) : !summary.isFetching ? <p className="text-sm text-muted-foreground">No player selected.</p> : null}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Dialog open={cashDialogOpen} onOpenChange={setCashDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Audited cash adjustment</DialogTitle>
+              <DialogDescription>Use only for beta support corrections. A reason and before/after values are recorded in the admin audit log.</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2"><Label>Amount</Label><Input type="number" value={cashAmount} onChange={(event) => setCashAmount(event.target.value)} placeholder="e.g. 500 or -250" /></div>
+              <div className="space-y-2"><Label>Reason</Label><Textarea value={actionReason} onChange={(event) => setActionReason(event.target.value)} placeholder="Describe the support ticket or beta issue being corrected..." /></div>
+              <Alert><AlertCircle className="h-4 w-4" /><AlertDescription>Confirm the selected player and reason before applying. This action changes economy state.</AlertDescription></Alert>
+            </div>
+            <DialogFooter><Button variant="outline" onClick={() => setCashDialogOpen(false)}>Cancel</Button><Button onClick={() => adjustCash.mutate()} disabled={adjustCash.isPending}>Confirm adjustment</Button></DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </AdminRoute>
   );
 }
+
+function Metric({ icon: Icon, label, value }: { icon: any; label: string; value: string }) {
+  return <div className="rounded-lg border p-3"><div className="flex items-center gap-2 text-xs text-muted-foreground"><Icon className="h-4 w-4" />{label}</div><div className="mt-1 font-semibold">{value}</div></div>;
+}
+function Section({ title, children }: { title: string; children: React.ReactNode }) { return <div className="space-y-2"><h3 className="font-semibold">{title}</h3>{children}</div>; }
+function InfoGrid({ rows }: { rows: Array<[string, any]> }) { return <div className="grid gap-2 md:grid-cols-2">{rows.map(([label, value]) => <div key={label} className="rounded border p-2"><div className="text-xs text-muted-foreground">{label}</div><div className="break-all text-sm">{value}</div></div>)}</div>; }
+function SimpleList({ rows, empty, render }: { rows?: Array<Record<string, any>>; empty: string; render: (row: Record<string, any>) => string }) { const list = rows ?? []; return list.length ? <div className="space-y-2">{list.map((row, index) => <div key={row.id ?? index} className="rounded border p-2 text-sm">{render(row)}</div>)}</div> : <p className="text-sm text-muted-foreground">{empty}</p>; }

--- a/supabase/migrations/20260710120000_beta_admin_support_tools.sql
+++ b/supabase/migrations/20260710120000_beta_admin_support_tools.sql
@@ -1,0 +1,264 @@
+-- Beta-focused admin support tools: scoped lookup, read-only summaries, audited corrections, and health metrics.
+
+CREATE TABLE IF NOT EXISTS public.admin_action_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  target_table text,
+  target_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.admin_action_audit ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Beta admins can read admin action audit" ON public.admin_action_audit;
+CREATE POLICY "Beta admins can read admin action audit"
+  ON public.admin_action_audit
+  FOR SELECT
+  TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'::public.app_role));
+
+DROP POLICY IF EXISTS "Admins can append admin action audit through RPC" ON public.admin_action_audit;
+CREATE POLICY "Admins can append admin action audit through RPC"
+  ON public.admin_action_audit
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.has_role(auth.uid(), 'admin'::public.app_role));
+
+CREATE OR REPLACE FUNCTION public.admin_search_players(p_query text, p_limit integer DEFAULT 25)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_query text := trim(coalesce(p_query, ''));
+  v_limit integer := least(greatest(coalesce(p_limit, 25), 1), 50);
+  v_results jsonb;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+
+  IF length(v_query) < 2 THEN
+    RETURN '[]'::jsonb;
+  END IF;
+
+  SELECT coalesce(jsonb_agg(to_jsonb(row_data)), '[]'::jsonb)
+  INTO v_results
+  FROM (
+    SELECT DISTINCT ON (p.id)
+      p.id AS profile_id,
+      p.user_id,
+      p.display_name,
+      p.username,
+      p.level,
+      p.cash,
+      p.fame,
+      p.fans,
+      p.current_city_id,
+      p.created_at,
+      c.name AS current_city_name,
+      b.id AS band_id,
+      b.name AS band_name,
+      bm.role AS band_role
+    FROM public.profiles p
+    LEFT JOIN public.cities c ON c.id = p.current_city_id
+    LEFT JOIN public.band_members bm ON bm.user_id = p.user_id
+    LEFT JOIN public.bands b ON b.id = bm.band_id
+    WHERE p.user_id::text = v_query
+       OR p.id::text = v_query
+       OR p.display_name ILIKE '%' || v_query || '%'
+       OR p.username ILIKE '%' || v_query || '%'
+       OR b.name ILIKE '%' || v_query || '%'
+    ORDER BY p.id, p.updated_at DESC NULLS LAST, p.created_at DESC
+    LIMIT v_limit
+  ) AS row_data;
+
+  INSERT INTO public.admin_action_audit (actor_user_id, action, target_table, metadata)
+  VALUES (auth.uid(), 'admin_search_players', 'profiles', jsonb_build_object('query_length', length(v_query), 'result_count', jsonb_array_length(v_results)));
+
+  RETURN v_results;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_get_player_support_summary(p_profile_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile public.profiles%ROWTYPE;
+  v_summary jsonb;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+
+  SELECT * INTO v_profile FROM public.profiles WHERE id = p_profile_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player profile not found';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'profile', to_jsonb(v_profile) - 'avatar_url',
+    'city', (SELECT to_jsonb(c) FROM public.cities c WHERE c.id = v_profile.current_city_id),
+    'band_memberships', coalesce((
+      SELECT jsonb_agg(jsonb_build_object('band_id', b.id, 'band_name', b.name, 'genre', b.genre, 'role', bm.role, 'joined_at', bm.joined_at, 'popularity', b.popularity, 'weekly_fans', b.weekly_fans))
+      FROM public.band_members bm JOIN public.bands b ON b.id = bm.band_id
+      WHERE bm.user_id = v_profile.user_id
+    ), '[]'::jsonb),
+    'activity_status', (SELECT to_jsonb(pas) FROM public.profile_activity_statuses pas WHERE pas.profile_id = v_profile.id),
+    'recent_songs', coalesce((
+      SELECT jsonb_agg(to_jsonb(s) - 'lyrics' - 'audio_layers') FROM (
+        SELECT id, title, genre, status, quality_score, streams, revenue, chart_position, release_date, created_at, updated_at
+        FROM public.songs WHERE user_id = v_profile.user_id OR profile_id = v_profile.id ORDER BY created_at DESC LIMIT 10
+      ) s
+    ), '[]'::jsonb),
+    'recent_releases', coalesce((
+      SELECT jsonb_agg(to_jsonb(r)) FROM (
+        SELECT id, title, release_type, release_status, total_streams, total_revenue, release_date, created_at, updated_at
+        FROM public.releases WHERE user_id = v_profile.user_id ORDER BY created_at DESC LIMIT 10
+      ) r
+    ), '[]'::jsonb),
+    'recent_activity_logs', coalesce((
+      SELECT jsonb_agg(to_jsonb(l)) FROM (
+        SELECT id, activity_type, activity_category, description, amount, metadata, created_at
+        FROM public.game_activity_logs WHERE user_id = v_profile.user_id ORDER BY created_at DESC LIMIT 15
+      ) l
+    ), '[]'::jsonb),
+    'recent_audit_actions', coalesce((
+      SELECT jsonb_agg(to_jsonb(a)) FROM (
+        SELECT id, actor_user_id, action, target_table, target_id, metadata, created_at
+        FROM public.admin_action_audit WHERE target_id IN (v_profile.id::text, v_profile.user_id::text) ORDER BY created_at DESC LIMIT 10
+      ) a
+    ), '[]'::jsonb)
+  ) INTO v_summary;
+
+  INSERT INTO public.admin_action_audit (actor_user_id, action, target_table, target_id, metadata)
+  VALUES (auth.uid(), 'admin_view_player_support_summary', 'profiles', v_profile.id::text, jsonb_build_object('target_user_id', v_profile.user_id));
+
+  RETURN v_summary;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_adjust_player_cash(p_profile_id uuid, p_amount integer, p_reason text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_before integer;
+  v_after integer;
+  v_reason text := trim(coalesce(p_reason, ''));
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+  IF length(v_reason) < 8 THEN
+    RAISE EXCEPTION 'A reason of at least 8 characters is required';
+  END IF;
+  IF p_amount = 0 OR abs(p_amount) > 1000000 THEN
+    RAISE EXCEPTION 'Cash adjustment must be between -1,000,000 and 1,000,000 and cannot be zero';
+  END IF;
+
+  SELECT cash INTO v_before FROM public.profiles WHERE id = p_profile_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player profile not found';
+  END IF;
+  v_after := greatest(0, coalesce(v_before, 0) + p_amount);
+  UPDATE public.profiles SET cash = v_after, updated_at = now() WHERE id = p_profile_id;
+
+  INSERT INTO public.admin_action_audit (actor_user_id, action, target_table, target_id, metadata)
+  VALUES (auth.uid(), 'admin_adjust_player_cash', 'profiles', p_profile_id::text,
+    jsonb_build_object('reason', v_reason, 'previous_value', v_before, 'new_value', v_after, 'delta', p_amount));
+
+  INSERT INTO public.game_activity_logs (user_id, activity_type, activity_category, description, amount, before_state, after_state, metadata)
+  SELECT user_id, 'admin_cash_adjustment', 'economy', 'Admin cash adjustment: ' || v_reason, p_amount,
+    jsonb_build_object('cash', v_before), jsonb_build_object('cash', v_after), jsonb_build_object('admin_user_id', auth.uid())
+  FROM public.profiles WHERE id = p_profile_id;
+
+  RETURN jsonb_build_object('previous_value', v_before, 'new_value', v_after, 'delta', p_amount);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_cancel_profile_activity(p_status_id uuid, p_reason text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_activity public.profile_activity_statuses%ROWTYPE;
+  v_reason text := trim(coalesce(p_reason, ''));
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+  IF length(v_reason) < 8 THEN
+    RAISE EXCEPTION 'A reason of at least 8 characters is required';
+  END IF;
+
+  SELECT * INTO v_activity FROM public.profile_activity_statuses WHERE id = p_status_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Activity status not found';
+  END IF;
+
+  DELETE FROM public.profile_activity_statuses WHERE id = p_status_id;
+
+  INSERT INTO public.admin_action_audit (actor_user_id, action, target_table, target_id, metadata)
+  VALUES (auth.uid(), 'admin_cancel_profile_activity', 'profile_activity_statuses', p_status_id::text,
+    jsonb_build_object('reason', v_reason, 'previous_value', to_jsonb(v_activity), 'profile_id', v_activity.profile_id));
+
+  RETURN jsonb_build_object('cancelled_activity', to_jsonb(v_activity));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_get_beta_health_overview()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'generated_at', now(),
+    'active_players_24h', (SELECT count(DISTINCT user_id) FROM public.game_activity_logs WHERE created_at >= now() - interval '24 hours'),
+    'new_profiles_24h', (SELECT count(*) FROM public.profiles WHERE created_at >= now() - interval '24 hours'),
+    'new_profiles_7d', (SELECT count(*) FROM public.profiles WHERE created_at >= now() - interval '7 days'),
+    'active_activity_statuses', (SELECT count(*) FROM public.profile_activity_statuses),
+    'stuck_activity_statuses', (SELECT count(*) FROM public.profile_activity_statuses WHERE ends_at IS NOT NULL AND ends_at < now() - interval '1 hour'),
+    'failed_recent_cron_jobs', (SELECT count(*) FROM public.cron_job_runs WHERE status <> 'success' AND started_at >= now() - interval '24 hours'),
+    'recent_activity_errors', (SELECT count(*) FROM public.game_activity_logs WHERE created_at >= now() - interval '24 hours' AND (activity_type ILIKE '%error%' OR activity_category ILIKE '%error%' OR description ILIKE '%fail%')),
+    'total_cash', (SELECT coalesce(sum(cash), 0) FROM public.profiles),
+    'recent_admin_actions', (SELECT count(*) FROM public.admin_action_audit WHERE created_at >= now() - interval '24 hours'),
+    'latest_errors', coalesce((
+      SELECT jsonb_agg(to_jsonb(l)) FROM (
+        SELECT id, user_id, activity_type, activity_category, description, metadata, created_at
+        FROM public.game_activity_logs
+        WHERE activity_type ILIKE '%error%' OR activity_category ILIKE '%error%' OR description ILIKE '%fail%'
+        ORDER BY created_at DESC LIMIT 10
+      ) l
+    ), '[]'::jsonb),
+    'latest_cron_jobs', coalesce((
+      SELECT jsonb_agg(to_jsonb(c)) FROM (
+        SELECT id, job_name, status, started_at, completed_at, error_message
+        FROM public.cron_job_runs ORDER BY started_at DESC LIMIT 10
+      ) c
+    ), '[]'::jsonb)
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_search_players(text, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_get_player_support_summary(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_adjust_player_cash(uuid, integer, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_cancel_profile_activity(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_get_beta_health_overview() TO authenticated;


### PR DESCRIPTION
### Motivation
- Provide safe, incremental admin/support tools for beta diagnostics and corrective actions without changing auth/roles or widening client privileges. 
- Enable staff to locate players, inspect read-only state, run limited reversible fixes, and view lightweight health signals to triage issues during beta.

### Description
- Add a Supabase migration that creates `admin_action_audit` and admin-only RPCs: `admin_search_players`, `admin_get_player_support_summary`, `admin_adjust_player_cash`, `admin_cancel_profile_activity`, and `admin_get_beta_health_overview`, with `SECURITY DEFINER`, role checks via `has_role`, RLS-aware policies, and `GRANT EXECUTE` to `authenticated` (`supabase/migrations/20260710120000_beta_admin_support_tools.sql`).
- Replace/refactor the client player admin UI to a server-authoritative support workflow in `src/pages/admin/PlayerManagement.tsx` that calls the new RPCs, shows loading/error/empty states, omits insecure email search, and requires confirmation and a reason for sensitive corrections (audited cash adjustments and activity cancellations). 
- Add a Beta Health Overview tile to `src/pages/admin/AdminDashboard.tsx` which queries `admin_get_beta_health_overview` and surfaces counts and recent error-like events and cron/job status with clear loading and error handling. 
- Ensure all corrective actions are performed server-side via RPCs, record audit metadata (actor, target, reason, previous/new values), and avoid exposing service-role keys or sensitive authentication data to the client. 

### Testing
- Ran `git diff --check` to validate code formatting and basic diff checks which completed without errors. 
- Attempted `npm install` but dependency installation failed due to a registry `403 Forbidden` for an external package, so frontend build/install tests could not be completed in this environment. 
- `npm run build` could not be run because `vite` and other dependencies were not available after the failed install, so no full build verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508c0de07c83259b6c030741398854)