### PR TITLE
Add social privacy settings foundation

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -60,7 +60,7 @@ Other players should become the most valuable content in RockMundo because they 
 - **Friends and follows**
   - Add clear distinction between mutual friends, one-way follows, blocked users, bandmates, company colleagues, mentors, mentees, contractors, and rivals.
   - Provide friend activity summaries such as upcoming gigs, new releases, job openings, contract requests, and major achievements.
-  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions.
+  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions. Initial owner-managed settings now exist; full enforcement across reads/writes remains a follow-up.
 
 - **Direct messages and group conversations**
   - Support one-to-one messages for negotiation, mentoring, hiring, and social play.

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -85,7 +85,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 ### Missing / risks
 
-- No global `profile_privacy_settings` or equivalent visibility matrix was found for city, online status, activity, relationship state, contact permissions, achievements, band/company history, or service availability.
+- ✅ `profile_privacy_settings` now covers the first visibility/contact slice for profile, city, activity, online status, relationship details, DM permission, and band/company invite opt-ins. Remaining gaps: achievements, band/company history, service availability, and full read/write enforcement across all social surfaces.
 - No block-aware profile access layer was found. A blocked player may still be able to discover/view public profile information unless blocked status is manually checked in every surface.
 - No explicit “public profile safe projection” view/API separates public-safe fields from private profile state.
 - No clear audit trail for profile edits, display-name/handle changes, or profile moderation actions outside Twaater-specific tooling.
@@ -343,7 +343,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Music catalogue/genres | Medium | Songs/releases/charts exist; profile/social projection partial.
 | Skills offered/services | Low | Skills exist; services offered are not first-class.
 | Activity history | Low-Medium | Logs/feeds exist, no unified privacy-aware social timeline.
-| Privacy controls | Low | Core blocker.
+| Privacy controls | Low-Medium | First owner-managed profile privacy/contact settings slice exists; enforcement across profile/search/DM/recruitment is still pending.
 | Friend requests/friendships | Medium | Implemented, needs rate/block integration.
 | Removing friends | Medium | Delete/cancel flows exist.
 | Blocking | Low-Medium | Enum exists; not cross-system.
@@ -376,7 +376,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 ## 10. Recommended Next PR Sequence
 
-1. **Social permission design PR:** Document visibility scopes, block/mute/report semantics, and public-safe profile fields.
+1. **Social permission design PR:** ✅ First slice implemented in `docs/social/implementation/PHASE_1_PR_01.md`, `src/features/social-privacy/*`, and `supabase/migrations/20260710120000_add_profile_privacy_settings.sql`. It adds owner-managed profile privacy/contact settings plus shared helper functions for owner checks, block checks, and DM eligibility. Remaining slices: migrate profile/search/DM/recruitment reads and writes to enforce these settings end-to-end.
 2. **Safety schema PR:** Add shared block/mute/report/audit primitives with no major UI exposure.
 3. **Profile projection PR:** Add safe profile views/RPCs and migrate search/profile reads to them.
 4. **Communication guard PR:** Add send guards and rate limits for DMs, friend requests, invites, Twaater DMs/follows, and chat.

--- a/docs/social/implementation/PHASE_1_PR_01.md
+++ b/docs/social/implementation/PHASE_1_PR_01.md
@@ -1,0 +1,72 @@
+# Phase 1 PR 01 — Social Permission Design: Profile Privacy Settings Slice
+
+## Problem
+
+The Phase 0 audit found that RockMundo exposes rich profile and social metadata without a clear repository-wide privacy/contact model. That blocks safer delivery of DMs, profile discovery, recruitment, recommendations, and richer social MMO systems.
+
+## Audit evidence
+
+- Privacy controls were rated **Low** readiness and called a core blocker.
+- Player profiles expose identity, city/location, activity-like state, band history, songs, achievements, skills, and social entry points without an explicit visibility matrix.
+- Blocking exists only as fragmented friendship state, so future communication/recruitment flows need shared helper semantics before new write-heavy social features are added.
+- The recommended next PR sequence starts with a **Social permission design PR** before safety schema, profile projections, communication guards, recruitment metadata, and unified moderation.
+
+## Solution
+
+This PR implements the first independently releasable slice of the audit recommendation:
+
+1. Adds `profile_privacy_settings` with safe defaults for profile visibility, city visibility, activity visibility, online status visibility, relationship visibility, DM permission, and invite opt-ins.
+2. Adds owner-only RLS policies for private settings.
+3. Adds a narrow `public_profile_privacy_settings` view exposing only contact/discovery preferences intended for future guards.
+4. Adds shared SQL helper functions:
+   - `profile_belongs_to_current_user(profile_id)`
+   - `are_profiles_blocked(first_profile_id, second_profile_id)`
+   - `can_profile_receive_dm(sender_profile_id, recipient_profile_id)`
+5. Adds a Social Privacy Settings card to the existing Relationships/Social page rather than creating a new hub.
+6. Adds validation, loading, empty, error, success, changed/unchanged, and duplicate-submit disabled states.
+
+## Files and migrations
+
+- `supabase/migrations/20260710120000_add_profile_privacy_settings.sql`
+- `src/features/social-privacy/services/socialPrivacySettings.ts`
+- `src/features/social-privacy/hooks/useSocialPrivacySettings.ts`
+- `src/features/social-privacy/components/SocialPrivacySettingsCard.tsx`
+- `src/features/social-privacy/__tests__/socialPrivacySettings.test.ts`
+- `src/features/social-privacy/__tests__/SocialPrivacySettingsCard.test.tsx`
+- `src/pages/Relationships.tsx`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Permissions model
+
+- Private settings are owner-managed through RLS by joining `profile_privacy_settings.profile_id` to `profiles.id` and requiring `profiles.user_id = auth.uid()`.
+- Unauthenticated and unrelated users cannot select/update private settings through `profile_privacy_settings`.
+- The public view intentionally exposes only coarse preferences future read/write guards need: profile visibility, DM permission, band invite opt-in, and company invite opt-in.
+- `can_profile_receive_dm` denies self-DMs, blocked pairs, and recipients whose DM preference is `none`; `friends` requires an accepted friendship.
+- Blocking still takes precedence over contact preferences.
+
+## Tests
+
+Automated coverage added for:
+
+- Successful owner load and save.
+- Safe defaults when no row exists.
+- Invalid input validation before backend writes.
+- Failed backend requests.
+- Unauthorized save failure propagation.
+- Unrelated/public-safe preference reads.
+- Unauthenticated/empty UI state.
+- Loading failure UI state.
+- Duplicate submission prevention while a save is pending.
+
+## Known limitations
+
+- Existing profile/search/DM/band/company surfaces are not yet fully migrated to enforce every privacy setting.
+- No new rewards, XP, money, reputation, or progression are attached to privacy settings.
+- No unified report queue or moderation console is added in this slice.
+- The public-safe profile projection remains the next dependency before broad profile/search reads should be changed.
+- Former band/company member write access was reviewed as not applicable to this owner-profile settings slice.
+
+## Next dependency-aware PR
+
+Implement the audit’s **Safety schema PR**: dedicated block/mute/report/audit primitives with minimal UI exposure, then migrate DMs, friend requests, invites, Twaater follows/messages, and recruitment writes to shared guard functions.

--- a/src/features/social-privacy/__tests__/SocialPrivacySettingsCard.test.tsx
+++ b/src/features/social-privacy/__tests__/SocialPrivacySettingsCard.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SocialPrivacySettingsCard } from "../components/SocialPrivacySettingsCard";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const maybeSingle = vi.fn();
+const single = vi.fn();
+const eq = vi.fn(() => ({ maybeSingle }));
+const selectAfterRead = vi.fn(() => ({ eq }));
+const selectAfterWrite = vi.fn(() => ({ single }));
+const upsert = vi.fn(() => ({ select: selectAfterWrite }));
+const from = vi.fn(() => ({ select: selectAfterRead, upsert }));
+
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { from } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const profileId = "11111111-1111-4111-8111-111111111111";
+const row = {
+  profile_id: profileId,
+  profile_visibility: "public",
+  city_visibility: "friends",
+  activity_visibility: "friends",
+  online_status_visibility: "private",
+  relationship_visibility: "friends",
+  dm_permission: "friends",
+  allow_band_invites: true,
+  allow_company_invites: true,
+};
+
+function renderCard(id: string | null = profileId) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(<QueryClientProvider client={client}><SocialPrivacySettingsCard profileId={id} /></QueryClientProvider>);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("SocialPrivacySettingsCard", () => {
+  it("shows an unauthenticated empty state", () => {
+    renderCard(null);
+    expect(screen.getByText(/sign in and select a character/i)).toBeInTheDocument();
+  });
+
+  it("shows an error state when loading fails", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: new Error("permission denied") });
+    renderCard();
+    expect(await screen.findByRole("alert")).toHaveTextContent("permission denied");
+  });
+
+  it("saves changed settings and prevents duplicate submissions while saving", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: row, error: null });
+    let resolveSave: (value: unknown) => void = () => undefined;
+    single.mockReturnValueOnce(new Promise((resolve) => { resolveSave = resolve; }));
+    const user = userEvent.setup();
+
+    renderCard();
+    const bandInviteSwitch = await screen.findByRole("switch", { name: /allow band invitations/i });
+    await user.click(bandInviteSwitch);
+    const saveButton = screen.getByRole("button", { name: /save privacy settings/i });
+    await user.click(saveButton);
+
+    expect(saveButton).toBeDisabled();
+    await user.click(saveButton);
+    expect(upsert).toHaveBeenCalledTimes(1);
+
+    resolveSave({ data: { ...row, allow_band_invites: false }, error: null });
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent(/up to date/i));
+  });
+});

--- a/src/features/social-privacy/__tests__/socialPrivacySettings.test.ts
+++ b/src/features/social-privacy/__tests__/socialPrivacySettings.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const maybeSingle = vi.fn();
+const single = vi.fn();
+const eq = vi.fn(() => ({ maybeSingle }));
+const selectAfterRead = vi.fn(() => ({ eq }));
+const selectAfterWrite = vi.fn(() => ({ single }));
+const upsert = vi.fn(() => ({ select: selectAfterWrite }));
+const from = vi.fn(() => ({ select: selectAfterRead, upsert }));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { from },
+}));
+
+const {
+  fetchOwnSocialPrivacySettings,
+  saveOwnSocialPrivacySettings,
+  fetchPublicSocialPrivacySettings,
+} = await import("../services/socialPrivacySettings");
+
+const dbRow = {
+  profile_id: "11111111-1111-4111-8111-111111111111",
+  profile_visibility: "public",
+  city_visibility: "friends",
+  activity_visibility: "private",
+  online_status_visibility: "private",
+  relationship_visibility: "friends",
+  dm_permission: "friends",
+  allow_band_invites: true,
+  allow_company_invites: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("social privacy settings service", () => {
+  it("loads persisted owner settings", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+
+    await expect(fetchOwnSocialPrivacySettings(dbRow.profile_id)).resolves.toMatchObject({
+      profileId: dbRow.profile_id,
+      activityVisibility: "private",
+      dmPermission: "friends",
+      allowCompanyInvites: false,
+    });
+    expect(from).toHaveBeenCalledWith("profile_privacy_settings");
+  });
+
+  it("returns safe defaults for an empty owner row", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    await expect(fetchOwnSocialPrivacySettings(dbRow.profile_id)).resolves.toMatchObject({
+      onlineStatusVisibility: "private",
+      cityVisibility: "friends",
+      dmPermission: "friends",
+    });
+  });
+
+  it("surfaces backend load failures", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: null, error: new Error("RLS denied") });
+
+    await expect(fetchOwnSocialPrivacySettings(dbRow.profile_id)).rejects.toThrow("RLS denied");
+  });
+
+  it("validates invalid input before saving", async () => {
+    await expect(saveOwnSocialPrivacySettings(dbRow.profile_id, {
+      profileVisibility: "public",
+      cityVisibility: "friends",
+      activityVisibility: "friends",
+      onlineStatusVisibility: "friends",
+      relationshipVisibility: "friends",
+      dmPermission: "invalid",
+      allowBandInvites: true,
+      allowCompanyInvites: true,
+    } as any)).rejects.toThrow();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("saves valid settings through idempotent upsert", async () => {
+    single.mockResolvedValueOnce({ data: dbRow, error: null });
+
+    await saveOwnSocialPrivacySettings(dbRow.profile_id, {
+      profileVisibility: "public",
+      cityVisibility: "friends",
+      activityVisibility: "private",
+      onlineStatusVisibility: "private",
+      relationshipVisibility: "friends",
+      dmPermission: "friends",
+      allowBandInvites: true,
+      allowCompanyInvites: false,
+    });
+
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ profile_id: dbRow.profile_id }), { onConflict: "profile_id" });
+  });
+
+  it("surfaces backend save failures for unauthorized users", async () => {
+    single.mockResolvedValueOnce({ data: null, error: new Error("not owner") });
+
+    await expect(saveOwnSocialPrivacySettings(dbRow.profile_id, {
+      profileVisibility: "public",
+      cityVisibility: "friends",
+      activityVisibility: "friends",
+      onlineStatusVisibility: "private",
+      relationshipVisibility: "friends",
+      dmPermission: "friends",
+      allowBandInvites: true,
+      allowCompanyInvites: true,
+    })).rejects.toThrow("not owner");
+  });
+
+  it("loads only public-safe contact preferences for unrelated users", async () => {
+    maybeSingle.mockResolvedValueOnce({ data: dbRow, error: null });
+
+    await expect(fetchPublicSocialPrivacySettings(dbRow.profile_id)).resolves.toEqual({
+      profileId: dbRow.profile_id,
+      profileVisibility: "public",
+      dmPermission: "friends",
+      allowBandInvites: true,
+      allowCompanyInvites: false,
+    });
+    expect(from).toHaveBeenCalledWith("public_profile_privacy_settings");
+  });
+});

--- a/src/features/social-privacy/components/SocialPrivacySettingsCard.tsx
+++ b/src/features/social-privacy/components/SocialPrivacySettingsCard.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, RefreshCw, ShieldCheck } from "lucide-react";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { useSocialPrivacySettings } from "../hooks/useSocialPrivacySettings";
+import type { SocialPrivacySettingsUpdate } from "../services/socialPrivacySettings";
+
+const visibilityOptions = [
+  { value: "public", label: "Public", help: "Visible to anyone who can view social surfaces." },
+  { value: "friends", label: "Friends only", help: "Reserved for accepted friends once guarded reads are wired in." },
+  { value: "private", label: "Private", help: "Hidden from public discovery and future social reads." },
+] as const;
+
+const dmOptions = [
+  { value: "everyone", label: "Everyone" },
+  { value: "friends", label: "Friends only" },
+  { value: "none", label: "No one" },
+] as const;
+
+const fieldConfig = [
+  { key: "profileVisibility", label: "Profile highlight reel", description: "Controls the public-safe profile summary used by future discovery." },
+  { key: "cityVisibility", label: "Current city", description: "Prevents location-style social discovery from becoming mandatory." },
+  { key: "activityVisibility", label: "Current activity", description: "Controls future display of what your character is doing now." },
+  { key: "onlineStatusVisibility", label: "Online status", description: "Defaults private so presence remains opt-in." },
+  { key: "relationshipVisibility", label: "Relationship details", description: "Controls future friend/band/company relationship indicators." },
+] satisfies Array<{ key: keyof Pick<SocialPrivacySettingsUpdate, "profileVisibility" | "cityVisibility" | "activityVisibility" | "onlineStatusVisibility" | "relationshipVisibility">; label: string; description: string }>;
+
+interface SocialPrivacySettingsCardProps {
+  profileId: string | null;
+  isProfileLoading?: boolean;
+}
+
+export function SocialPrivacySettingsCard({ profileId, isProfileLoading = false }: SocialPrivacySettingsCardProps) {
+  const { data, isLoading, isError, error, refetch, saveSettings, isSaving } = useSocialPrivacySettings(profileId);
+  const [draft, setDraft] = useState<SocialPrivacySettingsUpdate | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setDraft({
+        profileVisibility: data.profileVisibility,
+        cityVisibility: data.cityVisibility,
+        activityVisibility: data.activityVisibility,
+        onlineStatusVisibility: data.onlineStatusVisibility,
+        relationshipVisibility: data.relationshipVisibility,
+        dmPermission: data.dmPermission,
+        allowBandInvites: data.allowBandInvites,
+        allowCompanyInvites: data.allowCompanyInvites,
+      });
+    }
+  }, [data]);
+
+  const hasChanges = useMemo(() => {
+    if (!draft || !data) return false;
+    return Object.entries(draft).some(([key, value]) => data[key as keyof SocialPrivacySettingsUpdate] !== value);
+  }, [data, draft]);
+
+  const disabled = !profileId || isProfileLoading || isLoading || isSaving || !draft;
+
+  const updateField = <Key extends keyof SocialPrivacySettingsUpdate>(key: Key, value: SocialPrivacySettingsUpdate[Key]) => {
+    setDraft((current) => current ? { ...current, [key]: value } : current);
+  };
+
+  const handleSave = async () => {
+    if (!profileId || !draft || isSaving || !hasChanges) return;
+    try {
+      await saveSettings(draft);
+      toast.success("Social privacy settings saved");
+    } catch (saveError) {
+      toast.error(saveError instanceof Error ? saveError.message : "Could not save social privacy settings");
+    }
+  };
+
+  if (!profileId && !isProfileLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2"><ShieldCheck className="h-4 w-4" /> Social Privacy Settings</CardTitle>
+          <CardDescription>Sign in and select a character to manage social visibility.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (isProfileLoading || isLoading) {
+    return (
+      <Card aria-busy="true">
+        <CardHeader>
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-full max-w-xl" />
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, index) => <Skeleton key={index} className="h-20 w-full" />)}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert variant="destructive" role="alert">
+        <AlertTitle>Could not load social privacy settings</AlertTitle>
+        <AlertDescription className="space-y-3">
+          <p>{error instanceof Error ? error.message : "Please try again before changing social visibility."}</p>
+          <Button type="button" variant="outline" size="sm" onClick={() => void refetch()}>
+            <RefreshCw className="mr-2 h-4 w-4" /> Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!draft) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Social Privacy Settings</CardTitle>
+          <CardDescription>No settings exist yet; safe defaults will be created when you save.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-primary" /> Social Privacy Settings</CardTitle>
+        <CardDescription>
+          Choose what future social discovery, contact, and recruitment flows may expose. Blocks still take priority over every contact option.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {fieldConfig.map((field) => (
+            <div key={field.key} className="rounded-md border border-border/80 p-3 space-y-2">
+              <Label htmlFor={`social-privacy-${field.key}`} className="text-sm font-medium">{field.label}</Label>
+              <p className="text-xs text-muted-foreground">{field.description}</p>
+              <Select
+                value={draft[field.key]}
+                onValueChange={(value) => updateField(field.key, value as SocialPrivacySettingsUpdate[typeof field.key])}
+                disabled={disabled}
+              >
+                <SelectTrigger id={`social-privacy-${field.key}`} aria-label={field.label}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {visibilityOptions.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+
+          <div className="rounded-md border border-border/80 p-3 space-y-2">
+            <Label htmlFor="social-privacy-dmPermission" className="text-sm font-medium">Direct messages</Label>
+            <p className="text-xs text-muted-foreground">Future DM send guards will use this preference plus block checks.</p>
+            <Select value={draft.dmPermission} onValueChange={(value) => updateField("dmPermission", value as SocialPrivacySettingsUpdate["dmPermission"])} disabled={disabled}>
+              <SelectTrigger id="social-privacy-dmPermission" aria-label="Direct messages"><SelectValue /></SelectTrigger>
+              <SelectContent>{dmOptions.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}</SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-md border border-border/80 p-3 flex items-center justify-between gap-3">
+            <div><Label htmlFor="allow-band-invites">Allow band invitations</Label><p className="text-xs text-muted-foreground">Disabled means future band invite guards should reject unsolicited invites.</p></div>
+            <Switch id="allow-band-invites" checked={draft.allowBandInvites} onCheckedChange={(checked) => updateField("allowBandInvites", checked)} disabled={disabled} />
+          </div>
+          <div className="rounded-md border border-border/80 p-3 flex items-center justify-between gap-3">
+            <div><Label htmlFor="allow-company-invites">Allow company invitations</Label><p className="text-xs text-muted-foreground">Disabled means future hiring/contact guards should reject unsolicited company invites.</p></div>
+            <Switch id="allow-company-invites" checked={draft.allowCompanyInvites} onCheckedChange={(checked) => updateField("allowCompanyInvites", checked)} disabled={disabled} />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground" role="status">
+            {hasChanges ? "Unsaved changes" : "Settings are up to date"}
+          </p>
+          <Button type="button" onClick={() => void handleSave()} disabled={disabled || !hasChanges}>
+            {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {isSaving ? "Saving…" : "Save privacy settings"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/social-privacy/hooks/useSocialPrivacySettings.ts
+++ b/src/features/social-privacy/hooks/useSocialPrivacySettings.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchOwnSocialPrivacySettings,
+  saveOwnSocialPrivacySettings,
+  type SocialPrivacySettingsUpdate,
+} from "../services/socialPrivacySettings";
+
+export const socialPrivacySettingsQueryKey = (profileId: string | null) => [
+  "social-privacy-settings",
+  profileId,
+];
+
+export function useSocialPrivacySettings(profileId: string | null) {
+  const queryClient = useQueryClient();
+
+  const settingsQuery = useQuery({
+    queryKey: socialPrivacySettingsQueryKey(profileId),
+    queryFn: () => fetchOwnSocialPrivacySettings(profileId!),
+    enabled: Boolean(profileId),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (input: SocialPrivacySettingsUpdate) => saveOwnSocialPrivacySettings(profileId!, input),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(socialPrivacySettingsQueryKey(profileId), saved);
+    },
+  });
+
+  return {
+    ...settingsQuery,
+    saveSettings: saveMutation.mutateAsync,
+    isSaving: saveMutation.isPending,
+    saveError: saveMutation.error,
+  };
+}

--- a/src/features/social-privacy/services/socialPrivacySettings.ts
+++ b/src/features/social-privacy/services/socialPrivacySettings.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { supabase } from "@/integrations/supabase/client";
+
+export const visibilityScopeSchema = z.enum(["public", "friends", "private"]);
+export const dmPermissionSchema = z.enum(["everyone", "friends", "none"]);
+
+export const socialPrivacySettingsSchema = z.object({
+  profileId: z.string().uuid(),
+  profileVisibility: visibilityScopeSchema,
+  cityVisibility: visibilityScopeSchema,
+  activityVisibility: visibilityScopeSchema,
+  onlineStatusVisibility: visibilityScopeSchema,
+  relationshipVisibility: visibilityScopeSchema,
+  dmPermission: dmPermissionSchema,
+  allowBandInvites: z.boolean(),
+  allowCompanyInvites: z.boolean(),
+});
+
+export const socialPrivacySettingsUpdateSchema = socialPrivacySettingsSchema.omit({ profileId: true });
+
+export type SocialPrivacySettings = z.infer<typeof socialPrivacySettingsSchema>;
+export type SocialPrivacySettingsUpdate = z.infer<typeof socialPrivacySettingsUpdateSchema>;
+
+const DEFAULT_SETTINGS: SocialPrivacySettingsUpdate = {
+  profileVisibility: "public",
+  cityVisibility: "friends",
+  activityVisibility: "friends",
+  onlineStatusVisibility: "private",
+  relationshipVisibility: "friends",
+  dmPermission: "friends",
+  allowBandInvites: true,
+  allowCompanyInvites: true,
+};
+
+const DB_TO_CLIENT = {
+  profile_visibility: "profileVisibility",
+  city_visibility: "cityVisibility",
+  activity_visibility: "activityVisibility",
+  online_status_visibility: "onlineStatusVisibility",
+  relationship_visibility: "relationshipVisibility",
+  dm_permission: "dmPermission",
+  allow_band_invites: "allowBandInvites",
+  allow_company_invites: "allowCompanyInvites",
+} as const;
+
+const toClient = (row: Record<string, unknown>): SocialPrivacySettings => socialPrivacySettingsSchema.parse({
+  profileId: row.profile_id,
+  profileVisibility: row.profile_visibility,
+  cityVisibility: row.city_visibility,
+  activityVisibility: row.activity_visibility,
+  onlineStatusVisibility: row.online_status_visibility,
+  relationshipVisibility: row.relationship_visibility,
+  dmPermission: row.dm_permission,
+  allowBandInvites: row.allow_band_invites,
+  allowCompanyInvites: row.allow_company_invites,
+});
+
+const toDb = (profileId: string, input: SocialPrivacySettingsUpdate) => ({
+  profile_id: profileId,
+  profile_visibility: input.profileVisibility,
+  city_visibility: input.cityVisibility,
+  activity_visibility: input.activityVisibility,
+  online_status_visibility: input.onlineStatusVisibility,
+  relationship_visibility: input.relationshipVisibility,
+  dm_permission: input.dmPermission,
+  allow_band_invites: input.allowBandInvites,
+  allow_company_invites: input.allowCompanyInvites,
+});
+
+export function getDefaultSocialPrivacySettings(profileId: string): SocialPrivacySettings {
+  return socialPrivacySettingsSchema.parse({ profileId, ...DEFAULT_SETTINGS });
+}
+
+export async function fetchOwnSocialPrivacySettings(profileId: string): Promise<SocialPrivacySettings> {
+  if (!profileId) throw new Error("Profile is required");
+
+  const { data, error } = await (supabase as any)
+    .from("profile_privacy_settings")
+    .select("profile_id,profile_visibility,city_visibility,activity_visibility,online_status_visibility,relationship_visibility,dm_permission,allow_band_invites,allow_company_invites")
+    .eq("profile_id", profileId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return getDefaultSocialPrivacySettings(profileId);
+  return toClient(data);
+}
+
+export async function saveOwnSocialPrivacySettings(
+  profileId: string,
+  input: SocialPrivacySettingsUpdate,
+): Promise<SocialPrivacySettings> {
+  const parsed = socialPrivacySettingsUpdateSchema.parse(input);
+
+  const { data, error } = await (supabase as any)
+    .from("profile_privacy_settings")
+    .upsert(toDb(profileId, parsed), { onConflict: "profile_id" })
+    .select("profile_id,profile_visibility,city_visibility,activity_visibility,online_status_visibility,relationship_visibility,dm_permission,allow_band_invites,allow_company_invites")
+    .single();
+
+  if (error) throw error;
+  return toClient(data);
+}
+
+export async function fetchPublicSocialPrivacySettings(profileId: string): Promise<Pick<SocialPrivacySettings, "profileId" | "profileVisibility" | "dmPermission" | "allowBandInvites" | "allowCompanyInvites"> | null> {
+  if (!profileId) return null;
+
+  const { data, error } = await (supabase as any)
+    .from("public_profile_privacy_settings")
+    .select("profile_id,profile_visibility,dm_permission,allow_band_invites,allow_company_invites")
+    .eq("profile_id", profileId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  return {
+    profileId: String(data.profile_id),
+    profileVisibility: visibilityScopeSchema.parse(data.profile_visibility),
+    dmPermission: dmPermissionSchema.parse(data.dm_permission),
+    allowBandInvites: Boolean(data.allow_band_invites),
+    allowCompanyInvites: Boolean(data.allow_company_invites),
+  };
+}
+
+export const socialPrivacyFieldLabels: Record<keyof typeof DB_TO_CLIENT, string> = {
+  profile_visibility: "Profile visibility",
+  city_visibility: "Current city",
+  activity_visibility: "Current activity",
+  online_status_visibility: "Online status",
+  relationship_visibility: "Relationship details",
+  dm_permission: "Direct messages",
+  allow_band_invites: "Band invitations",
+  allow_company_invites: "Company invitations",
+};

--- a/src/pages/Relationships.tsx
+++ b/src/pages/Relationships.tsx
@@ -76,6 +76,7 @@ import { FamilyDashboard } from "@/components/family/FamilyDashboard";
 import { StreakBanner } from "@/features/relationships/components/StreakBanner";
 import { FriendActivityFeed } from "@/features/relationships/components/FriendActivityFeed";
 import { BestFriendsLeaderboard } from "@/features/relationships/components/BestFriendsLeaderboard";
+import { SocialPrivacySettingsCard } from "@/features/social-privacy/components/SocialPrivacySettingsCard";
 import { WeeklyRecapCard } from "@/features/relationships/components/WeeklyRecapCard";
 import { CoopSuggestionsCard } from "@/features/relationships/components/CoopSuggestionsCard";
 import { CoopQuestActivityLog } from "@/features/relationships/components/CoopQuestActivityLog";
@@ -2177,6 +2178,7 @@ export default function RelationshipsPage() {
                       </p>
                     </div>
                   ))}
+                  <SocialPrivacySettingsCard profileId={profileId ?? activeProfileId} isProfileLoading={!gameData && !activeProfileId} />
                   {privacyControls.map((control) => (
                     <div
                       key={control.name}

--- a/supabase/migrations/20260710120000_add_profile_privacy_settings.sql
+++ b/supabase/migrations/20260710120000_add_profile_privacy_settings.sql
@@ -1,0 +1,159 @@
+BEGIN;
+
+CREATE TYPE public.profile_visibility_scope AS ENUM ('public', 'friends', 'private');
+CREATE TYPE public.profile_dm_permission AS ENUM ('everyone', 'friends', 'none');
+
+CREATE TABLE public.profile_privacy_settings (
+  profile_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  profile_visibility public.profile_visibility_scope NOT NULL DEFAULT 'public',
+  city_visibility public.profile_visibility_scope NOT NULL DEFAULT 'friends',
+  activity_visibility public.profile_visibility_scope NOT NULL DEFAULT 'friends',
+  online_status_visibility public.profile_visibility_scope NOT NULL DEFAULT 'private',
+  relationship_visibility public.profile_visibility_scope NOT NULL DEFAULT 'friends',
+  dm_permission public.profile_dm_permission NOT NULL DEFAULT 'friends',
+  allow_band_invites boolean NOT NULL DEFAULT true,
+  allow_company_invites boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+COMMENT ON TABLE public.profile_privacy_settings IS 'Owner-managed social visibility and contact preferences used by profile, discovery, messaging, and recruitment guards.';
+COMMENT ON COLUMN public.profile_privacy_settings.online_status_visibility IS 'Defaults private; social presence is opt-in before per-player online status is exposed.';
+COMMENT ON COLUMN public.profile_privacy_settings.dm_permission IS 'Preference consumed by future direct-message send guards. Blocking still takes precedence.';
+
+CREATE INDEX profile_privacy_settings_dm_permission_idx
+  ON public.profile_privacy_settings (dm_permission);
+CREATE INDEX profile_privacy_settings_invites_idx
+  ON public.profile_privacy_settings (allow_band_invites, allow_company_invites);
+
+ALTER TABLE public.profile_privacy_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Profile owners can view their privacy settings"
+  ON public.profile_privacy_settings
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_privacy_settings.profile_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Profile owners can create their privacy settings"
+  ON public.profile_privacy_settings
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_privacy_settings.profile_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Profile owners can update their privacy settings"
+  ON public.profile_privacy_settings
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_privacy_settings.profile_id
+        AND p.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.id = profile_privacy_settings.profile_id
+        AND p.user_id = auth.uid()
+    )
+  );
+
+CREATE TRIGGER update_profile_privacy_settings_updated_at
+  BEFORE UPDATE ON public.profile_privacy_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE OR REPLACE VIEW public.public_profile_privacy_settings AS
+SELECT
+  profile_id,
+  profile_visibility,
+  dm_permission,
+  allow_band_invites,
+  allow_company_invites
+FROM public.profile_privacy_settings;
+
+GRANT SELECT ON public.public_profile_privacy_settings TO anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.profile_belongs_to_current_user(target_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = target_profile_id
+      AND p.user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.are_profiles_blocked(first_profile_id uuid, second_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.friendships f
+    WHERE f.status = 'blocked'::public.friendship_status
+      AND (
+        (f.requestor_id = first_profile_id AND f.addressee_id = second_profile_id)
+        OR (f.requestor_id = second_profile_id AND f.addressee_id = first_profile_id)
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_profile_receive_dm(sender_profile_id uuid, recipient_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH settings AS (
+    SELECT COALESCE(
+      (SELECT pps.dm_permission FROM public.profile_privacy_settings pps WHERE pps.profile_id = recipient_profile_id),
+      'friends'::public.profile_dm_permission
+    ) AS dm_permission
+  )
+  SELECT
+    sender_profile_id IS NOT NULL
+    AND recipient_profile_id IS NOT NULL
+    AND sender_profile_id <> recipient_profile_id
+    AND NOT public.are_profiles_blocked(sender_profile_id, recipient_profile_id)
+    AND (
+      (SELECT dm_permission FROM settings) = 'everyone'::public.profile_dm_permission
+      OR (
+        (SELECT dm_permission FROM settings) = 'friends'::public.profile_dm_permission
+        AND EXISTS (
+          SELECT 1
+          FROM public.friendships f
+          WHERE f.status = 'accepted'::public.friendship_status
+            AND (
+              (f.requestor_id = sender_profile_id AND f.addressee_id = recipient_profile_id)
+              OR (f.requestor_id = recipient_profile_id AND f.addressee_id = sender_profile_id)
+            )
+        )
+      )
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.profile_belongs_to_current_user(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.are_profiles_blocked(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_profile_receive_dm(uuid, uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Implement the audit’s first dependency-aware recommendation: the Social permission design PR, delivered as an independently releasable slice that provides owner-managed profile privacy/contact settings. 
- The Phase 0 audit identified profile privacy as a core blocker and recommended defining visibility scopes, block/mute/report semantics, and public-safe profile fields before adding messaging, recruitment, or recommendation features. 
- This slice is intentionally low-risk and unlocks later work (safety schema, profile projections, and communication guards) by adding canonical schema and helper functions rather than retrofitting existing systems in one large PR. 

### Description
- Database migration `supabase/migrations/20260710120000_add_profile_privacy_settings.sql` adds `profile_visibility_scope` and `profile_dm_permission` enums, the `profile_privacy_settings` table with safe defaults, indexes, owner RLS policies, a limited `public_profile_privacy_settings` view, and helper SQL functions `profile_belongs_to_current_user`, `are_profiles_blocked`, and `can_profile_receive_dm` for later enforcement. 
- Service and validation layer `src/features/social-privacy/services/socialPrivacySettings.ts` provides Zod-validated fetch/save helpers, idempotent upsert behavior, defaults, and a public-safe fetch helper. 
- React integration: `useSocialPrivacySettings` hook (`src/features/social-privacy/hooks/useSocialPrivacySettings.ts`) and a responsive, accessible UI card `SocialPrivacySettingsCard` (`src/features/social-privacy/components/SocialPrivacySettingsCard.tsx`) were added and integrated into the existing `Relationships` page to expose settings without adding a new hub route. 
- Tests and docs: added unit tests for service and component (`src/features/social-privacy/__tests__/*`), updated `docs/social/SOCIAL_SYSTEM_AUDIT.md` and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`, and created implementation note `docs/social/implementation/PHASE_1_PR_01.md`. 

### Testing
- Typecheck: ran `npm run typecheck` (TS `tsc --noEmit`) and it passed. 
- Unit tests: new Jest/Vitest-style unit tests were added for service and component flows, but `vitest` was not available in the execution environment so the test run could not be executed here (tests are present and exercise owner load/save, safe defaults, validation, failed backend cases, duplicate-submit prevention, and unauthenticated/error UI states). 
- Lint/build: `npm install` failed in this environment due to a registry/permission error (403 while fetching dependencies), so `npm run lint` and `npm run build` could not be executed here because required dev tools (`@eslint/js`, `vite`, `vitest`) were not installable in this run. 
- Summary: static type checking succeeded; automated unit and integration runs were not possible due to missing environment dependencies, but test files were added and should pass in a standard developer CI environment once dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a509937524883259da357645aee4858)