### PR TITLE
Add contribution-source adapter and verified recording participants (Phase 4 PR 02)

### DIFF
--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -120,7 +120,7 @@ Other players should become the most valuable content in RockMundo because they 
 1. Add documentation and UI labels for existing band responsibilities.
 2. Add role metadata and permission checks in small PRs.
 3. Guard band invitation creation/response and band application submission/approval/rejection/withdrawal before deeper collaboration work; the invitation lifecycle and application lifecycle now have server-authoritative RPCs with leader/founder recruitment checks where applicable, applicant-owned withdrawal, block checks, duplicate-membership idempotency, audit logging, notification deduplication/status updates, final-state notification display polish, narrow applicant/manager application history, and a local Supabase recruitment RLS/RPC verification harness.
-4. Add contribution logs for existing band actions. Initial server-authoritative, read-only contribution events now exist for completed band rehearsals, completed band recording sessions, and completed gig outcomes, with current-active-member-only visibility and no rewards.
+4. Add contribution logs for existing band actions. Initial server-authoritative, read-only contribution events now exist for completed band rehearsals, completed band recording sessions, and completed gig outcomes, with current-active-member-only visibility and no rewards. Recording contribution now uses a small source adapter to credit verified session participants from the session owner and uploaded production tracks where available; rehearsal and gig participant-level accuracy remains pending authoritative attendance/lineup records.
 5. Add objective templates using existing gig, song, rehearsal, and media systems.
 6. Add collaboration contracts after the generic contract framework is stable.
 

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -409,3 +409,15 @@ Confirmed remaining gaps are product decisions rather than security blockers: gl
 - ✅ The Band Management UI now exposes neutral recent contribution history and count summaries without XP, rewards, chemistry, achievements, leaderboards, or penalties.
 - ✅ Unit/component coverage was added for display mapping, safe fallback labels, summaries, empty/loading/error states, and rendering recent contributions.
 - ⚠️ Rehearsal and gig events currently credit active members at completion time because participant-level attendance records were not found. This is a shared-progression foundation, not a reward source yet.
+
+## Phase 4 PR 02 Update — Contribution Source Accuracy
+
+- ✅ Added a small server-side contribution-source adapter for completed band recording sessions.
+- ✅ Recording participation now uses verified participant records where available: the session owner/profile plus distinct `production_tracks` uploaders for the completed band session.
+- ✅ Contribution insertion now checks active band membership at the contribution time using `joined_at` where the schema supports it.
+- ✅ The Contributions tab now labels verified participant-sourced events neutrally and states summaries are based on recorded participation.
+- ⚠️ Rehearsal participation remains band-completion based because no authoritative rehearsal attendee, RSVP, invitation, or attendance-status table was found.
+- ⚠️ Gig participation remains band-outcome based because no authoritative performer lineup or member attendance table was found.
+- ⚠️ Jam participation remains excluded: `jam_session_outcomes` is participant-level, but jam sessions are not authoritatively tied to exactly one band.
+- ⚠️ Songwriting contribution remains excluded: completed band-owned accepted co-author credit is not clearly represented by the audited schema.
+- ✅ RLS/privacy posture is unchanged: contribution events remain read-only to normal clients and visible only to current active members of the band.

--- a/docs/social/implementation/PHASE_4_PR_02.md
+++ b/docs/social/implementation/PHASE_4_PR_02.md
@@ -1,0 +1,99 @@
+# Phase 4 PR 02 — Contribution Source Accuracy and Participant Adapters
+
+## Recommendation source
+
+Phase 4 PR 01 recommended adding a stricter contribution-source adapter layer and expanding participant-level sources only where repository data proves both participation and band relationship.
+
+## Source-system audit
+
+- **Rehearsals:** `band_rehearsals` is band-scoped and has completion/cancellation state, but no attendee, invitation, RSVP, or attendance-status table was found. It remains partially authoritative at the band completion level only.
+- **Gigs:** `gigs` and `gig_outcomes` are band-scoped completion records. `gig_song_performances` is song-level, not performer-level. No band-member lineup or performer attendance table was found. It remains partially authoritative at the band outcome level only.
+- **Recording:** `recording_sessions` is band-scoped when `band_id` is set and has completed state. `production_tracks` records uploaded tracks by profile user for the session, which is an explicit participant signal. The session owner/profile remains authoritative for the session they created.
+- **Jam sessions:** `jam_session_outcomes` and participant tables are participant-level, but `jam_sessions` has no single authoritative `band_id`; host/creator alone does not prove one-band ownership. It remains unsupported for band contribution.
+- **Songwriting:** `songwriting_projects` and `songwriting_sessions` are owner/session based. The audited schema does not provide accepted band co-author records tied to a stable band-owned completed song lifecycle. It remains unsupported for band contribution.
+
+## Authoritative sources found
+
+- Completed band `recording_sessions` with `band_id`.
+- Recording session owner/profile.
+- `production_tracks` rows for the same recording session, joined through `profiles.user_id`, as explicit uploaded-track participants.
+
+## Unsupported sources
+
+- Rehearsal attendee-level credit: no attendance source table found.
+- Gig performer-level credit: no lineup/performer source table found.
+- Jam contribution: participant outcomes exist, but sessions are not reliably band-scoped.
+- Songwriting credit: no accepted, band-owned completed co-author path was found.
+
+## Adapter design
+
+This PR adds a small database adapter function rather than a generic event bus:
+
+- `capture_contributions_for_recording_session(recording_session_id)` resolves the completed band recording source.
+- The adapter resolves the authoritative band from `recording_sessions.band_id`.
+- It resolves participants from session owner/profile plus uploaded `production_tracks` participants.
+- It delegates immutable insert/idempotency to `insert_band_contribution_event`.
+- It returns the number of newly inserted events and ignores unsupported/malformed sources safely.
+
+## Participant-resolution rules
+
+Recording contribution now credits:
+
+1. the completed band recording session owner/profile, if valid;
+2. each distinct profile with a `production_tracks` upload for that session;
+3. only profiles that pass band membership validation at the event time.
+
+NPC producers, orchestra bookings, declined invites, and implied collaborators are not credited because they are not explicit player contribution records for this band log.
+
+## Membership-at-time handling
+
+`is_band_member_at_time` validates the member is active and that `joined_at` is not after the contribution `occurred_at`. The current schema does not provide a reliable historical leave timestamp for `band_members`, so inactive/former members are not eligible for newly captured events, while previously inserted historical events remain immutable.
+
+## Contribution types added
+
+No new contribution types were added. The verified implementation reuses `recording_participation` because only recording has explicit participant rows that can be safely connected to a completed band source.
+
+## Server-authoritative integration points
+
+The existing completed-recording trigger now calls the recording adapter. Rehearsal and gig triggers remain conservative until authoritative attendance/lineup tables exist.
+
+## Idempotency model
+
+The existing unique constraint on `(band_id, profile_id, contribution_type, source_entity_type, source_entity_id)` remains the duplicate-safety boundary. Retrying the adapter or processing the same completion twice does not create duplicate events.
+
+## Privacy model
+
+The read model remains unchanged: current active band members can read contribution events for their band; former members, unrelated users, unauthenticated users, and direct client mutations remain denied. Metadata added by the adapter is limited to safe labels and verification category, not private schedules, messages, health, energy, skills, auth IDs, payments, or audit internals.
+
+## UI changes
+
+The Contributions tab now explains that summaries are based on recorded participation where supported and shows a neutral “Verified participation” indicator when metadata confirms participant-level source resolution.
+
+## Database changes
+
+- Added `is_band_member_at_time` helper with safe `search_path`.
+- Updated `insert_band_contribution_event` to use membership-at-time validation where available.
+- Added `capture_contributions_for_recording_session` as the first contribution-source adapter.
+- Added a narrow source lookup index for adapter/idempotency workflows.
+- Replaced the completed-recording trigger function body to call the adapter.
+
+## Tests
+
+- Unit coverage for verified participant metadata detection.
+- Component coverage for the verified participation label.
+- Database harness documentation updated for adapter cases.
+
+## Backfill decision
+
+No automatic backfill is included. Recording participants can be derived for historical sessions, but a separate reviewed migration should batch that narrowly after local fixture drift is resolved.
+
+## Known limitations
+
+- Rehearsals and gigs still use active members at completion because member-level attendance/lineup records were not found.
+- Jam outcomes remain excluded because the session is not authoritatively band-owned.
+- Songwriting remains excluded because accepted band co-author completion is not clearly represented.
+- Membership-at-time checks can prove `joined_at <= occurred_at`, but cannot prove historical leave time without future membership history data.
+
+## Recommended Phase 4 PR 03
+
+Add explicit participant tables for rehearsal attendance and gig lineups, or wire existing gameplay to such authoritative rows, then move rehearsal/gig contribution triggers from broad active-membership capture to verified participant adapters.

--- a/src/components/bands/BandContributionsTab.test.tsx
+++ b/src/components/bands/BandContributionsTab.test.tsx
@@ -17,7 +17,7 @@ const event = {
   source_entity_type: "band_rehearsal",
   source_entity_id: "rehearsal-1",
   occurred_at: "2026-07-10T10:00:00Z",
-  metadata: { label: "Completed band rehearsal" },
+  metadata: { label: "Completed band rehearsal", accuracy: "verified_participant" },
   created_at: "2026-07-10T10:00:01Z",
   profiles: { id: "profile-1", username: "riley", display_name: "Riley Riff", avatar_url: null },
 };
@@ -34,6 +34,7 @@ describe("BandContributionsTab", () => {
     expect(screen.getAllByText("Riley Riff").length).toBeGreaterThan(0);
     expect(screen.getByText("Rehearsal attendance")).toBeInTheDocument();
     expect(screen.getByText("Member summary")).toBeInTheDocument();
+    expect(screen.getByText("Verified participation")).toBeInTheDocument();
   });
 
   it("renders empty state", () => {

--- a/src/components/bands/BandContributionsTab.tsx
+++ b/src/components/bands/BandContributionsTab.tsx
@@ -7,6 +7,7 @@ import { useBandContributions } from "@/hooks/useBandContributions";
 import {
   getContributionDisplay,
   getContributionSourceLabel,
+  isVerifiedContribution,
   summarizeContributions,
   type BandContributionEvent,
 } from "@/lib/bandContributions";
@@ -75,7 +76,7 @@ export function BandContributionsTab({ bandId }: BandContributionsTabProps) {
         <Card>
           <CardHeader>
             <CardTitle>Band activity</CardTitle>
-            <CardDescription>Last 50 meaningful contribution events.</CardDescription>
+            <CardDescription>Last 50 contribution events. Based on recorded participation where source data supports it.</CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
             <div className="rounded-lg border p-3">
@@ -98,7 +99,7 @@ export function BandContributionsTab({ bandId }: BandContributionsTabProps) {
         <Card>
           <CardHeader>
             <CardTitle>Member summary</CardTitle>
-            <CardDescription>Counts only, not a ranking or reward calculation.</CardDescription>
+            <CardDescription>Based on recorded participation. Counts only, not a ranking or reward calculation.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
             {summary.byMember.map(({ profileId, profile, count }) => {
@@ -120,7 +121,7 @@ export function BandContributionsTab({ bandId }: BandContributionsTabProps) {
       <Card>
         <CardHeader>
           <CardTitle>Recent contributions</CardTitle>
-          <CardDescription>Read-only participation history visible to current band members.</CardDescription>
+          <CardDescription>Read-only participation history visible to current band members. Verified labels mean participant records were used.</CardDescription>
         </CardHeader>
         <CardContent>
           <ol className="space-y-3" aria-label="Recent band contribution events">
@@ -135,7 +136,7 @@ export function BandContributionsTab({ bandId }: BandContributionsTabProps) {
                     <div className="min-w-0">
                       <p className="truncate font-medium">{name}</p>
                       <p className="flex items-center gap-2 text-sm text-muted-foreground"><Icon className="h-4 w-4" aria-hidden="true" />{display.label}</p>
-                      <p className="text-xs text-muted-foreground">{getContributionSourceLabel(event)}</p>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"><span>{getContributionSourceLabel(event)}</span>{isVerifiedContribution(event) ? <Badge variant="outline">Verified participation</Badge> : null}</div>
                     </div>
                   </div>
                   <time className="text-sm text-muted-foreground" dateTime={event.occurred_at}>{formatTimestamp(event.occurred_at)}</time>

--- a/src/lib/bandContributions.test.ts
+++ b/src/lib/bandContributions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getContributionDisplay, getContributionSourceLabel, summarizeContributions, type BandContributionEvent } from "./bandContributions";
+import { getContributionDisplay, getContributionSourceLabel, isVerifiedContribution, summarizeContributions, type BandContributionEvent } from "./bandContributions";
 
 const base = (id: string, profileId: string, type: string): BandContributionEvent => ({
   id,
@@ -28,6 +28,12 @@ describe("band contribution display helpers", () => {
   it("prefers safe metadata labels and falls back to source type", () => {
     expect(getContributionSourceLabel(base("1", "profile-1", "rehearsal_attendance"))).toBe("Completed band rehearsal");
     expect(getContributionSourceLabel({ metadata: {}, source_entity_type: "gig_outcome" })).toBe("Gig Outcome");
+  });
+
+  it("detects verified participant metadata", () => {
+    expect(isVerifiedContribution({ metadata: { accuracy: "verified_participant" } })).toBe(true);
+    expect(isVerifiedContribution({ metadata: { accuracy: "legacy_member_completion" } })).toBe(false);
+    expect(isVerifiedContribution({ metadata: null })).toBe(false);
   });
 
   it("summarizes total, member, and type counts without ranking semantics", () => {

--- a/src/lib/bandContributions.ts
+++ b/src/lib/bandContributions.ts
@@ -18,7 +18,7 @@ export type BandContributionEvent = {
   source_entity_type: string;
   source_entity_id: string;
   occurred_at: string;
-  metadata: { label?: string; [key: string]: unknown } | null;
+  metadata: { label?: string; accuracy?: string; source_detail?: string; [key: string]: unknown } | null;
   created_at: string;
   profiles: {
     id: string;
@@ -51,6 +51,10 @@ export function getContributionSourceLabel(event: Pick<BandContributionEvent, "m
     .split("_")
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(" ");
+}
+
+export function isVerifiedContribution(event: Pick<BandContributionEvent, "metadata">) {
+  return event.metadata?.accuracy === "verified_participant";
 }
 
 export function summarizeContributions(events: BandContributionEvent[]) {

--- a/supabase/migrations/20290711020000_contribution_source_adapters.sql
+++ b/supabase/migrations/20290711020000_contribution_source_adapters.sql
@@ -1,0 +1,168 @@
+-- Phase 4 PR 02: contribution-source adapter helpers and verified recording participants.
+
+ALTER TABLE public.band_contribution_events
+  DROP CONSTRAINT IF EXISTS band_contribution_events_contribution_type_check,
+  DROP CONSTRAINT IF EXISTS band_contribution_events_source_entity_type_check;
+
+ALTER TABLE public.band_contribution_events
+  ADD CONSTRAINT band_contribution_events_contribution_type_check
+    CHECK (contribution_type IN ('rehearsal_attendance', 'recording_participation', 'gig_performance')),
+  ADD CONSTRAINT band_contribution_events_source_entity_type_check
+    CHECK (source_entity_type IN ('band_rehearsal', 'recording_session', 'gig_outcome'));
+
+CREATE INDEX IF NOT EXISTS band_contribution_events_source_idx
+  ON public.band_contribution_events (source_entity_type, source_entity_id, contribution_type);
+
+CREATE OR REPLACE FUNCTION public.is_band_member_at_time(
+  target_band_id uuid,
+  target_profile_id uuid,
+  target_occurred_at timestamptz DEFAULT now()
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT target_band_id IS NOT NULL
+    AND target_profile_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = target_band_id
+        AND bm.profile_id = target_profile_id
+        AND COALESCE(bm.member_status, 'active') = 'active'
+        AND (bm.joined_at IS NULL OR bm.joined_at <= COALESCE(target_occurred_at, now()))
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_band_member_at_time(uuid, uuid, timestamptz) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.insert_band_contribution_event(
+  p_band_id uuid,
+  p_profile_id uuid,
+  p_contribution_type text,
+  p_source_entity_type text,
+  p_source_entity_id uuid,
+  p_occurred_at timestamptz,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id uuid;
+BEGIN
+  IF p_band_id IS NULL OR p_profile_id IS NULL OR p_source_entity_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF NOT public.is_band_member_at_time(p_band_id, p_profile_id, COALESCE(p_occurred_at, now())) THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.band_contribution_events (
+    band_id, profile_id, contribution_type, source_entity_type, source_entity_id, occurred_at, metadata
+  ) VALUES (
+    p_band_id,
+    p_profile_id,
+    p_contribution_type,
+    p_source_entity_type,
+    p_source_entity_id,
+    COALESCE(p_occurred_at, now()),
+    COALESCE(p_metadata, '{}'::jsonb)
+  )
+  ON CONFLICT ON CONSTRAINT band_contribution_events_idempotency DO NOTHING
+  RETURNING id INTO v_event_id;
+
+  RETURN v_event_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insert_band_contribution_event(uuid, uuid, text, text, uuid, timestamptz, jsonb) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.capture_contributions_for_recording_session(p_recording_session_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_session record;
+  v_participant record;
+  v_inserted integer := 0;
+  v_event_id uuid;
+BEGIN
+  SELECT rs.id, rs.band_id, rs.profile_id, rs.user_id, rs.completed_at, rs.status
+  INTO v_session
+  FROM public.recording_sessions rs
+  WHERE rs.id = p_recording_session_id;
+
+  IF NOT FOUND OR v_session.band_id IS NULL OR v_session.status <> 'completed' THEN
+    RETURN 0;
+  END IF;
+
+  FOR v_participant IN
+    SELECT DISTINCT participant_profile_id AS profile_id
+    FROM (
+      SELECT p.id AS participant_profile_id
+      FROM public.production_tracks pt
+      JOIN public.profiles p ON p.user_id = pt.user_id
+      WHERE pt.session_id = v_session.id
+      UNION
+      SELECT v_session.profile_id AS participant_profile_id
+      UNION
+      SELECT p.id AS participant_profile_id
+      FROM public.profiles p
+      WHERE p.user_id = v_session.user_id AND v_session.profile_id IS NULL
+    ) participants
+    WHERE participant_profile_id IS NOT NULL
+  LOOP
+    v_event_id := public.insert_band_contribution_event(
+      v_session.band_id,
+      v_participant.profile_id,
+      'recording_participation',
+      'recording_session',
+      v_session.id,
+      COALESCE(v_session.completed_at, now()),
+      jsonb_build_object(
+        'label', 'Completed band recording',
+        'accuracy', 'verified_participant',
+        'source_detail', 'recording session owner or uploaded production track'
+      )
+    );
+
+    IF v_event_id IS NOT NULL THEN
+      v_inserted := v_inserted + 1;
+    END IF;
+  END LOOP;
+
+  RETURN v_inserted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.capture_contributions_for_recording_session(uuid) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.capture_completed_recording_contribution()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.band_id IS NULL OR NEW.status <> 'completed' OR (TG_OP = 'UPDATE' AND COALESCE(OLD.status, '') = 'completed') THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM public.capture_contributions_for_recording_session(NEW.id);
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'capture_completed_recording_contribution failed for recording_session %: %', NEW.id, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.capture_contributions_for_recording_session(uuid)
+  IS 'Contribution-source adapter for completed band recording sessions. Resolves authoritative band from recording_sessions and participants from session owner plus production_tracks uploads; insert helper enforces idempotency and active membership at occurred_at.';

--- a/supabase/tests/band_contribution_events_harness.sql
+++ b/supabase/tests/band_contribution_events_harness.sql
@@ -18,3 +18,10 @@ END $$;
 --   (band_id, profile_id, contribution_type, source_entity_type, source_entity_id) constraint.
 
 ROLLBACK;
+
+-- Phase 4 PR 02 adapter cases to validate in a seeded Supabase database:
+-- 1. capture_contributions_for_recording_session ignores missing, non-band, and non-completed sessions.
+-- 2. completed band recording credits the owner/profile and distinct production_tracks uploaders only once.
+-- 3. production_tracks uploaders who are not active members at completed_at are ignored.
+-- 4. repeated capture_contributions_for_recording_session calls create no duplicate rows because of band_contribution_events_idempotency.
+-- 5. contribution events remain read-only to clients and visible only to current active band members.


### PR DESCRIPTION
### Motivation

- Improve contribution-source accuracy by introducing a small server-side adapter layer and only credit participant-level events where repository data is authoritative. 
- Make recording participation participant-accurate by using explicit session participants (session owner + `production_tracks` uploaders) instead of broad membership-at-completion heuristics. 
- Preserve idempotency, RLS/privacy posture, and avoid adding rewards/XP/chemistry or fabricating participation for unsupported sources. 

### Description

- Database: added migration `supabase/migrations/20290711020000_contribution_source_adapters.sql` that creates `is_band_member_at_time`, narrows contribution type/source constraints, adds a source lookup index, updates `insert_band_contribution_event` to validate membership-at-time, and implements `capture_contributions_for_recording_session(recording_session_id)` plus a completed-recording trigger that calls the adapter. 
- Participant resolution: adapter resolves the authoritative `band_id` from `recording_sessions` and resolves participants from the session owner/profile plus distinct `production_tracks` uploaders, inserting `recording_participation` events with idempotency and a safe `metadata.accuracy = 'verified_participant'` tag. 
- UI and client helpers: added `isVerifiedContribution` and expanded `BandContributionEvent.metadata` typing, updated `BandContributionsTab` to show neutral copy and a "Verified participation" badge when metadata indicates a verified participant, and updated related unit/component helpers. 
- Documentation and audit: added `docs/social/implementation/PHASE_4_PR_02.md`, updated `docs/social/SOCIAL_SYSTEM_AUDIT.md` and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md` to record authoritative/unsupported sources and adapter design. 
- Tests and harness: added unit test for verified metadata detection and component test coverage for the verified label, and extended the DB harness notes `supabase/tests/band_contribution_events_harness.sql` with adapter validation cases (seeded DB checks expected separately). 

### Testing

- `npm run typecheck` completed successfully. 
- `npm run lint` failed to run in this environment due to missing/blocked dependency resolution for `@eslint/js` so linting was not validated here. 
- `npm run build` and front-end unit runner could not run because build/test tooling (`vite`, `vitest`) were not available in the environment, so full CI build/tests were not executed locally. 
- `npm install` attempted but failed due to registry access/permission errors for some packages, so restoring dev tooling was blocked. 
- Database/integration harness (`test:contributions:db`) was not executed because the Supabase CLI / DB URL were not available in the environment; the migration includes a narrow harness description for local Supabase validation. 
- Static checks performed here (`tsc --noEmit` and `git diff --check`) passed and unit/component changes were authored with tests updated to expect the new verified-label behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5144c3a84083258f6e66b3a5e11622)