### PR TITLE
Begin Phase 2: public-safe profile projection and player search migration

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -60,7 +60,7 @@ Other players should become the most valuable content in RockMundo because they 
 - **Friends and follows**
   - Add clear distinction between mutual friends, one-way follows, blocked users, bandmates, company colleagues, mentors, mentees, contractors, and rivals.
   - Provide friend activity summaries such as upcoming gigs, new releases, job openings, contract requests, and major achievements.
-  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions. Initial owner-managed settings now exist; direct-message sends enforce DM permission and blocks server-side; friend-request creation now enforces block checks, duplicate handling, cooldowns, and notification deduplication server-side; full enforcement across other reads/writes remains a follow-up.
+  - Allow privacy controls for online status, current city, current activity, relationship status, and direct-message permissions. Initial owner-managed settings now exist; player search now uses a public-safe projection with profile-visibility/block filtering; direct-message sends enforce DM permission and blocks server-side; friend-request creation now enforces block checks, duplicate handling, cooldowns, and notification deduplication server-side; full enforcement across other reads/writes remains a follow-up.
 
 - **Direct messages and group conversations**
   - Support one-to-one messages for negotiation, mentoring, hiring, and social play.
@@ -396,7 +396,7 @@ Safety is a core feature, not an afterthought.
 - ✅ Non-invasive notification improvements now exist for friend requests and social invites with deduped actionable routes.
 - Availability flags such as looking for band, hiring, open to gigs, seeking mentor, or open to collaboration remain pending.
 - Discovery filters for players, bands, companies, venues, jobs, and communities remain pending.
-- Public-safe profile/search projections remain the next dependency before richer discovery expansion.
+- Public-safe player search projection is now in place; profile detail and richer discovery projections remain dependencies before richer recruitment expansion.
 
 ### Phase 2: Safety and Trust Foundations
 - ✅ Dedicated block/mute/report/audit primitives are implemented for the first social safety slice.

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -66,7 +66,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 - `profiles` table stores core public identity and progression: `user_id`, `username`, `display_name`, `avatar_url`, `bio`, `level`, `experience`, `cash`, `fame`, timestamps; later migrations extend profiles with demographics, age, city/location, avatar, health, clothing/loadout, etc.
 - `PlayerProfile` fetches public profile fields including username/display name/avatar/bio, created date, age/gender, level/fame/fans/health/energy/experience, total hours, VIP/generation, current city, imprisonment/travel/activity, memberships, reputation, songs, achievements, skills, and activity-like tabs.
-- `PlayerSearch` lets users search profiles by username/display name and displays avatar, bio, fame/fans/level, city name, and bands.
+- ✅ `PlayerSearch` now uses the server-authoritative `search_public_profiles` RPC and `public_safe_profiles` projection for username/display-name search, returning safe summary fields, privacy-allowed city, and band badges while filtering blocked/private profiles. `PlayerProfile` detail pages still need migration.
 - Achievements are backed by `achievements` and `player_achievements`; profile UI surfaces unlocked achievements.
 - Career history is partially represented through gigs, bands, releases/songs, activity logs, jobs/employment, charts, awards, and profile/statistics pages, but it is not normalized into a single public career-history model.
 - Current band information is available through `band_members` joins and band profile/browser/search pages.
@@ -78,7 +78,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 ### Partial / fragmented
 
-- **Public vs private data boundaries are implicit.** The app queries many profile fields directly from public pages. Database RLS/policies need a field-by-field review for future privacy-sensitive attributes such as online status, current activity, city, health, relationship status, and direct-message availability.
+- **Public vs private data boundaries are partially explicit.** Player search now uses a public-safe projection and RPC, but profile detail and other discovery surfaces still query broader profile data directly. Database RLS/policies still need a field-by-field review for future privacy-sensitive attributes such as online status, current activity, city, health, relationship status, and direct-message availability.
 - **Reputation appears in multiple systems** (profile reputation hook, company reputation, Twaater fame, band ratings, public-image utilities) without a unified social reputation taxonomy.
 - **Skills offered/services offered are not first-class profile metadata.** Services can be inferred from skills, company shifts, producer profiles, mentors, jobs, and storefronts, but players cannot publish a coherent “services offered” profile.
 - **Career history is scattered.** Band memberships, releases, gigs, jobs, achievements, and awards are independent surfaces rather than a canonical career timeline.
@@ -86,8 +86,8 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 ### Missing / risks
 
 - ✅ `profile_privacy_settings` now covers the first visibility/contact slice for profile, city, activity, online status, relationship details, DM permission, and band/company invite opt-ins. Remaining gaps: achievements, band/company history, service availability, and full read/write enforcement across all social surfaces.
-- No block-aware profile access layer was found. A blocked player may still be able to discover/view public profile information unless blocked status is manually checked in every surface.
-- No explicit “public profile safe projection” view/API separates public-safe fields from private profile state.
+- ✅ Player search now filters blocked pairs through `can_view_public_profile_summary`; remaining profile detail and other discovery routes still need block-aware migration.
+- ✅ `public_safe_profiles` and `search_public_profiles` now separate player-search summary fields from private profile state. Remaining gaps: profile detail, richer discovery, and recruitment-specific projections.
 - No clear audit trail for profile edits, display-name/handle changes, or profile moderation actions outside Twaater-specific tooling.
 
 ### Recommended Phase 1 foundations
@@ -367,7 +367,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Online status | Low-Medium | Presence counts exist, not privacy-aware per-player status.
 | Last active | Low | No clear public/private model.
 | Looking-for states | Low | Band recruiting/storefront hiring partial; player availability missing.
-| Player search | Medium | Basic profile search exists.
+| Player search | Medium-High | Basic search now uses a public-safe RPC/projection with block and profile-visibility checks; richer discovery filters remain pending.
 | Recruitment search | Low-Medium | Band search exists; matching filters missing.
 | Band creation | Medium | Implemented.
 | Band invites | Medium | Implemented; policies/privacy need review.
@@ -378,7 +378,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 
 1. **Social permission design PR:** ✅ First slice implemented in `docs/social/implementation/PHASE_1_PR_01.md`, `src/features/social-privacy/*`, and `supabase/migrations/20260710120000_add_profile_privacy_settings.sql`. It adds owner-managed profile privacy/contact settings plus shared helper functions for owner checks, block checks, and DM eligibility. Remaining slices: migrate profile/search/DM/recruitment reads and writes to enforce these settings end-to-end.
 2. **Safety schema PR:** Add shared block/mute/report/audit primitives with no major UI exposure.
-3. **Profile projection PR:** Add safe profile views/RPCs and migrate search/profile reads to them.
+3. **Profile projection PR:** ✅ First slice implemented for player search via `public_safe_profiles` and `search_public_profiles`. Remaining slice: migrate profile detail and richer discovery reads.
 4. **Communication guard PR:** ✅ Direct-message send guards, friend-request send guards, and social-invite send/respond guards are implemented in Phase 1 PRs 03–05. Remaining slices: add broader rate limits and migrate Twaater DMs/follows, chat, recruitment writes, gifts, and friendship response/removal lifecycle operations.
 5. **Recruitment metadata PR:** Add opt-in availability fields and band recruiting metadata behind privacy settings.
 6. **Admin moderation PR:** Add unified social reports and evidence review console.

--- a/docs/social/implementation/PHASE_2_PR_01.md
+++ b/docs/social/implementation/PHASE_2_PR_01.md
@@ -1,0 +1,94 @@
+# Phase 2 PR 01 — Public-Safe Profile Projection and Player Search Migration
+
+## Selected Phase 2 recommendation
+
+Phase 1 review recommends starting the next foundation phase with a **public-safe profile projection and profile/search read migration PR** before richer availability, recruitment metadata, hiring profiles, recommendations, or social matchmaking.
+
+## Audit evidence
+
+`SOCIAL_SYSTEM_AUDIT.md` identifies raw profile/search reads as privacy-light and broad: profile/search surfaces expose identity, city, activity-adjacent state, band history, progression, and social action entry points without a dedicated safe projection. It also flags the lack of privacy-safe profile/search APIs as a security and discovery blocker before recruitment expansion.
+
+## Problem
+
+Players searching for bandmates or collaborators were querying the broad `profiles` table directly from the client. That made discovery depend on raw profile fields instead of the privacy settings and block primitives added in Phase 1.
+
+## Previous behaviour
+
+- `PlayerSearch` queried `profiles` directly.
+- City and playtime-style fields could be displayed from raw profile data.
+- Blocked/private profiles were not filtered by a server-authoritative profile/search read guard.
+- Band memberships were fetched with a second direct client query.
+
+## Implemented behaviour
+
+- Adds `public_safe_profiles`, a narrow projection for profile/search discovery.
+- Adds `can_view_public_profile_summary(viewer_profile_id, target_profile_id)`.
+- Replaces `search_public_profiles` with a server-authoritative RPC that resolves the actor profile from `auth.uid()`, validates input, filters blocked pairs, honors public/friends/private profile visibility, and returns only safe summary fields plus current public band badges.
+- Migrates `PlayerSearch` to call the RPC through `src/services/publicProfileSearch.ts`.
+- Adds loading, empty, error, disabled, and success states around the migrated search flow.
+
+## Full user flow
+
+1. A signed-in player opens Player Search.
+2. The player enters at least two characters.
+3. The client validates and normalizes the query.
+4. The RPC resolves the authenticated player profile server-side.
+5. The RPC filters results through block and profile-visibility checks.
+6. The page renders only public-safe summary fields: name, handle, avatar, bio, fame, fans, level, privacy-allowed city, and current band badges.
+7. Existing profile, friend, and message actions remain visible only through existing UI state and backend guards.
+
+## Files changed
+
+- `supabase/migrations/20260710200000_public_safe_profile_search.sql`
+- `src/services/publicProfileSearch.ts`
+- `src/services/__tests__/publicProfileSearch.test.ts`
+- `src/pages/PlayerSearch.tsx`
+- `docs/social/implementation/PHASE_2_PR_01.md`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Database changes
+
+A migration is required. It adds a projection view and replaces the search RPC. No new tables are added.
+
+## Permission model
+
+- The RPC requires `auth.uid()` and resolves the owned actor profile server-side.
+- Client-supplied viewer profile IDs are treated only as a selector among profiles owned by the authenticated user.
+- Blocked profile pairs are excluded.
+- Public profiles are discoverable, friends-only profiles are discoverable to accepted friends and self, and private profiles are discoverable only to self.
+- City is shown only when `city_visibility = 'public'`.
+
+## Notifications
+
+No notifications are created. This is a read-boundary and search migration slice.
+
+## Analytics
+
+No analytics events are added. This slice does not introduce a new analytics platform.
+
+## Automated tests
+
+Added service tests for input normalization, invalid input, RPC invocation, safe result mapping, and friendly backend error mapping.
+
+## Manual verification
+
+Recommended manual cases:
+
+- Search as a band leader.
+- Search as an ordinary member.
+- Search as an unrelated player.
+- Search while blocked from another player and confirm that profile is excluded.
+- Search for a private profile and confirm only the owner can see it.
+- Search on mobile and desktop.
+
+## Known limitations
+
+- `PlayerProfile` detail pages still need migration to safe profile-detail reads.
+- Band recruitment applications/invitations are not modified in this slice.
+- Broad social rate limiting and unified moderation remain unresolved.
+- The RPC uses the first owned profile until a canonical active-profile SQL helper is added.
+
+## Recommended Phase 2 PR 02
+
+Migrate the public player profile detail route to the same public-safe projection/visibility model, then begin the first guarded band recruitment write slice after profile/search reads no longer depend on raw profile access.

--- a/src/pages/PlayerSearch.tsx
+++ b/src/pages/PlayerSearch.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -15,25 +14,9 @@ import { resolveRelationshipPairKey } from "@/features/relationships/api";
 import { DirectMessagePanel } from "@/features/relationships/components/DirectMessagePanel";
 import { useToast } from "@/hooks/use-toast";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { searchPublicProfiles, type PublicProfileSearchResult } from "@/services/publicProfileSearch";
 
-interface PlayerProfile {
-  id: string;
-  user_id: string;
-  username: string;
-  display_name: string | null;
-  avatar_url: string | null;
-  bio: string | null;
-  fame: number;
-  fans: number;
-  level: number;
-  total_hours_played: number | null;
-  city_name: string | null;
-  bands?: Array<{
-    name: string;
-    genre: string | null;
-  }>;
-}
-
+type PlayerProfile = PublicProfileSearchResult;
 type FriendState = "none" | "friends" | "pending_sent" | "pending_received";
 
 export default function PlayerSearch() {
@@ -44,34 +27,12 @@ export default function PlayerSearch() {
   const { friendships, sendRequest, acceptRequest } = useFriendships(profile?.id);
   const { toast } = useToast();
 
-  const { data: players, isLoading } = useQuery({
-    queryKey: ["player-search", debouncedQuery],
+  const { data: players, isLoading, isError, error } = useQuery({
+    queryKey: ["player-search", debouncedQuery, profile?.id],
     queryFn: async () => {
       if (!debouncedQuery || debouncedQuery.length < 2) return [];
 
-      const { data: profiles, error } = await supabase
-        .from("profiles")
-        .select("id, username, display_name, avatar_url, bio, user_id, fame, fans, level, total_hours_played, current_city_id, cities!profiles_current_city_id_fkey(name)")
-        .or(`username.ilike.%${debouncedQuery}%,display_name.ilike.%${debouncedQuery}%`)
-        .limit(20);
-
-      if (error) throw error;
-      if (!profiles) return [];
-
-      // Fetch band memberships separately
-      const playerIds = profiles.map(p => p.user_id);
-      const { data: memberships } = await supabase
-        .from("band_members")
-        .select("user_id, bands!band_members_band_id_fkey(name, genre)")
-        .in("user_id", playerIds);
-
-      return profiles.map(profile => ({
-        ...profile,
-        city_name: (profile as any).cities?.name ?? null,
-        bands: memberships
-          ?.filter((m: any) => m.user_id === profile.user_id)
-          .map((m: any) => m.bands) || []
-      })) as PlayerProfile[];
+      return searchPublicProfiles(debouncedQuery, profile?.id);
     },
     enabled: debouncedQuery.length >= 2,
   });
@@ -148,7 +109,7 @@ export default function PlayerSearch() {
               placeholder="Search by username or display name..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyPress={handleKeyPress}
+              onKeyDown={handleKeyPress}
             />
             <Button onClick={handleSearch} disabled={searchQuery.length < 2}>
               <Search className="h-4 w-4" />
@@ -160,12 +121,22 @@ export default function PlayerSearch() {
       {isLoading && (
         <Card>
           <CardContent className="p-6">
-            <p className="text-center text-muted-foreground">Searching...</p>
+            <p className="text-center text-muted-foreground" aria-live="polite">Searching public-safe musician profiles...</p>
           </CardContent>
         </Card>
       )}
 
-      {!isLoading && debouncedQuery.length >= 2 && players && players.length === 0 && (
+      {isError && (
+        <Card role="alert">
+          <CardContent className="p-6">
+            <p className="text-center text-destructive">
+              {error instanceof Error ? error.message : "Player search is unavailable right now. Please try again."}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !isError && debouncedQuery.length >= 2 && players && players.length === 0 && (
         <Card>
           <CardContent className="p-6">
             <p className="text-center text-muted-foreground">No players found matching your search.</p>
@@ -173,7 +144,7 @@ export default function PlayerSearch() {
         </Card>
       )}
 
-      {players && players.length > 0 && (
+      {!isError && players && players.length > 0 && (
         <div className="space-y-3">
           {players.map((player) => {
             const isSelf = profile?.id === player.id;
@@ -220,12 +191,6 @@ export default function PlayerSearch() {
                           <Badge variant="outline" className="text-xs flex items-center gap-1">
                             <MapPin className="h-3 w-3" />
                             {player.city_name}
-                          </Badge>
-                        )}
-                        {player.total_hours_played != null && player.total_hours_played > 0 && (
-                          <Badge variant="outline" className="text-xs flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {Math.round(player.total_hours_played)}h played
                           </Badge>
                         )}
                       </div>

--- a/src/services/__tests__/publicProfileSearch.test.ts
+++ b/src/services/__tests__/publicProfileSearch.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
+
+const rpc = vi.fn();
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { rpc } }));
+
+const { searchPublicProfiles, __publicProfileSearchTestUtils } = await import("../publicProfileSearch");
+
+const viewerProfileId = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("public profile search service", () => {
+  it("validates and normalizes search input before backend reads", () => {
+    expect(__publicProfileSearchTestUtils.validatePublicProfileSearchInput("  jo   star  ", viewerProfileId, 100)).toEqual({
+      search_term: "jo star",
+      viewer_profile_id: viewerProfileId,
+      result_limit: 50,
+    });
+  });
+
+  it("rejects short queries before backend reads", async () => {
+    await expect(searchPublicProfiles("j", viewerProfileId)).rejects.toThrow("at least 2");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid viewer profile ids before backend reads", async () => {
+    await expect(searchPublicProfiles("jo", "not-a-profile")).rejects.toThrow("valid player");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("searches through the public-safe profile RPC", async () => {
+    rpc.mockResolvedValueOnce({
+      data: [{ profile_id: viewerProfileId, user_id: "11111111-1111-4111-8111-111111111111", username: "jo", display_name: null, avatar_url: null, bio: null, fame: null, fans: null, level: null, city_name: null, bands: null }],
+      error: null,
+    });
+
+    await expect(searchPublicProfiles("jo", viewerProfileId)).resolves.toEqual([
+      expect.objectContaining({ id: viewerProfileId, username: "jo", fame: 0, fans: 0, level: 1, bands: [] }),
+    ]);
+    expect(rpc).toHaveBeenCalledWith("search_public_profiles", { search_term: "jo", viewer_profile_id: viewerProfileId, result_limit: 20 });
+  });
+
+  it("maps backend failures to friendly errors", async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: "Authentication required to search player profiles" } });
+    await expect(searchPublicProfiles("jo", viewerProfileId)).rejects.toThrow("Sign in");
+  });
+});

--- a/src/services/publicProfileSearch.ts
+++ b/src/services/publicProfileSearch.ts
@@ -1,0 +1,100 @@
+import { supabase } from "@/integrations/supabase/client";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 80;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+export interface PublicProfileSearchBand {
+  name: string;
+  genre: string | null;
+}
+
+export interface PublicProfileSearchResult {
+  id: string;
+  user_id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  fame: number;
+  fans: number;
+  level: number;
+  city_name: string | null;
+  bands: PublicProfileSearchBand[];
+}
+
+interface SearchPublicProfilesRpcRow {
+  profile_id: string;
+  user_id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  fame: number | null;
+  fans: number | null;
+  level: number | null;
+  city_name: string | null;
+  bands: PublicProfileSearchBand[] | null;
+}
+
+export function validatePublicProfileSearchInput(searchTerm: string, viewerProfileId?: string | null, resultLimit = DEFAULT_LIMIT) {
+  const normalizedTerm = searchTerm.trim().replace(/\s+/g, " ");
+
+  if (normalizedTerm.length < MIN_QUERY_LENGTH) {
+    throw new Error("Enter at least 2 characters to search for musicians.");
+  }
+
+  if (normalizedTerm.length > MAX_QUERY_LENGTH) {
+    throw new Error("Search terms must be 80 characters or fewer.");
+  }
+
+  const normalizedViewerProfileId = viewerProfileId?.trim() || null;
+  if (normalizedViewerProfileId && !UUID_RE.test(normalizedViewerProfileId)) {
+    throw new Error("Sign in with a valid player profile before searching musicians.");
+  }
+
+  return {
+    search_term: normalizedTerm,
+    viewer_profile_id: normalizedViewerProfileId,
+    result_limit: Math.min(Math.max(Math.trunc(resultLimit) || DEFAULT_LIMIT, 1), MAX_LIMIT),
+  };
+}
+
+export function friendlyPublicProfileSearchError(message?: string) {
+  if (!message) return "Player search is unavailable right now. Please try again.";
+  if (/authentication|sign in|active player/i.test(message)) return "Sign in with an active player profile to search musicians.";
+  if (/blocked|not available|permission|42501/i.test(message)) return "Those player profiles are not available to this account.";
+  return message;
+}
+
+function mapSearchRow(row: SearchPublicProfilesRpcRow): PublicProfileSearchResult {
+  return {
+    id: row.profile_id,
+    user_id: row.user_id,
+    username: row.username,
+    display_name: row.display_name,
+    avatar_url: row.avatar_url,
+    bio: row.bio,
+    fame: row.fame ?? 0,
+    fans: row.fans ?? 0,
+    level: row.level ?? 1,
+    city_name: row.city_name,
+    bands: Array.isArray(row.bands) ? row.bands : [],
+  };
+}
+
+export async function searchPublicProfiles(searchTerm: string, viewerProfileId?: string | null, resultLimit = DEFAULT_LIMIT) {
+  const input = validatePublicProfileSearchInput(searchTerm, viewerProfileId, resultLimit);
+  const { data, error } = await supabase.rpc("search_public_profiles" as any, input);
+
+  if (error) throw new Error(friendlyPublicProfileSearchError(error.message));
+
+  return ((data ?? []) as SearchPublicProfilesRpcRow[]).map(mapSearchRow);
+}
+
+export const __publicProfileSearchTestUtils = {
+  validatePublicProfileSearchInput,
+  friendlyPublicProfileSearchError,
+};

--- a/supabase/migrations/20260710200000_public_safe_profile_search.sql
+++ b/supabase/migrations/20260710200000_public_safe_profile_search.sql
@@ -1,0 +1,156 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW public.public_safe_profiles AS
+SELECT
+  p.id AS profile_id,
+  p.user_id,
+  p.username,
+  p.display_name,
+  p.avatar_url,
+  p.bio,
+  COALESCE(p.fame, 0) AS fame,
+  COALESCE(p.fans, 0) AS fans,
+  COALESCE(p.level, 1) AS level,
+  CASE
+    WHEN COALESCE(pps.city_visibility, 'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope
+      THEN c.name
+    ELSE NULL
+  END AS city_name,
+  COALESCE(pps.profile_visibility, 'public'::public.profile_visibility_scope) AS profile_visibility,
+  COALESCE(pps.city_visibility, 'friends'::public.profile_visibility_scope) AS city_visibility
+FROM public.profiles p
+LEFT JOIN public.profile_privacy_settings pps ON pps.profile_id = p.id
+LEFT JOIN public.cities c ON c.id = p.current_city_id;
+
+COMMENT ON VIEW public.public_safe_profiles IS 'Public-safe profile/search projection for discovery surfaces. Excludes private gameplay state and hides city unless explicitly public.';
+
+GRANT SELECT ON public.public_safe_profiles TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.can_view_public_profile_summary(viewer_profile_id uuid, target_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH target_settings AS (
+    SELECT COALESCE(
+      (SELECT pps.profile_visibility FROM public.profile_privacy_settings pps WHERE pps.profile_id = target_profile_id),
+      'public'::public.profile_visibility_scope
+    ) AS profile_visibility
+  )
+  SELECT
+    target_profile_id IS NOT NULL
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = target_profile_id)
+    AND (
+      viewer_profile_id IS NULL
+      OR viewer_profile_id = target_profile_id
+      OR NOT public.are_profiles_blocked(viewer_profile_id, target_profile_id)
+    )
+    AND (
+      (SELECT profile_visibility FROM target_settings) = 'public'::public.profile_visibility_scope
+      OR viewer_profile_id = target_profile_id
+      OR (
+        (SELECT profile_visibility FROM target_settings) = 'friends'::public.profile_visibility_scope
+        AND EXISTS (
+          SELECT 1
+          FROM public.friendships f
+          WHERE f.status = 'accepted'::public.friendship_status
+            AND (
+              (f.requestor_id = viewer_profile_id AND f.addressee_id = target_profile_id)
+              OR (f.requestor_id = target_profile_id AND f.addressee_id = viewer_profile_id)
+            )
+        )
+      )
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.can_view_public_profile_summary(uuid, uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.search_public_profiles(
+  search_term text,
+  viewer_profile_id uuid DEFAULT NULL,
+  result_limit integer DEFAULT 20
+)
+RETURNS TABLE (
+  profile_id uuid,
+  user_id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  bio text,
+  fame integer,
+  fans integer,
+  level integer,
+  city_name text,
+  bands jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  normalized_limit integer := LEAST(GREATEST(COALESCE(result_limit, 20), 1), 50);
+  normalized_term text := NULLIF(BTRIM(COALESCE(search_term, '')), '');
+  actor_profile_id uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required to search player profiles'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF normalized_term IS NULL OR length(normalized_term) < 2 THEN
+    RAISE EXCEPTION 'Enter at least 2 characters to search player profiles'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT p.id INTO actor_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+    AND (viewer_profile_id IS NULL OR p.id = viewer_profile_id)
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF actor_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before searching player profiles'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    psp.profile_id,
+    psp.user_id,
+    psp.username::text,
+    psp.display_name::text,
+    psp.avatar_url::text,
+    psp.bio::text,
+    psp.fame,
+    psp.fans,
+    psp.level,
+    psp.city_name::text,
+    COALESCE(
+      (
+        SELECT jsonb_agg(jsonb_build_object('name', b.name, 'genre', b.genre) ORDER BY b.name)
+        FROM public.band_members bm
+        JOIN public.bands b ON b.id = bm.band_id
+        WHERE bm.user_id = psp.user_id
+      ),
+      '[]'::jsonb
+    ) AS bands
+  FROM public.public_safe_profiles psp
+  WHERE
+    public.can_view_public_profile_summary(actor_profile_id, psp.profile_id)
+    AND (
+      psp.username ILIKE '%' || normalized_term || '%'
+      OR COALESCE(psp.display_name, '') ILIKE '%' || normalized_term || '%'
+    )
+  ORDER BY
+    psp.display_name NULLS LAST,
+    psp.username
+  LIMIT normalized_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.search_public_profiles(text, uuid, integer) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Phase 1 review and the social audit identified raw profile/search reads as a blocking privacy risk for recruitment and discovery, so the next dependency is a public-safe profile projection and search migration. 
- PlayerSearch previously queried `profiles` and joined `band_members` client-side, exposing fields without respecting profile privacy settings or block checks. 
- Implementing a server-authoritative public-safe search is the smallest vertical slice that enables later recruitment and discovery work while preserving privacy and block semantics. 

### Description
- Added a database migration `supabase/migrations/20260710200000_public_safe_profile_search.sql` that creates `public.public_safe_profiles`, `can_view_public_profile_summary(...)`, and a guarded `search_public_profiles(...)` RPC which resolves the actor via `auth.uid()`, validates input, filters blocked/private results, and aggregates public band badges. 
- Introduced `src/services/publicProfileSearch.ts` which validates/search-input, calls `search_public_profiles` via `supabase.rpc`, maps results to a safe client shape, and exposes friendly error messages. 
- Migrated `src/pages/PlayerSearch.tsx` to use the new `searchPublicProfiles` service instead of direct `profiles`/`band_members` queries, and added improved loading/empty/error/accessibility states. 
- Added unit tests `src/services/__tests__/publicProfileSearch.test.ts` for input normalization, invalid input, RPC invocation, result mapping, and friendly backend error mapping. 
- Updated documentation: `docs/social/implementation/PHASE_2_PR_01.md`, `docs/social/SOCIAL_SYSTEM_AUDIT.md`, and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md` to record the change and remaining migration work (profile detail and richer discovery projections). 

### Testing
- Typecheck: `npm run typecheck` (`tsc --noEmit`) passed. 
- Basic repository checks: pre-commit/diff checks passed locally. 
- Lint/build/unit/smoke tests: could not run in this environment because development tooling is not installed (`@eslint/js`, `vite`, `vitest` were not available), so `npm run lint`, `npm run build`, and `npm run test:unit` / `test:smoke` were not executed. 
- New automated unit tests were added (`src/services/__tests__/publicProfileSearch.test.ts`) but were not executed here due to missing `vitest`; they exercise input validation, RPC mapping, and error mapping and should pass when run in CI with dependencies installed. 
- Migration note: apply `supabase/migrations/20260710200000_public_safe_profile_search.sql` to the database environment to enable the RPC/view; database-side lint/checks were not run because the Supabase CLI was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50eac952688325a17edef79faa1428)