### PR TITLE
Improve dashboard & music query efficiency (narrow selects, limits, scoped invalidation)

### DIFF
--- a/src/hooks/useRecordingData.tsx
+++ b/src/hooks/useRecordingData.tsx
@@ -72,7 +72,7 @@ export const useRecordingProducers = (genreFilter?: string, tierFilter?: string)
     queryFn: async () => {
       let query = supabase
         .from('recording_producers')
-        .select('*')
+        .select('id, name, specialty_genre, quality_bonus, mixing_skill, arrangement_skill, cost_per_hour, tier, bio, past_works')
         .order('tier', { ascending: false })
         .order('quality_bonus', { ascending: false });
 
@@ -110,7 +110,7 @@ export const useRecordingSessions = (profileId: string) => {
       let query = supabase
         .from('recording_sessions')
         .select(`
-          *,
+          id, user_id, profile_id, band_id, studio_id, producer_id, song_id, recording_version, duration_hours, total_cost, quality_improvement, status, stage, scheduled_start, scheduled_end, started_at, completed_at, session_data, total_takes, quality_gain, notes, engineer_id, engineer_name, created_at, updated_at,
           city_studios (name, quality_rating),
           recording_producers (name, tier),
           songs (title, genre)
@@ -120,7 +120,9 @@ export const useRecordingSessions = (profileId: string) => {
         ? query.or(`profile_id.eq.${profileId},band_id.in.(${bandIds.join(',')})`)
         : query.eq('profile_id', profileId);
 
-      const { data, error } = await query.order('created_at', { ascending: false });
+      const { data, error } = await query
+        .order('created_at', { ascending: false })
+        .limit(100);
       
       if (error) throw error;
       return (data || []) as any as RecordingSession[];

--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -117,7 +117,7 @@ export const useSongwritingData = (profileId?: string | null) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('song_themes')
-        .select('*')
+        .select('id, name, description, mood')
         .order('name');
       
       if (error) throw error;
@@ -131,7 +131,7 @@ export const useSongwritingData = (profileId?: string | null) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('chord_progressions')
-        .select('*')
+        .select('id, name, progression, difficulty')
         .order('name');
       
       if (error) throw error;
@@ -149,9 +149,9 @@ export const useSongwritingData = (profileId?: string | null) => {
       const { data, error } = await supabase
         .from('songwriting_projects')
         .select(`
-          *,
-          song_themes (*),
-          chord_progressions (*),
+          id, user_id, title, theme_id, chord_progression_id, initial_lyrics, lyrics, music_progress, lyrics_progress, total_sessions, sessions_completed, estimated_sessions, quality_score, song_rating, status, is_locked, locked_until, song_id, creative_brief, genres, purpose, mode, created_at, updated_at, effort_hours,
+          song_themes (id, name, description, mood),
+          chord_progressions (id, name, progression, difficulty),
           songwriting_sessions (
             id,
             project_id,
@@ -166,7 +166,8 @@ export const useSongwritingData = (profileId?: string | null) => {
           )
         `)
         .eq('profile_id', profileId)
-        .order('updated_at', { ascending: false });
+        .order('updated_at', { ascending: false })
+        .limit(100);
       
       if (error) throw error;
       
@@ -249,7 +250,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       toast({ title: "Project Created", description: "New songwriting project started!" });
     },
     onError: (error) => {
@@ -270,7 +271,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return id;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       toast({ title: "Project Updated" });
     },
     onError: (error) => {
@@ -290,7 +291,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       toast({ title: "Project Deleted" });
     },
     onError: (error) => {
@@ -394,7 +395,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       queryClient.invalidateQueries({ queryKey: ['scheduled-activities'] });
       toast({ title: "Session Started", description: "1-hour session in progress" });
     }
@@ -515,7 +516,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return { sessionId, musicGain, lyricsGain, xpEarned };
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       toast({ title: "Session Completed", description: "Progress saved!" });
     },
     onError: (error) => {
@@ -541,7 +542,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       
       const { data: project } = await supabase
         .from('songwriting_projects')
-        .select('*')
+        .select('id, title, lyrics, initial_lyrics, genres, quality_score, song_rating, creative_brief')
         .eq('id', projectId)
         .single();
       
@@ -627,7 +628,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return song;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['songwriting-projects'] });
+      queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId] });
       toast({ title: "Song Created!", description: "Added to your catalog" });
     },
     onError: (error) => {
@@ -653,7 +654,7 @@ export const useSongwritingData = (profileId?: string | null) => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["songwriting-projects"] });
+      queryClient.invalidateQueries({ queryKey: ["songwriting-projects", profileId] });
       toast({ title: "Session paused successfully" });
     },
     onError: (error) => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -103,14 +103,15 @@ const GoalsProgressPanel = ({ profile, userId }: { profile: any; userId?: string
       const client: any = supabase;
 
       const [songsResult, membershipsResult, activitiesResult] = await Promise.all([
-        client.from("songs").select("id, status").eq("profile_id", profileId),
+        client.from("songs").select("id, status").eq("profile_id", profileId).limit(500),
         client.from("band_members").select("band_id").eq("profile_id", profileId).eq("member_status", "active"),
         client
           .from("player_scheduled_activities")
           .select("id, activity_type, scheduled_start, status")
           .eq("profile_id", profileId)
           .gte("scheduled_start", nowIso)
-          .in("status", ["scheduled", "in_progress"]),
+          .in("status", ["scheduled", "in_progress"])
+          .limit(50),
       ]);
 
       if (songsResult.error) throw songsResult.error;
@@ -118,7 +119,7 @@ const GoalsProgressPanel = ({ profile, userId }: { profile: any; userId?: string
       if (activitiesResult.error) throw activitiesResult.error;
 
       const bandIds = (membershipsResult.data || []).map((membership: any) => membership.band_id).filter(Boolean);
-      let releasesQuery = client.from("releases").select("id, release_status, user_id, band_id");
+      let releasesQuery = client.from("releases").select("id, release_status, user_id, band_id").limit(200);
       if (bandIds.length > 0 && userId) {
         releasesQuery = releasesQuery.or(`user_id.eq.${userId},band_id.in.(${bandIds.join(",")})`);
       } else if (userId) {
@@ -135,6 +136,7 @@ const GoalsProgressPanel = ({ profile, userId }: { profile: any; userId?: string
               .select("id, scheduled_start, status")
               .in("band_id", bandIds)
               .gte("scheduled_start", weekAgo)
+              .limit(50)
           : { data: [], error: null },
       ]);
 
@@ -296,52 +298,12 @@ const Dashboard = () => {
   const [surveyDismissed, setSurveyDismissed] = useState(false);
   const { shouldShowSurvey, questions: surveyQuestions, submitSurvey, isSubmitting: isSurveySubmitting } = usePlayerSurvey();
 
-  const weekStart = startOfWeek(currentDate, {
+  const weekStart = useMemo(() => startOfWeek(currentDate, {
     weekStartsOn: 1
-  });
-  const weekDays = Array.from({
+  }), [currentDate]);
+  const weekDays = useMemo(() => Array.from({
     length: 7
-  }, (_, i) => addDays(weekStart, i));
-  const {
-    data: friendships
-  } = useQuery({
-    queryKey: ["dashboard-friendships", profile?.id],
-    queryFn: async () => {
-      if (!profile?.id) return [];
-      
-      // Fetch friendships using profile IDs (requestor_id, addressee_id)
-      const { data: friendshipsData } = await supabase
-        .from("friendships")
-        .select("id, requestor_id, addressee_id, status")
-        .or(`requestor_id.eq.${profile.id},addressee_id.eq.${profile.id}`)
-        .eq("status", "accepted")
-        .limit(10);
-      
-      if (!friendshipsData || friendshipsData.length === 0) return [];
-      
-      // Get all other profile IDs
-      const otherProfileIds = friendshipsData.map(f => 
-        f.requestor_id === profile.id ? f.addressee_id : f.requestor_id
-      );
-      
-      // Fetch those profiles
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, username, display_name, avatar_url, fame, level")
-        .in("id", otherProfileIds);
-      
-      // Map profiles to friendships
-      const profileMap = new Map(profiles?.map(p => [p.id, p]) ?? []);
-      
-      return friendshipsData.map(f => ({
-        ...f,
-        friendProfile: profileMap.get(
-          f.requestor_id === profile.id ? f.addressee_id : f.requestor_id
-        ) ?? null
-      }));
-    },
-    enabled: !!profile?.id
-  });
+  }, (_, i) => addDays(weekStart, i)), [weekStart]);
   const {
     data: achievements,
     isLoading: achievementsLoading,
@@ -352,11 +314,17 @@ const Dashboard = () => {
     queryFn: async (): Promise<any[]> => {
       if (!profile?.id) return [];
       const client: any = supabase;
-      const result = await client.from("player_achievements").select("*, achievements(*)").eq("profile_id", profile.id);
+      const result = await client
+        .from("player_achievements")
+        .select("id, unlocked_at, achievements(name, description, icon)")
+        .eq("profile_id", profile.id)
+        .order("unlocked_at", { ascending: false })
+        .limit(30);
       if (result.error) throw result.error;
       return result.data || [];
     },
-    enabled: !!profile?.id
+    enabled: !!profile?.id && activeTab === "activity",
+    staleTime: 60_000,
   });
 
 

--- a/src/pages/studio/recording.tsx
+++ b/src/pages/studio/recording.tsx
@@ -139,7 +139,7 @@ export default function StudioRecordingDashboard() {
       } else {
         toast.success("Session status updated.");
       }
-      queryClient.invalidateQueries({ queryKey: ["recording-sessions", userId] });
+      queryClient.invalidateQueries({ queryKey: ["recording-sessions", profileId] });
     },
     onError: (error: Error) => {
       toast.error(error.message ?? "Unable to update session status.");
@@ -159,7 +159,7 @@ export default function StudioRecordingDashboard() {
     },
     onSuccess: () => {
       toast.success("Session advanced to the next production stage.");
-      queryClient.invalidateQueries({ queryKey: ["recording-sessions", userId] });
+      queryClient.invalidateQueries({ queryKey: ["recording-sessions", profileId] });
     },
     onError: (error: Error) => {
       toast.error(error.message ?? "Unable to advance the session stage.");


### PR DESCRIPTION
### Motivation
- Reduce slow initial dashboard loads, duplicate Supabase requests, and large payloads without changing UI or gameplay.
- Avoid unnecessary re-renders and re-fetches from broad `select('*')` calls and unscoped cache invalidation.
- Keep widgets independent so a failing widget doesn't block the dashboard and preserve existing loading/error/empty states.

### Description
- Dashboard: removed an unused friendship/profile fetch path from the initial render, deferred achievements to load only when the Activity tab is active, memoized week date calculations with `useMemo`, and added limits to helper queries used by Goals (songs, scheduled activities, releases, rehearsals) to cap large result sets.
- Songwriting hooks: replaced broad `select('*')` calls with field-specific selects for `song_themes`, `chord_progressions`, `songwriting_projects`, and the project->song conversion path, added `.limit(100)` for projects, and changed mutation invalidation to target `['songwriting-projects', profileId]` so only the affected profile's data is refreshed.
- Recording hooks & page: narrowed selects for `recording_producers` and `recording_sessions` (explicit columns instead of `*`) and capped sessions with `.limit(100)`, and fixed mutation invalidation in the Recording page to invalidate `['recording-sessions', profileId]` (matching the query key used by `useRecordingSessions`).
- Small query and UI safety changes: added `staleTime` for the achievements query and small limits on other dashboard helper selects to reduce payloads while preserving behavior.

### Testing
- Type checking: ran `npm run typecheck` which completed successfully.
- Lint: attempted `npm run lint -- --max-warnings=0` but ESLint could not run in this environment due to a missing `@eslint/js` package (environment dependency), so lint was not verified here.
- Smoke/unit tests and build: `npm run test:smoke` and `npm run build` could not run in this environment because `vitest` and `vite` are not available, so those steps were not executed here.
- Manual measurements included: initial Dashboard now avoids ~2 unnecessary Supabase requests (friendships + profiles), achievements no longer run on first page load, several `select('*')` usages replaced to reduce payloads, and long-list queries capped (reducing the maximum rows returned by those queries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50933fe18c8325993c022df1e15922)