### PR TITLE
Band contribution event log MVP (Phase 4 PR 01)

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -120,7 +120,7 @@ Other players should become the most valuable content in RockMundo because they 
 1. Add documentation and UI labels for existing band responsibilities.
 2. Add role metadata and permission checks in small PRs.
 3. Guard band invitation creation/response and band application submission/approval/rejection/withdrawal before deeper collaboration work; the invitation lifecycle and application lifecycle now have server-authoritative RPCs with leader/founder recruitment checks where applicable, applicant-owned withdrawal, block checks, duplicate-membership idempotency, audit logging, notification deduplication/status updates, final-state notification display polish, narrow applicant/manager application history, and a local Supabase recruitment RLS/RPC verification harness.
-4. Add contribution logs for existing band actions.
+4. Add contribution logs for existing band actions. Initial server-authoritative, read-only contribution events now exist for completed band rehearsals, completed band recording sessions, and completed gig outcomes, with current-active-member-only visibility and no rewards.
 5. Add objective templates using existing gig, song, rehearsal, and media systems.
 6. Add collaboration contracts after the generic contract framework is stable.
 

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -399,3 +399,13 @@ Guarded RPC verification now covers `submit_band_application`, `respond_band_app
 Route verification now has shared unit coverage for applicant notifications to band profile routes, manager stale `?tab=applications` normalization, final-state recruitment notifications, missing/deleted destination handling, and invitation-route preservation. Full authenticated browser navigation remains a P1 follow-up because the repository does not currently provide Playwright authenticated fixtures.
 
 Confirmed remaining gaps are product decisions rather than security blockers: global one-band membership/application policy, role-specific vacancies, recruitment cooldowns, auditions, matching, applicant scoring, and recruitment rewards. Database tests are documented as a separate local Supabase command and are not yet wired into default CI.
+
+## Phase 4 PR 01 Update — Band Contribution Tracking
+
+- ✅ Added a dedicated `band_contribution_events` foundation for immutable, server-authoritative band participation history.
+- ✅ Initial contribution sources are limited to completed band rehearsals, completed band recording sessions, and completed gig outcomes. Jam-session and songwriting contribution events remain unresolved until band-scoped authoritative source data is clearer.
+- ✅ Contribution history is read-only to normal clients and visible only to authenticated current active members of the relevant band. Former/inactive members, unrelated users, and unauthenticated users are denied by default.
+- ✅ Idempotency is enforced with a source-based unique constraint so repeated completion processing does not create duplicate contribution rows.
+- ✅ The Band Management UI now exposes neutral recent contribution history and count summaries without XP, rewards, chemistry, achievements, leaderboards, or penalties.
+- ✅ Unit/component coverage was added for display mapping, safe fallback labels, summaries, empty/loading/error states, and rendering recent contributions.
+- ⚠️ Rehearsal and gig events currently credit active members at completion time because participant-level attendance records were not found. This is a shared-progression foundation, not a reward source yet.

--- a/docs/social/implementation/PHASE_4_PR_01.md
+++ b/docs/social/implementation/PHASE_4_PR_01.md
@@ -1,0 +1,122 @@
+# Phase 4 PR 01 — Band Contribution Event Log MVP
+
+## Recommendation source
+
+Phase 3 closed with the recommendation to add a server-authoritative contribution event log for existing band activity before introducing shared goals, rewards, XP, chemistry, achievements, or leaderboards.
+
+## Existing event/history foundations found
+
+- `band_history` exists for band lifecycle/management history, but it is generic band history rather than member contribution history.
+- `activity_feed` exists for broad player activity messages, but it is not band-scoped, immutable contribution accounting.
+- `gig_outcomes` is an authoritative completion record for completed gigs.
+- `recording_sessions.status = 'completed'` with `completed_at` is an authoritative completion record for a band recording session owner/participant.
+- `band_rehearsals.status = 'completed'` is an authoritative completion record for a band rehearsal, but there is no separate rehearsal attendance table in this repository.
+- `jam_session_outcomes` records participant-level jam results, but jam sessions are not reliably band-scoped, so they are not included in this PR.
+- Rich songwriting collaborator tables exist in forward-dated migrations, but completed band co-author credit is not used in this MVP because the stable completion/source ownership path is less clear than rehearsal, recording, and gig completion.
+
+## Selected contribution sources
+
+This MVP captures only new events after the migration for:
+
+1. `rehearsal_attendance` from completed `band_rehearsals`.
+2. `recording_participation` from completed band `recording_sessions`.
+3. `gig_performance` from inserted `gig_outcomes`.
+
+No XP, money, chemistry, fame, achievements, reputation, rewards, penalties, contracts, votes, or leaderboards are added.
+
+## Event model
+
+A new `band_contribution_events` table stores:
+
+- `id`
+- `band_id`
+- `profile_id`
+- `contribution_type`
+- `source_entity_type`
+- `source_entity_id`
+- `occurred_at`
+- safe display `metadata`
+- `created_at`
+
+The supported MVP contribution types are constrained to `rehearsal_attendance`, `recording_participation`, and `gig_performance`.
+
+## Server-authoritative creation method
+
+Events are created only by database trigger paths calling the guarded `insert_band_contribution_event` helper:
+
+- `band_rehearsals` after insert/update to `completed`.
+- `recording_sessions` after insert/update to `completed` for band sessions.
+- `gig_outcomes` after insert.
+
+The helper verifies the target profile is an active member of the target band before inserting.
+
+## Idempotency model
+
+The table has a unique constraint on `(band_id, profile_id, contribution_type, source_entity_type, source_entity_id)`. The helper inserts with `ON CONFLICT DO NOTHING`, so retries or repeated completion processing do not duplicate events.
+
+## Visibility and privacy model
+
+Contribution events are read-only to normal clients. The only RLS policy allows authenticated current active members to read events for their band through `is_active_band_member`. Former/inactive members, unrelated users, and unauthenticated users do not receive contribution feed access by default.
+
+Metadata is intentionally limited to safe labels such as `Completed band rehearsal`, `Completed band recording`, and `Completed band gig`. It does not expose private messages, internal audit metadata, schedules beyond event timestamps, health/energy values, hidden skills, auth data, service-role data, or rewards.
+
+## UI/read model
+
+The existing band management area now includes a read-only `Contributions` tab showing:
+
+- recent contribution events, newest first, limited to 50;
+- member public name/avatar;
+- contribution label and safe source label;
+- accessible timestamps;
+- empty, loading, and error states;
+- summary counts by member and by type.
+
+The summary is deliberately neutral and not a leaderboard or reward calculation.
+
+## Files changed
+
+- `supabase/migrations/20260711010000_create_band_contribution_events.sql`
+- `supabase/tests/band_contribution_events_harness.sql`
+- `package.json`
+- `src/lib/bandContributions.ts`
+- `src/lib/bandContributions.test.ts`
+- `src/hooks/useBandContributions.ts`
+- `src/components/bands/BandContributionsTab.tsx`
+- `src/components/bands/BandContributionsTab.test.tsx`
+- `src/pages/bands/[bandId]/management.tsx`
+- `docs/social/implementation/PHASE_4_PR_01.md`
+- `docs/social/SOCIAL_SYSTEM_AUDIT.md`
+- `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md`
+
+## Database changes
+
+- Adds immutable `band_contribution_events` table.
+- Adds foreign keys to `bands` and `profiles`.
+- Adds check constraints for supported contribution and source types.
+- Adds idempotency unique constraint.
+- Adds band/time, profile/time, and type/time indexes.
+- Enables RLS with current-active-member-only SELECT.
+- Adds `is_active_band_member` and `insert_band_contribution_event` SECURITY DEFINER helpers with safe `search_path`.
+- Adds triggers for completed rehearsals, completed recordings, and gig outcomes.
+
+## Tests
+
+- Unit tests cover display mapping, safe unsupported-type fallback, safe source labels, and summary aggregation.
+- Component tests cover recent contribution rendering, member summary rendering, empty state, error state, loading state, and unsupported-type fallback.
+- A local database harness stub documents the contribution RLS/idempotency cases and is wired as `npm run test:contributions:db`; a full data-seeding SQL harness remains a follow-up due to schema drift across local Supabase fixtures.
+
+## Backfill decision
+
+No historical backfill runs automatically. New events after the migration are sufficient for beta. A later optional backfill can derive conservative events from completed source rows in batches, but it should be reviewed separately because rehearsal and gig membership-at-time semantics are not fully represented.
+
+## Known limitations
+
+- Rehearsal and gig contribution capture currently uses active band membership at completion time because no participant-level attendance table was found for those systems.
+- Jam sessions are excluded because participant records are reliable but not clearly band-scoped.
+- Songwriting credit is excluded until completed band co-author credit can be tied to a stable authoritative source path.
+- Recording participation currently credits the session profile/user for completed band sessions, not every possible studio collaborator.
+- No rewards or progression calculations consume this log yet.
+
+## Recommended Phase 4 PR 02
+
+Add a stricter contribution-source adapter layer and expand participant-level sources only where repository data supports them, starting with band-scoped jam outcomes or explicit rehearsal/gig attendance rows. Keep rewards, XP, chemistry, achievements, and leaderboards out until event accuracy and privacy are proven.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run",
     "test:smoke": "vitest run src/testing/__tests__/betaSmokeScenarios.test.ts src/components/dashboard/GettingStartedPanel.test.ts src/utils/__tests__/activityBookingTime.test.ts src/lib/managerRecommendations.test.ts",
-    "test:recruitment:db": "bash -lc 'if ! command -v supabase >/dev/null; then echo Supabase CLI is required for recruitment DB tests; exit 127; fi; if [ -z \"$SUPABASE_DB_URL\" ]; then echo SUPABASE_DB_URL is required after supabase start/db reset; exit 2; fi; psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/tests/recruitment_rls_harness.sql'"
+    "test:recruitment:db": "bash -lc 'if ! command -v supabase >/dev/null; then echo Supabase CLI is required for recruitment DB tests; exit 127; fi; if [ -z \"$SUPABASE_DB_URL\" ]; then echo SUPABASE_DB_URL is required after supabase start/db reset; exit 2; fi; psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/tests/recruitment_rls_harness.sql'",
+    "test:contributions:db": "bash -lc 'if ! command -v supabase >/dev/null; then echo Supabase CLI is required for contribution DB tests; exit 127; fi; if [ -z \"$SUPABASE_DB_URL\" ]; then echo SUPABASE_DB_URL is required after supabase start/db reset; exit 2; fi; psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/tests/band_contribution_events_harness.sql'"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/components/bands/BandContributionsTab.test.tsx
+++ b/src/components/bands/BandContributionsTab.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let queryState: any;
+
+vi.mock("@/hooks/useBandContributions", () => ({
+  useBandContributions: () => queryState,
+}));
+
+import { BandContributionsTab } from "./BandContributionsTab";
+
+const event = {
+  id: "event-1",
+  band_id: "band-1",
+  profile_id: "profile-1",
+  contribution_type: "rehearsal_attendance",
+  source_entity_type: "band_rehearsal",
+  source_entity_id: "rehearsal-1",
+  occurred_at: "2026-07-10T10:00:00Z",
+  metadata: { label: "Completed band rehearsal" },
+  created_at: "2026-07-10T10:00:01Z",
+  profiles: { id: "profile-1", username: "riley", display_name: "Riley Riff", avatar_url: null },
+};
+
+beforeEach(() => {
+  queryState = { data: [event], isLoading: false, isError: false, error: null };
+});
+
+describe("BandContributionsTab", () => {
+  it("renders recent contributions and member summary", () => {
+    render(<BandContributionsTab bandId="band-1" />);
+
+    expect(screen.getByText("Recent contributions")).toBeInTheDocument();
+    expect(screen.getAllByText("Riley Riff").length).toBeGreaterThan(0);
+    expect(screen.getByText("Rehearsal attendance")).toBeInTheDocument();
+    expect(screen.getByText("Member summary")).toBeInTheDocument();
+  });
+
+  it("renders empty state", () => {
+    queryState = { data: [], isLoading: false, isError: false, error: null };
+    render(<BandContributionsTab bandId="band-1" />);
+
+    expect(screen.getByText(/No contribution events have been recorded yet/i)).toBeInTheDocument();
+  });
+
+  it("renders backend error state", () => {
+    queryState = { data: undefined, isLoading: false, isError: true, error: new Error("denied") };
+    render(<BandContributionsTab bandId="band-1" />);
+
+    expect(screen.getByText("Unable to load participation history")).toBeInTheDocument();
+    expect(screen.getByText("denied")).toBeInTheDocument();
+  });
+
+  it("renders loading state", () => {
+    queryState = { data: undefined, isLoading: true, isError: false, error: null };
+    const { container } = render(<BandContributionsTab bandId="band-1" />);
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("renders unsupported contribution type fallback", () => {
+    queryState = { data: [{ ...event, contribution_type: "future_type", metadata: {} }], isLoading: false, isError: false, error: null };
+    render(<BandContributionsTab bandId="band-1" />);
+
+    expect(screen.getByText("Band activity")).toBeInTheDocument();
+  });
+});

--- a/src/components/bands/BandContributionsTab.tsx
+++ b/src/components/bands/BandContributionsTab.tsx
@@ -1,0 +1,150 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertCircle, Activity } from "lucide-react";
+import { useBandContributions } from "@/hooks/useBandContributions";
+import {
+  getContributionDisplay,
+  getContributionSourceLabel,
+  summarizeContributions,
+  type BandContributionEvent,
+} from "@/lib/bandContributions";
+
+interface BandContributionsTabProps {
+  bandId: string;
+}
+
+function playerName(event: BandContributionEvent) {
+  return event.profiles?.display_name || event.profiles?.username || "Unknown player";
+}
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown time";
+  return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+export function BandContributionsTab({ bandId }: BandContributionsTabProps) {
+  const { data: events = [], isLoading, isError, error } = useBandContributions(bandId);
+  const summary = summarizeContributions(events);
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 lg:grid-cols-[1fr_2fr]">
+        <Skeleton className="h-48" />
+        <Skeleton className="h-72" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="border-destructive/40">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive"><AlertCircle className="h-5 w-5" /> Unable to load participation history</CardTitle>
+          <CardDescription>{error instanceof Error ? error.message : "Please try again later."}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2"><Activity className="h-5 w-5" /> Recent contributions</CardTitle>
+          <CardDescription>No contribution events have been recorded yet. New completed band activity will appear here.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.4fr)]">
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Band activity</CardTitle>
+            <CardDescription>Last 50 meaningful contribution events.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+            <div className="rounded-lg border p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Total</p>
+              <p className="text-2xl font-bold">{summary.total}</p>
+            </div>
+            {summary.byType.map(({ type, count }) => {
+              const display = getContributionDisplay(type);
+              const Icon = display.icon;
+              return (
+                <div key={type} className="flex items-center justify-between rounded-lg border p-3">
+                  <span className="flex items-center gap-2 text-sm"><Icon className="h-4 w-4" aria-hidden="true" />{display.shortLabel}</span>
+                  <Badge variant="secondary">{count}</Badge>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Member summary</CardTitle>
+            <CardDescription>Counts only, not a ranking or reward calculation.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {summary.byMember.map(({ profileId, profile, count }) => {
+              const name = profile?.display_name || profile?.username || "Unknown player";
+              return (
+                <div key={profileId} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <Avatar className="h-8 w-8"><AvatarImage src={profile?.avatar_url ?? undefined} alt="" /><AvatarFallback>{initials(name)}</AvatarFallback></Avatar>
+                    <span className="truncate text-sm font-medium">{name}</span>
+                  </div>
+                  <Badge variant="outline">{count}</Badge>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent contributions</CardTitle>
+          <CardDescription>Read-only participation history visible to current band members.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ol className="space-y-3" aria-label="Recent band contribution events">
+            {events.map((event) => {
+              const display = getContributionDisplay(event.contribution_type);
+              const Icon = display.icon;
+              const name = playerName(event);
+              return (
+                <li key={event.id} className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <Avatar><AvatarImage src={event.profiles?.avatar_url ?? undefined} alt="" /><AvatarFallback>{initials(name)}</AvatarFallback></Avatar>
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{name}</p>
+                      <p className="flex items-center gap-2 text-sm text-muted-foreground"><Icon className="h-4 w-4" aria-hidden="true" />{display.label}</p>
+                      <p className="text-xs text-muted-foreground">{getContributionSourceLabel(event)}</p>
+                    </div>
+                  </div>
+                  <time className="text-sm text-muted-foreground" dateTime={event.occurred_at}>{formatTimestamp(event.occurred_at)}</time>
+                </li>
+              );
+            })}
+          </ol>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/useBandContributions.ts
+++ b/src/hooks/useBandContributions.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { BAND_CONTRIBUTION_LIMIT, type BandContributionEvent } from "@/lib/bandContributions";
+
+export function useBandContributions(bandId: string, limit = BAND_CONTRIBUTION_LIMIT) {
+  return useQuery({
+    queryKey: ["band-contributions", bandId, limit],
+    enabled: Boolean(bandId),
+    queryFn: async () => {
+      const { data, error } = await (supabase as any)
+        .from("band_contribution_events")
+        .select(
+          "id, band_id, profile_id, contribution_type, source_entity_type, source_entity_id, occurred_at, metadata, created_at, profiles:profiles!band_contribution_events_profile_id_fkey(id, username, display_name, avatar_url)",
+        )
+        .eq("band_id", bandId)
+        .order("occurred_at", { ascending: false })
+        .order("created_at", { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+      return (data ?? []) as BandContributionEvent[];
+    },
+  });
+}

--- a/src/lib/bandContributions.test.ts
+++ b/src/lib/bandContributions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getContributionDisplay, getContributionSourceLabel, summarizeContributions, type BandContributionEvent } from "./bandContributions";
+
+const base = (id: string, profileId: string, type: string): BandContributionEvent => ({
+  id,
+  band_id: "band-1",
+  profile_id: profileId,
+  contribution_type: type,
+  source_entity_type: "band_rehearsal",
+  source_entity_id: `source-${id}`,
+  occurred_at: "2026-07-10T10:00:00Z",
+  metadata: { label: "Completed band rehearsal" },
+  created_at: "2026-07-10T10:00:01Z",
+  profiles: { id: profileId, username: profileId, display_name: null, avatar_url: null },
+});
+
+describe("band contribution display helpers", () => {
+  it("maps supported contribution types to player-facing labels", () => {
+    expect(getContributionDisplay("rehearsal_attendance").label).toBe("Rehearsal attendance");
+    expect(getContributionDisplay("recording_participation").label).toBe("Recording participation");
+    expect(getContributionDisplay("gig_performance").label).toBe("Gig performance");
+  });
+
+  it("uses a safe fallback for unsupported future contribution types", () => {
+    expect(getContributionDisplay("future_type").label).toBe("Band activity");
+  });
+
+  it("prefers safe metadata labels and falls back to source type", () => {
+    expect(getContributionSourceLabel(base("1", "profile-1", "rehearsal_attendance"))).toBe("Completed band rehearsal");
+    expect(getContributionSourceLabel({ metadata: {}, source_entity_type: "gig_outcome" })).toBe("Gig Outcome");
+  });
+
+  it("summarizes total, member, and type counts without ranking semantics", () => {
+    const summary = summarizeContributions([
+      base("1", "profile-1", "rehearsal_attendance"),
+      base("2", "profile-1", "gig_performance"),
+      base("3", "profile-2", "gig_performance"),
+    ]);
+
+    expect(summary.total).toBe(3);
+    expect(summary.byMember).toEqual(expect.arrayContaining([
+      expect.objectContaining({ profileId: "profile-1", count: 2 }),
+      expect.objectContaining({ profileId: "profile-2", count: 1 }),
+    ]));
+    expect(summary.byType).toEqual(expect.arrayContaining([
+      { type: "rehearsal_attendance", count: 1 },
+      { type: "gig_performance", count: 2 },
+    ]));
+  });
+});

--- a/src/lib/bandContributions.ts
+++ b/src/lib/bandContributions.ts
@@ -1,0 +1,72 @@
+import { CalendarCheck, Disc3, HelpCircle, Mic2 } from "lucide-react";
+
+export const BAND_CONTRIBUTION_LIMIT = 50;
+
+export const bandContributionTypes = [
+  "rehearsal_attendance",
+  "recording_participation",
+  "gig_performance",
+] as const;
+
+export type BandContributionType = (typeof bandContributionTypes)[number] | (string & {});
+
+export type BandContributionEvent = {
+  id: string;
+  band_id: string;
+  profile_id: string;
+  contribution_type: BandContributionType;
+  source_entity_type: string;
+  source_entity_id: string;
+  occurred_at: string;
+  metadata: { label?: string; [key: string]: unknown } | null;
+  created_at: string;
+  profiles: {
+    id: string;
+    username: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  } | null;
+};
+
+export const contributionTypeDisplay = {
+  rehearsal_attendance: { label: "Rehearsal attendance", shortLabel: "Rehearsals", icon: CalendarCheck },
+  recording_participation: { label: "Recording participation", shortLabel: "Recordings", icon: Disc3 },
+  gig_performance: { label: "Gig performance", shortLabel: "Gigs", icon: Mic2 },
+} as const;
+
+export function getContributionDisplay(type: BandContributionType) {
+  return contributionTypeDisplay[type as keyof typeof contributionTypeDisplay] ?? {
+    label: "Band activity",
+    shortLabel: "Other activity",
+    icon: HelpCircle,
+  };
+}
+
+export function getContributionSourceLabel(event: Pick<BandContributionEvent, "metadata" | "source_entity_type">) {
+  if (typeof event.metadata?.label === "string" && event.metadata.label.trim().length > 0) {
+    return event.metadata.label;
+  }
+
+  return event.source_entity_type
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function summarizeContributions(events: BandContributionEvent[]) {
+  const byMember = new Map<string, { profile: BandContributionEvent["profiles"]; count: number }>();
+  const byType = new Map<string, number>();
+
+  events.forEach((event) => {
+    const member = byMember.get(event.profile_id) ?? { profile: event.profiles, count: 0 };
+    member.count += 1;
+    byMember.set(event.profile_id, member);
+    byType.set(event.contribution_type, (byType.get(event.contribution_type) ?? 0) + 1);
+  });
+
+  return {
+    total: events.length,
+    byMember: Array.from(byMember.entries()).map(([profileId, value]) => ({ profileId, ...value })),
+    byType: Array.from(byType.entries()).map(([type, count]) => ({ type: type as BandContributionType, count })),
+  };
+}

--- a/src/pages/bands/[bandId]/management.tsx
+++ b/src/pages/bands/[bandId]/management.tsx
@@ -4,12 +4,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BandRosterTab } from "@/components/bands/BandRosterTab";
 import { BandRehearsalsTab } from "@/components/bands/BandRehearsalsTab";
 import { BandFinancesTab } from "@/components/bands/BandFinancesTab";
+import { BandContributionsTab } from "@/components/bands/BandContributionsTab";
 import { Card, CardContent } from "@/components/ui/card";
 
 const tabConfig = [
   { value: "roster", label: "Roster", description: "Manage lineup, roles, and leadership readiness." },
   { value: "rehearsals", label: "Rehearsals", description: "Oversee rehearsal cadence, costs, and preparation." },
   { value: "finances", label: "Finances", description: "Track band earnings, balance, and transactions." },
+  { value: "contributions", label: "Contributions", description: "Review recent participation history without rewards or rankings." },
 ] as const;
 
 export default function BandManagementPage() {
@@ -61,6 +63,10 @@ export default function BandManagementPage() {
 
         <TabsContent value="finances" className="space-y-6">
           <BandFinancesTab bandId={bandId} />
+        </TabsContent>
+
+        <TabsContent value="contributions" className="space-y-6">
+          <BandContributionsTab bandId={bandId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/supabase/migrations/20260711010000_create_band_contribution_events.sql
+++ b/supabase/migrations/20260711010000_create_band_contribution_events.sql
@@ -1,0 +1,236 @@
+-- Phase 4 PR 01: immutable, member-visible band contribution event log MVP.
+
+CREATE TABLE IF NOT EXISTS public.band_contribution_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  contribution_type text NOT NULL CHECK (contribution_type IN ('rehearsal_attendance', 'recording_participation', 'gig_performance')),
+  source_entity_type text NOT NULL CHECK (source_entity_type IN ('band_rehearsal', 'recording_session', 'gig_outcome')),
+  source_entity_id uuid NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT band_contribution_events_metadata_object CHECK (jsonb_typeof(metadata) = 'object'),
+  CONSTRAINT band_contribution_events_idempotency UNIQUE (band_id, profile_id, contribution_type, source_entity_type, source_entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS band_contribution_events_band_occurred_idx
+  ON public.band_contribution_events (band_id, occurred_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS band_contribution_events_profile_occurred_idx
+  ON public.band_contribution_events (profile_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS band_contribution_events_type_occurred_idx
+  ON public.band_contribution_events (band_id, contribution_type, occurred_at DESC);
+
+ALTER TABLE public.band_contribution_events ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.is_active_band_member(target_band_id uuid, actor_user_id uuid DEFAULT auth.uid())
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT target_band_id IS NOT NULL
+    AND actor_user_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = target_band_id
+        AND bm.user_id = actor_user_id
+        AND COALESCE(bm.member_status, 'active') = 'active'
+    );
+$$;
+
+CREATE POLICY "Active band members can view contribution events"
+ON public.band_contribution_events
+FOR SELECT
+TO authenticated
+USING (public.is_active_band_member(band_id, auth.uid()));
+
+CREATE OR REPLACE FUNCTION public.insert_band_contribution_event(
+  p_band_id uuid,
+  p_profile_id uuid,
+  p_contribution_type text,
+  p_source_entity_type text,
+  p_source_entity_id uuid,
+  p_occurred_at timestamptz,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id uuid;
+BEGIN
+  IF p_band_id IS NULL OR p_profile_id IS NULL OR p_source_entity_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.band_members bm
+    WHERE bm.band_id = p_band_id
+      AND bm.profile_id = p_profile_id
+      AND COALESCE(bm.member_status, 'active') = 'active'
+  ) THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.band_contribution_events (
+    band_id,
+    profile_id,
+    contribution_type,
+    source_entity_type,
+    source_entity_id,
+    occurred_at,
+    metadata
+  ) VALUES (
+    p_band_id,
+    p_profile_id,
+    p_contribution_type,
+    p_source_entity_type,
+    p_source_entity_id,
+    COALESCE(p_occurred_at, now()),
+    COALESCE(p_metadata, '{}'::jsonb)
+  )
+  ON CONFLICT ON CONSTRAINT band_contribution_events_idempotency DO NOTHING
+  RETURNING id INTO v_event_id;
+
+  RETURN v_event_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insert_band_contribution_event(uuid, uuid, text, text, uuid, timestamptz, jsonb) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.capture_completed_rehearsal_contributions()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_member record;
+BEGIN
+  IF NEW.status <> 'completed' OR (TG_OP = 'UPDATE' AND COALESCE(OLD.status, '') = 'completed') THEN
+    RETURN NEW;
+  END IF;
+
+  FOR v_member IN
+    SELECT bm.profile_id
+    FROM public.band_members bm
+    WHERE bm.band_id = NEW.band_id
+      AND bm.profile_id IS NOT NULL
+      AND COALESCE(bm.member_status, 'active') = 'active'
+  LOOP
+    PERFORM public.insert_band_contribution_event(
+      NEW.band_id,
+      v_member.profile_id,
+      'rehearsal_attendance',
+      'band_rehearsal',
+      NEW.id,
+      COALESCE(NEW.completed_at, NEW.scheduled_end, now()),
+      jsonb_build_object('label', 'Completed band rehearsal')
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS capture_completed_rehearsal_contributions ON public.band_rehearsals;
+CREATE TRIGGER capture_completed_rehearsal_contributions
+AFTER INSERT OR UPDATE OF status ON public.band_rehearsals
+FOR EACH ROW
+EXECUTE FUNCTION public.capture_completed_rehearsal_contributions();
+
+CREATE OR REPLACE FUNCTION public.capture_completed_recording_contribution()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile_id uuid;
+BEGIN
+  IF NEW.band_id IS NULL OR NEW.status <> 'completed' OR (TG_OP = 'UPDATE' AND COALESCE(OLD.status, '') = 'completed') THEN
+    RETURN NEW;
+  END IF;
+
+  v_profile_id := NEW.profile_id;
+  IF v_profile_id IS NULL THEN
+    SELECT p.id INTO v_profile_id FROM public.profiles p WHERE p.user_id = NEW.user_id LIMIT 1;
+  END IF;
+
+  PERFORM public.insert_band_contribution_event(
+    NEW.band_id,
+    v_profile_id,
+    'recording_participation',
+    'recording_session',
+    NEW.id,
+    COALESCE(NEW.completed_at, now()),
+    jsonb_build_object('label', 'Completed band recording')
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS capture_completed_recording_contribution ON public.recording_sessions;
+CREATE TRIGGER capture_completed_recording_contribution
+AFTER INSERT OR UPDATE OF status ON public.recording_sessions
+FOR EACH ROW
+EXECUTE FUNCTION public.capture_completed_recording_contribution();
+
+CREATE OR REPLACE FUNCTION public.capture_completed_gig_contributions()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_band_id uuid;
+  v_occurred_at timestamptz;
+  v_member record;
+BEGIN
+  v_band_id := NEW.band_id;
+  IF v_band_id IS NULL THEN
+    SELECT g.band_id, g.scheduled_date INTO v_band_id, v_occurred_at FROM public.gigs g WHERE g.id = NEW.gig_id;
+  ELSE
+    SELECT g.scheduled_date INTO v_occurred_at FROM public.gigs g WHERE g.id = NEW.gig_id;
+  END IF;
+
+  IF v_band_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  FOR v_member IN
+    SELECT bm.profile_id
+    FROM public.band_members bm
+    WHERE bm.band_id = v_band_id
+      AND bm.profile_id IS NOT NULL
+      AND COALESCE(bm.member_status, 'active') = 'active'
+  LOOP
+    PERFORM public.insert_band_contribution_event(
+      v_band_id,
+      v_member.profile_id,
+      'gig_performance',
+      'gig_outcome',
+      NEW.id,
+      COALESCE(v_occurred_at, NEW.created_at, now()),
+      jsonb_build_object('label', 'Completed band gig')
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS capture_completed_gig_contributions ON public.gig_outcomes;
+CREATE TRIGGER capture_completed_gig_contributions
+AFTER INSERT ON public.gig_outcomes
+FOR EACH ROW
+EXECUTE FUNCTION public.capture_completed_gig_contributions();

--- a/supabase/tests/band_contribution_events_harness.sql
+++ b/supabase/tests/band_contribution_events_harness.sql
@@ -1,0 +1,20 @@
+-- Local Supabase-only RLS/idempotency harness for Phase 4 PR 01.
+-- Run against a disposable database after migrations are applied.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    RAISE NOTICE 'Skipping harness: Supabase local roles are not installed.';
+  END IF;
+END $$;
+
+-- This harness intentionally documents the critical cases covered by the migration:
+-- - active leader/member select is allowed through is_active_band_member
+-- - former/unrelated/anonymous select is denied by the SELECT-only RLS policy
+-- - direct insert/update/delete are denied because no mutation policies exist
+-- - completion triggers call insert_band_contribution_event and rely on the unique
+--   (band_id, profile_id, contribution_type, source_entity_type, source_entity_id) constraint.
+
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Provide a conservative, server-authoritative, read-only contribution history for bands to record meaningful cooperative activity without adding rewards, XP, chemistry, or leaderboards. 
- Capture only low-risk authoritative sources that already have completion records to ensure reliability and idempotency. 
- Establish privacy and visibility defaults that limit reads to current active band members and create a reusable foundation for later shared goals and rewards. 

### Description
- Add a new migration that creates `band_contribution_events` with constrained `contribution_type`/`source_entity_type`, safe `metadata`, useful indexes, and a unique idempotency constraint on `(band_id, profile_id, contribution_type, source_entity_type, source_entity_id)`. 
- Introduce guarded DB helpers and RLS: `is_active_band_member` for visibility and `insert_band_contribution_event` as a `SECURITY DEFINER` insert helper, and triggers that call the helper on authoritative completions (completed `band_rehearsals`, completed `recording_sessions`, and inserted `gig_outcomes`). 
- Add a read-only UI surface and query layer: `BandContributionsTab` component, `useBandContributions` hook, typed `src/lib/bandContributions.ts` mappings and summaries, and neutral display logic with safe fallbacks for unsupported types. 
- Add tests and documentation: unit tests for display/summarize helpers, component tests for loading/empty/error/fallback states, a local Supabase SQL harness stub `supabase/tests/band_contribution_events_harness.sql`, and `docs/social/implementation/PHASE_4_PR_01.md` plus audit/plan updates. 

### Testing
- `npm run typecheck` (`tsc --noEmit`) completed successfully. 
- Linting could not run in this environment because `@eslint/js` is missing, causing `npm run lint` to fail with a missing package error. 
- Build and unit test runners could not be executed here because runtime tools are not installed: `vite` is missing for `npm run build` and `vitest` is missing for `npm run test:unit`. 
- The DB harness `npm run test:contributions:db` could not be executed because the Supabase CLI / local DB environment was not available in this environment; the harness is included for local/dev use.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513f8b4a488325b3083e8843847e71)