### PR TITLE
Guard band application submissions (submit_band_application RPC + UI)

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -119,7 +119,7 @@ Other players should become the most valuable content in RockMundo because they 
 **Implementation approach**
 1. Add documentation and UI labels for existing band responsibilities.
 2. Add role metadata and permission checks in small PRs.
-3. Guard band invitation creation/response and band application approval/rejection before deeper collaboration work; the invitation lifecycle and application response path now have server-authoritative RPCs with leader/founder recruitment checks, block checks, duplicate-membership idempotency, audit logging, and notification deduplication/status updates.
+3. Guard band invitation creation/response and band application submission/approval/rejection before deeper collaboration work; the invitation lifecycle and application lifecycle now have server-authoritative RPCs with leader/founder recruitment checks, block checks, duplicate-membership idempotency, audit logging, and notification deduplication/status updates.
 4. Add contribution logs for existing band actions.
 5. Add objective templates using existing gig, song, rehearsal, and media systems.
 6. Add collaboration contracts after the generic contract framework is stable.
@@ -403,13 +403,13 @@ Safety is a core feature, not an afterthought.
 - ✅ Dedicated block/mute/report/audit primitives are implemented for the first social safety slice.
 - ✅ Invite permission checks and duplicate pending handling now exist for social invites.
 - ✅ Audit logging exists for migrated denied direct-contact actions.
-- Expand block/mute/report coverage across Twaater, realtime chat, application submission, gifts, and remaining social surfaces; guarded band invitation creation/response and application approval/rejection now cover core recruitment membership-entry decisions.
+- Expand block/mute/report coverage across Twaater, realtime chat, gifts, and remaining social surfaces; guarded band invitation creation/response and application submission/approval/rejection now cover core recruitment membership-entry decisions.
 - Add broader rate limits and admin/moderator review views before launching high-impact systems.
 
 ### Phase 3: Band and Company Cooperation
-- Add broader band roles, permissions, and contribution history; guarded band invitation creation/response and application approval/rejection now share the first server-authoritative recruitment permission and membership-entry helper path.
+- Add broader band roles, permissions, and contribution history; guarded band invitation creation/response and application submission/approval/rejection now share the first server-authoritative recruitment permission and membership-entry helper path.
 - Add company hiring profiles and job boards.
-- Add guarded application submission with safe messaging constraints; application approval/rejection is now guarded, but submission still needs its own server-authoritative entry point.
+- Guarded application submission with safe messaging constraints is now in place; remaining recruitment expansion should define withdrawal, vacancies, and auditions without bypassing the RPC lifecycle.
 - Add task templates tied to existing systems.
 
 ### Phase 4: Contracts and Escrow

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -13,7 +13,7 @@ The most important Phase 0 findings are:
 2. **Friendship exists, but block/follow/mute semantics are fragmented.** `friendships` includes a `blocked` enum state, Twaater has one-way follows, and DMs/invites exist, but block enforcement is not consistently integrated across DMs, invites, profiles, recruitment, Twaater mentions, or chat.
 3. **Communication is fragmented across Inbox, DMs, Twaater DMs, Twaater posts/replies, ChatWindow, band chat, and social invites.** Unread counts and realtime updates exist in places, but there is no single permission/muting/moderation/rate-limit layer.
 4. **Presence is count-oriented, not social-discovery-oriented.** There are Supabase presence hooks for online counts and realtime chat presence, but no public availability flags such as looking for band, members, producer, work, or services.
-5. **Band recruitment exists.** Bands have creation/management, guarded invitation creation/response, applications, member roles, band search/browser, and recruiting flags. Missing pieces include auditions, structured recruitment search filters, guarded application flows, and richer permission matrices. See `docs/social/implementation/PHASE_2_REVIEW.md` for the Phase 2 closure review.
+5. **Band recruitment exists.** Bands have creation/management, guarded invitation creation/response, guarded application submission/response, member roles, band search/browser, and recruiting flags. Missing pieces include auditions, structured recruitment search filters, withdrawal hardening, and richer permission matrices. See `docs/social/implementation/PHASE_2_REVIEW.md` for the Phase 2 closure review.
 6. **Company and employment systems exist, but social labor-market safeguards are immature.** There are companies, employees, public storefronts, reviews, shifts, jobs, and player employment. They do not yet provide a full contract-backed hiring pipeline with escrow, dispute handling, labor analytics, or block/report protections.
 7. **Moderation/admin coverage is partial.** Twaater moderation/admin exists, and reports are present in the Twaater schema, but general profile/DM/chat/invite/band/company report queues and evidence bundles are not unified.
 8. **Security posture is mixed.** Several tables use RLS participant checks, but some public read policies are intentionally broad (profiles, storefronts, shifts, reviews, band invitations) and need explicit privacy/abuse review before the MMO social expansion builds on them.
@@ -211,7 +211,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 - Bands can be created and managed through band manager/components.
 - `bands`, `band_members`, roles, instrument/vocal roles, leader/founder concepts, status, chemistry/cohesion, finances, repertoire, gigs, riders, vehicles, gear, and chat surfaces exist.
 - ✅ `band_invitations` creation now uses the guarded `send_band_invitation` RPC for new client flows, with server-side actor resolution, invite permission checks, target privacy/block checks, active-member rejection, duplicate pending invite idempotency, validation constraints, denied-attempt audit logging, and notification dedupe. Invitation responses now use the guarded `respond_band_invitation` RPC, and leader/founder cancellation has the guarded `cancel_band_invitation` RPC; response creates membership idempotently and updates related notifications.
-- ✅ `band_applications` supports applications with applicant profile, instrument/vocal role, message, status, responded timestamp, uniqueness per band/applicant, and applicant self-view. Approval/rejection now uses the guarded `respond_band_application` RPC with server-side actor resolution, pending/final-state checks, leader/founder recruitment authorization, former-member exclusion through active membership checks, applicant self-approval denial, block checks, duplicate active-membership prevention, safe default member role creation, notification dedupe, and audit logging.
+- ✅ `band_applications` supports applications with applicant profile, instrument/vocal role, message, status, responded timestamp, pending-only duplicate prevention per band/applicant, and applicant self-view. Creation now uses the guarded `submit_band_application` RPC with server-side applicant resolution, recruiting-open checks, current-member denial, block checks against recruitment managers, role/message validation, manager notification dedupe, retry idempotency, and audit logging. Approval/rejection uses the guarded `respond_band_application` RPC with server-side actor resolution, pending/final-state checks, leader/founder recruitment authorization, former-member exclusion through active membership checks, applicant self-approval denial, block checks, duplicate active-membership prevention, safe default member role creation, notification dedupe, and audit logging.
 - `bands.is_recruiting` exists.
 - Band browser/search lets players discover bands; band ratings and profiles exist.
 - Collaboration invite hooks and cross-band collaboration utilities exist for adjacent collaboration concepts.
@@ -222,13 +222,13 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 - Band leader checks vary across older schema surfaces, but invitation creation/cancellation and application approval/rejection now use the dedicated `can_manage_band_invitations` helper. The helper now requires current active leader/founder membership unless the actor is the band `leader_id`. Other band actions still need migration.
 - Auditions are not first-class. Applications include role/message but not scheduled auditions, audition media, votes, or review history.
 - Band roles exist but are not yet a complete permission matrix for finances, bookings, releases, contracts, chat moderation, invites, applications, and public announcements.
-- Band invitation creation/response and band application approval/rejection are now block-aware, duplicate-membership guarded, and server-authoritative. Application submission, auditions, leader-side invitation cancellation UI, and broader recruitment rate limits remain unresolved.
+- Band invitation creation/response and band application submission/approval/rejection are now block-aware, duplicate guarded, and server-authoritative. Auditions, application withdrawal hardening, leader-side invitation cancellation UI, and broader recruitment rate limits remain unresolved.
 
 ### Missing / risks
 
 - No structured audition flow.
 - No recruitment-specific search/matching over missing instruments, skill thresholds, city, genre, schedule, language, or availability.
-- No broad anti-spam cooldowns for invites/applications beyond duplicate pending band invitation idempotency and response idempotency.
+- No broad anti-spam cooldowns for invites/applications beyond duplicate pending band invitation/application idempotency and response idempotency.
 - No invite/application report flow or evidence retention.
 - No membership history archive with role changes and join/leave reasons as a canonical profile/band career timeline.
 
@@ -371,7 +371,7 @@ This document intentionally distinguishes **implemented**, **partial**, **fragme
 | Recruitment search | Low-Medium | Band search exists; matching filters missing.
 | Band creation | Medium | Implemented.
 | Band invites | Medium | Partial; creation is guarded server-side with privacy/block/duplicate checks, while response/read policies still need review.
-| Band applications | Medium | Implemented; auditions/matching missing.
+| Band applications | Medium | Guarded submission and response implemented; withdrawal hardening, auditions, and matching missing.
 | Auditions | Low | Not first-class.
 
 ## 10. Recommended Next PR Sequence

--- a/docs/social/implementation/PHASE_3_PR_02.md
+++ b/docs/social/implementation/PHASE_3_PR_02.md
@@ -1,0 +1,92 @@
+# Phase 3 PR 02 — Guarded Band Application Submission MVP
+
+## Recommendation source
+
+This PR implements the Phase 3 PR 01 recommendation to move band application creation behind a guarded server RPC before adding auditions, matching, contribution rewards, or broader recruitment redesign.
+
+## Previous submission flow
+
+`BandApplicationDialog` inserted directly into `band_applications` with client-supplied `band_id`, `applicant_profile_id`, instrument/vocal roles, and message. `BandProfile` hid the submit button when `bands.is_recruiting` was false, when the viewer was already in the band, or when any existing application row was found, but those were frontend checks only.
+
+## Problem
+
+Authenticated clients could attempt direct inserts, choose applicant profile IDs, choose status-adjacent fields by bypassing UI defaults, race duplicate clicks, and bypass server-side recruitment, block, message, notification, and audit rules.
+
+## Implemented flow
+
+`submit_band_application(band_id, requested_role, message)` now owns application creation. It resolves the applicant from `auth.uid()`, loads the target band, requires `bands.is_recruiting`, validates the requested instrument role and plain-text message, blocks current active target-band members, checks block relationships against leader/founder recruitment managers, returns an existing pending application on retry, creates one pending row, notifies recruitment managers once, and writes audit records without message contents.
+
+The application dialog calls the RPC through `submitBandApplication`, validates before submit, disables controls while saving, reports backend errors, invalidates application/band queries, and updates the page into an `Application Pending` state after success.
+
+## RPC contract
+
+```sql
+submit_band_application(
+  band_id uuid,
+  requested_role text default 'Guitar',
+  message text default null
+)
+returns public.band_applications
+```
+
+The RPC does not accept applicant IDs, user IDs, status, membership role, or band ownership data from the client.
+
+## Eligibility rules confirmed
+
+- Band application submission uses the existing `bands.is_recruiting` flag as the application-open check.
+- Existing UI allowed empty messages, so the RPC stores empty/whitespace-only messages as `NULL`.
+- Existing one-band global membership rules were not present for applications; this PR preserves that ambiguity and only denies active membership in the target band.
+- Existing role-specific vacancy data was not found; requested role remains a preference stored in `instrument_role`.
+- Existing application visibility remains applicant self-view plus leader/founder band application view.
+
+## Files changed
+
+- `supabase/migrations/20260710234000_guard_band_application_submission.sql`
+- `src/services/bandApplications.ts`
+- `src/services/__tests__/bandApplications.test.ts`
+- `src/components/band/BandApplicationDialog.tsx`
+- `src/components/band/BandApplicationDialog.test.tsx`
+- `src/pages/BandProfile.tsx`
+- `docs/social/implementation/PHASE_3_PR_02.md`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Database changes
+
+A corrective migration is required because the historical insert policy allowed direct authenticated inserts. The migration adds submission audit enum values, replaces the broad insert policy with a deny-all insert policy, adds a partial unique index for one pending application per applicant/band, adds an applicant/status lookup index, relaxes the old all-history uniqueness by dropping the table-level `(band_id, applicant_profile_id)` constraint, and adds a message length/trim check.
+
+## Permission model
+
+Only authenticated users with an active profile can execute the RPC. The server resolves the applicant profile from `auth.uid()`, checks target-band recruitment state, rejects target-band active members, validates fields, and checks block relationships against known recruitment managers. Frontend checks remain advisory.
+
+## Notification behaviour
+
+A valid new application creates manager notifications for leader/founder recruitment managers and the band `leader_id` owner profile when present. Notifications route to `/bands/:bandId?tab=applications`, contain application/band/applicant IDs only, and are deduped by `band_application_id`. Retries returning an existing pending application do not create duplicate manager notifications.
+
+## Audit behaviour
+
+Successful submissions, duplicate retries, invalid band attempts, missing bands, closed recruitment, invalid roles, malformed/overlong messages, and block denials are written to `social_action_audit_log`. Application message contents are not logged.
+
+## Rate-limit/cooldown handling
+
+This MVP adds a beta-safe idempotency foundation rather than a broad rate-limit framework: one active pending application per applicant and band, with repeat submissions returning the existing row. No historical rejected/accepted cooldown was invented.
+
+## Automated tests
+
+Service tests cover valid submission, invalid band ID, unsupported role, HTML/overlong message validation, backend failure, empty RPC responses, and the existing response RPC. UI tests cover guarded submission, success state callback, validation feedback, disabled saving controls, and backend error feedback.
+
+## Manual verification
+
+Recommended checks: eligible solo applicant, applicant already in target band, applicant in another band, recruiting open/closed bands, blocked applicant/manager pair, duplicate rapid clicks, valid message, invalid/overlong message, and mobile/desktop dialog layouts.
+
+## Known limitations
+
+- No structured auditions, matching, applicant scoring, reputation, or social rewards were added.
+- No role vacancy schema was found, so role-specific capacity is not enforced.
+- No global one-band application/member restriction was found; product should decide whether applicants may apply while in another band.
+- Application withdrawal remains outside this PR.
+- Local database migration validation still requires a Supabase database toolchain.
+
+## Recommended Phase 3 PR 03
+
+Implement safe application withdrawal/cancellation and recruitment manager application views around the guarded submission/response lifecycle, or define explicit role vacancy and one-band membership rules before auditions.

--- a/src/components/band/BandApplicationDialog.test.tsx
+++ b/src/components/band/BandApplicationDialog.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutate = vi.fn();
+const invalidateQueries = vi.fn();
+const toast = vi.fn();
+let mutationPending = false;
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries }),
+  useMutation: (options: any) => {
+    mutate.mockImplementation(async () => {
+      try {
+        const result = await options.mutationFn();
+        options.onSuccess?.(result);
+      } catch (error) {
+        options.onError?.(error);
+      }
+    });
+    return { mutate, isPending: mutationPending };
+  },
+}));
+vi.mock("@/hooks/use-toast", () => ({ useToast: () => ({ toast }) }));
+vi.mock("@/services/bandApplications", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/services/bandApplications")>();
+  return {
+    ...actual,
+    submitBandApplication: vi.fn(async () => ({ id: "app-1", band_id: "11111111-1111-4111-8111-111111111111", status: "pending" })),
+  };
+});
+
+import { submitBandApplication } from "@/services/bandApplications";
+import { BandApplicationDialog } from "./BandApplicationDialog";
+
+const bandId = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutationPending = false;
+});
+
+describe("BandApplicationDialog", () => {
+  it("submits through the guarded service and shows success state", async () => {
+    const onSubmitted = vi.fn();
+    render(<BandApplicationDialog bandId={bandId} bandName="The Tests" profileId="profile-1" onSubmitted={onSubmitted} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /apply to join/i }));
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: "Ready to rehearse." } });
+    fireEvent.click(screen.getByRole("button", { name: /send application/i }));
+
+    await waitFor(() => expect(submitBandApplication).toHaveBeenCalledWith(bandId, "Guitar", "Ready to rehearse."));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: "Application Sent" }));
+    expect(onSubmitted).toHaveBeenCalledWith(expect.objectContaining({ status: "pending" }));
+  });
+
+  it("validates unsupported roles and overlong/html messages before submit", async () => {
+    render(<BandApplicationDialog bandId={bandId} bandName="The Tests" profileId="profile-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /apply to join/i }));
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: "<b>bad</b>" } });
+    fireEvent.click(screen.getByRole("button", { name: /send application/i }));
+    expect(submitBandApplication).not.toHaveBeenCalled();
+    expect(await screen.findByText(/plain text/i)).toBeInTheDocument();
+  });
+
+  it("disables submit while saving", () => {
+    mutationPending = true;
+    render(<BandApplicationDialog bandId={bandId} bandName="The Tests" profileId="profile-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /apply to join/i }));
+    expect(screen.getByRole("button", { name: /sending/i })).toBeDisabled();
+  });
+
+  it("shows friendly backend errors", async () => {
+    vi.mocked(submitBandApplication).mockRejectedValueOnce(new Error("This band is not accepting applications right now."));
+    render(<BandApplicationDialog bandId={bandId} bandName="The Tests" profileId="profile-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /apply to join/i }));
+    fireEvent.click(screen.getByRole("button", { name: /send application/i }));
+
+    await waitFor(() => expect(toast).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Error",
+      description: "This band is not accepting applications right now.",
+      variant: "destructive",
+    })));
+  });
+});

--- a/src/components/band/BandApplicationDialog.tsx
+++ b/src/components/band/BandApplicationDialog.tsx
@@ -1,57 +1,68 @@
-import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { useToast } from '@/hooks/use-toast';
-import { UserPlus } from 'lucide-react';
-
-const INSTRUMENT_ROLES = ['Guitar', 'Bass', 'Drums', 'Vocals', 'Keyboard', 'Rhythm Guitar', 'Lead Guitar', 'Saxophone', 'Trumpet', 'Violin'];
-const VOCAL_ROLES = ['Lead Vocals', 'Backing Vocals', 'None'];
+import { useId, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { UserPlus } from "lucide-react";
+import {
+  BAND_APPLICATION_MESSAGE_MAX_LENGTH,
+  BAND_APPLICATION_ROLES,
+  normalizeBandApplicationSubmissionInput,
+  submitBandApplication,
+  type BandApplicationResult,
+} from "@/services/bandApplications";
 
 interface BandApplicationDialogProps {
   bandId: string;
   bandName: string;
-  profileId: string;
+  profileId?: string;
+  onSubmitted?: (application: BandApplicationResult) => void;
 }
 
-export function BandApplicationDialog({ bandId, bandName, profileId }: BandApplicationDialogProps) {
+export function BandApplicationDialog({ bandId, bandName, profileId, onSubmitted }: BandApplicationDialogProps) {
   const [open, setOpen] = useState(false);
-  const [instrumentRole, setInstrumentRole] = useState('Guitar');
-  const [vocalRole, setVocalRole] = useState('');
-  const [message, setMessage] = useState('');
+  const [instrumentRole, setInstrumentRole] = useState("Guitar");
+  const [message, setMessage] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const statusId = useId();
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const applyMutation = useMutation({
-    mutationFn: async () => {
-      const { error } = await supabase
-        .from('band_applications')
-        .insert({
-          band_id: bandId,
-          applicant_profile_id: profileId,
-          instrument_role: instrumentRole,
-          vocal_role: vocalRole || null,
-          message: message || null,
-        });
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      toast({ title: 'Application Sent', description: `Your application to ${bandName} has been submitted.` });
-      queryClient.invalidateQueries({ queryKey: ['band-application', bandId, profileId] });
+    mutationFn: async () => submitBandApplication(bandId, instrumentRole, message),
+    onSuccess: (application) => {
+      toast({ title: "Application Sent", description: `Your application to ${bandName} has been submitted.` });
+      queryClient.invalidateQueries({ queryKey: ["band-application", bandId, profileId] });
+      queryClient.invalidateQueries({ queryKey: ["band-profile", bandId] });
+      onSubmitted?.(application);
       setOpen(false);
-      setMessage('');
+      setMessage("");
+      setValidationError(null);
     },
     onError: (error: any) => {
-      const msg = error.message?.includes('duplicate') 
-        ? 'You have already applied to this band.' 
-        : error.message;
-      toast({ title: 'Error', description: msg, variant: 'destructive' });
+      const msg = error.message?.includes("duplicate") ? "You have already applied to this band." : error.message;
+      setValidationError(msg || "Could not submit your application.");
+      toast({ title: "Error", description: msg, variant: "destructive" });
     },
   });
+
+  const handleSubmit = () => {
+    try {
+      normalizeBandApplicationSubmissionInput(bandId, instrumentRole, message);
+      setValidationError(null);
+      applyMutation.mutate();
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "Check your application and try again.";
+      setValidationError(description);
+      toast({ title: "Check Application", description, variant: "destructive" });
+    }
+  };
+
+  const messageLength = message.trim().length;
+  const isSubmitDisabled = applyMutation.isPending || !profileId;
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -70,41 +81,39 @@ export function BandApplicationDialog({ bandId, bandName, profileId }: BandAppli
         </DialogHeader>
         <div className="space-y-4">
           <div>
-            <Label>Instrument Role</Label>
-            <Select value={instrumentRole} onValueChange={setInstrumentRole}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
+            <Label htmlFor="band-application-role">Instrument Role</Label>
+            <Select value={instrumentRole} onValueChange={setInstrumentRole} disabled={applyMutation.isPending}>
+              <SelectTrigger id="band-application-role" aria-label="Instrument role"><SelectValue /></SelectTrigger>
               <SelectContent>
-                {INSTRUMENT_ROLES.map(r => (
-                  <SelectItem key={r} value={r}>{r}</SelectItem>
+                {BAND_APPLICATION_ROLES.map((role) => (
+                  <SelectItem key={role} value={role}>{role}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
           <div>
-            <Label>Vocal Role (optional)</Label>
-            <Select value={vocalRole} onValueChange={setVocalRole}>
-              <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-              <SelectContent>
-                {VOCAL_ROLES.map(r => (
-                  <SelectItem key={r} value={r}>{r}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label>Message (optional)</Label>
+            <Label htmlFor="band-application-message">Message (optional)</Label>
             <Textarea
+              id="band-application-message"
               placeholder="Tell the band why you'd be a great fit..."
               value={message}
               onChange={(e) => setMessage(e.target.value)}
-              maxLength={500}
+              maxLength={BAND_APPLICATION_MESSAGE_MAX_LENGTH}
+              disabled={applyMutation.isPending}
+              aria-describedby={statusId}
             />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {messageLength}/{BAND_APPLICATION_MESSAGE_MAX_LENGTH} characters. Plain text only.
+            </p>
+          </div>
+          <div id={statusId} role="status" aria-live="polite" className="min-h-5 text-sm text-muted-foreground">
+            {applyMutation.isPending ? "Submitting your application…" : validationError}
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
-          <Button onClick={() => applyMutation.mutate()} disabled={applyMutation.isPending}>
-            {applyMutation.isPending ? 'Sending...' : 'Send Application'}
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={applyMutation.isPending}>Cancel</Button>
+          <Button onClick={handleSubmit} disabled={isSubmitDisabled}>
+            {applyMutation.isPending ? "Sending..." : "Send Application"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/pages/BandProfile.tsx
+++ b/src/pages/BandProfile.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
@@ -17,6 +18,7 @@ export default function BandProfile() {
   const { t } = useTranslation();
   const { bandId } = useParams();
   const { profileId } = useActiveProfile();
+  const [submittedApplication, setSubmittedApplication] = useState<{ id: string; status: string } | null>(null);
 
   const { data: band, isLoading } = useQuery({
     queryKey: ["band-profile", bandId],
@@ -76,6 +78,9 @@ export default function BandProfile() {
         .select("id, status")
         .eq("band_id", bandId)
         .eq("applicant_profile_id", profileId)
+        .eq("status", "pending")
+        .order("created_at", { ascending: false })
+        .limit(1)
         .maybeSingle();
       return data;
     },
@@ -106,7 +111,8 @@ export default function BandProfile() {
     );
   }
 
-  const canApply = band.is_recruiting && !isMember && !existingApplication && profileId;
+  const activeApplication = submittedApplication || existingApplication;
+  const canApply = band.is_recruiting && !isMember && !activeApplication && profileId;
 
   return (
     <FMPageScaffold title={band.name} subtitle={band.genre || undefined} icon={Users} backTo="/hub/band">
@@ -165,11 +171,12 @@ export default function BandProfile() {
                     bandId={band.id}
                     bandName={band.name}
                     profileId={profileId!}
+                    onSubmitted={(application) => setSubmittedApplication({ id: application.id, status: application.status })}
                   />
                 )}
-                {existingApplication && (
+                {activeApplication && (
                   <Badge variant="outline" className="text-xs">
-                    {existingApplication.status === 'pending' ? 'Application Pending' : `Application ${existingApplication.status}`}
+                    {activeApplication.status === 'pending' ? 'Application Pending' : `Application ${activeApplication.status}`}
                   </Badge>
                 )}
               </div>

--- a/src/services/__tests__/bandApplications.test.ts
+++ b/src/services/__tests__/bandApplications.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeBandApplicationResponseInput,
+  normalizeBandApplicationSubmissionInput,
   respondBandApplication,
+  submitBandApplication,
 } from "../bandApplications";
 
 vi.mock("@/integrations/supabase/client", () => ({
@@ -17,6 +19,44 @@ const validBandId = "11111111-1111-4111-8111-111111111111";
 
 describe("band application service", () => {
   beforeEach(() => vi.clearAllMocks());
+
+
+  it("normalizes valid submission input", () => {
+    expect(normalizeBandApplicationSubmissionInput(` ${validBandId} `, "Guitar", "  Ready to rehearse.  ")).toEqual({
+      bandId: validBandId,
+      requestedRole: "Guitar",
+      message: "Ready to rehearse.",
+    });
+  });
+
+  it("rejects invalid submission input before calling the backend", async () => {
+    expect(() => normalizeBandApplicationSubmissionInput("bad-id", "Guitar", "")).toThrow("valid band");
+    expect(() => normalizeBandApplicationSubmissionInput(validBandId, "leader", "")).toThrow("valid instrument");
+    expect(() => normalizeBandApplicationSubmissionInput(validBandId, "Guitar", "<b>hi</b>")).toThrow("plain text");
+    expect(() => normalizeBandApplicationSubmissionInput(validBandId, "Guitar", "x".repeat(501))).toThrow("500 characters");
+    await expect(submitBandApplication("bad-id", "Guitar", "")).rejects.toThrow("valid band");
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("calls guarded submission RPC for application requests", async () => {
+    const row = { id: validApplicationId, band_id: validBandId, status: "pending", instrument_role: "Guitar" };
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: row, error: null } as never);
+
+    await expect(submitBandApplication(validBandId, "Guitar", " Let me join. ")).resolves.toBe(row);
+    expect(supabase.rpc).toHaveBeenCalledWith("submit_band_application", {
+      band_id: validBandId,
+      requested_role: "Guitar",
+      message: "Let me join.",
+    });
+  });
+
+  it("surfaces submission backend failures and empty responses", async () => {
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: null, error: { message: "This band is not accepting applications right now." } } as never);
+    await expect(submitBandApplication(validBandId, "Guitar", "")).rejects.toThrow("not accepting applications");
+
+    vi.mocked(supabase.rpc).mockResolvedValueOnce({ data: null, error: null } as never);
+    await expect(submitBandApplication(validBandId, "Guitar", "")).rejects.toThrow("could not be submitted");
+  });
 
   it("normalizes valid response input and rejects invalid decisions", () => {
     expect(normalizeBandApplicationResponseInput(` ${validApplicationId} `, "approve")).toEqual({

--- a/src/services/bandApplications.ts
+++ b/src/services/bandApplications.ts
@@ -14,7 +14,25 @@ export interface BandApplicationResult {
 
 export type BandApplicationDecision = "approve" | "reject";
 
+export const BAND_APPLICATION_MESSAGE_MAX_LENGTH = 500;
+export const BAND_APPLICATION_ROLES = [
+  "Guitar",
+  "Bass",
+  "Drums",
+  "Vocals",
+  "Keyboard",
+  "Rhythm Guitar",
+  "Lead Guitar",
+  "Saxophone",
+  "Trumpet",
+  "Violin",
+  "Other",
+] as const;
+
+export type BandApplicationRole = (typeof BAND_APPLICATION_ROLES)[number];
+
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HTML_PATTERN = /<[^>]*>/;
 
 function assertUuid(value: string | undefined | null, message: string): string {
   const normalized = value?.trim();
@@ -22,6 +40,39 @@ function assertUuid(value: string | undefined | null, message: string): string {
     throw new Error(message);
   }
   return normalized;
+}
+
+export function normalizeBandApplicationSubmissionInput(bandId: string | undefined | null, requestedRole: string, message: string) {
+  const normalizedBandId = assertUuid(bandId, "Choose a valid band before applying.");
+  const normalizedRole = requestedRole.trim() || "Guitar";
+  if (!BAND_APPLICATION_ROLES.includes(normalizedRole as BandApplicationRole)) {
+    throw new Error("Choose a valid instrument role.");
+  }
+  const trimmedMessage = message.trim();
+  if (trimmedMessage.length > BAND_APPLICATION_MESSAGE_MAX_LENGTH) {
+    throw new Error(`Band application messages must be ${BAND_APPLICATION_MESSAGE_MAX_LENGTH} characters or fewer.`);
+  }
+  if (HTML_PATTERN.test(trimmedMessage)) {
+    throw new Error("Band application messages must be plain text.");
+  }
+  return { bandId: normalizedBandId, requestedRole: normalizedRole, message: trimmedMessage };
+}
+
+export async function submitBandApplication(bandId: string, requestedRole: string, message: string): Promise<BandApplicationResult> {
+  const normalized = normalizeBandApplicationSubmissionInput(bandId, requestedRole, message);
+  const { data, error } = await (supabase.rpc as any)("submit_band_application", {
+    band_id: normalized.bandId,
+    requested_role: normalized.requestedRole,
+    message: normalized.message,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Failed to submit band application.");
+  }
+  if (!data) {
+    throw new Error("Band application could not be submitted.");
+  }
+  return data as BandApplicationResult;
 }
 
 export function normalizeBandApplicationResponseInput(applicationId: string, decision: BandApplicationDecision) {

--- a/supabase/migrations/20260710234000_guard_band_application_submission.sql
+++ b/supabase/migrations/20260710234000_guard_band_application_submission.sql
@@ -1,0 +1,167 @@
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_submitted';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_submit_denied';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_application_submit_retry';
+
+ALTER TABLE public.band_applications
+  DROP CONSTRAINT IF EXISTS band_applications_band_id_applicant_profile_id_key;
+
+ALTER TABLE public.band_applications
+  DROP CONSTRAINT IF EXISTS band_applications_message_length;
+ALTER TABLE public.band_applications
+  ADD CONSTRAINT band_applications_message_length
+  CHECK (message IS NULL OR (message = btrim(message) AND char_length(message) <= 500));
+
+CREATE UNIQUE INDEX IF NOT EXISTS band_applications_one_pending_per_profile_band_idx
+  ON public.band_applications (band_id, applicant_profile_id)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS band_applications_applicant_status_created_idx
+  ON public.band_applications (applicant_profile_id, status, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.submit_band_application(
+  band_id uuid,
+  requested_role text DEFAULT 'Guitar',
+  message text DEFAULT NULL
+)
+RETURNS public.band_applications
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  target_band_id ALIAS FOR $1;
+  raw_requested_role ALIAS FOR $2;
+  raw_message ALIAS FOR $3;
+  applicant_profile_id uuid;
+  target_band public.bands;
+  normalized_role text;
+  trimmed_message text;
+  existing_application public.band_applications;
+  application_row public.band_applications;
+  manager_record record;
+BEGIN
+  SELECT p.id INTO applicant_profile_id
+  FROM public.profiles p
+  WHERE p.user_id = auth.uid()
+  ORDER BY p.created_at ASC
+  LIMIT 1;
+
+  IF applicant_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Sign in with an active player profile before applying to bands.' USING ERRCODE = '28000';
+  END IF;
+  IF target_band_id IS NULL THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', jsonb_build_object('reason', 'invalid_band'));
+    RAISE EXCEPTION 'Choose a valid band before applying.' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO target_band FROM public.bands b WHERE b.id = target_band_id;
+  IF target_band.id IS NULL THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'missing_band'));
+    RAISE EXCEPTION 'That band could not be found.' USING ERRCODE = '22023';
+  END IF;
+  IF NOT COALESCE(target_band.is_recruiting, false) THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'recruitment_closed'));
+    RAISE EXCEPTION 'This band is not accepting applications right now.' USING ERRCODE = '22023';
+  END IF;
+
+  normalized_role := COALESCE(NULLIF(btrim(raw_requested_role), ''), 'Guitar');
+  IF normalized_role NOT IN ('Guitar', 'Bass', 'Drums', 'Vocals', 'Keyboard', 'Rhythm Guitar', 'Lead Guitar', 'Saxophone', 'Trumpet', 'Violin', 'Other') THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'invalid_role'));
+    RAISE EXCEPTION 'Choose a valid instrument role.' USING ERRCODE = '22023';
+  END IF;
+
+  trimmed_message := NULLIF(btrim(COALESCE(raw_message, '')), '');
+  IF trimmed_message IS NOT NULL AND char_length(trimmed_message) > 500 THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'message_too_long'));
+    RAISE EXCEPTION 'Band application messages must be 500 characters or fewer.' USING ERRCODE = '22023';
+  END IF;
+  IF trimmed_message IS NOT NULL AND trimmed_message <> regexp_replace(trimmed_message, '<[^>]*>', '', 'g') THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'html_message'));
+    RAISE EXCEPTION 'Band application messages must be plain text.' USING ERRCODE = '22023';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.band_members bm
+    WHERE bm.band_id = target_band_id
+      AND (bm.profile_id = applicant_profile_id OR bm.user_id = auth.uid())
+      AND COALESCE(bm.member_status, 'active') = 'active'
+  ) THEN
+    RAISE EXCEPTION 'You already belong to this band.' USING ERRCODE = '22023';
+  END IF;
+
+  FOR manager_record IN
+    SELECT DISTINCT COALESCE(bm.profile_id, p.id) AS profile_id
+    FROM public.band_members bm
+    LEFT JOIN public.profiles p ON p.user_id = bm.user_id
+    WHERE bm.band_id = target_band_id
+      AND lower(bm.role) IN ('leader', 'founder')
+      AND COALESCE(bm.member_status, 'active') = 'active'
+      AND COALESCE(bm.profile_id, p.id) IS NOT NULL
+    UNION
+    SELECT p.id FROM public.profiles p WHERE p.user_id = target_band.leader_id
+  LOOP
+    IF public.are_profiles_blocked(applicant_profile_id, manager_record.profile_id) THEN
+      INSERT INTO public.social_action_audit_log (actor_profile_id, target_profile_id, action, target_type, target_id, metadata)
+      VALUES (applicant_profile_id, manager_record.profile_id, 'band_application_submit_denied'::public.social_action_audit_kind, 'band', target_band_id, jsonb_build_object('reason', 'block_guard'));
+      RAISE EXCEPTION 'You cannot apply to this band while one of you has blocked the other.' USING ERRCODE = '42501';
+    END IF;
+  END LOOP;
+
+  SELECT * INTO existing_application
+  FROM public.band_applications ba
+  WHERE ba.band_id = target_band_id AND ba.applicant_profile_id = applicant_profile_id AND ba.status = 'pending'
+  ORDER BY ba.created_at DESC
+  LIMIT 1;
+  IF existing_application.id IS NOT NULL THEN
+    INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+    VALUES (applicant_profile_id, 'band_application_submit_retry'::public.social_action_audit_kind, 'band_application', existing_application.id, jsonb_build_object('band_id', target_band_id));
+    RETURN existing_application;
+  END IF;
+
+  INSERT INTO public.band_applications (band_id, applicant_profile_id, instrument_role, vocal_role, message, status)
+  VALUES (target_band_id, applicant_profile_id, normalized_role, NULL, trimmed_message, 'pending')
+  RETURNING * INTO application_row;
+
+  INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+  SELECT DISTINCT manager_user_id, manager_profile_id, 'band', 'band_request', 'New band application', 'A player applied to join ' || COALESCE(target_band.name, 'your band') || '.',
+    '/bands/' || target_band_id::text || '?tab=applications',
+    jsonb_build_object('band_application_id', application_row.id, 'band_id', target_band_id, 'applicant_profile_id', applicant_profile_id)
+  FROM (
+    SELECT bm.user_id AS manager_user_id, COALESCE(bm.profile_id, p.id) AS manager_profile_id
+    FROM public.band_members bm
+    LEFT JOIN public.profiles p ON p.user_id = bm.user_id
+    WHERE bm.band_id = target_band_id
+      AND lower(bm.role) IN ('leader', 'founder')
+      AND COALESCE(bm.member_status, 'active') = 'active'
+    UNION
+    SELECT target_band.leader_id, p.id FROM public.profiles p WHERE p.user_id = target_band.leader_id
+  ) managers
+  WHERE manager_user_id IS NOT NULL
+    AND manager_profile_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.notifications n
+      WHERE n.user_id = manager_user_id
+        AND n.type = 'band_request'
+        AND n.metadata->>'band_application_id' = application_row.id::text
+    );
+
+  INSERT INTO public.social_action_audit_log (actor_profile_id, action, target_type, target_id, metadata)
+  VALUES (applicant_profile_id, 'band_application_submitted'::public.social_action_audit_kind, 'band_application', application_row.id, jsonb_build_object('band_id', target_band_id, 'requested_role', normalized_role));
+
+  RETURN application_row;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_band_application(uuid, text, text) TO authenticated;
+
+DROP POLICY IF EXISTS "Users can apply to bands" ON public.band_applications;
+DROP POLICY IF EXISTS "Band application submissions use guarded RPC" ON public.band_applications;
+CREATE POLICY "Band application submissions use guarded RPC"
+ON public.band_applications FOR INSERT TO authenticated
+WITH CHECK (false);


### PR DESCRIPTION
### Motivation
- Replace unsafe client-side inserts into `band_applications` with a server-authoritative submission path to enforce eligibility, block/privacy checks, and consistent notifications. 
- Prevent duplicate pending applications and duplicate manager notifications while preserving existing approval/rejection behavior.
- Add conservative message/role validation, an idempotency foundation for rapid retries, and minimal UI submission states without introducing auditions, scoring, or broad permission redesign.

### Description
- Add a guarded RPC `submit_band_application(band_id uuid, requested_role text, message text)` implemented in `supabase/migrations/20260710234000_guard_band_application_submission.sql` that resolves the applicant from `auth.uid()`, validates the band and `is_recruiting`, enforces block checks against recruitment managers, returns an existing pending application on retry, creates one `pending` application row, inserts manager notifications once, and writes audit entries (without logging message contents). 
- Harden DB constraints and indexes by adding `band_applications_message_length` check, a partial unique index `band_applications_one_pending_per_profile_band_idx` for pending-only duplicate prevention, and an applicant/status lookup index; replace the broad authenticated INSERT policy with a deny policy so the RPC is the authoritative creation path. 
- Add client service helpers in `src/services/bandApplications.ts`: `normalizeBandApplicationSubmissionInput`, `submitBandApplication`, role/message constants, and reuse of the existing `respondBandApplication` helpers. 
- Update UI components to use the guarded RPC: `BandApplicationDialog.tsx` now validates input, disables controls while saving, displays accessible status text, handles backend errors, invalidates queries, and calls a post-submit callback; `BandProfile.tsx` now queries pending-only applications and merges a local `submittedApplication` state so the page immediately shows an "Application Pending" state after success. 
- Add focused tests: service tests in `src/services/__tests__/bandApplications.test.ts` for submission normalization/validation and RPC invocation, and UI tests in `src/components/band/BandApplicationDialog.test.tsx` for submit flow, validation, disabled state, and error feedback. 
- Add docs and audit updates at `docs/social/implementation/PHASE_3_PR_02.md` and update `docs/social/SOCIAL_SYSTEM_AUDIT.md` and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md` to reflect guarded submission and remaining limitations.

### Testing
- Ran typechecking with `npm run typecheck` which succeeded. 
- Ran `git diff --check` which reported no diff problems. 
- Attempted unit tests with `npm run test:unit` / `vitest` but the environment lacks `vitest` so unit tests could not be executed here (tests were added under `src/services/__tests__` and `src/components/band`). 
- Attempted lint and build via `npm run lint` and `npm run build` but these could not complete in this environment due to missing dev dependencies (`@eslint/js`, `vite`) and `npm install` failing against registry access for a dependency, so full lint/build and migration validation were not run. 
- Migration SQL was added for review and should be validated and applied in a Supabase-enabled environment; local Supabase CLI/migration validation was not available in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51306c56a48325bddf5ec935abf984)