### PR TITLE
Guard friend request sends

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -60,7 +60,7 @@ Other players should become the most valuable content in RockMundo because they 
 - **Friends and follows**
   - Add clear distinction between mutual friends, one-way follows, blocked users, bandmates, company colleagues, mentors, mentees, contractors, and rivals.
   - Provide friend activity summaries such as upcoming gigs, new releases, job openings, contract requests, and major achievements.
-  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions. Initial owner-managed settings now exist; direct-message sends now enforce DM permission and blocks server-side, while full enforcement across other reads/writes remains a follow-up.
+  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions. Initial owner-managed settings now exist; direct-message sends enforce DM permission and blocks server-side; friend-request creation now enforces block checks, duplicate handling, cooldowns, and notification deduplication server-side; full enforcement across other reads/writes remains a follow-up.
 
 - **Direct messages and group conversations**
   - Support one-to-one messages for negotiation, mentoring, hiring, and social play.
@@ -85,7 +85,7 @@ Other players should become the most valuable content in RockMundo because they 
 1. Inventory existing profile, notification, and social media surfaces.
 2. Add read-only relationship indicators before adding new write actions.
 3. Introduce server-side social relationship records and privacy checks.
-4. Migrate messaging incrementally onto block/report/moderation foundations; one-to-one direct-message sends now use the shared server-side guard.
+4. Migrate messaging incrementally onto block/report/moderation foundations; one-to-one direct-message sends and friend-request creation now use shared server-side guards.
 5. Connect conversations to existing game objects such as bands, companies, gigs, and contracts.
 
 ### Bands, Crews, and Artist Collaboration

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -120,7 +120,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 ### Missing / risks
 
 - No global relationship type model distinguishes friend, follower, blocked, muted, ignored, bandmate, company colleague, mentor, mentee, contractor, rival, family, or romantic partner for permission checks.
-- No anti-spam cooldowns were found on friend requests at the database level.
+- ✅ Friend-request sends now use a server-authoritative `send_friend_request` RPC with block checks, idempotent pending-request handling, recipient notification deduplication, denied-attempt audit records, and a seven-day recently-declined resend cooldown. Remaining gaps: accept/decline/remove/block lifecycle writes still need dedicated RPCs and broader social rate limiting remains unresolved.
 - No block-aware routing protection for shared group contexts (band/company/chat) was found.
 - No social-graph recommendations should be added until block/privacy foundations exist.
 
@@ -158,7 +158,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 - No global report queue for DMs, inbox messages, chat messages, profile content, band/company listings, invitations, and contracts.
 - No message retention/evidence bundle policy was found outside Twaater-specific moderation.
-- ✅ Direct-message sends now use the shared `can_profile_receive_dm` guard through a server-authoritative `send_direct_message` RPC and guarded insert policy. Remaining gaps: social invites, friend requests, Twaater messages/follows/mentions, realtime chat, band recruitment, gifts, and other communication surfaces still need consistent block/mute/report enforcement.
+- ✅ Direct-message sends now use the shared `can_profile_receive_dm` guard through a server-authoritative `send_direct_message` RPC and guarded insert policy. ✅ Friend-request sends now use `send_friend_request` with shared block checks, duplicate handling, cooldowns, notification dedupe, and denied-attempt audit logging. Remaining gaps: social invites, Twaater messages/follows/mentions, realtime chat, band recruitment, gifts, and other communication surfaces still need consistent block/mute/report enforcement.
 - No attachment limit/schema, malware/content validation, or moderation workflow for future attachments.
 - No company chat identified as a first-class communication channel.
 - No clear SSE-specific implementation; realtime appears primarily Supabase Realtime channels/subscriptions.
@@ -344,7 +344,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Skills offered/services | Low | Skills exist; services offered are not first-class.
 | Activity history | Low-Medium | Logs/feeds exist, no unified privacy-aware social timeline.
 | Privacy controls | Low-Medium | First owner-managed profile privacy/contact settings slice exists; direct-message sends now enforce DM permission server-side. Profile/search/recruitment reads and other writes remain pending. |
-| Friend requests/friendships | Medium | Implemented, needs rate/block integration.
+| Friend requests/friendships | Medium | Request creation is now block-aware and server-authoritative; accept/decline/remove/block lifecycle writes and broader rate limiting remain partial.
 | Removing friends | Medium | Delete/cancel flows exist.
 | Blocking | Low-Medium | Dedicated safety primitives exist and direct-message sends now use the shared block guard. Other write surfaces still need migration. |
 | Ignoring/muting | Low | Not global.
@@ -379,7 +379,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 1. **Social permission design PR:** ✅ First slice implemented in `docs/social/implementation/PHASE_1_PR_01.md`, `src/features/social-privacy/*`, and `supabase/migrations/20260710120000_add_profile_privacy_settings.sql`. It adds owner-managed profile privacy/contact settings plus shared helper functions for owner checks, block checks, and DM eligibility. Remaining slices: migrate profile/search/DM/recruitment reads and writes to enforce these settings end-to-end.
 2. **Safety schema PR:** Add shared block/mute/report/audit primitives with no major UI exposure.
 3. **Profile projection PR:** Add safe profile views/RPCs and migrate search/profile reads to them.
-4. **Communication guard PR:** ✅ First direct-message send guard slice implemented in `docs/social/implementation/PHASE_1_PR_03.md`, `src/features/direct-messages/*`, and `supabase/migrations/20260710150000_guard_direct_message_sends.sql`. Remaining slices: add rate limits and migrate friend requests, social invites, Twaater DMs/follows, chat, and recruitment writes.
+4. **Communication guard PR:** ✅ First direct-message send guard slice implemented in `docs/social/implementation/PHASE_1_PR_03.md`, `src/features/direct-messages/*`, and `supabase/migrations/20260710150000_guard_direct_message_sends.sql`. Remaining slices: add broader rate limits and migrate social invites, Twaater DMs/follows, chat, recruitment writes, and friendship response/removal lifecycle operations.
 5. **Recruitment metadata PR:** Add opt-in availability fields and band recruiting metadata behind privacy settings.
 6. **Admin moderation PR:** Add unified social reports and evidence review console.
 7. **Only after the above:** Add richer social features such as group conversations, attachments, auditions, job applications, reputation, and social recommendations.

--- a/docs/social/implementation/PHASE_1_PR_04.md
+++ b/docs/social/implementation/PHASE_1_PR_04.md
@@ -1,0 +1,122 @@
+# Phase 1 PR 04 — Server-Authoritative Friend Request Safety Guards
+
+## Selected recommendation
+
+This PR implements the Phase 1 PR 03 recommendation to migrate **friend requests** to the shared server-authoritative social safety guard pattern.
+
+## Evidence
+
+- `PHASE_1_PR_03.md` recommends migrating friend requests or social invites next.
+- `SOCIAL_SYSTEM_AUDIT.md` identifies friend requests as implemented but missing consistent block integration and database-level anti-spam controls.
+- Phase 1 PR 01/02 added privacy and block primitives; Phase 1 PR 03 proved the same migration pattern for direct-message sends.
+
+## Problem
+
+Friend requests are a direct player-contact flow. Before this slice, clients could insert pending friendships directly if they owned the requestor profile, which left block checks, duplicate handling, cooldowns, actionable notifications, and friendly errors inconsistent across entry points.
+
+## Previous behaviour
+
+- Relationship search used the shared friendship integration, but the integration inserted into `friendships` directly.
+- Player profile pages also inserted rows into `friendships` directly.
+- The insert RLS policy verified requestor ownership only.
+- Duplicate, blocked, unauthenticated, and recently declined cases were mostly raw database errors or client-dependent checks.
+- Friend-request notifications were not created by the guarded request creation path.
+
+## Implemented behaviour
+
+- Adds `can_send_friend_request(sender_profile_id, recipient_profile_id)` as a shared SQL guard.
+- Adds `send_friend_request(target_profile_id)` as a SECURITY DEFINER RPC with `SET search_path = public`.
+- Resolves the sender profile from `auth.uid()` server-side.
+- Validates missing target, self-request, missing recipient, existing accepted friendship, blocked relationships, and recently declined resend cooldowns.
+- Treats an existing pending request as an idempotent success to prevent duplicate actions and duplicate notifications.
+- Reopens an older declined friendship as a new pending request after the cooldown window.
+- Creates one actionable `notifications` row for the recipient with `/relationships` as the destination, deduped by friendship ID.
+- Replaces the friendship insert policy so direct inserts must be pending, owned by the requester, and pass the shared guard.
+- Moves profile-page friend requests onto the same integration service used by relationship search.
+- Adds friendly client-side validation and error mapping for friend-request sends.
+
+## User flow
+
+1. Player A opens player search or Player B's profile.
+2. Player A chooses to add Player B as a friend.
+3. The client disables the pending action through existing mutation state and calls `send_friend_request`.
+4. The RPC resolves Player A's active profile from `auth.uid()`.
+5. The RPC rejects invalid, self, blocked, accepted, or recently declined requests with clear errors.
+6. If an identical pending request already exists, the RPC returns it without creating duplicate rows or notifications.
+7. If allowed, the RPC creates or reopens a pending friendship and creates one actionable notification for Player B.
+8. Player B can open `/relationships` to accept or decline through the existing relationship-management UI.
+
+## Files changed
+
+- `supabase/migrations/20260710170000_guard_friend_request_sends.sql`
+- `src/integrations/supabase/friends.ts`
+- `src/integrations/supabase/__tests__/friends.test.ts`
+- `src/pages/PlayerProfile.tsx`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+- `docs/social/implementation/PHASE_1_PR_04.md`
+
+## Database changes
+
+- Adds `friend_request_send_denied` to `social_action_audit_kind`.
+- Adds `can_send_friend_request(uuid, uuid)`.
+- Adds `send_friend_request(uuid)`.
+- Replaces the broad friendship insert policy with a guarded pending-request policy.
+- Adds no new tables.
+
+## Permission model
+
+- Sender identity is resolved from `auth.uid()` and `profiles.user_id` in the RPC.
+- Clients no longer choose the authoritative requestor for the primary friend-request flow.
+- Participant-only friendship read/update/delete policies remain unchanged.
+- Direct inserts are still constrained by RLS to pending, owner-created requests that pass the shared guard.
+- Dedicated `social_profile_blocks` and legacy `friendships.status = blocked` both deny new requests through `are_profiles_blocked`.
+
+## Notifications
+
+- The recipient receives one actionable `notifications` row per friendship ID.
+- The destination is `/relationships`.
+- Duplicate pending submissions return the existing friendship and do not create duplicate notifications.
+- Blocked or unavailable recipients do not receive notifications.
+
+## Analytics
+
+No new analytics platform or event schema was added. Blocked friend-request attempts are recorded in `social_action_audit_log` as backend safety telemetry.
+
+## Automated tests
+
+Added friend-request service tests for:
+
+- successful guarded RPC flow,
+- invalid target profile input,
+- backend request failure for blocked/unauthorized attempts,
+- duplicate pending request idempotency,
+- unauthenticated user friendly error,
+- recently declined cooldown friendly error.
+
+RLS/RPC behavior is covered by the SQL migration and should be validated against a Supabase test database as part of migration checks.
+
+## Manual verification
+
+Recommended manual cases:
+
+- Player A sends Player B a friend request from search.
+- Player A sends Player B a friend request from Player B's profile page.
+- Player A cannot send to Player B after either profile blocks the other.
+- Re-clicking while a pending request exists does not create another friendship or notification.
+- Player B receives a single notification linking to `/relationships`.
+- Unrelated Player C cannot read A/B friendship rows.
+- A recently declined request shows the cooldown message.
+- Mobile and desktop layouts keep existing search/profile controls usable.
+
+## Known limitations
+
+- Accept, decline, remove, and block lifecycle writes still use existing table update/delete paths and need a future server-authoritative RPC slice.
+- The cooldown is fixed at seven days and has no per-user/admin tuning UI.
+- Full rate limiting across all social write surfaces remains unresolved.
+- If a user owns multiple profiles, the RPC uses the first profile associated with `auth.uid()` pending a canonical active-profile SQL helper.
+- Social invites, Twaater interactions, chat, and recruitment still need migration to shared guards.
+
+## Recommended Phase 1 PR 05
+
+Migrate **social invites** to the same server-authoritative guard pattern, including sender ownership, recipient block checks, invite-specific duplicate/expiry handling, actionable notification deduplication, and audit records for denied attempts.

--- a/src/integrations/supabase/__tests__/friends.test.ts
+++ b/src/integrations/supabase/__tests__/friends.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const rpc = vi.fn();
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    rpc,
+    from: vi.fn(),
+  },
+}));
+
+const { sendFriendRequest, __friendRequestTestUtils } = await import("../friends");
+
+const requestorProfileId = "11111111-1111-4111-8111-111111111111";
+const addresseeProfileId = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("friend request safety service", () => {
+  it("rejects invalid target profile IDs before backend writes", async () => {
+    await expect(sendFriendRequest({ requestorProfileId, addresseeProfileId: "bad-id" })).rejects.toThrow("valid player");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("sends valid friend requests through the guarded RPC", async () => {
+    rpc.mockResolvedValueOnce({
+      data: { id: "friendship-1", requestor_id: requestorProfileId, addressee_id: addresseeProfileId, status: "pending" },
+      error: null,
+    });
+
+    await expect(sendFriendRequest({ requestorProfileId, addresseeProfileId })).resolves.toMatchObject({ status: "pending" });
+    expect(rpc).toHaveBeenCalledWith("send_friend_request", { target_profile_id: addresseeProfileId });
+  });
+
+  it("treats duplicate pending requests as a successful idempotent response", async () => {
+    rpc.mockResolvedValueOnce({
+      data: { id: "friendship-1", requestor_id: requestorProfileId, addressee_id: addresseeProfileId, status: "pending" },
+      error: null,
+    });
+
+    await expect(sendFriendRequest({ requestorProfileId, addresseeProfileId })).resolves.toMatchObject({ id: "friendship-1" });
+  });
+
+  it("maps blocked or unauthorized backend failures to friendly errors", async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: "This player is not available for friend requests." } });
+
+    await expect(sendFriendRequest({ requestorProfileId, addresseeProfileId })).rejects.toThrow("not available");
+  });
+
+  it("maps unauthenticated backend failures to friendly errors", async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: "Sign in with an active player profile before sending friend requests." } });
+
+    await expect(sendFriendRequest({ requestorProfileId, addresseeProfileId })).rejects.toThrow("Sign in");
+  });
+
+  it("maps declined cooldown backend failures to friendly errors", () => {
+    expect(__friendRequestTestUtils.friendlyFriendRequestError("That friend request was declined recently."))
+      .toContain("declined recently");
+  });
+});

--- a/src/integrations/supabase/friends.ts
+++ b/src/integrations/supabase/friends.ts
@@ -87,27 +87,50 @@ export const fetchProfilesByIds = async (
   }, {});
 };
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function validateFriendRequestInput(addresseeProfileId: string | null | undefined) {
+  if (!addresseeProfileId || !UUID_RE.test(addresseeProfileId)) {
+    throw new Error("Choose a valid player to add as a friend.");
+  }
+
+  return addresseeProfileId;
+}
+
+function friendlyFriendRequestError(message?: string) {
+  if (!message) return "We couldn't send that friend request. Please try again.";
+  if (/not available for friend requests|permission denied|row-level security|42501/i.test(message)) {
+    return "This player is not available for friend requests.";
+  }
+  if (/active player profile|not authenticated|jwt|auth/i.test(message)) {
+    return "Sign in with an active player profile before sending friend requests.";
+  }
+  if (/already friends/i.test(message)) return "You are already friends with this player.";
+  if (/declined recently|42901/i.test(message)) {
+    return "That friend request was declined recently. Please wait before trying again.";
+  }
+  if (/not found/i.test(message)) return "That player could not be found.";
+  return message;
+}
+
 export const sendFriendRequest = async ({
-  requestorProfileId,
   addresseeProfileId,
 }: SendFriendRequestParams): Promise<FriendshipRow> => {
-  const payload: Database["public"]["Tables"]["friendships"]["Insert"] = {
-    requestor_id: requestorProfileId,
-    addressee_id: addresseeProfileId,
-    status: "pending",
-  };
-
-  const { data, error } = await supabase
-    .from("friendships")
-    .insert(payload)
-    .select("id, requestor_id, addressee_id, status, created_at, updated_at, responded_at")
-    .single();
+  const targetProfileId = validateFriendRequestInput(addresseeProfileId);
+  const { data, error } = await (supabase as any).rpc("send_friend_request", {
+    target_profile_id: targetProfileId,
+  });
 
   if (error) {
-    throw error;
+    throw new Error(friendlyFriendRequestError(error.message));
   }
 
   return data as FriendshipRow;
+};
+
+export const __friendRequestTestUtils = {
+  friendlyFriendRequestError,
+  validateFriendRequestInput,
 };
 
 export const deleteFriendship = async (friendshipId: string): Promise<void> => {

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -21,6 +21,7 @@ import {
 import { format } from "date-fns";
 import { NominateButton } from "@/components/elections/NominateButton";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { sendFriendRequest } from "@/integrations/supabase/friends";
 
 const INSTRUMENTS = ['Guitar', 'Bass', 'Drums', 'Keyboard', 'Other'];
 const VOCAL_ROLES = ['Lead Vocals', 'Backing Vocals', 'None'];
@@ -151,12 +152,7 @@ export default function PlayerProfile() {
   const sendRequest = useMutation({
     mutationFn: async () => {
       if (!currentUser?.id || !playerId) throw new Error("Missing IDs");
-      const { error } = await supabase.from("friendships").insert({
-        requestor_id: currentUser.id,
-        addressee_id: playerId,
-        status: "pending",
-      });
-      if (error) throw error;
+      await sendFriendRequest({ requestorProfileId: currentUser.id, addresseeProfileId: playerId });
     },
     onSuccess: () => {
       toast({ title: "Friend request sent!" });

--- a/supabase/migrations/20260710170000_guard_friend_request_sends.sql
+++ b/supabase/migrations/20260710170000_guard_friend_request_sends.sql
@@ -1,0 +1,162 @@
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'friend_request_send_denied';
+
+CREATE OR REPLACE FUNCTION public.can_send_friend_request(
+  sender_profile_id uuid,
+  recipient_profile_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT sender_profile_id IS NOT NULL
+    AND recipient_profile_id IS NOT NULL
+    AND sender_profile_id <> recipient_profile_id
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = sender_profile_id)
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = recipient_profile_id)
+    AND NOT public.are_profiles_blocked(sender_profile_id, recipient_profile_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.send_friend_request(
+  target_profile_id uuid
+)
+RETURNS public.friendships
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sender_profile_id uuid;
+  recipient_user_id uuid;
+  existing_friendship public.friendships;
+  new_friendship public.friendships;
+  resend_after interval := interval '7 days';
+BEGIN
+  SELECT p.id
+    INTO sender_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF sender_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before sending friend requests.' USING ERRCODE = '28000';
+  END IF;
+
+  IF target_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Choose a player to add as a friend.' USING ERRCODE = '22023';
+  END IF;
+
+  IF sender_profile_id = target_profile_id THEN
+    RAISE EXCEPTION 'You cannot send a friend request to yourself.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT p.user_id
+    INTO recipient_user_id
+  FROM public.profiles p
+  WHERE p.id = target_profile_id;
+
+  IF recipient_user_id IS NULL THEN
+    RAISE EXCEPTION 'That player could not be found.' USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT public.can_send_friend_request(sender_profile_id, target_profile_id) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, metadata)
+    VALUES (
+      sender_profile_id,
+      target_profile_id,
+      'friend_request_send_denied'::public.social_action_audit_kind,
+      'profile',
+      jsonb_build_object('reason', 'block_guard')
+    );
+
+    RAISE EXCEPTION 'This player is not available for friend requests.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT *
+    INTO existing_friendship
+  FROM public.friendships f
+  WHERE (f.requestor_id = sender_profile_id AND f.addressee_id = target_profile_id)
+     OR (f.requestor_id = target_profile_id AND f.addressee_id = sender_profile_id)
+  LIMIT 1;
+
+  IF existing_friendship.id IS NOT NULL THEN
+    IF existing_friendship.status = 'pending'::public.friendship_status THEN
+      RETURN existing_friendship;
+    END IF;
+
+    IF existing_friendship.status = 'accepted'::public.friendship_status THEN
+      RAISE EXCEPTION 'You are already friends with this player.' USING ERRCODE = '23505';
+    END IF;
+
+    IF existing_friendship.status = 'blocked'::public.friendship_status THEN
+      INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, metadata)
+      VALUES (
+        sender_profile_id,
+        target_profile_id,
+        'friend_request_send_denied'::public.social_action_audit_kind,
+        'profile',
+        jsonb_build_object('reason', 'legacy_blocked_friendship', 'friendship_id', existing_friendship.id)
+      );
+      RAISE EXCEPTION 'This player is not available for friend requests.' USING ERRCODE = '42501';
+    END IF;
+
+    IF existing_friendship.status = 'declined'::public.friendship_status
+       AND existing_friendship.responded_at IS NOT NULL
+       AND existing_friendship.responded_at > timezone('utc', now()) - resend_after THEN
+      RAISE EXCEPTION 'That friend request was declined recently. Please wait before trying again.' USING ERRCODE = '42901';
+    END IF;
+
+    UPDATE public.friendships
+       SET requestor_id = sender_profile_id,
+           addressee_id = target_profile_id,
+           status = 'pending'::public.friendship_status,
+           responded_at = NULL,
+           updated_at = timezone('utc', now())
+     WHERE id = existing_friendship.id
+     RETURNING * INTO new_friendship;
+  ELSE
+    INSERT INTO public.friendships (requestor_id, addressee_id, status)
+    VALUES (sender_profile_id, target_profile_id, 'pending'::public.friendship_status)
+    RETURNING * INTO new_friendship;
+  END IF;
+
+  INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+  SELECT
+    recipient_user_id,
+    target_profile_id,
+    'relationship',
+    'friend_request',
+    'New friend request',
+    'Another artist wants to connect with you.',
+    '/relationships',
+    jsonb_build_object(
+      'friendship_id', new_friendship.id,
+      'requestor_profile_id', sender_profile_id,
+      'addressee_profile_id', target_profile_id,
+      'priority', 'normal'
+    )
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.notifications n
+    WHERE n.user_id = recipient_user_id
+      AND n.type = 'friend_request'
+      AND n.metadata->>'friendship_id' = new_friendship.id::text
+  );
+
+  RETURN new_friendship;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.can_send_friend_request(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.send_friend_request(uuid) TO authenticated;
+
+DROP POLICY IF EXISTS "Requesters can create friendships" ON public.friendships;
+CREATE POLICY "Requesters can create guarded pending friendships"
+  ON public.friendships
+  FOR INSERT
+  WITH CHECK (
+    status = 'pending'::public.friendship_status
+    AND public.profile_belongs_to_current_user(requestor_id)
+    AND public.can_send_friend_request(requestor_id, addressee_id)
+  );


### PR DESCRIPTION
### Motivation

- PHASE_1_PR_03 recommended migrating friend requests (or social invites) to the server-authoritative safety-guard pattern used for DMs to ensure block/privacy rules are enforced server-side.  
- The social audit flagged friend-request creation as an existing write flow that could bypass block/mute/recent-decline checks when inserted client-side.  
- The selected small vertical slice is friend-request creation only so the change is independently releasable and strengthens contact safety without redesigning relationship lifecycles.

### Description

- Adds a migration `supabase/migrations/20260710170000_guard_friend_request_sends.sql` that: adds `friend_request_send_denied` to `social_action_audit_kind`, implements `can_send_friend_request(uuid, uuid)`, implements `send_friend_request(target_profile_id)` as a `SECURITY DEFINER` RPC (resolving sender from `auth.uid()`), creates idempotent pending-request handling, enforces blocked/accepted/declined/resend-cooldown rules, creates a deduped actionable `notifications` row for recipients, and replaces the friendship insert policy with a guarded pending-insert policy.  
- Updates client integration in `src/integrations/supabase/friends.ts` to validate target IDs, call the `send_friend_request` RPC, and map backend errors to friendly messages; exposes small test utils for error mapping.  
- Routes profile-page sends to the shared service by updating `src/pages/PlayerProfile.tsx` to call the guarded `sendFriendRequest` path instead of inserting directly into `friendships`.  
- Adds tests and docs: new unit tests at `src/integrations/supabase/__tests__/friends.test.ts` for input validation, success, idempotency, and friendly error mapping, and documentation at `docs/social/implementation/PHASE_1_PR_04.md` plus factual updates to `docs/social/SOCIAL_SYSTEM_AUDIT.md` and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`.

### Testing

- `npm run typecheck` (`tsc --noEmit`) passed in the environment where changes were prepared.  
- `git diff --check` passed (no whitespace/errors reported).  
- Added unit tests (`src/integrations/supabase/__tests__/friends.test.ts`) were created and exercise input validation, RPC call routing, idempotent pending response handling, and friendly error mapping, but `npm run test:unit` could not be executed because `vitest` was not installed in the current environment.  
- `npm install` failed in the environment due to registry `403` responses (preventing installing `vitest`, `vite`, `@eslint/js`, and other dev deps), so `npm run lint` and `npm run build` could not be run; SQL migration application and RLS validation should be executed against a Supabase test database as part of CI/migration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e274bf68832587193ab4696854e8)