### PR TITLE
Guarded Band Application Response MVP

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -119,7 +119,7 @@ Other players should become the most valuable content in RockMundo because they 
 **Implementation approach**
 1. Add documentation and UI labels for existing band responsibilities.
 2. Add role metadata and permission checks in small PRs.
-3. Guard band invitation creation and response before deeper collaboration work; the first server-authoritative invitation lifecycle now exists with leader/founder creation/cancellation checks, target invite privacy, block checks, duplicate-pending and duplicate-membership idempotency, audit logging, and notification deduplication/status updates.
+3. Guard band invitation creation/response and band application approval/rejection before deeper collaboration work; the invitation lifecycle and application response path now have server-authoritative RPCs with leader/founder recruitment checks, block checks, duplicate-membership idempotency, audit logging, and notification deduplication/status updates.
 4. Add contribution logs for existing band actions.
 5. Add objective templates using existing gig, song, rehearsal, and media systems.
 6. Add collaboration contracts after the generic contract framework is stable.
@@ -403,13 +403,13 @@ Safety is a core feature, not an afterthought.
 - ✅ Dedicated block/mute/report/audit primitives are implemented for the first social safety slice.
 - ✅ Invite permission checks and duplicate pending handling now exist for social invites.
 - ✅ Audit logging exists for migrated denied direct-contact actions.
-- Expand block/mute/report coverage across Twaater, realtime chat, band application flows, gifts, and remaining social surfaces; guarded band invitation creation and response now cover the first end-to-end recruitment invitation lifecycle.
+- Expand block/mute/report coverage across Twaater, realtime chat, application submission, gifts, and remaining social surfaces; guarded band invitation creation/response and application approval/rejection now cover core recruitment membership-entry decisions.
 - Add broader rate limits and admin/moderator review views before launching high-impact systems.
 
 ### Phase 3: Band and Company Cooperation
-- Add broader band roles, permissions, and contribution history; guarded band invitation creation/response now has the first server-authoritative recruitment permission and membership-entry helper path.
+- Add broader band roles, permissions, and contribution history; guarded band invitation creation/response and application approval/rejection now share the first server-authoritative recruitment permission and membership-entry helper path.
 - Add company hiring profiles and job boards.
-- Add simple application flows with safe messaging constraints.
+- Add guarded application submission with safe messaging constraints; application approval/rejection is now guarded, but submission still needs its own server-authoritative entry point.
 - Add task templates tied to existing systems.
 
 ### Phase 4: Contracts and Escrow

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -211,7 +211,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 - Bands can be created and managed through band manager/components.
 - `bands`, `band_members`, roles, instrument/vocal roles, leader/founder concepts, status, chemistry/cohesion, finances, repertoire, gigs, riders, vehicles, gear, and chat surfaces exist.
 - ✅ `band_invitations` creation now uses the guarded `send_band_invitation` RPC for new client flows, with server-side actor resolution, invite permission checks, target privacy/block checks, active-member rejection, duplicate pending invite idempotency, validation constraints, denied-attempt audit logging, and notification dedupe. Invitation responses now use the guarded `respond_band_invitation` RPC, and leader/founder cancellation has the guarded `cancel_band_invitation` RPC; response creates membership idempotently and updates related notifications.
-- `band_applications` supports applications with applicant profile, instrument/vocal role, message, status, responded timestamp, uniqueness per band/applicant, applicant self-view, and leader response policies.
+- ✅ `band_applications` supports applications with applicant profile, instrument/vocal role, message, status, responded timestamp, uniqueness per band/applicant, and applicant self-view. Approval/rejection now uses the guarded `respond_band_application` RPC with server-side actor resolution, pending/final-state checks, leader/founder recruitment authorization, former-member exclusion through active membership checks, applicant self-approval denial, block checks, duplicate active-membership prevention, safe default member role creation, notification dedupe, and audit logging.
 - `bands.is_recruiting` exists.
 - Band browser/search lets players discover bands; band ratings and profiles exist.
 - Collaboration invite hooks and cross-band collaboration utilities exist for adjacent collaboration concepts.
@@ -219,10 +219,10 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 ### Partial / fragmented
 
 - Invitation policies are broad in one migration: invitations are viewable by everyone. This may be acceptable for public recruiting but is risky for private invitations.
-- Band leader checks vary across older schema surfaces, but invitation creation/cancellation now use the dedicated `can_manage_band_invitations` helper for the first guarded recruitment lifecycle. Other band actions still need migration.
+- Band leader checks vary across older schema surfaces, but invitation creation/cancellation and application approval/rejection now use the dedicated `can_manage_band_invitations` helper. The helper now requires current active leader/founder membership unless the actor is the band `leader_id`. Other band actions still need migration.
 - Auditions are not first-class. Applications include role/message but not scheduled auditions, audition media, votes, or review history.
 - Band roles exist but are not yet a complete permission matrix for finances, bookings, releases, contracts, chat moderation, invites, applications, and public announcements.
-- Band invitation creation and response are now block-aware, duplicate-pending/duplicate-membership guarded, and server-authoritative. Band applications, auditions, leader-side cancellation UI, and broader recruitment rate limits remain unresolved.
+- Band invitation creation/response and band application approval/rejection are now block-aware, duplicate-membership guarded, and server-authoritative. Application submission, auditions, leader-side invitation cancellation UI, and broader recruitment rate limits remain unresolved.
 
 ### Missing / risks
 

--- a/docs/social/implementation/PHASE_3_PR_01.md
+++ b/docs/social/implementation/PHASE_3_PR_01.md
@@ -1,0 +1,92 @@
+# Phase 3 PR 01 — Guarded Band Application Response MVP
+
+## Recommendation source
+
+This PR implements the Phase 2 review recommendation to harden band application approval/rejection before shared band progression work begins. Phase 2 closed the invitation lifecycle with guarded RPCs and identified applications as the remaining recruitment prerequisite.
+
+## Current application flow
+
+Before this PR, players submitted applications directly into `band_applications` from the application dialog. The manager list selected pending applications by `band_id` and `status = pending`. Approving directly updated `band_applications.status`, inserted `band_members` from the client, then performed a second client query/update to backfill `user_id`. Rejecting directly updated the application row. No server-authoritative approval/rejection RPC guarded pending status, role authorization, block state, duplicate membership, notifications, or audit logging.
+
+## Problem
+
+The previous response path trusted client-side band/application/member data and split approval across multiple writes. Rapid clicks, stale data, ordinary-member access, blocked pairs, existing membership conflicts, and final-state retries could produce raw errors or inconsistent state.
+
+## Implemented flow
+
+`respond_band_application(application_id, decision)` now owns application approval and rejection. It resolves the acting profile from `auth.uid()`, locks the application row, verifies the application exists and is pending, checks that the actor can manage recruitment for the band, rejects applicant self-approval, checks block state, verifies the applicant profile maps to a user, creates exactly one safe default `member` membership on approval, updates the application final state atomically, sends one applicant notification, and records audit entries.
+
+The UI now calls the guarded service instead of direct table updates/inserts, shows current status, disables controls while saving, keeps final-state rows read-only, and invalidates application/member/band data after success.
+
+## RPC contract
+
+```sql
+respond_band_application(application_id uuid, decision text)
+returns public.band_applications
+```
+
+Accepted decisions are `approve`, `approved`, `accept`, `accepted`, `reject`, and `rejected`; the frontend sends only `approve` or `reject`. Approval maps to existing status `accepted`; rejection maps to existing status `rejected`.
+
+Controlled errors are returned for unauthenticated users, invalid IDs, invalid decisions, missing applications, non-pending conflicting final states, unauthorized actors, self-approval attempts, blocked applicant/manager relationships, missing applicant users, duplicate active band membership, and membership creation failures. Repeating the same final-state decision returns the final row without duplicating membership or notifications.
+
+## Files changed
+
+- `supabase/migrations/20260710232000_guard_band_application_responses.sql`
+- `src/services/bandApplications.ts`
+- `src/services/__tests__/bandApplications.test.ts`
+- `src/components/band/BandApplicationsList.tsx`
+- `src/components/band/BandApplicationsList.test.tsx`
+- `docs/social/implementation/PHASE_3_PR_01.md`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Migration and database changes
+
+A corrective migration is required because historical policies allowed direct leader updates and no guarded response RPC existed. The migration adds narrow application-response audit enum values, application/member lookup indexes, tightens `can_manage_band_invitations` so inactive/former membership rows do not grant recruitment power, creates `respond_band_application` with `SECURITY DEFINER` and `SET search_path = public`, grants execute to authenticated users, and replaces direct application update policy with a deny-all update policy so decisions must use the RPC.
+
+No historical migration was edited. Existing lifecycle statuses are preserved: `pending`, `accepted`, and `rejected`.
+
+## Permission model
+
+- Authenticated users with an active profile are required.
+- Band `leader_id`, current leader membership, and current founder membership may decide applications.
+- Ordinary members, inactive/former members, unrelated users, unauthenticated users, and applicants themselves cannot decide applications.
+- The RPC does not trust client-supplied band IDs, applicant IDs, status, role, or membership data.
+- The frontend still hides controls behind the existing manager context, but backend checks are authoritative.
+
+## Notification behaviour
+
+Approval creates one `band_request` notification telling the applicant they joined the band and routes to `/bands/:bandId`. Rejection creates one respectful declined notification with the same route. Notification dedupe uses the application id and final status in metadata, so repeated same-state calls do not create duplicate notifications.
+
+## Audit behaviour
+
+Approved and rejected outcomes are recorded in `social_action_audit_log`. Denied unauthorized/self/block attempts and duplicate same-state retries are also logged with minimal metadata. Application messages and private profile details are not logged.
+
+## Automated tests
+
+Service tests cover valid approval, valid rejection, invalid application IDs, invalid decision values, backend failures, and empty backend responses. UI tests cover application details, approval and rejection calls, saving/disabled controls, error toast feedback, and final-state rows without active controls.
+
+The SQL migration is designed to cover permission, integrity, notification, audit, and RLS/RPC acceptance criteria; live database concurrency requires Supabase migration validation in an environment with the local database toolchain available.
+
+## Manual verification
+
+Recommended scenarios:
+
+- Band leader approves and rejects pending applications.
+- Band founder approves and rejects pending applications.
+- Ordinary member, former member, unrelated player, unauthenticated user, and applicant cannot decide.
+- Blocked manager/applicant pair cannot decide.
+- Applicant already in the band cannot be approved again.
+- Two rapid approval actions create one membership and one notification.
+- Mobile and desktop member-tab layouts keep controls reachable and final-state rows read-only.
+
+## Known limitations
+
+- Application creation remains a direct insert path and should receive a separate guarded submission RPC before broader scale.
+- Structured auditions, recruitment cooldowns/rate limits, advanced matching, and contribution/progression rewards remain out of scope.
+- Broader band permission matrices for non-recruitment systems remain unresolved.
+- Live concurrency behaviour should be verified against a real Supabase database.
+
+## Recommended Phase 3 PR 02
+
+Recommended next PR: **Guarded Band Application Submission MVP**. Move application creation into a server-authoritative RPC that validates recruiting/applications-open state, applicant eligibility, privacy/block state, duplicate pending applications, message length, role values, notification dedupe for managers, and rate-limit hooks without adding auditions or matching.

--- a/src/components/band/BandApplicationsList.test.tsx
+++ b/src/components/band/BandApplicationsList.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutate = vi.fn();
+const invalidateQueries = vi.fn();
+const toast = vi.fn();
+let queryState: any;
+let mutationPending = false;
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => queryState,
+  useQueryClient: () => ({ invalidateQueries }),
+  useMutation: (options: any) => {
+    mutate.mockImplementation(async (vars: any) => {
+      try {
+        const result = await options.mutationFn(vars);
+        options.onSuccess?.(result, vars);
+      } catch (error) {
+        options.onError?.(error, vars);
+      }
+    });
+    return { mutate, isPending: mutationPending };
+  },
+}));
+vi.mock("react-router-dom", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { from: vi.fn(), rpc: vi.fn() } }));
+vi.mock("@/services/bandApplications", () => ({
+  respondBandApplication: vi.fn(async (applicationId: string, decision: string) => ({
+    id: applicationId,
+    band_id: "band-1",
+    status: decision === "approve" ? "accepted" : "rejected",
+  })),
+}));
+
+import { respondBandApplication } from "@/services/bandApplications";
+import { BandApplicationsList } from "./BandApplicationsList";
+
+const pendingApp = {
+  id: "44444444-4444-4444-8444-444444444444",
+  applicant_profile_id: "profile-1",
+  instrument_role: "Guitar",
+  vocal_role: "Lead Vocals",
+  message: "I can rehearse nightly.",
+  status: "pending",
+  created_at: "2026-07-10T00:00:00Z",
+  profiles: { display_name: "Riley Riff", username: "riley", avatar_url: null },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutationPending = false;
+  queryState = { data: [pendingApp], isLoading: false, isError: false, error: null };
+});
+
+describe("BandApplicationsList", () => {
+  it("shows application details and calls the guarded approval service", async () => {
+    const onMemberAdded = vi.fn();
+    render(<BandApplicationsList bandId="band-1" onMemberAdded={onMemberAdded} />);
+
+    expect(screen.getByText("Riley Riff")).toBeInTheDocument();
+    expect(screen.getByText("I can rehearse nightly.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /approve application/i }));
+
+    await waitFor(() => expect(respondBandApplication).toHaveBeenCalledWith(pendingApp.id, "approve"));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: "Application Approved" }));
+    expect(onMemberAdded).toHaveBeenCalled();
+  });
+
+  it("calls the guarded rejection service and shows success feedback", async () => {
+    render(<BandApplicationsList bandId="band-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /reject application/i }));
+
+    await waitFor(() => expect(respondBandApplication).toHaveBeenCalledWith(pendingApp.id, "reject"));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: "Application Rejected" }));
+  });
+
+  it("disables decision controls while saving", () => {
+    mutationPending = true;
+    render(<BandApplicationsList bandId="band-1" />);
+
+    expect(screen.getByRole("button", { name: /approve application/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /reject application/i })).toBeDisabled();
+  });
+
+  it("shows friendly backend errors", async () => {
+    vi.mocked(respondBandApplication).mockRejectedValueOnce(new Error("You are not allowed to respond to applications for this band."));
+    render(<BandApplicationsList bandId="band-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /approve application/i }));
+
+    await waitFor(() => expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Error",
+      description: "You are not allowed to respond to applications for this band.",
+      variant: "destructive",
+    })));
+  });
+
+  it("hides active decision controls for final-state applications", () => {
+    queryState = { data: [{ ...pendingApp, status: "accepted" }], isLoading: false, isError: false, error: null };
+    render(<BandApplicationsList bandId="band-1" />);
+
+    expect(screen.queryByRole("button", { name: /approve application/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reject application/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText("accepted").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/band/BandApplicationsList.tsx
+++ b/src/components/band/BandApplicationsList.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useToast } from '@/hooks/use-toast';
 import { Check, X, ClipboardList, User, ExternalLink } from 'lucide-react';
+import { respondBandApplication, type BandApplicationDecision } from '@/services/bandApplications';
 
 interface BandApplicationsListProps {
   bandId: string;
@@ -18,7 +19,7 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  const { data: applications, isLoading } = useQuery({
+  const { data: applications, isLoading, isError, error } = useQuery({
     queryKey: ['band-applications', bandId],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -39,7 +40,6 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
           )
         `)
         .eq('band_id', bandId)
-        .eq('status', 'pending')
         .order('created_at', { ascending: true });
       if (error) throw error;
       return data;
@@ -47,53 +47,18 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
   });
 
   const respondMutation = useMutation({
-    mutationFn: async ({ applicationId, status, application }: { applicationId: string; status: 'accepted' | 'rejected'; application: any }) => {
-      // Update application status
-      const { error: updateError } = await supabase
-        .from('band_applications')
-        .update({ status, responded_at: new Date().toISOString() })
-        .eq('id', applicationId);
-      if (updateError) throw updateError;
-
-      // If accepted, add as band member
-      if (status === 'accepted') {
-        const { error: memberError } = await supabase
-          .from('band_members')
-          .insert({
-            band_id: bandId,
-            user_id: null, // Will need to look up from profile
-            profile_id: application.applicant_profile_id,
-            instrument_role: application.instrument_role,
-            vocal_role: application.vocal_role || null,
-            role: 'member',
-            member_status: 'active',
-          });
-        
-        // Get user_id from profile and update
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('user_id')
-          .eq('id', application.applicant_profile_id)
-          .single();
-        
-        if (profile?.user_id) {
-          await supabase
-            .from('band_members')
-            .update({ user_id: profile.user_id })
-            .eq('band_id', bandId)
-            .eq('profile_id', application.applicant_profile_id);
-        }
-        
-        if (memberError) throw memberError;
-      }
+    mutationFn: async ({ applicationId, decision }: { applicationId: string; decision: BandApplicationDecision }) => {
+      return respondBandApplication(applicationId, decision);
     },
-    onSuccess: (_, { status }) => {
+    onSuccess: (result, { decision }) => {
       toast({
-        title: status === 'accepted' ? 'Application Accepted' : 'Application Rejected',
-        description: status === 'accepted' ? 'New member added to the band!' : 'Application has been rejected.',
+        title: decision === 'approve' ? 'Application Approved' : 'Application Rejected',
+        description: decision === 'approve' ? 'New member added to the band.' : 'Application has been rejected.',
       });
       queryClient.invalidateQueries({ queryKey: ['band-applications', bandId] });
-      if (onMemberAdded) onMemberAdded();
+      queryClient.invalidateQueries({ queryKey: ['band-members', bandId] });
+      queryClient.invalidateQueries({ queryKey: ['band', bandId] });
+      if (result.status === 'accepted' && onMemberAdded) onMemberAdded();
     },
     onError: (error: any) => {
       toast({ title: 'Error', description: error.message, variant: 'destructive' });
@@ -101,6 +66,16 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
   });
 
   if (isLoading) return null;
+  if (isError) {
+    return (
+      <Card role="alert">
+        <CardHeader>
+          <CardTitle>Band Applications</CardTitle>
+          <CardDescription>{(error as Error)?.message || 'Applications could not be loaded.'}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
   if (!applications || applications.length === 0) return null;
 
   return (
@@ -108,13 +83,13 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
       <CardHeader>
         <div className="flex items-center gap-2">
           <ClipboardList className="h-5 w-5" />
-          <CardTitle>Pending Applications</CardTitle>
+          <CardTitle>Band Applications</CardTitle>
         </div>
-        <CardDescription>{applications.length} pending application(s)</CardDescription>
+        <CardDescription>{applications.filter((app: any) => app.status === 'pending').length} pending application(s)</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         {applications.map((app: any) => (
-          <div key={app.id} className="flex items-center justify-between rounded-lg border p-3">
+          <div key={app.id} className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
             <div 
               className="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity flex-1 min-w-0"
               onClick={() => navigate(`/player/${app.applicant_profile_id}`)}
@@ -129,8 +104,9 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
                   {app.profiles?.display_name || app.profiles?.username || 'Unknown'}
                   <ExternalLink className="h-3 w-3 text-muted-foreground" />
                 </p>
-                <div className="flex gap-2 text-xs text-muted-foreground">
+                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
                   <Badge variant="outline" className="text-xs">{app.instrument_role}</Badge>
+                  <Badge variant={app.status === 'pending' ? 'secondary' : 'outline'} className="text-xs capitalize">{app.status}</Badge>
                   {app.vocal_role && app.vocal_role !== 'None' && (
                     <Badge variant="outline" className="text-xs">{app.vocal_role}</Badge>
                   )}
@@ -140,25 +116,31 @@ export function BandApplicationsList({ bandId, onMemberAdded }: BandApplications
                 )}
               </div>
             </div>
-            <div className="flex gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                className="text-destructive"
-                onClick={() => respondMutation.mutate({ applicationId: app.id, status: 'rejected', application: app })}
-                disabled={respondMutation.isPending}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => respondMutation.mutate({ applicationId: app.id, status: 'accepted', application: app })}
-                disabled={respondMutation.isPending}
-              >
-                <Check className="h-4 w-4 mr-1" />
-                Accept
-              </Button>
-            </div>
+            {app.status === 'pending' ? (
+              <div className="flex gap-2 self-end sm:self-center">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="text-destructive"
+                  aria-label={`Reject application from ${app.profiles?.display_name || app.profiles?.username || 'applicant'}`}
+                  onClick={() => respondMutation.mutate({ applicationId: app.id, decision: 'reject' })}
+                  disabled={respondMutation.isPending}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  aria-label={`Approve application from ${app.profiles?.display_name || app.profiles?.username || 'applicant'}`}
+                  onClick={() => respondMutation.mutate({ applicationId: app.id, decision: 'approve' })}
+                  disabled={respondMutation.isPending}
+                >
+                  <Check className="h-4 w-4 mr-1" />
+                  {respondMutation.isPending ? 'Saving...' : 'Approve'}
+                </Button>
+              </div>
+            ) : (
+              <Badge variant="outline" className="self-end capitalize sm:self-center">{app.status}</Badge>
+            )}
           </div>
         ))}
       </CardContent>

--- a/src/services/__tests__/bandApplications.test.ts
+++ b/src/services/__tests__/bandApplications.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeBandApplicationResponseInput,
+  respondBandApplication,
+} from "../bandApplications";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    rpc: vi.fn(),
+  },
+}));
+
+import { supabase } from "@/integrations/supabase/client";
+
+const validApplicationId = "44444444-4444-4444-8444-444444444444";
+const validBandId = "11111111-1111-4111-8111-111111111111";
+
+describe("band application service", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("normalizes valid response input and rejects invalid decisions", () => {
+    expect(normalizeBandApplicationResponseInput(` ${validApplicationId} `, "approve")).toEqual({
+      applicationId: validApplicationId,
+      decision: "approve",
+    });
+    expect(() => normalizeBandApplicationResponseInput(validApplicationId, "accepted" as never)).toThrow("approve or reject");
+  });
+
+  it("rejects invalid application IDs before calling the backend", async () => {
+    await expect(respondBandApplication("bad-id", "approve")).rejects.toThrow("valid band application");
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("calls guarded response RPC for approval requests", async () => {
+    const row = { id: validApplicationId, band_id: validBandId, status: "accepted" };
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: row, error: null } as never);
+
+    await expect(respondBandApplication(validApplicationId, "approve")).resolves.toBe(row);
+    expect(supabase.rpc).toHaveBeenCalledWith("respond_band_application", {
+      application_id: validApplicationId,
+      decision: "approve",
+    });
+  });
+
+  it("calls guarded response RPC for rejection requests", async () => {
+    const row = { id: validApplicationId, band_id: validBandId, status: "rejected" };
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: row, error: null } as never);
+
+    await expect(respondBandApplication(validApplicationId, "reject")).resolves.toBe(row);
+    expect(supabase.rpc).toHaveBeenCalledWith("respond_band_application", {
+      application_id: validApplicationId,
+      decision: "reject",
+    });
+  });
+
+  it("surfaces backend failures", async () => {
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: null, error: { message: "This band application is no longer pending." } } as never);
+
+    await expect(respondBandApplication(validApplicationId, "reject")).rejects.toThrow("no longer pending");
+  });
+
+  it("rejects empty RPC results", async () => {
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: null, error: null } as never);
+
+    await expect(respondBandApplication(validApplicationId, "approve")).rejects.toThrow("could not be saved");
+  });
+});

--- a/src/services/bandApplications.ts
+++ b/src/services/bandApplications.ts
@@ -1,0 +1,49 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface BandApplicationResult {
+  id: string;
+  band_id: string;
+  applicant_profile_id: string;
+  instrument_role: string;
+  vocal_role: string | null;
+  message: string | null;
+  status: string;
+  created_at: string;
+  responded_at: string | null;
+}
+
+export type BandApplicationDecision = "approve" | "reject";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function assertUuid(value: string | undefined | null, message: string): string {
+  const normalized = value?.trim();
+  if (!normalized || !UUID_PATTERN.test(normalized)) {
+    throw new Error(message);
+  }
+  return normalized;
+}
+
+export function normalizeBandApplicationResponseInput(applicationId: string, decision: BandApplicationDecision) {
+  const normalizedApplicationId = assertUuid(applicationId, "Choose a valid band application.");
+  if (decision !== "approve" && decision !== "reject") {
+    throw new Error("Choose approve or reject for this band application.");
+  }
+  return { applicationId: normalizedApplicationId, decision };
+}
+
+export async function respondBandApplication(applicationId: string, decision: BandApplicationDecision): Promise<BandApplicationResult> {
+  const normalized = normalizeBandApplicationResponseInput(applicationId, decision);
+  const { data, error } = await (supabase.rpc as any)("respond_band_application", {
+    application_id: normalized.applicationId,
+    decision: normalized.decision,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Failed to respond to band application.");
+  }
+  if (!data) {
+    throw new Error("Band application response could not be saved.");
+  }
+  return data as BandApplicationResult;
+}

--- a/supabase/migrations/20260710232000_guard_band_application_responses.sql
+++ b/supabase/migrations/20260710232000_guard_band_application_responses.sql
@@ -1,0 +1,186 @@
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_approved';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_rejected';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_response_denied';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_response_retry';
+
+CREATE INDEX IF NOT EXISTS band_applications_band_status_created_idx
+  ON public.band_applications (band_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS band_members_active_profile_band_idx
+  ON public.band_members (profile_id, band_id)
+  WHERE profile_id IS NOT NULL AND COALESCE(member_status, 'active') = 'active';
+
+CREATE OR REPLACE FUNCTION public.can_manage_band_invitations(target_band_id uuid, actor_user_id uuid DEFAULT auth.uid())
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT target_band_id IS NOT NULL
+    AND actor_user_id IS NOT NULL
+    AND (
+      EXISTS (SELECT 1 FROM public.bands b WHERE b.id = target_band_id AND b.leader_id = actor_user_id)
+      OR EXISTS (
+        SELECT 1 FROM public.band_members bm
+        WHERE bm.band_id = target_band_id
+          AND bm.user_id = actor_user_id
+          AND lower(bm.role) IN ('leader', 'founder')
+          AND COALESCE(bm.member_status, 'active') = 'active'
+      )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.respond_band_application(
+  application_id uuid,
+  decision text
+)
+RETURNS public.band_applications
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_profile_id uuid;
+  applicant_user_id uuid;
+  application_row public.band_applications;
+  normalized_decision text;
+  final_status text;
+  member_id uuid;
+  band_name text;
+  notification_title text;
+  notification_message text;
+BEGIN
+  SELECT p.id INTO actor_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF actor_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before responding to band applications.' USING ERRCODE = '28000';
+  END IF;
+  IF application_id IS NULL THEN
+    RAISE EXCEPTION 'Choose a valid band application.' USING ERRCODE = '22023';
+  END IF;
+
+  normalized_decision := lower(btrim(COALESCE(decision, '')));
+  IF normalized_decision NOT IN ('approve', 'approved', 'accept', 'accepted', 'reject', 'rejected') THEN
+    RAISE EXCEPTION 'Choose approve or reject for this band application.' USING ERRCODE = '22023';
+  END IF;
+  final_status := CASE WHEN normalized_decision IN ('approve', 'approved', 'accept', 'accepted') THEN 'accepted' ELSE 'rejected' END;
+
+  SELECT * INTO application_row
+  FROM public.band_applications ba
+  WHERE ba.id = application_id
+  FOR UPDATE;
+
+  IF application_row.id IS NULL THEN
+    RAISE EXCEPTION 'That band application could not be found.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT p.user_id INTO applicant_user_id
+  FROM public.profiles p
+  WHERE p.id = application_row.applicant_profile_id;
+
+  IF applicant_user_id IS NULL THEN
+    RAISE EXCEPTION 'That applicant profile could not be found.' USING ERRCODE = '22023';
+  END IF;
+
+  IF application_row.applicant_profile_id = actor_profile_id THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+    VALUES (actor_profile_id, application_row.applicant_profile_id, 'band_application_response_denied'::public.social_action_audit_kind, 'band_application', application_id, jsonb_build_object('reason', 'self_approval_guard'));
+    RAISE EXCEPTION 'You cannot approve or reject your own band application.' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT public.can_manage_band_invitations(application_row.band_id, auth.uid()) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+    VALUES (actor_profile_id, application_row.applicant_profile_id, 'band_application_response_denied'::public.social_action_audit_kind, 'band_application', application_id, jsonb_build_object('reason', 'unauthorised_band_role'));
+    RAISE EXCEPTION 'You are not allowed to respond to applications for this band.' USING ERRCODE = '42501';
+  END IF;
+
+  IF application_row.status = final_status THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+    VALUES (actor_profile_id, application_row.applicant_profile_id, 'band_application_response_retry'::public.social_action_audit_kind, 'band_application', application_id, jsonb_build_object('status', final_status));
+    RETURN application_row;
+  END IF;
+  IF application_row.status <> 'pending' THEN
+    RAISE EXCEPTION 'This band application is no longer pending.' USING ERRCODE = '22023';
+  END IF;
+
+  IF public.are_profiles_blocked(actor_profile_id, application_row.applicant_profile_id) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+    VALUES (actor_profile_id, application_row.applicant_profile_id, 'band_application_response_denied'::public.social_action_audit_kind, 'band_application', application_id, jsonb_build_object('reason', 'block_guard'));
+    RAISE EXCEPTION 'This application cannot be approved or rejected while one of you has blocked the other.' USING ERRCODE = '42501';
+  END IF;
+
+  IF final_status = 'accepted' THEN
+    SELECT bm.id INTO member_id
+    FROM public.band_members bm
+    WHERE bm.band_id = application_row.band_id
+      AND (bm.user_id = applicant_user_id OR bm.profile_id = application_row.applicant_profile_id)
+      AND COALESCE(bm.member_status, 'active') = 'active'
+    LIMIT 1;
+
+    IF member_id IS NOT NULL THEN
+      RAISE EXCEPTION 'That player already belongs to this band.' USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO public.band_members (band_id, user_id, profile_id, role, instrument_role, vocal_role, member_status)
+    VALUES (application_row.band_id, applicant_user_id, application_row.applicant_profile_id, 'member', application_row.instrument_role, application_row.vocal_role, 'active')
+    ON CONFLICT (band_id, user_id) DO NOTHING
+    RETURNING id INTO member_id;
+
+    IF member_id IS NULL THEN
+      SELECT bm.id INTO member_id
+      FROM public.band_members bm
+      WHERE bm.band_id = application_row.band_id
+        AND bm.user_id = applicant_user_id
+        AND COALESCE(bm.member_status, 'active') = 'active'
+      LIMIT 1;
+    END IF;
+    IF member_id IS NULL THEN
+      RAISE EXCEPTION 'Band membership could not be created.' USING ERRCODE = '23505';
+    END IF;
+  END IF;
+
+  UPDATE public.band_applications
+  SET status = final_status, responded_at = now()
+  WHERE id = application_id
+  RETURNING * INTO application_row;
+
+  SELECT COALESCE(b.name, 'the band') INTO band_name FROM public.bands b WHERE b.id = application_row.band_id;
+  notification_title := CASE WHEN final_status = 'accepted' THEN 'Band application approved' ELSE 'Band application declined' END;
+  notification_message := CASE WHEN final_status = 'accepted'
+    THEN 'You joined ' || band_name || '.'
+    ELSE band_name || ' declined your band application.' END;
+
+  INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+  SELECT applicant_user_id, application_row.applicant_profile_id, 'band', 'band_request', notification_title, notification_message,
+    '/bands/' || application_row.band_id::text,
+    jsonb_build_object('band_application_id', application_row.id, 'band_id', application_row.band_id, 'band_application_status', final_status)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.notifications n
+    WHERE n.user_id = applicant_user_id
+      AND n.type = 'band_request'
+      AND n.metadata->>'band_application_id' = application_row.id::text
+      AND n.metadata->>'band_application_status' = final_status
+  );
+
+  INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+  VALUES (actor_profile_id, application_row.applicant_profile_id,
+    CASE WHEN final_status = 'accepted' THEN 'band_application_approved'::public.social_action_audit_kind ELSE 'band_application_rejected'::public.social_action_audit_kind END,
+    'band_application', application_id, jsonb_build_object('band_id', application_row.band_id));
+
+  RETURN application_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.respond_band_application(uuid, text) TO authenticated;
+
+DROP POLICY IF EXISTS "Leaders can respond to applications" ON public.band_applications;
+DROP POLICY IF EXISTS "Band application responses use guarded RPC" ON public.band_applications;
+CREATE POLICY "Band application responses use guarded RPC"
+ON public.band_applications FOR UPDATE
+USING (false)
+WITH CHECK (false);


### PR DESCRIPTION
### Motivation
- Hardening band application approval/rejection to be server-authoritative and idempotent, matching the guarded invitation flow implemented in Phase 2.
- Prevent client-trusted multi-write flows that produced duplicate memberships, stale updates, blocked-pair leaks, and inconsistent notifications.
- Provide a clear, auditable, and permission-checked path for leaders/founders to accept or reject applications without redesigning recruitment or adding auditions/rewards.

### Description
- Add a guarded RPC `respond_band_application(application_id uuid, decision text)` as a `SECURITY DEFINER` function that resolves `auth.uid()` to an actor profile, normalizes/validates decisions, locks the application row, enforces pending/final-state idempotency, enforces `can_manage_band_invitations` recruitment authority, blocks self-approval and blocked pairs, creates one `member` membership atomically on approval, updates `band_applications` final state, dedupes `notifications`, and records audit entries in `social_action_audit_log`.
- Add a corrective migration `supabase/migrations/20260710232000_guard_band_application_responses.sql` that introduces audit enum values, lookup indexes, tightens `can_manage_band_invitations`, grants RPC execution to `authenticated`, and replaces direct application-update policies with a deny-all update policy so the RPC must be used.
- Frontend/service changes: add `src/services/bandApplications.ts` and route `BandApplicationsList` UI to call `respondBandApplication()` instead of performing client-side updates/inserts; UI now shows statuses, disables controls while saving, prevents double submissions, invalidates related queries, and preserves final-state read-only views.
- Tests and docs: add service tests `src/services/__tests__/bandApplications.test.ts`, UI tests `src/components/band/BandApplicationsList.test.tsx`, and documentation `docs/social/implementation/PHASE_3_PR_01.md`, plus small factual updates to `docs/social/SOCIAL_SYSTEM_AUDIT.md` and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`.

### Testing
- Typecheck: ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully in this environment.
- Lint/build/tests: dependency installation failed in this environment (registry access issues), so `npm install` failed and `vitest`, `vite`, and ESLint plugins were not available; therefore `npm run lint`, `npm run build`, and the unit/smoke test runs could not be executed here and reported dependency/tooling failures.
- Added automated tests (service + UI) that exercise valid approval, valid rejection, invalid IDs/decisions, backend failure, empty RPC responses, disabled saving state, and final-state UI behavior; these tests were committed but could not be run due to the missing test toolchain in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a512cf3c848832584e47abbcbb06a6b)