### PR TITLE
Add social safety primitives (blocks, mutes, reports, audit)

### DIFF
--- a/docs/social/implementation/PHASE_1_PR_02.md
+++ b/docs/social/implementation/PHASE_1_PR_02.md
@@ -1,0 +1,47 @@
+# Phase 1 PR 02 — Social Safety Primitives: Blocks, Mutes, Reports, and Audit Logs
+
+## Problem
+
+Phase 1 PR 01 added owner-managed privacy settings and helper functions, but RockMundo still lacked dedicated cross-system safety primitives. Blocking existed only as a friendship status, while mute, report, and abuse-audit records were fragmented or missing for shared social guards.
+
+## Selection rationale
+
+This PR follows the recommended next social PR from `PHASE_1_PR_01.md`: the **Safety schema PR**. It still matches the P0 priorities in the social audit because DMs, friend requests, invites, Twaater, chat, and recruitment need shared block/mute/report/audit foundations before new write-heavy social features are expanded.
+
+## Solution
+
+1. Adds dedicated owner-managed `social_profile_blocks` and `social_profile_mutes` tables.
+2. Adds private `social_reports` records for moderator-ready future review.
+3. Adds append-only `social_action_audit_log` records for retryable safety actions.
+4. Updates `are_profiles_blocked` to honor both dedicated block records and legacy blocked friendships.
+5. Adds shared RPCs for block, unblock, mute, unmute, report, and mute checks.
+6. Adds a Relationships/Social safety card with loading, empty, error, disabled, duplicate-submit, success, and validation states.
+7. Adds frontend service/hook coverage for validation, RPC calls, idempotent actions, status checks, and report submission.
+
+## Files and migrations
+
+- `supabase/migrations/20260710133000_add_social_safety_primitives.sql`
+- `src/features/social-safety/services/socialSafety.ts`
+- `src/features/social-safety/hooks/useSocialSafety.ts`
+- `src/features/social-safety/components/SocialSafetyCard.tsx`
+- `src/features/social-safety/__tests__/socialSafety.test.ts`
+- `src/pages/Relationships.tsx`
+- `docs/social/implementation/PHASE_1_PR_02.md`
+
+## Permissions model
+
+- Owners can manage only their own block and mute records through RLS and `profile_belongs_to_current_user`.
+- Reporters can create and read only their own reports in this slice.
+- Unrelated users cannot read private block notes, mute notes, reports, or audit logs.
+- SECURITY DEFINER RPCs resolve the current profile from `auth.uid()` and use `SET search_path = public`.
+- Block/mute/report actions are server-authoritative and do not modify gameplay rewards, reputation, economy, contracts, or roles.
+
+## Known limitations
+
+- Existing DM, friend request, invite, recruitment, Twaater, and chat write flows are not all migrated to call the new RPCs in this PR.
+- The UI accepts a target profile ID as a minimal entry point until profile/message/context menus wire direct target actions.
+- Admin moderation queues for `social_reports` are intentionally deferred to a later moderation PR.
+
+## Next dependency-aware PR
+
+Migrate the highest-risk existing write flow to the shared safety guards, preferably direct messages or friend requests, so blocked users cannot bypass contact restrictions through an already-shipped social surface.

--- a/src/features/social-safety/__tests__/socialSafety.test.ts
+++ b/src/features/social-safety/__tests__/socialSafety.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const rpc = vi.fn();
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { rpc } }));
+
+const {
+  blockProfile,
+  fetchSocialSafetyStatus,
+  muteProfile,
+  reportSocialTarget,
+  unblockProfile,
+} = await import("../services/socialSafety");
+
+const viewerProfileId = "11111111-1111-4111-8111-111111111111";
+const targetProfileId = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("social safety service", () => {
+  it("loads blocked and muted status through shared RPC guards", async () => {
+    rpc
+      .mockResolvedValueOnce({ data: true, error: null })
+      .mockResolvedValueOnce({ data: false, error: null });
+
+    await expect(fetchSocialSafetyStatus(viewerProfileId, targetProfileId)).resolves.toEqual({ isBlocked: true, isMuted: false });
+    expect(rpc).toHaveBeenCalledWith("are_profiles_blocked", { first_profile_id: viewerProfileId, second_profile_id: targetProfileId });
+    expect(rpc).toHaveBeenCalledWith("is_profile_muted", { viewer_profile_id: viewerProfileId, target_profile_id: targetProfileId });
+  });
+
+  it("validates target IDs before block RPC calls", async () => {
+    await expect(blockProfile("not-a-uuid")).rejects.toThrow();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("calls block_profile with a trimmed optional note", async () => {
+    rpc.mockResolvedValueOnce({ data: { blocked_profile_id: targetProfileId }, error: null });
+
+    await blockProfile(targetProfileId, " spam ");
+    expect(rpc).toHaveBeenCalledWith("block_profile", { target_profile_id: targetProfileId, note: "spam" });
+  });
+
+  it("calls unblock_profile idempotently", async () => {
+    rpc.mockResolvedValueOnce({ data: true, error: null });
+
+    await expect(unblockProfile(targetProfileId)).resolves.toBe(true);
+    expect(rpc).toHaveBeenCalledWith("unblock_profile", { target_profile_id: targetProfileId });
+  });
+
+  it("rejects overlong mute notes before backend writes", async () => {
+    await expect(muteProfile(targetProfileId, "x".repeat(281))).rejects.toThrow("280");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("validates report reason length before submitting", async () => {
+    await expect(reportSocialTarget({
+      reportedProfileId: targetProfileId,
+      targetType: "profile",
+      category: "spam",
+      reason: "short",
+    })).rejects.toThrow("at least 10");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("submits a validated report with safe context", async () => {
+    rpc.mockResolvedValueOnce({ data: { id: "33333333-3333-4333-8333-333333333333" }, error: null });
+
+    await reportSocialTarget({
+      reportedProfileId: targetProfileId,
+      targetType: "profile",
+      category: "harassment",
+      reason: "Repeated unwanted messages after I asked them to stop.",
+      context: { surface: "test" },
+    });
+
+    expect(rpc).toHaveBeenCalledWith("report_social_target", {
+      reported_profile_id: targetProfileId,
+      target_type: "profile",
+      target_id: null,
+      category: "harassment",
+      reason: "Repeated unwanted messages after I asked them to stop.",
+      context: { surface: "test" },
+    });
+  });
+});

--- a/src/features/social-safety/components/SocialSafetyCard.tsx
+++ b/src/features/social-safety/components/SocialSafetyCard.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { AlertTriangle, Loader2, RefreshCw, ShieldAlert, VolumeX } from "lucide-react";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useSocialSafety } from "../hooks/useSocialSafety";
+import { socialReportCategoryLabels, type SocialReportCategory } from "../services/socialSafety";
+
+interface SocialSafetyCardProps {
+  viewerProfileId: string | null;
+  isProfileLoading?: boolean;
+}
+
+const categoryOptions = Object.entries(socialReportCategoryLabels) as Array<[SocialReportCategory, string]>;
+
+export function SocialSafetyCard({ viewerProfileId, isProfileLoading = false }: SocialSafetyCardProps) {
+  const [targetProfileId, setTargetProfileId] = useState("");
+  const [note, setNote] = useState("");
+  const [category, setCategory] = useState<SocialReportCategory>("harassment");
+  const [reason, setReason] = useState("");
+  const normalizedTarget = targetProfileId.trim() || null;
+  const hasTarget = Boolean(normalizedTarget && normalizedTarget !== viewerProfileId);
+
+  const safety = useSocialSafety(viewerProfileId, hasTarget ? normalizedTarget : null);
+  const busy = safety.isBlocking || safety.isUnblocking || safety.isMuting || safety.isUnmuting || safety.isReporting;
+  const noteTooLong = note.trim().length > 280;
+  const canSubmitAction = Boolean(viewerProfileId && hasTarget && !busy && !noteTooLong);
+  const canSubmitReport = canSubmitAction && reason.trim().length >= 10 && reason.trim().length <= 2000;
+
+  const statusText = useMemo(() => {
+    if (!hasTarget) return "Enter a profile target to review available safety actions.";
+    if (safety.isLoading) return "Checking current block and mute status…";
+    if (safety.data?.isBlocked) return "Blocked: this player cannot pass shared contact guards.";
+    if (safety.data?.isMuted) return "Muted: future feeds and notifications can suppress this player.";
+    return "No active block or mute for this target.";
+  }, [hasTarget, safety.data?.isBlocked, safety.data?.isMuted, safety.isLoading]);
+
+  const runAction = async (action: "block" | "unblock" | "mute" | "unmute" | "report") => {
+    try {
+      if (action === "block") await safety.blockProfile({ note });
+      if (action === "unblock") await safety.unblockProfile();
+      if (action === "mute") await safety.muteProfile({ note });
+      if (action === "unmute") await safety.unmuteProfile();
+      if (action === "report") {
+        await safety.reportSocialTarget({
+          reportedProfileId: normalizedTarget,
+          targetType: "profile",
+          category,
+          reason,
+          context: { surface: "relationships_social_safety_card" },
+        });
+        setReason("");
+      }
+      toast.success(action === "report" ? "Report submitted for moderator review" : "Social safety preference updated");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not complete that safety action");
+    }
+  };
+
+  if (!viewerProfileId && !isProfileLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2"><ShieldAlert className="h-4 w-4" /> Social Safety</CardTitle>
+          <CardDescription>Sign in and select a character to block, mute, or report social abuse.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (isProfileLoading) {
+    return (
+      <Card aria-busy="true">
+        <CardHeader><Skeleton className="h-5 w-40" /><Skeleton className="h-4 w-full max-w-xl" /></CardHeader>
+        <CardContent className="space-y-3"><Skeleton className="h-10 w-full" /><Skeleton className="h-24 w-full" /></CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2"><ShieldAlert className="h-4 w-4 text-primary" /> Social Safety</CardTitle>
+        <CardDescription>
+          Block, mute, or report another player. These actions are private, retry-safe, and do not grant gameplay rewards.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(12rem,0.5fr)]">
+          <div className="space-y-2">
+            <Label htmlFor="social-safety-target">Target profile ID</Label>
+            <Input
+              id="social-safety-target"
+              value={targetProfileId}
+              onChange={(event) => setTargetProfileId(event.target.value)}
+              placeholder="Paste the profile ID from a profile or message context"
+              disabled={busy}
+              aria-describedby="social-safety-status"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="social-safety-note">Private note</Label>
+            <Input id="social-safety-note" value={note} onChange={(event) => setNote(event.target.value)} maxLength={280} disabled={busy} placeholder="Optional" />
+          </div>
+        </div>
+
+        <p id="social-safety-status" className="text-xs text-muted-foreground" role="status">{statusText}</p>
+        {noteTooLong ? <p className="text-xs text-destructive">Notes must be 280 characters or fewer.</p> : null}
+        {safety.isError ? (
+          <Alert variant="destructive" role="alert">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Could not load safety status</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{safety.error instanceof Error ? safety.error.message : "Try again before changing this relationship."}</p>
+              <Button type="button" variant="outline" size="sm" onClick={() => void safety.refetch()}><RefreshCw className="mr-2 h-4 w-4" /> Retry</Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+          <Button type="button" variant="destructive" disabled={!canSubmitAction || safety.data?.isBlocked} onClick={() => void runAction("block")}>
+            {safety.isBlocking ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldAlert className="mr-2 h-4 w-4" />} Block
+          </Button>
+          <Button type="button" variant="outline" disabled={!canSubmitAction || !safety.data?.isBlocked} onClick={() => void runAction("unblock")}>Unblock</Button>
+          <Button type="button" variant="secondary" disabled={!canSubmitAction || safety.data?.isMuted || safety.data?.isBlocked} onClick={() => void runAction("mute")}>
+            {safety.isMuting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <VolumeX className="mr-2 h-4 w-4" />} Mute
+          </Button>
+          <Button type="button" variant="outline" disabled={!canSubmitAction || !safety.data?.isMuted} onClick={() => void runAction("unmute")}>Unmute</Button>
+        </div>
+
+        <div className="rounded-md border border-border/80 p-3 space-y-3">
+          <div className="grid gap-3 md:grid-cols-[16rem_1fr]">
+            <div className="space-y-2">
+              <Label htmlFor="social-report-category">Report category</Label>
+              <Select value={category} onValueChange={(value) => setCategory(value as SocialReportCategory)} disabled={busy}>
+                <SelectTrigger id="social-report-category"><SelectValue /></SelectTrigger>
+                <SelectContent>{categoryOptions.map(([value, label]) => <SelectItem key={value} value={value}>{label}</SelectItem>)}</SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="social-report-reason">What happened?</Label>
+              <Textarea id="social-report-reason" value={reason} onChange={(event) => setReason(event.target.value)} disabled={busy} maxLength={2000} placeholder="Give moderators enough context to review the issue." />
+              <p className="text-xs text-muted-foreground">{reason.trim().length}/2000 characters. Minimum 10.</p>
+            </div>
+          </div>
+          <Button type="button" disabled={!canSubmitReport} onClick={() => void runAction("report")}>
+            {safety.isReporting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null} Submit report
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/social-safety/hooks/useSocialSafety.ts
+++ b/src/features/social-safety/hooks/useSocialSafety.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  blockProfile,
+  fetchSocialSafetyStatus,
+  muteProfile,
+  reportSocialTarget,
+  unblockProfile,
+  unmuteProfile,
+  type ReportSocialTargetInput,
+} from "../services/socialSafety";
+
+export const socialSafetyStatusQueryKey = (viewerProfileId: string | null, targetProfileId: string | null) => [
+  "social-safety-status",
+  viewerProfileId,
+  targetProfileId,
+];
+
+interface SafetyActionInput {
+  note?: string;
+}
+
+export function useSocialSafety(viewerProfileId: string | null, targetProfileId: string | null) {
+  const queryClient = useQueryClient();
+
+  const statusQuery = useQuery({
+    queryKey: socialSafetyStatusQueryKey(viewerProfileId, targetProfileId),
+    queryFn: () => fetchSocialSafetyStatus(viewerProfileId!, targetProfileId!),
+    enabled: Boolean(viewerProfileId && targetProfileId && viewerProfileId !== targetProfileId),
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: socialSafetyStatusQueryKey(viewerProfileId, targetProfileId) });
+
+  const blockMutation = useMutation({
+    mutationFn: ({ note }: SafetyActionInput = {}) => blockProfile(targetProfileId!, note),
+    onSuccess: invalidate,
+  });
+  const unblockMutation = useMutation({
+    mutationFn: () => unblockProfile(targetProfileId!),
+    onSuccess: invalidate,
+  });
+  const muteMutation = useMutation({
+    mutationFn: ({ note }: SafetyActionInput = {}) => muteProfile(targetProfileId!, note),
+    onSuccess: invalidate,
+  });
+  const unmuteMutation = useMutation({
+    mutationFn: () => unmuteProfile(targetProfileId!),
+    onSuccess: invalidate,
+  });
+  const reportMutation = useMutation({ mutationFn: (input: ReportSocialTargetInput) => reportSocialTarget(input) });
+
+  return {
+    ...statusQuery,
+    blockProfile: blockMutation.mutateAsync,
+    unblockProfile: unblockMutation.mutateAsync,
+    muteProfile: muteMutation.mutateAsync,
+    unmuteProfile: unmuteMutation.mutateAsync,
+    reportSocialTarget: reportMutation.mutateAsync,
+    isBlocking: blockMutation.isPending,
+    isUnblocking: unblockMutation.isPending,
+    isMuting: muteMutation.isPending,
+    isUnmuting: unmuteMutation.isPending,
+    isReporting: reportMutation.isPending,
+  };
+}

--- a/src/features/social-safety/services/socialSafety.ts
+++ b/src/features/social-safety/services/socialSafety.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { supabase } from "@/integrations/supabase/client";
+
+export const socialReportTargetTypeSchema = z.enum([
+  "profile",
+  "direct_message",
+  "social_invite",
+  "band",
+  "company",
+  "twaater_post",
+  "chat_message",
+  "other",
+]);
+export const socialReportCategorySchema = z.enum([
+  "harassment",
+  "spam",
+  "hate",
+  "sexual_content",
+  "threats",
+  "impersonation",
+  "scam",
+  "self_harm",
+  "other",
+]);
+
+const uuidSchema = z.string().uuid();
+const noteSchema = z.string().trim().max(280, "Notes must be 280 characters or fewer").optional();
+
+export const reportSocialTargetInputSchema = z.object({
+  reportedProfileId: uuidSchema.optional().nullable(),
+  targetType: socialReportTargetTypeSchema,
+  targetId: uuidSchema.optional().nullable(),
+  category: socialReportCategorySchema,
+  reason: z.string().trim().min(10, "Tell moderators what happened in at least 10 characters").max(2000, "Reports must be 2000 characters or fewer"),
+  context: z.record(z.unknown()).optional().default({}),
+}).refine((value) => Boolean(value.reportedProfileId || value.targetId), {
+  message: "Choose a player or social item to report",
+  path: ["reportedProfileId"],
+});
+
+export type SocialReportTargetType = z.infer<typeof socialReportTargetTypeSchema>;
+export type SocialReportCategory = z.infer<typeof socialReportCategorySchema>;
+export type ReportSocialTargetInput = z.input<typeof reportSocialTargetInputSchema>;
+
+export interface SocialSafetyStatus {
+  isBlocked: boolean;
+  isMuted: boolean;
+}
+
+export async function fetchSocialSafetyStatus(viewerProfileId: string, targetProfileId: string): Promise<SocialSafetyStatus> {
+  uuidSchema.parse(viewerProfileId);
+  uuidSchema.parse(targetProfileId);
+
+  const [{ data: isBlocked, error: blockError }, { data: isMuted, error: muteError }] = await Promise.all([
+    (supabase as any).rpc("are_profiles_blocked", { first_profile_id: viewerProfileId, second_profile_id: targetProfileId }),
+    (supabase as any).rpc("is_profile_muted", { viewer_profile_id: viewerProfileId, target_profile_id: targetProfileId }),
+  ]);
+
+  if (blockError) throw blockError;
+  if (muteError) throw muteError;
+
+  return { isBlocked: Boolean(isBlocked), isMuted: Boolean(isMuted) };
+}
+
+export async function blockProfile(targetProfileId: string, note?: string) {
+  uuidSchema.parse(targetProfileId);
+  const parsedNote = noteSchema.parse(note);
+  const { data, error } = await (supabase as any).rpc("block_profile", {
+    target_profile_id: targetProfileId,
+    note: parsedNote || null,
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function unblockProfile(targetProfileId: string): Promise<boolean> {
+  uuidSchema.parse(targetProfileId);
+  const { data, error } = await (supabase as any).rpc("unblock_profile", { target_profile_id: targetProfileId });
+  if (error) throw error;
+  return Boolean(data);
+}
+
+export async function muteProfile(targetProfileId: string, note?: string, muteUntil?: string | null) {
+  uuidSchema.parse(targetProfileId);
+  const parsedNote = noteSchema.parse(note);
+  const { data, error } = await (supabase as any).rpc("mute_profile", {
+    target_profile_id: targetProfileId,
+    mute_until: muteUntil ?? null,
+    note: parsedNote || null,
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function unmuteProfile(targetProfileId: string): Promise<boolean> {
+  uuidSchema.parse(targetProfileId);
+  const { data, error } = await (supabase as any).rpc("unmute_profile", { target_profile_id: targetProfileId });
+  if (error) throw error;
+  return Boolean(data);
+}
+
+export async function reportSocialTarget(input: ReportSocialTargetInput) {
+  const parsed = reportSocialTargetInputSchema.parse(input);
+  const { data, error } = await (supabase as any).rpc("report_social_target", {
+    reported_profile_id: parsed.reportedProfileId ?? null,
+    target_type: parsed.targetType,
+    target_id: parsed.targetId ?? null,
+    category: parsed.category,
+    reason: parsed.reason,
+    context: parsed.context,
+  });
+  if (error) throw error;
+  return data;
+}
+
+export const socialReportCategoryLabels: Record<SocialReportCategory, string> = {
+  harassment: "Harassment or bullying",
+  spam: "Spam or repeated unwanted contact",
+  hate: "Hate or hateful conduct",
+  sexual_content: "Sexual content",
+  threats: "Threats or violence",
+  impersonation: "Impersonation",
+  scam: "Scam or fraud",
+  self_harm: "Self-harm concern",
+  other: "Other safety issue",
+};

--- a/src/pages/Relationships.tsx
+++ b/src/pages/Relationships.tsx
@@ -77,6 +77,7 @@ import { StreakBanner } from "@/features/relationships/components/StreakBanner";
 import { FriendActivityFeed } from "@/features/relationships/components/FriendActivityFeed";
 import { BestFriendsLeaderboard } from "@/features/relationships/components/BestFriendsLeaderboard";
 import { SocialPrivacySettingsCard } from "@/features/social-privacy/components/SocialPrivacySettingsCard";
+import { SocialSafetyCard } from "@/features/social-safety/components/SocialSafetyCard";
 import { WeeklyRecapCard } from "@/features/relationships/components/WeeklyRecapCard";
 import { CoopSuggestionsCard } from "@/features/relationships/components/CoopSuggestionsCard";
 import { CoopQuestActivityLog } from "@/features/relationships/components/CoopQuestActivityLog";
@@ -2179,6 +2180,7 @@ export default function RelationshipsPage() {
                     </div>
                   ))}
                   <SocialPrivacySettingsCard profileId={profileId ?? activeProfileId} isProfileLoading={!gameData && !activeProfileId} />
+                  <SocialSafetyCard viewerProfileId={profileId ?? activeProfileId} isProfileLoading={!gameData && !activeProfileId} />
                   {privacyControls.map((control) => (
                     <div
                       key={control.name}

--- a/supabase/migrations/20260710133000_add_social_safety_primitives.sql
+++ b/supabase/migrations/20260710133000_add_social_safety_primitives.sql
@@ -1,0 +1,283 @@
+BEGIN;
+
+CREATE TYPE public.social_report_target_type AS ENUM ('profile', 'direct_message', 'social_invite', 'band', 'company', 'twaater_post', 'chat_message', 'other');
+CREATE TYPE public.social_report_category AS ENUM ('harassment', 'spam', 'hate', 'sexual_content', 'threats', 'impersonation', 'scam', 'self_harm', 'other');
+CREATE TYPE public.social_report_status AS ENUM ('open', 'triaged', 'actioned', 'dismissed');
+CREATE TYPE public.social_action_audit_kind AS ENUM ('block', 'unblock', 'mute', 'unmute', 'report');
+
+CREATE TABLE public.social_profile_blocks (
+  blocker_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  blocked_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  PRIMARY KEY (blocker_profile_id, blocked_profile_id),
+  CONSTRAINT social_profile_blocks_no_self CHECK (blocker_profile_id <> blocked_profile_id),
+  CONSTRAINT social_profile_blocks_reason_length CHECK (reason IS NULL OR char_length(reason) <= 280)
+);
+
+COMMENT ON TABLE public.social_profile_blocks IS 'Dedicated cross-system player safety blocks. Blocks are owner-managed and consumed by shared social guards.';
+COMMENT ON COLUMN public.social_profile_blocks.reason IS 'Optional private owner note; not visible to the blocked profile.';
+
+CREATE INDEX social_profile_blocks_blocked_idx ON public.social_profile_blocks (blocked_profile_id, created_at DESC);
+
+CREATE TABLE public.social_profile_mutes (
+  muter_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  muted_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  expires_at timestamptz,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  PRIMARY KEY (muter_profile_id, muted_profile_id),
+  CONSTRAINT social_profile_mutes_no_self CHECK (muter_profile_id <> muted_profile_id),
+  CONSTRAINT social_profile_mutes_reason_length CHECK (reason IS NULL OR char_length(reason) <= 280)
+);
+
+COMMENT ON TABLE public.social_profile_mutes IS 'Owner-managed social mutes for future feed, notification, and communication suppression.';
+
+CREATE INDEX social_profile_mutes_muted_idx ON public.social_profile_mutes (muted_profile_id, created_at DESC);
+CREATE INDEX social_profile_mutes_active_idx ON public.social_profile_mutes (muter_profile_id, muted_profile_id, expires_at);
+
+CREATE TABLE public.social_reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reported_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  target_type public.social_report_target_type NOT NULL,
+  target_id uuid,
+  category public.social_report_category NOT NULL,
+  reason text NOT NULL,
+  context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status public.social_report_status NOT NULL DEFAULT 'open',
+  moderator_notes text,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  resolved_at timestamptz,
+  CONSTRAINT social_reports_reason_length CHECK (char_length(btrim(reason)) BETWEEN 10 AND 2000),
+  CONSTRAINT social_reports_context_object CHECK (jsonb_typeof(context) = 'object'),
+  CONSTRAINT social_reports_target_present CHECK (reported_profile_id IS NOT NULL OR target_id IS NOT NULL)
+);
+
+COMMENT ON TABLE public.social_reports IS 'Private player-submitted social safety reports retained for future moderation review.';
+COMMENT ON COLUMN public.social_reports.context IS 'Optional sanitized context such as route, message preview, or client surface; never store auth internals or private emails.';
+
+CREATE INDEX social_reports_reporter_idx ON public.social_reports (reporter_profile_id, created_at DESC);
+CREATE INDEX social_reports_reported_idx ON public.social_reports (reported_profile_id, created_at DESC) WHERE reported_profile_id IS NOT NULL;
+CREATE INDEX social_reports_status_idx ON public.social_reports (status, created_at DESC);
+CREATE INDEX social_reports_target_idx ON public.social_reports (target_type, target_id) WHERE target_id IS NOT NULL;
+
+CREATE TABLE public.social_action_audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  target_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  action public.social_action_audit_kind NOT NULL,
+  target_type public.social_report_target_type,
+  target_id uuid,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT social_action_audit_metadata_object CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+COMMENT ON TABLE public.social_action_audit_log IS 'Append-only lightweight audit trail for retryable social safety actions.';
+
+CREATE INDEX social_action_audit_actor_idx ON public.social_action_audit_log (actor_profile_id, created_at DESC);
+CREATE INDEX social_action_audit_target_idx ON public.social_action_audit_log (target_profile_id, created_at DESC) WHERE target_profile_id IS NOT NULL;
+
+ALTER TABLE public.social_profile_blocks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.social_profile_mutes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.social_reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.social_action_audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Profile owners manage their blocks" ON public.social_profile_blocks
+  FOR ALL USING (public.profile_belongs_to_current_user(blocker_profile_id))
+  WITH CHECK (public.profile_belongs_to_current_user(blocker_profile_id));
+
+CREATE POLICY "Profile owners manage their mutes" ON public.social_profile_mutes
+  FOR ALL USING (public.profile_belongs_to_current_user(muter_profile_id))
+  WITH CHECK (public.profile_belongs_to_current_user(muter_profile_id));
+
+CREATE POLICY "Reporters can create reports" ON public.social_reports
+  FOR INSERT WITH CHECK (public.profile_belongs_to_current_user(reporter_profile_id));
+
+CREATE POLICY "Reporters can view their reports" ON public.social_reports
+  FOR SELECT USING (public.profile_belongs_to_current_user(reporter_profile_id));
+
+CREATE POLICY "Actors can view their social safety audit log" ON public.social_action_audit_log
+  FOR SELECT USING (public.profile_belongs_to_current_user(actor_profile_id));
+
+CREATE TRIGGER update_social_profile_blocks_updated_at
+  BEFORE UPDATE ON public.social_profile_blocks
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_social_profile_mutes_updated_at
+  BEFORE UPDATE ON public.social_profile_mutes
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE TRIGGER update_social_reports_updated_at
+  BEFORE UPDATE ON public.social_reports
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE OR REPLACE FUNCTION public.are_profiles_blocked(first_profile_id uuid, second_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.social_profile_blocks b
+    WHERE (b.blocker_profile_id = first_profile_id AND b.blocked_profile_id = second_profile_id)
+       OR (b.blocker_profile_id = second_profile_id AND b.blocked_profile_id = first_profile_id)
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.friendships f
+    WHERE f.status = 'blocked'::public.friendship_status
+      AND (
+        (f.requestor_id = first_profile_id AND f.addressee_id = second_profile_id)
+        OR (f.requestor_id = second_profile_id AND f.addressee_id = first_profile_id)
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_profile_muted(viewer_profile_id uuid, target_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.social_profile_mutes m
+    WHERE m.muter_profile_id = viewer_profile_id
+      AND m.muted_profile_id = target_profile_id
+      AND (m.expires_at IS NULL OR m.expires_at > timezone('utc', now()))
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.block_profile(target_profile_id uuid, note text DEFAULT NULL)
+RETURNS public.social_profile_blocks
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_profile_id uuid;
+  block_row public.social_profile_blocks;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  IF target_profile_id IS NULL OR target_profile_id = actor_profile_id THEN RAISE EXCEPTION 'Choose another player to block'; END IF;
+  IF note IS NOT NULL AND char_length(note) > 280 THEN RAISE EXCEPTION 'Block note must be 280 characters or fewer'; END IF;
+
+  INSERT INTO public.social_profile_blocks (blocker_profile_id, blocked_profile_id, reason)
+  VALUES (actor_profile_id, target_profile_id, NULLIF(btrim(note), ''))
+  ON CONFLICT (blocker_profile_id, blocked_profile_id)
+  DO UPDATE SET reason = COALESCE(EXCLUDED.reason, public.social_profile_blocks.reason), updated_at = timezone('utc', now())
+  RETURNING * INTO block_row;
+
+  DELETE FROM public.social_profile_mutes WHERE muter_profile_id = actor_profile_id AND muted_profile_id = target_profile_id;
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action)
+  VALUES (actor_profile_id, target_profile_id, 'block');
+  RETURN block_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.unblock_profile(target_profile_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE actor_profile_id uuid;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  DELETE FROM public.social_profile_blocks WHERE blocker_profile_id = actor_profile_id AND blocked_profile_id = target_profile_id;
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action) VALUES (actor_profile_id, target_profile_id, 'unblock');
+  RETURN true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mute_profile(target_profile_id uuid, mute_until timestamptz DEFAULT NULL, note text DEFAULT NULL)
+RETURNS public.social_profile_mutes
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_profile_id uuid;
+  mute_row public.social_profile_mutes;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  IF target_profile_id IS NULL OR target_profile_id = actor_profile_id THEN RAISE EXCEPTION 'Choose another player to mute'; END IF;
+  IF note IS NOT NULL AND char_length(note) > 280 THEN RAISE EXCEPTION 'Mute note must be 280 characters or fewer'; END IF;
+
+  INSERT INTO public.social_profile_mutes (muter_profile_id, muted_profile_id, expires_at, reason)
+  VALUES (actor_profile_id, target_profile_id, mute_until, NULLIF(btrim(note), ''))
+  ON CONFLICT (muter_profile_id, muted_profile_id)
+  DO UPDATE SET expires_at = EXCLUDED.expires_at, reason = COALESCE(EXCLUDED.reason, public.social_profile_mutes.reason), updated_at = timezone('utc', now())
+  RETURNING * INTO mute_row;
+
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action) VALUES (actor_profile_id, target_profile_id, 'mute');
+  RETURN mute_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.unmute_profile(target_profile_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE actor_profile_id uuid;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  DELETE FROM public.social_profile_mutes WHERE muter_profile_id = actor_profile_id AND muted_profile_id = target_profile_id;
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action) VALUES (actor_profile_id, target_profile_id, 'unmute');
+  RETURN true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.report_social_target(
+  reported_profile_id uuid,
+  target_type public.social_report_target_type,
+  target_id uuid,
+  category public.social_report_category,
+  reason text,
+  context jsonb DEFAULT '{}'::jsonb
+)
+RETURNS public.social_reports
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_profile_id uuid;
+  report_row public.social_reports;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  IF reported_profile_id IS NULL AND target_id IS NULL THEN RAISE EXCEPTION 'Report target is required'; END IF;
+  IF reported_profile_id = actor_profile_id THEN RAISE EXCEPTION 'You cannot report yourself'; END IF;
+  IF reason IS NULL OR char_length(btrim(reason)) < 10 OR char_length(btrim(reason)) > 2000 THEN RAISE EXCEPTION 'Report reason must be 10 to 2000 characters'; END IF;
+  IF context IS NULL OR jsonb_typeof(context) <> 'object' THEN RAISE EXCEPTION 'Report context must be an object'; END IF;
+
+  INSERT INTO public.social_reports (reporter_profile_id, reported_profile_id, target_type, target_id, category, reason, context)
+  VALUES (actor_profile_id, reported_profile_id, target_type, target_id, category, btrim(reason), context)
+  RETURNING * INTO report_row;
+
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+  VALUES (actor_profile_id, reported_profile_id, 'report', target_type, target_id, jsonb_build_object('category', category));
+  RETURN report_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.is_profile_muted(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.block_profile(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.unblock_profile(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.mute_profile(uuid, timestamptz, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.unmute_profile(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.report_social_target(uuid, public.social_report_target_type, uuid, public.social_report_category, text, jsonb) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Follow-up to the profile privacy slice: implement the recommended Safety schema to provide repository-wide, server-authoritative safety primitives before expanding DMs/invites/recruitment. 
- Provide a single cross-system guard for blocking/muting and a private reporting/audit foundation so existing fragmented friendship-based blocks cannot be bypassed. 
- Keep the change small and dependency-aware so later communication and recruitment writes can call the new guards without a large redesign. 

### Description
- Database: add migration `supabase/migrations/20260710133000_add_social_safety_primitives.sql` creating `social_profile_blocks`, `social_profile_mutes`, `social_reports`, and `social_action_audit_log` tables, enums, indexes, RLS policies, triggers, and `SECURITY DEFINER` RPCs `block_profile`, `unblock_profile`, `mute_profile`, `unmute_profile`, `report_social_target`, plus `is_profile_muted` and an updated `are_profiles_blocked` that considers both new block rows and legacy blocked friendships. 
- Frontend services/hooks: add `src/features/social-safety/services/socialSafety.ts` with Zod validation and RPC mappings and `src/features/social-safety/hooks/useSocialSafety.ts` which exposes React Query status and mutations with cache invalidation. 
- UI: add `src/features/social-safety/components/SocialSafetyCard.tsx` and mount it beside the Social Privacy card on `src/pages/Relationships.tsx`; the card includes signed-out/loading/error/disabled/duplicate-submit states, validation, and report UI. 
- Tests/docs: add unit tests `src/features/social-safety/__tests__/socialSafety.test.ts` covering validation and RPC call behavior, and add `docs/social/implementation/PHASE_1_PR_02.md` documenting rationale, permissions model, scope, and next steps. 
- Security & patterns: all new SECURITY DEFINER functions set `search_path = public`, RLS ties owners to `profile_belongs_to_current_user`, reports/mutes/blocks are owner-managed and private, actions are idempotent where applicable, and the action audit log records retryable events. 

### Testing
- `npm run typecheck` (`tsc --noEmit`) completed successfully. 
- `git diff --check` / whitespace checks passed successfully. 
- Added unit tests for the frontend service (`src/features/social-safety/__tests__/socialSafety.test.ts`) and existing social privacy tests remain present, but `vitest` could not be executed in this environment so those tests were not run. 
- `npm install` was attempted to restore dev dependencies but failed against the registry (403 for a package), and `npm run lint` failed due to missing dev deps, so linting and full test execution were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50de6921648325b4e0aa5627c951b9)