### PR TITLE
Phase 1 PR 05 — Guarded Social Invite Sends/Responses

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -391,16 +391,19 @@ Safety is a core feature, not an afterthought.
 - Add this plan and follow-up technical design documents only.
 
 ### Phase 1: Visibility and Discovery Foundations
-- Add improved profile social metadata and privacy settings.
-- Add availability flags such as looking for band, hiring, open to gigs, seeking mentor, or open to collaboration.
-- Add discovery filters for players, bands, companies, venues, jobs, and communities.
-- Add non-invasive notification improvements for invitations and applications.
+- ✅ First-slice profile privacy/contact settings are implemented.
+- ✅ Shared social safety primitives and guarded direct-contact writes now cover direct-message sends, friend-request sends, and social-invite sends/responses.
+- ✅ Non-invasive notification improvements now exist for friend requests and social invites with deduped actionable routes.
+- Availability flags such as looking for band, hiring, open to gigs, seeking mentor, or open to collaboration remain pending.
+- Discovery filters for players, bands, companies, venues, jobs, and communities remain pending.
+- Public-safe profile/search projections remain the next dependency before richer discovery expansion.
 
 ### Phase 2: Safety and Trust Foundations
-- Add block/mute/report coverage across all social surfaces.
-- Add invite cooldowns and permission checks.
-- Add audit logging for social actions and contract-like offers.
-- Add admin/moderator review views before launching high-impact systems.
+- ✅ Dedicated block/mute/report/audit primitives are implemented for the first social safety slice.
+- ✅ Invite permission checks and duplicate pending handling now exist for social invites.
+- ✅ Audit logging exists for migrated denied direct-contact actions.
+- Expand block/mute/report coverage across Twaater, realtime chat, recruitment, gifts, and remaining social surfaces.
+- Add broader rate limits and admin/moderator review views before launching high-impact systems.
 
 ### Phase 3: Band and Company Cooperation
 - Add band roles, permissions, and contribution history.

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -158,7 +158,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 - No global report queue for DMs, inbox messages, chat messages, profile content, band/company listings, invitations, and contracts.
 - No message retention/evidence bundle policy was found outside Twaater-specific moderation.
-- ✅ Direct-message sends now use the shared `can_profile_receive_dm` guard through a server-authoritative `send_direct_message` RPC and guarded insert policy. ✅ Friend-request sends now use `send_friend_request` with shared block checks, duplicate handling, cooldowns, notification dedupe, and denied-attempt audit logging. Remaining gaps: social invites, Twaater messages/follows/mentions, realtime chat, band recruitment, gifts, and other communication surfaces still need consistent block/mute/report enforcement.
+- ✅ Direct-message sends now use the shared `can_profile_receive_dm` guard through a server-authoritative `send_direct_message` RPC and guarded insert policy. ✅ Friend-request sends now use `send_friend_request` with shared block checks, duplicate handling, cooldowns, notification dedupe, and denied-attempt audit logging. ✅ Social invite sends/responses now use `send_social_invite` and `respond_social_invite` with sender/recipient authority checks, shared block checks, duplicate pending handling, expiry handling, notification dedupe, and denied-attempt audit logging. Remaining gaps: Twaater messages/follows/mentions, realtime chat, band recruitment, gifts, and other communication surfaces still need consistent block/mute/report enforcement.
 - No attachment limit/schema, malware/content validation, or moderation workflow for future attachments.
 - No company chat identified as a first-class communication channel.
 - No clear SSE-specific implementation; realtime appears primarily Supabase Realtime channels/subscriptions.
@@ -346,7 +346,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Privacy controls | Low-Medium | First owner-managed profile privacy/contact settings slice exists; direct-message sends now enforce DM permission server-side. Profile/search/recruitment reads and other writes remain pending. |
 | Friend requests/friendships | Medium | Request creation is now block-aware and server-authoritative; accept/decline/remove/block lifecycle writes and broader rate limiting remain partial.
 | Removing friends | Medium | Delete/cancel flows exist.
-| Blocking | Low-Medium | Dedicated safety primitives exist and direct-message sends now use the shared block guard. Other write surfaces still need migration. |
+| Blocking | Low-Medium | Dedicated safety primitives exist; direct-message sends, friend-request sends, and social invite sends/responses now use shared block guards. Other write surfaces still need migration. |
 | Ignoring/muting | Low | Not global.
 | Following | Medium for Twaater; low globally | Twaater follows only.
 | Profile access | Low-Medium | Public access exists; relationship/privacy controls missing.
@@ -360,7 +360,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Company chat | Low | Not identified as first-class.
 | Group conversations | Low-Medium | Band/global/Twaater DMs exist; general group DMs missing.
 | Unread counts | Medium | Per-surface counts exist; not consolidated.
-| Notifications | Medium | Multiple notification systems; fragmented.
+| Notifications | Medium | Multiple notification systems remain fragmented; friend-request and social-invite creation now include actionable deduped notifications.
 | SSE/realtime | Medium | Supabase Realtime present; no explicit SSE layer.
 | Moderation hooks | Low-Medium | Twaater strong; general social weak.
 | Rate limiting | Low | Needs dedicated work.
@@ -379,7 +379,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 1. **Social permission design PR:** ✅ First slice implemented in `docs/social/implementation/PHASE_1_PR_01.md`, `src/features/social-privacy/*`, and `supabase/migrations/20260710120000_add_profile_privacy_settings.sql`. It adds owner-managed profile privacy/contact settings plus shared helper functions for owner checks, block checks, and DM eligibility. Remaining slices: migrate profile/search/DM/recruitment reads and writes to enforce these settings end-to-end.
 2. **Safety schema PR:** Add shared block/mute/report/audit primitives with no major UI exposure.
 3. **Profile projection PR:** Add safe profile views/RPCs and migrate search/profile reads to them.
-4. **Communication guard PR:** ✅ First direct-message send guard slice implemented in `docs/social/implementation/PHASE_1_PR_03.md`, `src/features/direct-messages/*`, and `supabase/migrations/20260710150000_guard_direct_message_sends.sql`. Remaining slices: add broader rate limits and migrate social invites, Twaater DMs/follows, chat, recruitment writes, and friendship response/removal lifecycle operations.
+4. **Communication guard PR:** ✅ Direct-message send guards, friend-request send guards, and social-invite send/respond guards are implemented in Phase 1 PRs 03–05. Remaining slices: add broader rate limits and migrate Twaater DMs/follows, chat, recruitment writes, gifts, and friendship response/removal lifecycle operations.
 5. **Recruitment metadata PR:** Add opt-in availability fields and band recruiting metadata behind privacy settings.
 6. **Admin moderation PR:** Add unified social reports and evidence review console.
 7. **Only after the above:** Add richer social features such as group conversations, attachments, auditions, job applications, reputation, and social recommendations.

--- a/docs/social/implementation/PHASE_1_PR_05.md
+++ b/docs/social/implementation/PHASE_1_PR_05.md
@@ -1,0 +1,126 @@
+# Phase 1 PR 05 — Server-Authoritative Social Invite Safety Guards
+
+## Selected recommendation
+
+This PR implements the **Recommended Phase 1 PR 05** from `PHASE_1_PR_04.md`: migrate social invites to the same server-authoritative guard pattern used for direct-message sends and friend-request sends.
+
+## Evidence
+
+- `PHASE_1_PR_04.md` recommends migrating social invites next with sender ownership, block checks, invite-specific duplicate/expiry handling, notification dedupe, and audit records for denied attempts.
+- `SOCIAL_SYSTEM_AUDIT.md` still identified social invites as a direct communication surface without consistent shared block/mute/report enforcement.
+- Phase 1 PRs 01–02 added profile privacy and safety primitives; PRs 03–04 proved the pattern for DMs and friend requests.
+
+## Problem
+
+Social invites are a player-to-player direct interaction. Before this slice, clients inserted and updated `social_invites` directly, so duplicate pending invites, block checks, sender/recipient authority, expired invite handling, and user-facing errors were not consistently enforced by the backend.
+
+## Previous behaviour
+
+- `useCreateInvite` inserted rows directly into `social_invites`.
+- `useRespondInvite` updated rows directly from the client.
+- Insert RLS only checked sender profile ownership.
+- Update RLS allowed either participant to write broad status changes.
+- Notifications were not created by the invite-send path.
+- Duplicate, blocked, expired, unauthenticated, and invalid transitions could surface as raw database/client errors.
+
+## Implemented behaviour
+
+- Adds `can_send_social_invite(sender_profile_id, recipient_profile_id)` as a shared SQL guard.
+- Adds `send_social_invite(...)` as a SECURITY DEFINER RPC with `SET search_path = public`.
+- Adds `respond_social_invite(invite_id, next_status)` as a SECURITY DEFINER RPC.
+- Resolves the actor profile from `auth.uid()` server-side.
+- Validates target, kind, self-invites, past scheduled times, missing recipients, and message length.
+- Enforces shared block checks before send and response.
+- Treats an existing recent pending invite of the same kind and pair as an idempotent success.
+- Marks pending past scheduled invites as expired when acted upon.
+- Creates one actionable notification for the recipient linking to `/social?tab=invites` and dedupes by invite ID.
+- Replaces direct insert policy with a guarded sender policy and removes direct client update access so status changes go through `respond_social_invite`.
+- Moves invite create/respond hooks onto the guarded RPC service.
+- Improves invite dialog and inbox loading, unauthenticated, empty, error, success, pending, disabled, cancelled, declined, expired, and accessibility states.
+
+## User flow
+
+1. Player A opens an invite dialog for Player B.
+2. Player A chooses a type, optional future time, and optional message.
+3. The send button disables while pending and the client calls `send_social_invite`.
+4. The RPC resolves Player A's active profile and checks whether Player B is valid and not blocked.
+5. If an equivalent pending invite already exists, the RPC returns it without creating another row or notification.
+6. If allowed, the RPC creates the invite and one actionable notification for Player B.
+7. Player B opens `/social?tab=invites` and can accept or decline a pending incoming invite.
+8. Player A can cancel a pending outgoing invite.
+9. Expired, declined, cancelled, or blocked invites are displayed as terminal states and cannot be advanced through normal actions.
+
+## Files changed
+
+- `supabase/migrations/20260710183000_guard_social_invites.sql`
+- `src/features/social-hub/services/socialInvites.ts`
+- `src/features/social-hub/__tests__/socialInvites.test.ts`
+- `src/hooks/useSocialInvites.ts`
+- `src/features/social-hub/components/InviteFriendDialog.tsx`
+- `src/features/social-hub/components/InvitesInbox.tsx`
+- `docs/social/implementation/PHASE_1_PR_05.md`
+- `docs/social/implementation/PHASE_1_REVIEW.md`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Database changes
+
+- Adds `social_invite_send_denied` and `social_invite_response_denied` audit enum values.
+- Adds a message-length check for `social_invites.message`.
+- Adds an active pair/kind/status index for duplicate lookup.
+- Adds `can_send_social_invite`, `send_social_invite`, and `respond_social_invite`.
+- Replaces the broad social invite insert policy with a guarded sender policy and removes the broad client update policy.
+- Adds no new tables.
+
+## Permission model
+
+- Sender/respondent identity is resolved from `auth.uid()` and the first owned profile.
+- Senders can create pending invites only when the target exists, is not self, and the pair is not blocked.
+- Recipients can accept or decline only their own pending incoming invites.
+- Senders can cancel only their own pending outgoing invites.
+- Unrelated profiles remain unable to read private invite rows through participant RLS.
+- Blocked pairs cannot send or continue restricted invite interactions.
+
+## Notifications
+
+- The invite recipient receives one `notifications` row per created invite.
+- The route is `/social?tab=invites`.
+- Duplicate pending sends return the existing invite and do not create duplicate notifications.
+- Blocked, invalid, unauthenticated, or unavailable recipients receive no notifications.
+
+## Analytics
+
+No new analytics platform was added. Denied send/response attempts are recorded in `social_action_audit_log` using existing safety telemetry.
+
+## Automated tests
+
+Added social invite service tests for successful sends, invalid target input, overlong messages, duplicate/idempotent backend success, response RPC calls, invalid status rejection, blocked backend failures, and unauthenticated friendly errors.
+
+## Manual verification
+
+Recommended manual cases:
+
+- Player A sends Player B a social invite.
+- Player A repeats the same pending invite and no duplicate notification is created.
+- Player B accepts and declines incoming invites from `/social?tab=invites`.
+- Player A cancels an outgoing pending invite.
+- Player A cannot invite Player B when either profile blocks the other.
+- Unrelated Player C cannot read or respond to A/B invite rows.
+- An expired scheduled invite is shown as expired when acted upon.
+- Mobile and desktop layouts keep invite rows readable and actions reachable.
+
+## Known limitations
+
+- Broad social rate limiting remains unresolved.
+- Invite expiration is enforced when acted upon, not by a scheduled cleanup job.
+- The RPC uses the first profile owned by `auth.uid()` pending a canonical active-profile SQL helper.
+- Twaater follows/messages/mentions, realtime chat, band recruitment, gifts, and friendship lifecycle writes still need guard migration.
+- No unified moderator evidence console is added in this slice.
+
+## Phase 1 closure outcome
+
+Phase 1 is **Complete with accepted limitations** for the narrow communication/presence foundation scope delivered by PRs 01–05: profile privacy settings, safety primitives, guarded direct-message sends, guarded friend-request sends, and guarded social-invite sends/responses now exist. It is not complete for the broader Social MMO vision because profile projections, global rate limits, Twaater/chat/recruitment guards, unified moderation, and richer presence/discovery availability remain pending.
+
+## Recommended next PR
+
+Start the next phase with a **public-safe profile projection and profile/search read migration PR**, because privacy/contact settings now exist but profile/search reads still need a clear public-safe boundary before richer discovery and availability features expand.

--- a/docs/social/implementation/PHASE_1_REVIEW.md
+++ b/docs/social/implementation/PHASE_1_REVIEW.md
@@ -1,0 +1,75 @@
+# Phase 1 Review — Communication and Presence Foundation
+
+## Phase 1 objective
+
+Establish the smallest safe foundation for social visibility, direct communication, and presence-adjacent discovery before expanding into recruitment, hiring, contracts, mentoring, or reputation-heavy MMO systems.
+
+## PRs completed
+
+1. **PR 01 — Profile Privacy Settings Slice:** owner-managed social privacy/contact preferences and shared helper functions.
+2. **PR 02 — Social Safety Primitives:** profile blocks, mutes, reports, safety audit logs, and shared block/mute/report RPCs.
+3. **PR 03 — Direct Message Safety Guards:** server-authoritative guarded direct-message send RPC and client service.
+4. **PR 04 — Friend Request Safety Guards:** server-authoritative guarded friend-request RPC, duplicate/cooldown handling, and recipient notification dedupe.
+5. **PR 05 — Social Invite Safety Guards:** server-authoritative guarded invite send/respond RPCs, duplicate/expiry handling, and recipient notification dedupe.
+
+## Player-facing flows now available
+
+- Players can configure first-slice profile privacy/contact settings.
+- Players can create blocks, mutes, and reports from the Relationships/Social safety UI.
+- Direct-message sends respect DM permissions and block status server-side.
+- Friend requests respect block status, duplicate pending state, declined cooldowns, and recipient notification dedupe.
+- Social invites respect block status, duplicate pending state, invite status transitions, expired scheduled invites, and recipient notification dedupe.
+
+## Systems still partial
+
+- Public profile/search reads still use broad profile fields rather than a dedicated safe projection.
+- Friend accept/decline/remove/block lifecycle writes are still not fully migrated to dedicated RPCs.
+- Twaater DMs/follows/mentions and realtime chat still need shared block/mute/report enforcement.
+- Band recruitment and company hiring/contact flows still need privacy/block integration.
+- Presence remains count-oriented and not a privacy-aware per-player availability system.
+- Notifications are improved for friend requests and invites but remain fragmented across systems.
+- Rate limiting is still broad and incomplete.
+
+## Systems still broken or not safe enough for expansion
+
+- There is no unified moderation/evidence queue for non-Twaater social reports.
+- There is no repository-wide social rate-limit service for DMs, invites, chat, follows, mentions, or recruitment.
+- There is no global mute suppression layer for notifications, feeds, chat, or search.
+- There is no active-profile SQL helper for multi-profile users; Phase 1 RPCs use the first owned profile.
+
+## Security/privacy status
+
+Improved. Core direct contact writes for DMs, friend requests, and social invites now resolve actor identity server-side and check shared block/privacy guards where applicable. However, profile/search read privacy and several older social write surfaces remain partial.
+
+## Moderation/blocking status
+
+Dedicated block, mute, report, and audit primitives now exist. Blocking is enforced for the three migrated high-risk direct-contact writes. Unified moderation review and evidence tooling remains pending.
+
+## Analytics coverage
+
+No new analytics platform was added. Backend safety telemetry records denied actions in `social_action_audit_log` for migrated flows. Client flow analytics remain limited.
+
+## Test coverage
+
+Automated service tests cover the new client-side validation, friendly errors, guarded RPC calls, duplicate/idempotent success paths, and status-transition inputs for the Phase 1 direct-contact slices. Full RLS integration tests require applying migrations against a Supabase test database.
+
+## Known limitations
+
+- Broad rate limiting is unresolved.
+- Public-safe profile projection is not implemented.
+- Twaater, chat, recruitment, gifts, and lifecycle relationship operations still need migration.
+- Presence/availability flags are still not implemented.
+- Invite expiration has no scheduled cleanup job.
+- Multi-profile active identity selection remains approximate.
+
+## Phase 1 status
+
+**Complete with accepted limitations.**
+
+## Exact reason for status
+
+The planned Phase 1 safety foundation for the selected direct communication surfaces is in place: privacy preferences, safety primitives, DM send guards, friend request guards, and social invite guards are implemented. The status is not simply based on five PRs; it is based on the repository now having reusable server-authoritative primitives for the core direct-contact flows identified in PR 04. Limitations are accepted because broader Social MMO requirements—profile projections, rate limiting, unified moderation, Twaater/chat/recruitment guards, and rich presence/discovery availability—are intentionally deferred and remain documented.
+
+## Recommended next phase and first PR
+
+Proceed to the next foundation phase with a **public-safe profile projection and profile/search read migration PR**. That should define and enforce safe read boundaries for profile and discovery surfaces before adding richer availability flags, recruitment metadata, hiring profiles, recommendations, or social matchmaking.

--- a/src/features/social-hub/__tests__/socialInvites.test.ts
+++ b/src/features/social-hub/__tests__/socialInvites.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const rpc = vi.fn();
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { rpc } }));
+
+const { sendSocialInvite, respondSocialInvite, __socialInviteTestUtils } = await import("../services/socialInvites");
+
+const profileId = "22222222-2222-4222-8222-222222222222";
+const inviteId = "33333333-3333-4333-8333-333333333333";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("social invite safety service", () => {
+  it("validates and trims invite input before backend writes", () => {
+    expect(__socialInviteTestUtils.validateSocialInviteInput({ toProfileId: profileId, kind: "jam", message: " hi " })).toMatchObject({
+      target_profile_id: profileId,
+      invite_kind: "jam",
+      invite_message: "hi",
+    });
+  });
+
+  it("rejects invalid target profiles before backend writes", async () => {
+    await expect(sendSocialInvite({ toProfileId: "bad", kind: "jam" })).rejects.toThrow("valid player");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("rejects overlong invite messages before backend writes", async () => {
+    await expect(sendSocialInvite({ toProfileId: profileId, kind: "jam", message: "x".repeat(281) })).rejects.toThrow("280");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("sends valid invites through the guarded RPC", async () => {
+    rpc.mockResolvedValueOnce({ data: { id: inviteId, status: "pending", kind: "jam" }, error: null });
+    await expect(sendSocialInvite({ toProfileId: profileId, kind: "jam", message: " hi " })).resolves.toMatchObject({ status: "pending" });
+    expect(rpc).toHaveBeenCalledWith("send_social_invite", expect.objectContaining({ target_profile_id: profileId, invite_kind: "jam", invite_message: "hi" }));
+  });
+
+  it("treats duplicate pending invites as idempotent backend success", async () => {
+    rpc.mockResolvedValueOnce({ data: { id: inviteId, status: "pending" }, error: null });
+    await expect(sendSocialInvite({ toProfileId: profileId, kind: "meetup" })).resolves.toMatchObject({ id: inviteId });
+  });
+
+  it("responds to pending invites through the guarded RPC", async () => {
+    rpc.mockResolvedValueOnce({ data: { id: inviteId, status: "accepted" }, error: null });
+    await expect(respondSocialInvite(inviteId, "accepted")).resolves.toMatchObject({ status: "accepted" });
+    expect(rpc).toHaveBeenCalledWith("respond_social_invite", { invite_id: inviteId, next_status: "accepted" });
+  });
+
+  it("rejects invalid response statuses before backend writes", async () => {
+    await expect(respondSocialInvite(inviteId, "expired")).rejects.toThrow("accept, decline, or cancel");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("maps blocked backend failures to friendly errors", async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: "This player is not available for invites." } });
+    await expect(sendSocialInvite({ toProfileId: profileId, kind: "jam" })).rejects.toThrow("not available");
+  });
+
+  it("maps unauthenticated backend failures to friendly errors", () => {
+    expect(__socialInviteTestUtils.friendlySocialInviteError("Sign in with an active player profile before sending invites.")).toContain("Sign in");
+  });
+});

--- a/src/features/social-hub/components/InviteFriendDialog.tsx
+++ b/src/features/social-hub/components/InviteFriendDialog.tsx
@@ -55,7 +55,13 @@ export function InviteFriendDialog({
   const [message, setMessage] = useState("");
   const create = useCreateInvite();
 
+  const trimmedMessage = message.trim();
+  const isMessageTooLong = trimmedMessage.length > 280;
+  const isPastTime = scheduledAt ? new Date(scheduledAt).getTime() < Date.now() - 5 * 60 * 1000 : false;
+  const canSubmit = !create.isPending && !isMessageTooLong && !isPastTime;
+
   const submit = () => {
+    if (!canSubmit) return;
     create.mutate(
       {
         from_profile_id: myProfileId,
@@ -83,9 +89,9 @@ export function InviteFriendDialog({
         </DialogHeader>
         <div className="space-y-3">
           <div>
-            <Label>What kind of invite?</Label>
+            <Label htmlFor="social-invite-kind">What kind of invite?</Label>
             <Select value={kind} onValueChange={(v) => setKind(v as SocialInviteKind)}>
-              <SelectTrigger>
+              <SelectTrigger id="social-invite-kind" aria-label="Invite type">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -98,29 +104,36 @@ export function InviteFriendDialog({
             </Select>
           </div>
           <div>
-            <Label>When?</Label>
+            <Label htmlFor="social-invite-time">When?</Label>
             <Input
+              id="social-invite-time"
+              aria-invalid={isPastTime}
               type="datetime-local"
               value={scheduledAt}
               onChange={(e) => setScheduledAt(e.target.value)}
             />
           </div>
           <div>
-            <Label>Message (optional)</Label>
+            <Label htmlFor="social-invite-message">Message (optional)</Label>
             <Textarea
+              id="social-invite-message"
+              aria-invalid={isMessageTooLong}
               value={message}
               onChange={(e) => setMessage(e.target.value)}
               placeholder="A short note…"
               maxLength={280}
             />
+            <p className="mt-1 text-xs text-muted-foreground" aria-live="polite">
+              {trimmedMessage.length}/280 characters{isPastTime ? " · Choose a future time" : ""}
+            </p>
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={create.isPending}>
             Cancel
           </Button>
-          <Button onClick={submit} disabled={create.isPending}>
-            Send invite
+          <Button onClick={submit} disabled={!canSubmit} aria-busy={create.isPending}>
+            {create.isPending ? "Sending…" : "Send invite"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/social-hub/components/InvitesInbox.tsx
+++ b/src/features/social-hub/components/InvitesInbox.tsx
@@ -45,6 +45,10 @@ function InviteRow({
           </p>
         )}
         {invite.message && <p className="mt-1 text-xs">{invite.message}</p>}
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          {outgoing ? "Sent by you" : "Received by you"} · {format(new Date(invite.created_at), "PPp")}
+          {invite.responded_at ? ` · Updated ${format(new Date(invite.responded_at), "PPp")}` : ""}
+        </p>
       </div>
       {!outgoing && invite.status === "pending" && (
         <div className="flex flex-col gap-1">
@@ -53,6 +57,7 @@ function InviteRow({
             variant="default"
             onClick={() => respond.mutate({ id: invite.id, status: "accepted" })}
             disabled={respond.isPending}
+            aria-label={`Accept ${INVITE_KIND_LABELS[invite.kind]} invite`}
           >
             <Check className="h-3 w-3 mr-1" /> Accept
           </Button>
@@ -61,6 +66,7 @@ function InviteRow({
             variant="outline"
             onClick={() => respond.mutate({ id: invite.id, status: "declined" })}
             disabled={respond.isPending}
+            aria-label={`Decline ${INVITE_KIND_LABELS[invite.kind]} invite`}
           >
             <X className="h-3 w-3 mr-1" /> Decline
           </Button>
@@ -72,6 +78,7 @@ function InviteRow({
           variant="outline"
           onClick={() => respond.mutate({ id: invite.id, status: "cancelled" })}
           disabled={respond.isPending}
+          aria-label={`Cancel ${INVITE_KIND_LABELS[invite.kind]} invite`}
         >
           Cancel
         </Button>
@@ -94,6 +101,16 @@ export function InvitesInbox({ profileId }: { profileId: string | null | undefin
     [incoming.data],
   );
 
+  if (!profileId) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-sm text-muted-foreground">
+          Sign in with an active player profile to view invites.
+        </CardContent>
+      </Card>
+    );
+  }
+
   if (incoming.isLoading || outgoing.isLoading) {
     return (
       <div className="flex h-40 items-center justify-center text-muted-foreground">
@@ -102,8 +119,18 @@ export function InvitesInbox({ profileId }: { profileId: string | null | undefin
     );
   }
 
+  if (incoming.isError || outgoing.isError) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-sm text-destructive" role="alert">
+          We could not load your invites. Please try again.
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div className="grid gap-4 md:grid-cols-2" aria-live="polite">
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">

--- a/src/features/social-hub/services/socialInvites.ts
+++ b/src/features/social-hub/services/socialInvites.ts
@@ -1,0 +1,89 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SocialInviteKind, SocialInviteRow, SocialInviteStatus } from "@/hooks/useSocialInvites";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i;
+const MAX_INVITE_MESSAGE_LENGTH = 280;
+
+export interface SendSocialInviteInput {
+  toProfileId: string | null | undefined;
+  kind: SocialInviteKind;
+  scheduledAt?: string | null;
+  locationCityId?: string | null;
+  refId?: string | null;
+  message?: string | null;
+}
+
+export function validateSocialInviteInput(input: SendSocialInviteInput) {
+  if (!input.toProfileId || !UUID_RE.test(input.toProfileId)) {
+    throw new Error("Choose a valid player to invite.");
+  }
+  if (!input.kind) {
+    throw new Error("Choose an invite type.");
+  }
+
+  const trimmedMessage = input.message?.trim() || null;
+  if (trimmedMessage && trimmedMessage.length > MAX_INVITE_MESSAGE_LENGTH) {
+    throw new Error("Invite messages must be 280 characters or fewer.");
+  }
+
+  let scheduledFor: string | null = null;
+  if (input.scheduledAt) {
+    const scheduledDate = new Date(input.scheduledAt);
+    if (Number.isNaN(scheduledDate.getTime())) {
+      throw new Error("Choose a valid invite time.");
+    }
+    if (scheduledDate.getTime() < Date.now() - 5 * 60 * 1000) {
+      throw new Error("Choose a future time for this invite.");
+    }
+    scheduledFor = scheduledDate.toISOString();
+  }
+
+  return {
+    target_profile_id: input.toProfileId,
+    invite_kind: input.kind,
+    scheduled_for: scheduledFor,
+    invite_message: trimmedMessage,
+    invite_ref_id: input.refId || null,
+    invite_location_city_id: input.locationCityId || null,
+  };
+}
+
+export function friendlySocialInviteError(message?: string) {
+  if (!message) return "We couldn't update that invite. Please try again.";
+  if (/not available for invites|can no longer be updated|permission denied|row-level security|42501/i.test(message)) {
+    return "This player is not available for invites.";
+  }
+  if (/active player profile|not authenticated|jwt|auth|sign in/i.test(message)) {
+    return "Sign in with an active player profile before using invites.";
+  }
+  if (/future time/i.test(message)) return "Choose a future time for this invite.";
+  if (/not found/i.test(message)) return "That invite or player could not be found.";
+  return message;
+}
+
+export async function sendSocialInvite(input: SendSocialInviteInput): Promise<SocialInviteRow> {
+  const params = validateSocialInviteInput(input);
+  const { data, error } = await (supabase as any).rpc("send_social_invite", params);
+  if (error) throw new Error(friendlySocialInviteError(error.message));
+  return data as SocialInviteRow;
+}
+
+export async function respondSocialInvite(id: string, status: SocialInviteStatus): Promise<SocialInviteRow> {
+  if (!id || !UUID_RE.test(id)) {
+    throw new Error("Choose a valid invite to update.");
+  }
+  if (!["accepted", "declined", "cancelled"].includes(status)) {
+    throw new Error("Choose accept, decline, or cancel for this invite.");
+  }
+  const { data, error } = await (supabase as any).rpc("respond_social_invite", {
+    invite_id: id,
+    next_status: status,
+  });
+  if (error) throw new Error(friendlySocialInviteError(error.message));
+  return data as SocialInviteRow;
+}
+
+export const __socialInviteTestUtils = {
+  friendlySocialInviteError,
+  validateSocialInviteInput,
+};

--- a/src/hooks/useSocialInvites.ts
+++ b/src/hooks/useSocialInvites.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
+import { respondSocialInvite, sendSocialInvite } from "@/features/social-hub/services/socialInvites";
 
 export type SocialInviteKind =
   | "gig"
@@ -100,7 +101,7 @@ export function useInviteRealtime(profileId?: string | null) {
 }
 
 export interface CreateInviteInput {
-  from_profile_id: string;
+  from_profile_id?: string;
   to_profile_id: string;
   kind: SocialInviteKind;
   scheduled_at?: string | null;
@@ -113,17 +114,19 @@ export function useCreateInvite() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: CreateInviteInput) => {
-      const { data, error } = await (supabase as any)
-        .from("social_invites")
-        .insert(input)
-        .select("*")
-        .single();
-      if (error) throw error;
-      return data as SocialInviteRow;
+      return sendSocialInvite({
+        toProfileId: input.to_profile_id,
+        kind: input.kind,
+        scheduledAt: input.scheduled_at,
+        locationCityId: input.location_city_id,
+        refId: input.ref_id,
+        message: input.message,
+      });
     },
     onSuccess: (row) => {
       toast.success(`${INVITE_KIND_LABELS[row.kind]} invite sent`);
       queryClient.invalidateQueries({ queryKey: ["social-invites-out", row.from_profile_id] });
+      queryClient.invalidateQueries({ queryKey: ["social-invites-in", row.to_profile_id] });
     },
     onError: (error: Error) => {
       toast.error(error.message ?? "Failed to send invite");
@@ -135,15 +138,18 @@ export function useRespondInvite() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (params: { id: string; status: SocialInviteStatus }) => {
-      const { error } = await (supabase as any)
-        .from("social_invites")
-        .update({ status: params.status, responded_at: new Date().toISOString() })
-        .eq("id", params.id);
-      if (error) throw error;
+      return respondSocialInvite(params.id, params.status);
     },
-    onSuccess: () => {
+    onSuccess: (row) => {
+      const action = row.status === "cancelled" ? "cancelled" : row.status;
+      toast.success(`Invite ${action}`);
       queryClient.invalidateQueries({ queryKey: ["social-invites-in"] });
       queryClient.invalidateQueries({ queryKey: ["social-invites-out"] });
+      queryClient.invalidateQueries({ queryKey: ["social-invites-in", row.to_profile_id] });
+      queryClient.invalidateQueries({ queryKey: ["social-invites-out", row.from_profile_id] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message ?? "Failed to update invite");
     },
   });
 }

--- a/supabase/migrations/20260710183000_guard_social_invites.sql
+++ b/supabase/migrations/20260710183000_guard_social_invites.sql
@@ -1,0 +1,189 @@
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'social_invite_send_denied';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'social_invite_response_denied';
+
+ALTER TABLE public.social_invites
+  ADD CONSTRAINT social_invites_message_length CHECK (message IS NULL OR char_length(btrim(message)) BETWEEN 1 AND 280);
+
+CREATE INDEX IF NOT EXISTS social_invites_active_pair_kind_idx
+  ON public.social_invites (from_profile_id, to_profile_id, kind, status, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.can_send_social_invite(
+  sender_profile_id uuid,
+  recipient_profile_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT sender_profile_id IS NOT NULL
+    AND recipient_profile_id IS NOT NULL
+    AND sender_profile_id <> recipient_profile_id
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = sender_profile_id)
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = recipient_profile_id)
+    AND NOT public.are_profiles_blocked(sender_profile_id, recipient_profile_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.send_social_invite(
+  target_profile_id uuid,
+  invite_kind public.social_invite_kind,
+  scheduled_for timestamptz DEFAULT NULL,
+  invite_message text DEFAULT NULL,
+  invite_ref_id uuid DEFAULT NULL,
+  invite_location_city_id uuid DEFAULT NULL
+)
+RETURNS public.social_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sender_profile_id uuid;
+  recipient_user_id uuid;
+  trimmed_message text;
+  existing_invite public.social_invites;
+  invite_row public.social_invites;
+BEGIN
+  SELECT p.id INTO sender_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF sender_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before sending invites.' USING ERRCODE = '28000';
+  END IF;
+  IF target_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Choose a player to invite.' USING ERRCODE = '22023';
+  END IF;
+  IF invite_kind IS NULL THEN
+    RAISE EXCEPTION 'Choose an invite type.' USING ERRCODE = '22023';
+  END IF;
+  IF sender_profile_id = target_profile_id THEN
+    RAISE EXCEPTION 'You cannot invite yourself.' USING ERRCODE = '22023';
+  END IF;
+  IF scheduled_for IS NOT NULL AND scheduled_for < timezone('utc', now()) - interval '5 minutes' THEN
+    RAISE EXCEPTION 'Choose a future time for this invite.' USING ERRCODE = '22023';
+  END IF;
+
+  trimmed_message := NULLIF(btrim(COALESCE(invite_message, '')), '');
+  IF trimmed_message IS NOT NULL AND char_length(trimmed_message) > 280 THEN
+    RAISE EXCEPTION 'Invite messages must be 280 characters or fewer.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT p.user_id INTO recipient_user_id FROM public.profiles p WHERE p.id = target_profile_id;
+  IF recipient_user_id IS NULL THEN
+    RAISE EXCEPTION 'That player could not be found.' USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT public.can_send_social_invite(sender_profile_id, target_profile_id) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, metadata)
+    VALUES (sender_profile_id, target_profile_id, 'social_invite_send_denied'::public.social_action_audit_kind, 'social_invite', jsonb_build_object('reason', 'block_guard', 'kind', invite_kind));
+    RAISE EXCEPTION 'This player is not available for invites.' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO existing_invite
+  FROM public.social_invites i
+  WHERE i.from_profile_id = sender_profile_id
+    AND i.to_profile_id = target_profile_id
+    AND i.kind = invite_kind
+    AND i.status = 'pending'::public.social_invite_status
+    AND (i.scheduled_at IS NULL OR i.scheduled_at > timezone('utc', now()) - interval '1 day')
+  ORDER BY i.created_at DESC
+  LIMIT 1;
+
+  IF existing_invite.id IS NOT NULL THEN
+    RETURN existing_invite;
+  END IF;
+
+  INSERT INTO public.social_invites (from_profile_id, to_profile_id, kind, ref_id, scheduled_at, location_city_id, message, status)
+  VALUES (sender_profile_id, target_profile_id, invite_kind, invite_ref_id, scheduled_for, invite_location_city_id, trimmed_message, 'pending')
+  RETURNING * INTO invite_row;
+
+  INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+  SELECT recipient_user_id, target_profile_id, 'relationship', 'social_invite', 'New social invite', 'Another artist sent you an invite.', '/social?tab=invites',
+    jsonb_build_object('social_invite_id', invite_row.id, 'from_profile_id', sender_profile_id, 'to_profile_id', target_profile_id, 'kind', invite_kind)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.notifications n
+    WHERE n.user_id = recipient_user_id
+      AND n.type = 'social_invite'
+      AND n.metadata->>'social_invite_id' = invite_row.id::text
+  );
+
+  RETURN invite_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.respond_social_invite(
+  invite_id uuid,
+  next_status public.social_invite_status
+)
+RETURNS public.social_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_profile_id uuid;
+  invite_row public.social_invites;
+BEGIN
+  SELECT p.id INTO actor_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF actor_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before responding to invites.' USING ERRCODE = '28000';
+  END IF;
+  IF invite_id IS NULL THEN
+    RAISE EXCEPTION 'Choose an invite to update.' USING ERRCODE = '22023';
+  END IF;
+  IF next_status NOT IN ('accepted'::public.social_invite_status, 'declined'::public.social_invite_status, 'cancelled'::public.social_invite_status) THEN
+    RAISE EXCEPTION 'Choose accept, decline, or cancel for this invite.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO invite_row FROM public.social_invites WHERE id = invite_id;
+  IF invite_row.id IS NULL THEN
+    RAISE EXCEPTION 'That invite could not be found.' USING ERRCODE = '22023';
+  END IF;
+  IF invite_row.status <> 'pending'::public.social_invite_status THEN
+    RETURN invite_row;
+  END IF;
+  IF invite_row.scheduled_at IS NOT NULL AND invite_row.scheduled_at < timezone('utc', now()) THEN
+    UPDATE public.social_invites SET status = 'expired'::public.social_invite_status, responded_at = timezone('utc', now()) WHERE id = invite_row.id RETURNING * INTO invite_row;
+    RETURN invite_row;
+  END IF;
+  IF public.are_profiles_blocked(invite_row.from_profile_id, invite_row.to_profile_id) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+    VALUES (actor_profile_id, CASE WHEN actor_profile_id = invite_row.from_profile_id THEN invite_row.to_profile_id ELSE invite_row.from_profile_id END, 'social_invite_response_denied'::public.social_action_audit_kind, 'social_invite', invite_row.id, jsonb_build_object('reason', 'block_guard'));
+    RAISE EXCEPTION 'This invite can no longer be updated.' USING ERRCODE = '42501';
+  END IF;
+  IF next_status = 'cancelled'::public.social_invite_status AND actor_profile_id <> invite_row.from_profile_id THEN
+    RAISE EXCEPTION 'Only the sender can cancel this invite.' USING ERRCODE = '42501';
+  END IF;
+  IF next_status IN ('accepted'::public.social_invite_status, 'declined'::public.social_invite_status) AND actor_profile_id <> invite_row.to_profile_id THEN
+    RAISE EXCEPTION 'Only the recipient can accept or decline this invite.' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.social_invites SET status = next_status, responded_at = timezone('utc', now()) WHERE id = invite_row.id RETURNING * INTO invite_row;
+  RETURN invite_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.can_send_social_invite(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.send_social_invite(uuid, public.social_invite_kind, timestamptz, text, uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.respond_social_invite(uuid, public.social_invite_status) TO authenticated;
+
+DROP POLICY IF EXISTS "Invite created by sender" ON public.social_invites;
+CREATE POLICY "Invite created by guarded sender"
+ON public.social_invites FOR INSERT
+WITH CHECK (
+  status = 'pending'::public.social_invite_status
+  AND public.profile_belongs_to_current_user(from_profile_id)
+  AND public.can_send_social_invite(from_profile_id, to_profile_id)
+);
+
+DROP POLICY IF EXISTS "Invite updated by either party" ON public.social_invites;
+-- Direct client updates are intentionally not re-granted. Status changes go through respond_social_invite().


### PR DESCRIPTION
### Motivation
- Finish the Phase 1 communication guard pattern by migrating the existing client-side `social_invites` flow to a server-authoritative guard as recommended by Phase 1 PR 04. 
- Close a remaining direct-contact surface so block/privacy checks, duplicate/expiry handling, actionable notification deduplication, and audit logging are consistently enforced server-side. 
- Keep this change small and dependency-aware by reusing the existing `social_invites` table, notifications, and the shared block/mute/report helpers introduced in earlier PRs. 

### Description
- Adds a new migration `supabase/migrations/20260710183000_guard_social_invites.sql` that introduces `can_send_social_invite`, `send_social_invite(...)`, and `respond_social_invite(...)` RPCs, message-length constraint, duplicate/pair-kind index, audit-kind values, and tight RLS changes so status transitions go through the RPCs. 
- Adds a client-side service `src/features/social-hub/services/socialInvites.ts` with validation, friendly error mapping, and RPC wrappers, and replaces direct table writes in `src/hooks/useSocialInvites.ts` to call the guarded RPCs. 
- Improves invite UI behaviour and accessibility in `InviteFriendDialog.tsx` (validation, loading/disabled/pending states, aria attributes, character counter) and `InvitesInbox.tsx` (unauthenticated, loading, error, timestamps, status clarity, accessible action labels). 
- Adds unit tests `src/features/social-hub/__tests__/socialInvites.test.ts`, documentation `PHASE_1_PR_05.md` and `PHASE_1_REVIEW.md`, and factual updates to `SOCIAL_SYSTEM_AUDIT.md` and `SOCIAL_MMO_EXPANSION_PLAN.md` describing the implemented guard and Phase 1 review outcome. 

### Testing
- Added automated service unit tests covering validation, guarded RPC send, idempotent duplicate pending behavior, guarded response RPC, invalid inputs, and friendly error mapping in `src/features/social-hub/__tests__/socialInvites.test.ts`. 
- Ran type checking with `npm run typecheck` which passed in this environment. 
- Attempted lint/build/unit test runs but they could not complete in the current environment because required tools are not available (`eslint` plugin `@eslint/js` missing for lint, `vite` missing for build, and `vitest` missing so unit tests could not be executed here). 
- SQL migration file was validated as readable and included index/RPC/RLS changes; full RLS/RPC integration tests should be run against a Supabase test database during CI/migration validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50e4980cdc8325915fe821c662a4ae)