### PR TITLE
Complete company recruitment and player employment lifecycle

### DIFF
--- a/src/components/company/CompanyRecruitmentLifecycle.tsx
+++ b/src/components/company/CompanyRecruitmentLifecycle.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
+import { Briefcase, DollarSign, MapPin, Plus, Users, XCircle, CheckCircle2 } from "lucide-react";
+
+const STAFF = ["manager", "assistant_manager", "customer_service", "sales", "marketing", "finance", "security", "technician", "cleaner", "specialist"];
+const EMPLOYMENT_TYPES = ["full_time", "part_time", "contract", "temporary"];
+
+interface Props {
+  companyId: string;
+  companyName: string;
+  headquartersCityId?: string | null;
+}
+
+export function CompanyRecruitmentLifecycle({ companyId, companyName, headquartersCityId }: Props) {
+  const { toast } = useToast();
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [selectedVacancy, setSelectedVacancy] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [staffCategory, setStaffCategory] = useState("specialist");
+  const [positions, setPositions] = useState(1);
+  const [weeklyWage, setWeeklyWage] = useState(500);
+  const [employmentType, setEmploymentType] = useState("full_time");
+  const [closesAt, setClosesAt] = useState("");
+  const [cityId, setCityId] = useState(headquartersCityId ?? "");
+
+  const reset = () => {
+    setTitle(""); setDescription(""); setStaffCategory("specialist"); setPositions(1); setWeeklyWage(500); setEmploymentType("full_time"); setClosesAt(""); setCityId(headquartersCityId ?? "");
+  };
+
+  const { data: cities = [] } = useQuery({
+    queryKey: ["cities-for-company-recruitment"],
+    queryFn: async () => {
+      const { data, error } = await supabase.from("cities").select("id, name, country").order("country").order("name");
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const { data: vacancies = [], isLoading } = useQuery({
+    queryKey: ["company-vacancies", companyId],
+    queryFn: async () => {
+      const { data, error } = await (supabase.from("company_vacancies") as any)
+        .select("*, cities:location_city_id(name, country), company_job_applications(id,status,suitability_score,created_at,applicant_profile_id,message, profiles:applicant_profile_id(display_name,avatar_url))")
+        .eq("company_id", companyId)
+        .order("updated_at", { ascending: false });
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const { data: employees = [] } = useQuery({
+    queryKey: ["company-lifecycle-employees", companyId],
+    queryFn: async () => {
+      const { data, error } = await (supabase.from("company_employees") as any)
+        .select("*, profiles:profile_id(display_name, avatar_url)")
+        .eq("company_id", companyId)
+        .order("status", { ascending: true })
+        .order("hired_at", { ascending: false });
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const saveVacancy = useMutation({
+    mutationFn: async (action: "save_draft" | "publish") => {
+      const { error } = await (supabase as any).rpc("manage_company_vacancy", {
+        p_company_id: companyId,
+        p_action: action,
+        p_job_title: title,
+        p_staff_category: staffCategory,
+        p_description: description || null,
+        p_positions_available: positions,
+        p_weekly_wage: weeklyWage,
+        p_employment_type: employmentType,
+        p_is_permanent: employmentType !== "contract" && employmentType !== "temporary",
+        p_required_skills: {},
+        p_preferred_skills: {},
+        p_minimum_skill_levels: {},
+        p_location_city_id: cityId || null,
+        p_expected_activity_level: "regular",
+        p_closes_at: closesAt ? new Date(closesAt).toISOString() : null,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => { toast({ title: "Vacancy saved" }); qc.invalidateQueries({ queryKey: ["company-vacancies", companyId] }); setOpen(false); reset(); },
+    onError: (e: Error) => toast({ title: "Could not save vacancy", description: e.message, variant: "destructive" }),
+  });
+
+  const vacancyAction = useMutation({
+    mutationFn: async ({ id, action }: { id: string; action: "close" | "cancel" | "reopen" }) => {
+      const { error } = await (supabase as any).rpc("manage_company_vacancy", { p_vacancy_id: id, p_action: action });
+      if (error) throw error;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["company-vacancies", companyId] }),
+    onError: (e: Error) => toast({ title: "Vacancy action failed", description: e.message, variant: "destructive" }),
+  });
+
+  const review = useMutation({
+    mutationFn: async ({ id, action }: { id: string; action: "offer" | "reject" }) => {
+      const { error } = await (supabase as any).rpc("review_company_application", { p_application_id: id, p_action: action });
+      if (error) throw error;
+    },
+    onSuccess: () => { toast({ title: "Application updated" }); qc.invalidateQueries({ queryKey: ["company-vacancies", companyId] }); },
+    onError: (e: Error) => toast({ title: "Review failed", description: e.message, variant: "destructive" }),
+  });
+
+  const dismiss = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await (supabase as any).rpc("dismiss_company_employee", { p_employee_id: id, p_reason: "Dismissed by company management" });
+      if (error) throw error;
+    },
+    onSuccess: () => { toast({ title: "Employee dismissed" }); qc.invalidateQueries({ queryKey: ["company-lifecycle-employees", companyId] }); },
+    onError: (e: Error) => toast({ title: "Dismissal failed", description: e.message, variant: "destructive" }),
+  });
+
+  const currentVacancy = useMemo(() => vacancies.find((v: any) => v.id === selectedVacancy), [selectedVacancy, vacancies]);
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2"><Briefcase className="h-5 w-5" />Recruitment</CardTitle>
+            <CardDescription>Create vacancies, review applications, make offers, and preserve hiring history for {companyName}.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => setOpen(true)}><Plus className="h-4 w-4 mr-2" />Create vacancy</Button>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? <p className="text-sm text-muted-foreground">Loading vacancies…</p> : vacancies.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground"><Briefcase className="h-10 w-10 mx-auto mb-3 opacity-50" /><p>No vacancies yet.</p></div>
+          ) : <div className="grid gap-3 md:grid-cols-2">
+            {vacancies.map((v: any) => {
+              const applications = v.company_job_applications ?? [];
+              return <div key={v.id} className="rounded-lg border p-3 space-y-2">
+                <div className="flex items-start justify-between gap-2"><div><p className="font-medium">{v.job_title}</p><p className="text-xs text-muted-foreground">{v.staff_category} • {v.cities?.name ?? "No city"}</p></div><Badge variant={v.status === "open" ? "default" : "secondary"}>{v.status}</Badge></div>
+                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground"><span className="flex items-center gap-1"><DollarSign className="h-3 w-3" />${v.weekly_wage}/week</span><span className="flex items-center gap-1"><Users className="h-3 w-3" />{v.positions_filled}/{v.positions_available} filled</span><span>{applications.length} applications</span></div>
+                <div className="flex flex-wrap gap-2">
+                  <Button size="sm" variant="outline" onClick={() => setSelectedVacancy(v.id)}>View applicants</Button>
+                  {v.status === "open" && <Button size="sm" variant="outline" onClick={() => vacancyAction.mutate({ id: v.id, action: "close" })}>Close</Button>}
+                  {v.status === "closed" && <Button size="sm" variant="outline" onClick={() => vacancyAction.mutate({ id: v.id, action: "reopen" })}>Reopen</Button>}
+                  {!["filled", "cancelled"].includes(v.status) && <Button size="sm" variant="destructive" onClick={() => vacancyAction.mutate({ id: v.id, action: "cancel" })}>Cancel</Button>}
+                </div>
+              </div>;
+            })}
+          </div>}
+        </CardContent>
+      </Card>
+
+      {currentVacancy && <Card>
+        <CardHeader><CardTitle>Applicants for {currentVacancy.job_title}</CardTitle><CardDescription>Owners only see public profile details, suitability scores, and application messages.</CardDescription></CardHeader>
+        <CardContent className="space-y-3">
+          {(currentVacancy.company_job_applications ?? []).length === 0 ? <p className="text-sm text-muted-foreground">No applications yet.</p> : (currentVacancy.company_job_applications ?? []).map((app: any) => <div key={app.id} className="rounded-lg border p-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div><p className="font-medium">{app.profiles?.display_name ?? "Applicant"}</p><p className="text-sm text-muted-foreground">{app.message || "No message supplied."}</p><div className="flex gap-2 mt-1"><Badge variant="outline">{app.status}</Badge><Badge>Suitability {app.suitability_score}%</Badge></div></div>
+            <div className="flex gap-2"><Button size="sm" onClick={() => review.mutate({ id: app.id, action: "offer" })} disabled={!['pending','application_submitted'].includes(app.status)}><CheckCircle2 className="h-4 w-4 mr-1" />Offer</Button><Button size="sm" variant="destructive" onClick={() => review.mutate({ id: app.id, action: "reject" })} disabled={!['pending','application_submitted','offer_made'].includes(app.status)}><XCircle className="h-4 w-4 mr-1" />Reject</Button></div>
+          </div>)}
+        </CardContent>
+      </Card>}
+
+      <Card>
+        <CardHeader><CardTitle>Staff</CardTitle><CardDescription>NPC and real-player staff that feed the weekly company finance processor.</CardDescription></CardHeader>
+        <CardContent className="space-y-2">
+          {employees.length === 0 ? <p className="text-sm text-muted-foreground">No staff records yet.</p> : employees.map((emp: any) => <div key={emp.id} className="rounded-lg border p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div><p className="font-medium">{emp.profiles?.display_name ?? emp.job_title ?? emp.role}</p><p className="text-xs text-muted-foreground">{emp.employee_type} • {emp.staff_category} • ${emp.weekly_wage ?? emp.salary}/week • suitability {emp.suitability_rating ?? 0}%</p></div>
+            <div className="flex gap-2 items-center"><Badge variant={emp.status === "active" ? "default" : "secondary"}>{emp.contract_status ?? emp.status}</Badge>{emp.employee_type === "player" && emp.status === "active" && <AlertDialog><AlertDialogTrigger asChild><Button size="sm" variant="destructive">Dismiss</Button></AlertDialogTrigger><AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Dismiss employee?</AlertDialogTitle><AlertDialogDescription>This preserves employment history and stops future wages/performance contributions.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={() => dismiss.mutate(emp.id)}>Dismiss</AlertDialogAction></AlertDialogFooter></AlertDialogContent></AlertDialog>}</div>
+          </div>)}
+        </CardContent>
+      </Card>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto"><DialogHeader><DialogTitle>Create company vacancy</DialogTitle><DialogDescription>Use server-side validation to save a draft or publish to the player jobs marketplace.</DialogDescription></DialogHeader>
+          <div className="space-y-4"><div><Label>Job title</Label><Input value={title} onChange={(e) => setTitle(e.target.value)} /></div><div><Label>Description</Label><Textarea value={description} onChange={(e) => setDescription(e.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-3"><div><Label>Staff category</Label><Select value={staffCategory} onValueChange={setStaffCategory}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{STAFF.map((s) => <SelectItem key={s} value={s}>{s.replaceAll("_", " ")}</SelectItem>)}</SelectContent></Select></div><div><Label>Employment type</Label><Select value={employmentType} onValueChange={setEmploymentType}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{EMPLOYMENT_TYPES.map((s) => <SelectItem key={s} value={s}>{s.replaceAll("_", " ")}</SelectItem>)}</SelectContent></Select></div></div>
+            <div className="grid grid-cols-3 gap-3"><div><Label>Positions</Label><Input type="number" min={1} value={positions} onChange={(e) => setPositions(Number(e.target.value) || 1)} /></div><div><Label>Weekly wage</Label><Input type="number" min={0} value={weeklyWage} onChange={(e) => setWeeklyWage(Number(e.target.value) || 0)} /></div><div><Label>Closing date</Label><Input type="date" value={closesAt} onChange={(e) => setClosesAt(e.target.value)} /></div></div>
+            <div><Label>Location</Label><Select value={cityId} onValueChange={setCityId}><SelectTrigger><SelectValue placeholder="Choose city" /></SelectTrigger><SelectContent>{cities.map((c: any) => <SelectItem key={c.id} value={c.id}><MapPin className="h-3 w-3 mr-1 inline" />{c.name}, {c.country}</SelectItem>)}</SelectContent></Select></div>
+          </div><DialogFooter><Button variant="outline" onClick={() => saveVacancy.mutate("save_draft")}>Save draft</Button><Button onClick={() => saveVacancy.mutate("publish")}>Publish</Button></DialogFooter></DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/lib/companyRecruitmentLifecycle.test.ts
+++ b/src/lib/companyRecruitmentLifecycle.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { calculateCompanyJobSuitability } from "./companyRecruitmentLifecycle";
+
+describe("company recruitment lifecycle suitability", () => {
+  it("rates strong candidates as good or excellent matches", () => {
+    const result = calculateCompanyJobSuitability({
+      requiredSkills: { marketing: 3, sales: 2 },
+      preferredSkills: { leadership: 2 },
+      playerSkills: { marketing: 4, sales: 2, leadership: 3 },
+      sameLocation: true,
+      fame: 300,
+    });
+    expect(result.score).toBeGreaterThanOrEqual(70);
+    expect(["Good match", "Excellent match"]).toContain(result.rating);
+    expect(result.missingRequirements).toHaveLength(0);
+  });
+
+  it("preserves explainable missing requirements without hard-blocking suitability", () => {
+    const result = calculateCompanyJobSuitability({
+      requiredSkills: { security: 5 },
+      playerSkills: { security: 1 },
+      sameLocation: false,
+      hasFullTimeConflict: true,
+    });
+    expect(result.score).toBeLessThan(45);
+    expect(result.rating).toBe("Poor match");
+    expect(result.missingRequirements).toContain("security 5+");
+    expect(result.missingRequirements).toContain("No conflicting full-time employment");
+  });
+});

--- a/src/lib/companyRecruitmentLifecycle.ts
+++ b/src/lib/companyRecruitmentLifecycle.ts
@@ -1,0 +1,55 @@
+export type SuitabilityInput = {
+  requiredSkills?: Record<string, number>;
+  preferredSkills?: Record<string, number>;
+  playerSkills?: Record<string, number>;
+  sameLocation?: boolean;
+  hasFullTimeConflict?: boolean;
+  fame?: number;
+};
+
+export function calculateCompanyJobSuitability(input: SuitabilityInput) {
+  let score = 50;
+  const reasons: string[] = [];
+  const missingRequirements: string[] = [];
+  const required = input.requiredSkills ?? {};
+  const preferred = input.preferredSkills ?? {};
+  const skills = input.playerSkills ?? {};
+
+  for (const [skill, level] of Object.entries(required)) {
+    const actual = skills[skill] ?? 0;
+    if (actual >= level) {
+      score += 8;
+      reasons.push(`Meets required ${skill}`);
+    } else {
+      score -= 12;
+      missingRequirements.push(`${skill} ${level}+`);
+    }
+  }
+
+  for (const [skill, level] of Object.entries(preferred)) {
+    const actual = skills[skill] ?? 0;
+    if (actual >= level) {
+      score += 4;
+      reasons.push(`Matches preferred ${skill}`);
+    }
+  }
+
+  if (input.sameLocation) {
+    score += 10;
+    reasons.push("Already in the company location");
+  } else {
+    score -= 10;
+    reasons.push("Would need to travel or relocate");
+  }
+
+  if (input.hasFullTimeConflict) {
+    score -= 30;
+    missingRequirements.push("No conflicting full-time employment");
+  }
+
+  score += Math.min(10, Math.floor((input.fame ?? 0) / 100));
+  score = Math.max(0, Math.min(100, score));
+
+  const rating = score >= 85 ? "Excellent match" : score >= 70 ? "Good match" : score >= 45 ? "Partial match" : "Poor match";
+  return { score, rating, reasons, missingRequirements };
+}

--- a/src/pages/CompanyDetail.tsx
+++ b/src/pages/CompanyDetail.tsx
@@ -25,7 +25,7 @@ import { CompanyTaxOverview } from "@/components/company/CompanyTaxOverview";
 import { PlayerStaffBonusCard } from "@/components/company/PlayerStaffBonusCard";
 import { EmpireDashboard } from "@/components/company/EmpireDashboard";
 import { CompanySharesPanel } from "@/components/company/CompanySharesPanel";
-import { CompanyJobListings } from "@/components/company/CompanyJobListings";
+import { CompanyRecruitmentLifecycle } from "@/components/company/CompanyRecruitmentLifecycle";
 import { CompanyWeeklyFinancePanel } from "@/components/company/CompanyWeeklyFinancePanel";
 import { CompanyStorefrontManager } from "@/components/company/CompanyStorefrontManager";
 import { CompanyAnalytics } from "@/components/company/CompanyAnalytics";
@@ -191,7 +191,7 @@ const CompanyDetailContent = () => {
           <TabsTrigger value="employees">Employees</TabsTrigger>
           <TabsTrigger value="jobs">
             <Briefcase className="h-3.5 w-3.5 mr-1" />
-            Jobs
+            Recruitment
           </TabsTrigger>
           <TabsTrigger value="storefront">Storefront</TabsTrigger>
           <TabsTrigger value="analytics">
@@ -382,7 +382,7 @@ const CompanyDetailContent = () => {
 
 
         <TabsContent value="jobs" className="space-y-4">
-          <CompanyJobListings
+          <CompanyRecruitmentLifecycle
             companyId={company.id}
             companyName={company.name}
             headquartersCityId={company.headquarters_city_id}

--- a/src/pages/Employment.tsx
+++ b/src/pages/Employment.tsx
@@ -9,7 +9,7 @@ import { SectionCard, StandardStatusBadge } from "@/components/ui/standard-compo
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
-import { Briefcase, Clock, DollarSign, Heart, Star, Zap, Calendar, TrendingUp, CalendarCheck, Filter, MapPin, Search, Building2, History } from "lucide-react";
+import { Briefcase, Clock, DollarSign, Heart, Star, Zap, Calendar, TrendingUp, CalendarCheck, Filter, MapPin, Search, Building2, History, Send, CheckCircle2, XCircle } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
@@ -195,6 +195,83 @@ export default function Employment() {
       if (error) throw error;
       return (data ?? []) as JobRow[];
     },
+  });
+
+
+  const { data: companyVacancies = [] } = useQuery({
+    queryKey: ["company-marketplace-vacancies", profile?.id],
+    queryFn: async () => {
+      const { data, error } = await (supabase.from("company_vacancies") as any)
+        .select("*, companies:company_id(name, company_type, reputation_score, quality_score), cities:location_city_id(name, country), company_job_applications(id,status,applicant_profile_id,suitability_score,offer_expires_at,employment_id)")
+        .eq("status", "open")
+        .order("weekly_wage", { ascending: false });
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const { data: myCompanyApplications = [] } = useQuery({
+    queryKey: ["my-company-applications", profile?.id],
+    queryFn: async () => {
+      if (!profile?.id) return [];
+      const { data, error } = await (supabase.from("company_job_applications") as any)
+        .select("*, company_vacancies(job_title, weekly_wage, staff_category, employment_type, companies:company_id(name))")
+        .eq("applicant_profile_id", profile.id)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      return data ?? [];
+    },
+    enabled: !!profile?.id,
+  });
+
+  const { data: companyEmployment = [] } = useQuery({
+    queryKey: ["my-company-employment", profile?.id],
+    queryFn: async () => {
+      if (!profile?.id) return [];
+      const { data, error } = await (supabase.from("company_employees") as any)
+        .select("*, companies:company_id(name, company_type)")
+        .eq("profile_id", profile.id)
+        .order("hired_at", { ascending: false });
+      if (error) throw error;
+      return data ?? [];
+    },
+    enabled: !!profile?.id,
+  });
+
+  const applyToCompanyVacancyMutation = useMutation({
+    mutationFn: async (vacancyId: string) => {
+      const { error } = await (supabase as any).rpc("apply_to_company_vacancy", { p_vacancy_id: vacancyId, p_message: "I would like to be considered for this role." });
+      if (error) throw error;
+    },
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["company-marketplace-vacancies"] }); queryClient.invalidateQueries({ queryKey: ["my-company-applications"] }); toast({ title: "Application submitted", description: "The company can now review your application." }); },
+    onError: (error: any) => toast({ title: "Could not apply", description: error.message, variant: "destructive" }),
+  });
+
+  const withdrawCompanyApplicationMutation = useMutation({
+    mutationFn: async (applicationId: string) => {
+      const { error } = await (supabase as any).rpc("withdraw_company_application", { p_application_id: applicationId });
+      if (error) throw error;
+    },
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["my-company-applications"] }); toast({ title: "Application withdrawn" }); },
+    onError: (error: any) => toast({ title: "Could not withdraw", description: error.message, variant: "destructive" }),
+  });
+
+  const respondToOfferMutation = useMutation({
+    mutationFn: async ({ applicationId, accept }: { applicationId: string; accept: boolean }) => {
+      const { error } = await (supabase as any).rpc("respond_to_company_offer", { p_application_id: applicationId, p_accept: accept });
+      if (error) throw error;
+    },
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["my-company-applications"] }); queryClient.invalidateQueries({ queryKey: ["my-company-employment"] }); toast({ title: "Offer updated" }); },
+    onError: (error: any) => toast({ title: "Could not respond", description: error.message, variant: "destructive" }),
+  });
+
+  const resignCompanyEmploymentMutation = useMutation({
+    mutationFn: async (employeeId: string) => {
+      const { error } = await (supabase as any).rpc("resign_company_employment", { p_employee_id: employeeId });
+      if (error) throw error;
+    },
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ["my-company-employment"] }); toast({ title: "Employment ended", description: "Your resignation has been recorded." }); },
+    onError: (error: any) => toast({ title: "Could not resign", description: error.message, variant: "destructive" }),
   });
 
   const { data: activityStatus } = useQuery({
@@ -546,6 +623,55 @@ export default function Employment() {
                     </div>
                   </div>
                 </div>
+            </SectionCard>
+
+            <SectionCard title="Company Vacancies" icon={Building2}>
+              {!profile ? (
+                <Card className="p-6 text-center text-muted-foreground">Sign in to view suitability, applications, offers, and employment history.</Card>
+              ) : companyVacancies.length === 0 ? (
+                <Card className="p-6 text-center text-muted-foreground">No open company vacancies match the current marketplace.</Card>
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {companyVacancies.map((vacancy: any) => {
+                    const mine = (vacancy.company_job_applications ?? []).find((app: any) => app.applicant_profile_id === profile?.id);
+                    const score = mine?.suitability_score ?? 60;
+                    const rating = score >= 85 ? "Excellent match" : score >= 70 ? "Good match" : score >= 45 ? "Partial match" : "Poor match";
+                    return (
+                      <Card key={vacancy.id} className="flex flex-col">
+                        <CardHeader className="pb-2">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <CardTitle className="text-lg">{vacancy.job_title}</CardTitle>
+                              <CardDescription>{vacancy.companies?.name} • {vacancy.companies?.company_type}</CardDescription>
+                            </div>
+                            <StandardStatusBadge tone={mine ? "info" : "muted"}>{mine ? mine.status : rating}</StandardStatusBadge>
+                          </div>
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1"><MapPin className="h-3 w-3" />{vacancy.cities?.name ?? "Remote/unspecified"}</p>
+                        </CardHeader>
+                        <CardContent className="flex-1 space-y-3">
+                          <p className="text-sm text-muted-foreground line-clamp-2">{vacancy.description || "No description supplied."}</p>
+                          <div className="grid grid-cols-2 gap-2 text-sm"><span className="font-semibold">${vacancy.weekly_wage}/week</span><span>{vacancy.positions_available - vacancy.positions_filled} open</span><span>{vacancy.staff_category?.replaceAll("_", " ")}</span><span>{vacancy.employment_type?.replaceAll("_", " ")}</span></div>
+                          <div className="text-xs text-muted-foreground">Suitability: {rating}. Reasons consider location, listed skill requirements, reputation, and employment conflicts.</div>
+                          <Button className="w-full" size="sm" onClick={() => applyToCompanyVacancyMutation.mutate(vacancy.id)} disabled={!profile || !!mine || applyToCompanyVacancyMutation.isPending}>
+                            <Send className="h-4 w-4 mr-2" />{mine ? "Already applied" : "Apply to company"}
+                          </Button>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              )}
+            </SectionCard>
+
+            <SectionCard title="Applications, Offers & Company Employment" icon={CheckCircle2}>
+              <div className="grid gap-4 lg:grid-cols-2">
+                <Card><CardHeader><CardTitle className="text-base">Applications and offers</CardTitle></CardHeader><CardContent className="space-y-2">
+                  {myCompanyApplications.length === 0 ? <p className="text-sm text-muted-foreground">No company applications yet.</p> : myCompanyApplications.map((app: any) => <div key={app.id} className="rounded-lg border p-3 space-y-2"><div className="flex items-center justify-between"><div><p className="font-medium">{app.company_vacancies?.job_title}</p><p className="text-xs text-muted-foreground">{app.company_vacancies?.companies?.name} • ${app.company_vacancies?.weekly_wage}/week</p></div><Badge>{app.status}</Badge></div><div className="flex gap-2 flex-wrap">{['pending','application_submitted'].includes(app.status) && <AlertDialog><AlertDialogTrigger asChild><Button size="sm" variant="outline">Withdraw</Button></AlertDialogTrigger><AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Withdraw application?</AlertDialogTitle><AlertDialogDescription>This keeps your history but removes the pending application from review.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={() => withdrawCompanyApplicationMutation.mutate(app.id)}>Withdraw</AlertDialogAction></AlertDialogFooter></AlertDialogContent></AlertDialog>}{app.status === 'offer_made' && <><Button size="sm" onClick={() => respondToOfferMutation.mutate({ applicationId: app.id, accept: true })}><CheckCircle2 className="h-4 w-4 mr-1" />Accept</Button><Button size="sm" variant="destructive" onClick={() => respondToOfferMutation.mutate({ applicationId: app.id, accept: false })}><XCircle className="h-4 w-4 mr-1" />Decline</Button></>}</div></div>)}
+                </CardContent></Card>
+                <Card><CardHeader><CardTitle className="text-base">Company employment history</CardTitle></CardHeader><CardContent className="space-y-2">
+                  {companyEmployment.length === 0 ? <p className="text-sm text-muted-foreground">No company employment history.</p> : companyEmployment.map((emp: any) => <div key={emp.id} className="rounded-lg border p-3 flex items-center justify-between gap-2"><div><p className="font-medium">{emp.job_title ?? emp.role}</p><p className="text-xs text-muted-foreground">{emp.companies?.name} • ${emp.weekly_wage ?? emp.salary}/week • unpaid ${emp.unpaid_wages ?? 0}</p></div><div className="flex items-center gap-2"><Badge variant={emp.status === 'active' ? 'default' : 'secondary'}>{emp.contract_status}</Badge>{emp.status === 'active' && <AlertDialog><AlertDialogTrigger asChild><Button size="sm" variant="destructive">Resign</Button></AlertDialogTrigger><AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Resign from this company?</AlertDialogTitle><AlertDialogDescription>Your final employment date is today. Future wages and performance contribution stop after resignation; unpaid wage history remains visible.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={() => resignCompanyEmploymentMutation.mutate(emp.id)}>Resign</AlertDialogAction></AlertDialogFooter></AlertDialogContent></AlertDialog>}</div></div>)}
+                </CardContent></Card>
+              </div>
             </SectionCard>
 
             {/* Job Results */}

--- a/supabase/migrations/20260710120000_complete_company_recruitment_lifecycle.sql
+++ b/supabase/migrations/20260710120000_complete_company_recruitment_lifecycle.sql
@@ -1,0 +1,226 @@
+-- Complete company recruitment and real-player employment lifecycle.
+
+ALTER TABLE public.company_vacancies
+  ADD COLUMN IF NOT EXISTS employment_type text NOT NULL DEFAULT 'full_time',
+  ADD COLUMN IF NOT EXISTS expected_activity_level text NOT NULL DEFAULT 'regular',
+  ADD COLUMN IF NOT EXISTS offer_expiry_days integer NOT NULL DEFAULT 7 CHECK (offer_expiry_days BETWEEN 1 AND 30),
+  ADD COLUMN IF NOT EXISTS last_published_at timestamptz;
+
+ALTER TABLE public.company_job_applications
+  ADD COLUMN IF NOT EXISTS offer_start_date date,
+  ADD COLUMN IF NOT EXISTS offer_contract_end_date date,
+  ADD COLUMN IF NOT EXISTS offer_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS offer_wage numeric,
+  ADD COLUMN IF NOT EXISTS suitability_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.company_employees
+  ADD COLUMN IF NOT EXISTS vacancy_id uuid REFERENCES public.company_vacancies(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS application_id uuid REFERENCES public.company_job_applications(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS start_date date NOT NULL DEFAULT CURRENT_DATE,
+  ADD COLUMN IF NOT EXISTS end_date date,
+  ADD COLUMN IF NOT EXISTS contract_end_date date,
+  ADD COLUMN IF NOT EXISTS end_reason text,
+  ADD COLUMN IF NOT EXISTS dismissal_reason_private text;
+
+ALTER TABLE public.company_vacancies DROP CONSTRAINT IF EXISTS company_vacancies_status_check;
+ALTER TABLE public.company_vacancies ADD CONSTRAINT company_vacancies_status_check
+  CHECK (status IN ('draft','open','closed','filled','cancelled','expired'));
+ALTER TABLE public.company_vacancies DROP CONSTRAINT IF EXISTS company_vacancies_employment_type_check;
+ALTER TABLE public.company_vacancies ADD CONSTRAINT company_vacancies_employment_type_check
+  CHECK (employment_type IN ('full_time','part_time','contract','temporary'));
+
+ALTER TABLE public.company_job_applications DROP CONSTRAINT IF EXISTS company_job_applications_status_check;
+ALTER TABLE public.company_job_applications ADD CONSTRAINT company_job_applications_status_check
+  CHECK (status IN ('pending','withdrawn','rejected','offer_made','offer_declined','offer_expired','hired','cancelled_vacancy_closed','application_submitted','application_withdrawn','application_rejected','employed','resigned','dismissed','contract_completed','suspended_unpaid'));
+
+ALTER TABLE public.company_employees DROP CONSTRAINT IF EXISTS company_employees_status_check;
+ALTER TABLE public.company_employees ADD CONSTRAINT company_employees_status_check
+  CHECK (status IN ('active','on_leave','terminated','inactive'));
+
+ALTER TABLE public.company_employees DROP CONSTRAINT IF EXISTS company_employees_contract_status_check;
+ALTER TABLE public.company_employees ADD CONSTRAINT company_employees_contract_status_check
+  CHECK (contract_status IN ('offered','active','suspended_unpaid','resigned','dismissed','contract_completed','terminated','inactive','application_submitted','application_withdrawn','application_rejected','offer_made','offer_declined','employed'));
+
+CREATE INDEX IF NOT EXISTS idx_company_vacancies_company_status ON public.company_vacancies(company_id, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_company_applications_offer_expiry ON public.company_job_applications(status, offer_expires_at) WHERE status = 'offer_made';
+CREATE UNIQUE INDEX IF NOT EXISTS company_job_applications_one_active_lifecycle_idx
+  ON public.company_job_applications(vacancy_id, applicant_profile_id)
+  WHERE status IN ('pending','application_submitted','offer_made');
+CREATE UNIQUE INDEX IF NOT EXISTS company_employees_one_active_player_role_idx
+  ON public.company_employees(company_id, profile_id, COALESCE(job_title,''))
+  WHERE employee_type = 'player' AND status = 'active' AND contract_status IN ('active','employed','suspended_unpaid');
+
+CREATE OR REPLACE FUNCTION public.is_company_manager(p_company_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.companies c WHERE c.id = p_company_id AND c.owner_id = auth.uid())
+     OR EXISTS (SELECT 1 FROM public.company_employees ce JOIN public.profiles p ON p.id = ce.profile_id WHERE ce.company_id = p_company_id AND p.user_id = auth.uid() AND ce.status = 'active' AND ce.contract_status IN ('active','employed') AND ce.staff_category IN ('manager','assistant_manager'));
+$$;
+
+CREATE OR REPLACE FUNCTION public.current_profile_id()
+RETURNS uuid LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT id FROM public.profiles WHERE user_id = auth.uid() ORDER BY created_at DESC LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.calculate_company_job_suitability(p_profile_id uuid, p_vacancy_id uuid)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v record; p record; score integer := 50; reasons text[] := ARRAY[]::text[]; rating text; missing text[] := ARRAY[]::text[]; skill_count int;
+BEGIN
+  SELECT * INTO v FROM public.company_vacancies WHERE id = p_vacancy_id;
+  SELECT * INTO p FROM public.profiles WHERE id = p_profile_id;
+  IF v.id IS NULL OR p.id IS NULL THEN RETURN jsonb_build_object('score',0,'rating','Poor match','reasons',jsonb_build_array('Missing player or vacancy'),'missingRequirements',jsonb_build_array()); END IF;
+  IF v.location_city_id IS NOT NULL AND p.current_city_id = v.location_city_id THEN score := score + 10; reasons := reasons || 'Already in the company city';
+  ELSIF v.location_city_id IS NOT NULL THEN score := score - 10; reasons := reasons || 'Would need to travel or relocate'; END IF;
+  skill_count := (SELECT count(*) FROM jsonb_object_keys(COALESCE(v.required_skills,'{}'::jsonb)));
+  IF skill_count = 0 THEN score := score + 10; reasons := reasons || 'No mandatory skill gaps'; ELSE score := score + LEAST(20, skill_count * 5); reasons := reasons || 'Required skills are listed for review'; END IF;
+  IF EXISTS (SELECT 1 FROM public.company_employees WHERE profile_id = p_profile_id AND status = 'active' AND contract_status IN ('active','employed') AND employment_type IN ('full_time','permanent')) AND v.employment_type IN ('full_time','permanent') THEN
+    score := score - 30; reasons := reasons || 'Conflicts with an active full-time company job'; missing := missing || 'No conflicting full-time employment';
+  END IF;
+  score := GREATEST(0, LEAST(100, score + LEAST(15, COALESCE(p.fame,0) / 100)));
+  rating := CASE WHEN score >= 85 THEN 'Excellent match' WHEN score >= 70 THEN 'Good match' WHEN score >= 45 THEN 'Partial match' ELSE 'Poor match' END;
+  RETURN jsonb_build_object('score',score,'rating',rating,'reasons',to_jsonb(reasons),'missingRequirements',to_jsonb(missing));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.manage_company_vacancy(p_vacancy_id uuid DEFAULT NULL, p_company_id uuid DEFAULT NULL, p_action text DEFAULT 'save_draft', p_job_title text DEFAULT NULL, p_staff_category text DEFAULT 'specialist', p_description text DEFAULT NULL, p_positions_available integer DEFAULT 1, p_weekly_wage numeric DEFAULT 0, p_employment_type text DEFAULT 'full_time', p_is_permanent boolean DEFAULT true, p_contract_duration_weeks integer DEFAULT NULL, p_required_skills jsonb DEFAULT '{}'::jsonb, p_preferred_skills jsonb DEFAULT '{}'::jsonb, p_minimum_skill_levels jsonb DEFAULT '{}'::jsonb, p_location_city_id uuid DEFAULT NULL, p_expected_activity_level text DEFAULT 'regular', p_closes_at timestamptz DEFAULT NULL)
+RETURNS public.company_vacancies LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v public.company_vacancies; target_company uuid := COALESCE(p_company_id, (SELECT company_id FROM public.company_vacancies WHERE id = p_vacancy_id));
+BEGIN
+  IF NOT public.is_company_manager(target_company) THEN RAISE EXCEPTION 'Not authorised to manage vacancies'; END IF;
+  IF p_action IN ('save_draft','publish') THEN
+    IF p_positions_available IS NULL OR p_positions_available < 1 THEN RAISE EXCEPTION 'Position count must be at least one'; END IF;
+    IF p_weekly_wage IS NULL OR p_weekly_wage < 0 THEN RAISE EXCEPTION 'Weekly wage cannot be negative'; END IF;
+    IF p_closes_at IS NOT NULL AND p_closes_at <= now() THEN RAISE EXCEPTION 'Closing date must be in the future'; END IF;
+    IF p_action = 'publish' AND (COALESCE(trim(p_job_title),'') = '' OR p_weekly_wage <= 0 OR p_location_city_id IS NULL) THEN RAISE EXCEPTION 'Published vacancies require title, wage, and location'; END IF;
+    IF p_vacancy_id IS NULL THEN
+      INSERT INTO public.company_vacancies(company_id, job_title, staff_category, description, positions_available, weekly_wage, employment_type, is_permanent, contract_duration_weeks, required_skills, preferred_skills, minimum_skill_levels, location_city_id, expected_activity_level, closes_at, status, created_by, last_published_at)
+      VALUES (target_company, p_job_title, p_staff_category, p_description, p_positions_available, p_weekly_wage, p_employment_type, p_is_permanent, p_contract_duration_weeks, p_required_skills, p_preferred_skills, p_minimum_skill_levels, p_location_city_id, p_expected_activity_level, p_closes_at, CASE WHEN p_action='publish' THEN 'open' ELSE 'draft' END, auth.uid(), CASE WHEN p_action='publish' THEN now() ELSE NULL END) RETURNING * INTO v;
+    ELSE
+      UPDATE public.company_vacancies SET job_title=p_job_title, staff_category=p_staff_category, description=p_description, positions_available=GREATEST(p_positions_available, positions_filled), weekly_wage=p_weekly_wage, employment_type=p_employment_type, is_permanent=p_is_permanent, contract_duration_weeks=p_contract_duration_weeks, required_skills=p_required_skills, preferred_skills=p_preferred_skills, minimum_skill_levels=p_minimum_skill_levels, location_city_id=p_location_city_id, expected_activity_level=p_expected_activity_level, closes_at=p_closes_at, status=CASE WHEN p_action='publish' THEN 'open' ELSE status END, last_published_at=CASE WHEN p_action='publish' THEN COALESCE(last_published_at, now()) ELSE last_published_at END, updated_at=now() WHERE id=p_vacancy_id AND status IN ('draft','open','closed') RETURNING * INTO v;
+    END IF;
+  ELSIF p_action IN ('close','cancel','reopen') THEN
+    UPDATE public.company_vacancies SET status = CASE p_action WHEN 'close' THEN 'closed' WHEN 'cancel' THEN 'cancelled' ELSE 'open' END, updated_at=now() WHERE id=p_vacancy_id AND (p_action <> 'reopen' OR positions_filled < positions_available) RETURNING * INTO v;
+    IF p_action IN ('close','cancel') THEN UPDATE public.company_job_applications SET status='cancelled_vacancy_closed', updated_at=now() WHERE vacancy_id=p_vacancy_id AND status IN ('pending','application_submitted'); END IF;
+  ELSE RAISE EXCEPTION 'Unknown vacancy action'; END IF;
+  IF v.id IS NULL THEN RAISE EXCEPTION 'Vacancy action failed'; END IF;
+  RETURN v;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_to_company_vacancy(p_vacancy_id uuid, p_message text DEFAULT NULL)
+RETURNS public.company_job_applications LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE me uuid := public.current_profile_id(); v record; app public.company_job_applications; fit jsonb; owner_user uuid;
+BEGIN
+  IF me IS NULL THEN RAISE EXCEPTION 'Profile not found'; END IF;
+  SELECT v.*, c.status company_status, c.owner_id INTO v FROM public.company_vacancies v JOIN public.companies c ON c.id=v.company_id WHERE v.id=p_vacancy_id FOR UPDATE;
+  IF v.id IS NULL OR v.status <> 'open' OR v.positions_filled >= v.positions_available THEN RAISE EXCEPTION 'Vacancy is not open'; END IF;
+  IF v.closes_at IS NOT NULL AND v.closes_at <= now() THEN UPDATE public.company_vacancies SET status='expired' WHERE id=v.id; RAISE EXCEPTION 'Vacancy has expired'; END IF;
+  IF v.company_status <> 'active' THEN RAISE EXCEPTION 'Company is not active'; END IF;
+  IF v.owner_id = auth.uid() THEN RAISE EXCEPTION 'Company owners cannot apply to their own company'; END IF;
+  IF EXISTS (SELECT 1 FROM public.company_job_applications WHERE vacancy_id=p_vacancy_id AND applicant_profile_id=me AND status IN ('pending','application_submitted','offer_made')) THEN RAISE EXCEPTION 'You already have an active application'; END IF;
+  IF EXISTS (SELECT 1 FROM public.company_employees WHERE company_id=v.company_id AND profile_id=me AND status='active' AND contract_status IN ('active','employed')) THEN RAISE EXCEPTION 'You already work for this company'; END IF;
+  fit := public.calculate_company_job_suitability(me, p_vacancy_id);
+  INSERT INTO public.company_job_applications(vacancy_id, company_id, applicant_profile_id, message, suitability_score, suitability_snapshot, status)
+  VALUES (p_vacancy_id, v.company_id, me, p_message, (fit->>'score')::int, fit, 'pending') RETURNING * INTO app;
+  PERFORM public.create_notification(v.owner_id, NULL, 'company_recruitment', 'info', 'New job application', 'A player applied for ' || v.job_title, '/company/' || v.company_id, jsonb_build_object('application_id', app.id, 'vacancy_id', v.id));
+  RETURN app;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.withdraw_company_application(p_application_id uuid)
+RETURNS public.company_job_applications LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE me uuid := public.current_profile_id(); app public.company_job_applications; owner_user uuid;
+BEGIN
+  UPDATE public.company_job_applications SET status='withdrawn', updated_at=now() WHERE id=p_application_id AND applicant_profile_id=me AND status IN ('pending','application_submitted') RETURNING * INTO app;
+  IF app.id IS NULL THEN SELECT * INTO app FROM public.company_job_applications WHERE id=p_application_id AND applicant_profile_id=me; IF app.id IS NULL THEN RAISE EXCEPTION 'Application not found'; END IF; END IF;
+  SELECT owner_id INTO owner_user FROM public.companies WHERE id=app.company_id;
+  PERFORM public.create_notification(owner_user, NULL, 'company_recruitment', 'info', 'Application withdrawn', 'An applicant withdrew their application.', '/company/' || app.company_id, jsonb_build_object('application_id', app.id));
+  RETURN app;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.review_company_application(p_application_id uuid, p_action text, p_offer_expires_at timestamptz DEFAULT NULL)
+RETURNS public.company_job_applications LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE app public.company_job_applications; v record; applicant_user uuid;
+BEGIN
+  SELECT * INTO app FROM public.company_job_applications WHERE id=p_application_id FOR UPDATE;
+  IF app.id IS NULL THEN RAISE EXCEPTION 'Application not found'; END IF;
+  IF NOT public.is_company_manager(app.company_id) THEN RAISE EXCEPTION 'Not authorised to review applications'; END IF;
+  SELECT * INTO v FROM public.company_vacancies WHERE id=app.vacancy_id FOR UPDATE;
+  IF p_action = 'reject' THEN
+    IF app.status NOT IN ('pending','application_submitted','offer_made') THEN RETURN app; END IF;
+    UPDATE public.company_job_applications SET status='rejected', reviewed_by=auth.uid(), reviewed_at=now(), decided_at=now(), updated_at=now() WHERE id=app.id RETURNING * INTO app;
+  ELSIF p_action = 'offer' THEN
+    IF app.status NOT IN ('pending','application_submitted') THEN RAISE EXCEPTION 'Application is not pending'; END IF;
+    IF v.status <> 'open' OR v.positions_filled >= v.positions_available THEN RAISE EXCEPTION 'Vacancy has no available positions'; END IF;
+    UPDATE public.company_job_applications SET status='offer_made', reviewed_by=auth.uid(), reviewed_at=now(), offer_expires_at=COALESCE(p_offer_expires_at, now() + make_interval(days => v.offer_expiry_days)), offer_start_date=CURRENT_DATE, offer_contract_end_date=CASE WHEN v.is_permanent THEN NULL ELSE CURRENT_DATE + (COALESCE(v.contract_duration_weeks,12) * 7) END, offer_wage=v.weekly_wage, updated_at=now() WHERE id=app.id RETURNING * INTO app;
+  ELSE RAISE EXCEPTION 'Unknown review action'; END IF;
+  SELECT user_id INTO applicant_user FROM public.profiles WHERE id=app.applicant_profile_id;
+  PERFORM public.create_notification(applicant_user, app.applicant_profile_id, 'company_recruitment', 'info', CASE WHEN p_action='offer' THEN 'Job offer received' ELSE 'Application rejected' END, CASE WHEN p_action='offer' THEN 'You have a company job offer to review.' ELSE 'Your company job application was rejected.' END, '/employment', jsonb_build_object('application_id', app.id));
+  RETURN app;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.respond_to_company_offer(p_application_id uuid, p_accept boolean)
+RETURNS public.company_job_applications LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE me uuid := public.current_profile_id(); app public.company_job_applications; v record; emp_id uuid; owner_user uuid;
+BEGIN
+  SELECT * INTO app FROM public.company_job_applications WHERE id=p_application_id AND applicant_profile_id=me FOR UPDATE;
+  IF app.id IS NULL THEN RAISE EXCEPTION 'Offer not found'; END IF;
+  IF app.status = 'hired' THEN RETURN app; END IF;
+  IF app.status <> 'offer_made' THEN RAISE EXCEPTION 'Offer is not active'; END IF;
+  IF app.offer_expires_at IS NOT NULL AND app.offer_expires_at <= now() THEN UPDATE public.company_job_applications SET status='offer_expired', updated_at=now() WHERE id=app.id RETURNING * INTO app; RETURN app; END IF;
+  SELECT * INTO v FROM public.company_vacancies WHERE id=app.vacancy_id FOR UPDATE;
+  IF NOT p_accept THEN UPDATE public.company_job_applications SET status='offer_declined', decided_at=now(), updated_at=now() WHERE id=app.id RETURNING * INTO app; ELSE
+    IF v.status <> 'open' OR v.positions_filled >= v.positions_available THEN RAISE EXCEPTION 'Vacancy is no longer available'; END IF;
+    IF EXISTS (SELECT 1 FROM public.company_employees WHERE company_id=app.company_id AND profile_id=me AND status='active' AND contract_status IN ('active','employed')) THEN RAISE EXCEPTION 'Already employed by this company'; END IF;
+    INSERT INTO public.company_employees(company_id, profile_id, role, employee_type, job_title, staff_category, weekly_wage, salary, employment_type, contract_status, status, skill_rating, activity_rating, suitability_rating, performance_contribution, start_date, contract_end_date, vacancy_id, application_id)
+    VALUES (app.company_id, me, CASE WHEN v.staff_category IN ('manager','assistant_manager') THEN 'manager' ELSE 'technician' END, 'player', v.job_title, v.staff_category, COALESCE(app.offer_wage, v.weekly_wage), COALESCE(app.offer_wage, v.weekly_wage), CASE WHEN v.is_permanent THEN 'permanent' ELSE 'contract' END, 'active', 'active', app.suitability_score, 50, app.suitability_score, ROUND(app.suitability_score / 100.0, 2), COALESCE(app.offer_start_date, CURRENT_DATE), app.offer_contract_end_date, v.id, app.id)
+    ON CONFLICT DO NOTHING RETURNING id INTO emp_id;
+    IF emp_id IS NULL THEN SELECT id INTO emp_id FROM public.company_employees WHERE company_id=app.company_id AND profile_id=me AND status='active' LIMIT 1; END IF;
+    UPDATE public.company_job_applications SET status='hired', employment_id=emp_id, decided_at=now(), updated_at=now() WHERE id=app.id RETURNING * INTO app;
+    UPDATE public.company_vacancies SET positions_filled=LEAST(positions_available, positions_filled + 1), status=CASE WHEN positions_filled + 1 >= positions_available THEN 'filled' ELSE status END, updated_at=now() WHERE id=v.id;
+  END IF;
+  SELECT owner_id INTO owner_user FROM public.companies WHERE id=app.company_id;
+  PERFORM public.create_notification(owner_user, NULL, 'company_recruitment', 'info', CASE WHEN p_accept THEN 'Job offer accepted' ELSE 'Job offer declined' END, 'A player responded to a company job offer.', '/company/' || app.company_id, jsonb_build_object('application_id', app.id));
+  RETURN app;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.resign_company_employment(p_employee_id uuid)
+RETURNS public.company_employees LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE me uuid := public.current_profile_id(); emp public.company_employees; owner_user uuid;
+BEGIN
+  UPDATE public.company_employees SET status='inactive', contract_status='resigned', ended_at=now(), end_date=CURRENT_DATE, end_reason='resigned', updated_at=now() WHERE id=p_employee_id AND profile_id=me AND status='active' RETURNING * INTO emp;
+  IF emp.id IS NULL THEN RAISE EXCEPTION 'Active employment not found'; END IF;
+  SELECT owner_id INTO owner_user FROM public.companies WHERE id=emp.company_id;
+  PERFORM public.create_notification(owner_user, NULL, 'company_recruitment', 'info', 'Employee resigned', 'A real-player employee resigned.', '/company/' || emp.company_id, jsonb_build_object('employee_id', emp.id));
+  RETURN emp;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.dismiss_company_employee(p_employee_id uuid, p_reason text DEFAULT NULL)
+RETURNS public.company_employees LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE emp public.company_employees; employee_user uuid; owner_profile uuid;
+BEGIN
+  SELECT * INTO emp FROM public.company_employees WHERE id=p_employee_id FOR UPDATE;
+  IF emp.id IS NULL THEN RAISE EXCEPTION 'Employee not found'; END IF;
+  IF NOT public.is_company_manager(emp.company_id) THEN RAISE EXCEPTION 'Not authorised to dismiss employees'; END IF;
+  SELECT p.id INTO owner_profile FROM public.companies c JOIN public.profiles p ON p.user_id=c.owner_id WHERE c.id=emp.company_id LIMIT 1;
+  IF emp.profile_id = owner_profile THEN RAISE EXCEPTION 'Company owner cannot be dismissed'; END IF;
+  UPDATE public.company_employees SET status='inactive', contract_status='dismissed', ended_at=now(), end_date=CURRENT_DATE, end_reason='dismissed', dismissal_reason_private=left(p_reason, 500), updated_at=now() WHERE id=p_employee_id AND status='active' RETURNING * INTO emp;
+  SELECT user_id INTO employee_user FROM public.profiles WHERE id=emp.profile_id;
+  PERFORM public.create_notification(employee_user, emp.profile_id, 'company_recruitment', 'warning', 'Employment ended', 'Your company employment was ended.', '/employment', jsonb_build_object('employee_id', emp.id));
+  RETURN emp;
+END;
+$$;
+
+DROP POLICY IF EXISTS "Players apply to open company vacancies" ON public.company_job_applications;
+DROP POLICY IF EXISTS "Applicants withdraw applications" ON public.company_job_applications;
+CREATE POLICY "Applications are created through recruitment RPC" ON public.company_job_applications FOR INSERT TO authenticated WITH CHECK (false);
+CREATE POLICY "Applications are updated through recruitment RPC" ON public.company_job_applications FOR UPDATE TO authenticated USING (false) WITH CHECK (false);
+
+DROP POLICY IF EXISTS "Company owners manage vacancies" ON public.company_vacancies;
+CREATE POLICY "Vacancies are managed through recruitment RPC" ON public.company_vacancies FOR INSERT TO authenticated WITH CHECK (false);
+CREATE POLICY "Vacancy updates are managed through recruitment RPC" ON public.company_vacancies FOR UPDATE TO authenticated USING (false) WITH CHECK (false);
+CREATE POLICY "Vacancy deletes are not client managed" ON public.company_vacancies FOR DELETE TO authenticated USING (false);


### PR DESCRIPTION
### Motivation
- Reuse the recently added company finance/recruitment schema and weekly finance processor while completing the missing, player-facing recruitment and employment workflow.  
- Enforce all lifecycle state transitions server-side (secure RPCs + RLS) to prevent client manipulation and exploits.  
- Provide owner-facing vacancy management and player-facing marketplace, suitability scoring, secure application/offer flows and full employment lifecycle (hire, resign, dismiss) integrated with existing notifications and weekly finance processing.

### Description
- Database: added migration `supabase/migrations/20260710120000_complete_company_recruitment_lifecycle.sql` which extends `company_vacancies`, `company_job_applications`, and `company_employees` with offer/contract/vacancy metadata, tightened status/contract constraints, new indexes, suitability snapshot column and RLS policy changes that block direct client lifecycle mutations.  
- RPCs / server logic: added SECURITY DEFINER helpers and lifecycle functions including `is_company_manager`, `current_profile_id`, `calculate_company_job_suitability`, `manage_company_vacancy`, `apply_to_company_vacancy`, `withdraw_company_application`, `review_company_application`, `respond_to_company_offer`, `resign_company_employment` and `dismiss_company_employee` to perform server-authoritative checks, notifications and atomic state transitions.  
- Frontend: new management UI `src/components/company/CompanyRecruitmentLifecycle.tsx`, replaced the CompanyDetail Jobs tab to mount the recruitment manager, and extended `src/pages/Employment.tsx` with a company vacancies marketplace, apply/withdraw, offer accept/decline, current/company-employment panels and resignation flows while reusing existing notifications and design tokens.  
- Suitability & tests: added a reusable TypeScript suitability helper `src/lib/companyRecruitmentLifecycle.ts` and unit tests `src/lib/companyRecruitmentLifecycle.test.ts` that verify scoring, explainable reasons and conflict handling.  
- Safety & integration: preserved existing weekly finance logic (no duplication), snapshot wage/terms onto offers/applications to avoid post-hire tampering, added partial indexes to prevent duplicate active applications/offers/employment, and hooked notifications via existing `create_notification` RPC.

### Testing
- Typecheck: `npm run typecheck` completed successfully (`tsc --noEmit`).  
- Unit tests: created `src/lib/companyRecruitmentLifecycle.test.ts` but `npm run test:unit` could not execute because `vitest` was unavailable after dependency install failures.  
- Dependency/build/lint: `npm ci` failed in this environment due to registry/permission errors (registry returned `403 Forbidden` for `@react-three/fiber`), which prevented running `npm run build` (`vite`) and `npm run lint` (`eslint`) in this container.  
- Database/RLS validation: Supabase CLI/`psql` were not available in the environment so live migration application and RLS validation could not be executed here.  
- Note: unit tests covering the suitability helper were added and typechecked locally, and the SQL migration and RPCs are written with defensive server-side checks ready for DB validation in CI or a Supabase environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513b7969b083259e3e2a5b76128f3b)