### PR TITLE
Implement rehearsal attendance correction requests (Phase 4 PR 08)

### DIFF
--- a/docs/social/ATTENDANCE_AND_LINEUP_RULES.md
+++ b/docs/social/ATTENDANCE_AND_LINEUP_RULES.md
@@ -376,3 +376,8 @@ Keep the current FM/RockMundo card/table style; do not redesign rehearsal or gig
 | Public lineup visibility | Post-beta decision |
 | Automated penalties/reputation | Post-beta decision |
 | Required-role gig completion blocking | Post-beta decision unless gameplay owners require beta |
+
+
+### Phase 4 PR 08 implementation status — rehearsal attendance corrections
+
+Rehearsal attendance correction requests are now implemented for final `attended` ↔ `missed` rows only. Affected participants can open one pending request within the 24-hour database-enforced correction window; authorised current managers or admin/support resolvers can approve or reject through guarded RPCs. The workflow preserves append-only audit history, keeps request reasons and resolution notes private, sends deduped resolver/requester notifications, and corrects rehearsal contribution eligibility by inserting missed-to-attended events idempotently or voiding attended-to-missed events without deleting the original contribution row. Gig lineup management, performer confirmation, gig disputes, absence reasons, rewards, penalties, XP, chemistry, reputation, attendance percentages, and reliability scoring remain out of scope.

--- a/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
+++ b/docs/social/SOCIAL_MMO_EXPANSION_PLAN.md
@@ -564,3 +564,8 @@ The expansion should be considered successful when:
 - Rehearsal contribution creation is now tied to final `attended` rows only, with manager-finalisation metadata and existing idempotency.
 - The existing rehearsal page exposes narrow manager controls without changing ordinary member RSVP behaviour.
 - Corrections, disputes, absence reasons, gig lineup management, rewards, penalties, XP, chemistry, and attendance analytics remain deferred.
+
+
+### Phase 4 PR 08 implementation status — rehearsal attendance corrections
+
+Rehearsal attendance correction requests are now implemented for final `attended` ↔ `missed` rows only. Affected participants can open one pending request within the 24-hour database-enforced correction window; authorised current managers or admin/support resolvers can approve or reject through guarded RPCs. The workflow preserves append-only audit history, keeps request reasons and resolution notes private, sends deduped resolver/requester notifications, and corrects rehearsal contribution eligibility by inserting missed-to-attended events idempotently or voiding attended-to-missed events without deleting the original contribution row. Gig lineup management, performer confirmation, gig disputes, absence reasons, rewards, penalties, XP, chemistry, reputation, attendance percentages, and reliability scoring remain out of scope.

--- a/docs/social/SOCIAL_SYSTEM_AUDIT.md
+++ b/docs/social/SOCIAL_SYSTEM_AUDIT.md
@@ -465,3 +465,8 @@ Phase 4 PR 06 status update: Rehearsal participant and gig lineup details are su
 - Audit coverage records successful rehearsal finalisation, participant attended/missed markings, and denied attempts for permission, timing, cancellation, invalid payload, wrong participant, and final/declined conflicts.
 - RLS remains unchanged for direct participant mutation; clients use only the SECURITY DEFINER RPC with safe `search_path` and narrow authenticated execute grant.
 - Participant DB harness documents PR 07 RPC coverage markers; full integration validation requires a running Supabase database.
+
+
+### Phase 4 PR 08 implementation status — rehearsal attendance corrections
+
+Rehearsal attendance correction requests are now implemented for final `attended` ↔ `missed` rows only. Affected participants can open one pending request within the 24-hour database-enforced correction window; authorised current managers or admin/support resolvers can approve or reject through guarded RPCs. The workflow preserves append-only audit history, keeps request reasons and resolution notes private, sends deduped resolver/requester notifications, and corrects rehearsal contribution eligibility by inserting missed-to-attended events idempotently or voiding attended-to-missed events without deleting the original contribution row. Gig lineup management, performer confirmation, gig disputes, absence reasons, rewards, penalties, XP, chemistry, reputation, attendance percentages, and reliability scoring remain out of scope.

--- a/docs/social/implementation/PHASE_4_PR_08.md
+++ b/docs/social/implementation/PHASE_4_PR_08.md
@@ -1,0 +1,119 @@
+# Phase 4 PR 08 — Rehearsal Attendance Correction Request MVP
+
+## Recommendation source
+
+Implements the rehearsal-only correction window recommended by `docs/social/ATTENDANCE_AND_LINEUP_RULES.md` after PR 06 self-response and PR 07 manager-owned final attendance.
+
+## Previous correction gap
+
+Final `attended` and `missed` rows were intentionally locked outside `finalise_rehearsal_attendance`, but there was no safe path for genuine mistakes. Contribution events were immutable and summaries counted every inserted rehearsal attendance event.
+
+## Correction lifecycle
+
+1. The affected participant requests a correction for their own final rehearsal attendance row.
+2. The request remains `pending`; attendance and contribution records do not change at request time.
+3. An authorised current manager or admin/support resolver approves or rejects.
+4. Rejection leaves attendance and contribution unchanged.
+5. Approval updates the participant row to the new authoritative final status, preserves original audit rows, and appends correction audit records.
+
+Supported request statuses are `pending`, `approved`, `rejected`, and `cancelled`; cancellation is reserved in the data model but no cancellation RPC is exposed in this MVP.
+
+## Correction window
+
+Requests are accepted for 24 hours after `band_rehearsals.completed_at`, falling back to `scheduled_end`. The database helper `rehearsal_attendance_correction_window()` is the single timing constant, and `is_rehearsal_attendance_correction_open()` enforces the window with database time. Frontend deadline text is advisory.
+
+## Request RPC contract
+
+`request_rehearsal_attendance_correction(participant_id uuid, requested_status text, reason text default null)`:
+
+- requires an authenticated profile;
+- loads and locks the participant and rehearsal server-side;
+- requires the requester to own the participant row;
+- accepts only `attended -> missed` or `missed -> attended`;
+- rejects provisional `invited`, `confirmed`, and `declined` rows;
+- enforces the 24-hour window;
+- trims optional plain text reason to 280 characters and rejects angle brackets;
+- creates or returns one active pending request per participant;
+- notifies current authorised resolvers without exposing reason text in notification metadata;
+- writes append-only social audit metadata without private reason text.
+
+## Resolution RPC contract
+
+`resolve_rehearsal_attendance_correction(correction_request_id uuid, decision text, resolution_note text default null)`:
+
+- requires an authenticated profile;
+- locks the pending request, participant, and rehearsal;
+- accepts `approve` or `reject`;
+- requires a current leader/founder/co-leader/manager according to existing `is_band_leader_or_manager`, or an admin role;
+- leaves attendance and contribution unchanged on reject;
+- atomically updates request resolution fields;
+- notifies the requester once;
+- returns the final request row and treats already-final requests as idempotent retry reads.
+
+## Conflict-of-interest rule
+
+The database uses existing role support and records the resolver in full audit metadata. The beta limitation is that the schema does not yet identify the original per-row finalising manager as a resolvable conflict key, so PR 08 documents the policy but does not block that actor automatically. Admin/support may resolve under support policy.
+
+## Attendance correction behaviour
+
+The current participant row reflects the latest authoritative final status after approval. Original finalisation audit records are not removed or rewritten. Correction request, correction decision, attendance corrected, and contribution correction audit rows append the correction request ID, band, rehearsal, participant, previous status, requested status, decision, and resulting status.
+
+## Contribution correction model
+
+PR 08 uses the narrowest model compatible with current immutable events: append-only metadata plus void markers on the original event. `band_contribution_events` gains `voided_at`, `voided_by_profile_id`, and `voided_by_correction_request_id`. The original row remains auditable, but contribution queries and summaries filter `voided_at IS NULL`.
+
+- `missed -> attended`: inserts the normal `rehearsal_attendance` event idempotently.
+- `attended -> missed`: marks the effective event voided once and preserves the original row.
+- No XP, money, chemistry, reputation, rewards, or penalties are changed.
+
+## Privacy model
+
+Request reasons and resolution notes are stored only on the private operational request table. They are not added to contribution feeds, public profiles, public pages, broad notification metadata, or general audit metadata.
+
+## Permission model
+
+- Requester: affected participant only.
+- Resolver: current leader, founder, co-leader, manager, or admin/support role.
+- Denied: ordinary members, unrelated users, inactive/former managers, unauthenticated users, and requests against another participant.
+
+## Notification behaviour
+
+Request notifications go only to current authorised resolvers and dedupe by correction request ID. Resolution notifications go to the requester once and include the decision, route, and IDs but no private notes or reason text.
+
+## Audit behaviour
+
+The migration adds audit kinds for requested, approved, rejected, corrected, denied, and contribution correction created. Audit metadata is operational and excludes private text.
+
+## Concurrency model
+
+The pending partial unique index permits one active pending request per participant. Request and resolution RPCs lock relevant rows. Pending-only updates make racing resolvers produce one decision; retries return the already-final request. Contribution insertion uses the existing idempotency constraint and voiding only affects unvoided rows.
+
+## Files changed
+
+- `supabase/migrations/20260711110000_rehearsal_attendance_corrections.sql`
+- `src/components/social/ParticipantStatusList.tsx`
+- `src/hooks/useParticipationDetails.ts`
+- `src/hooks/useBandContributions.ts`
+- `src/lib/participationStatus.ts`
+- `src/lib/bandContributions.ts`
+- `src/lib/participationStatus.test.ts`
+- social planning/audit docs
+
+## Database changes
+
+Adds the correction request table, RLS, indexes, timing helpers, request/resolve RPCs, contribution void columns, audit enum values, and grants for authenticated RPC execution.
+
+## Tests
+
+Added status mapping unit coverage for correction statuses. Manual validation should cover request/resolve RPC paths with Supabase DB tests once a local database URL is available.
+
+## Known limitations
+
+- No cancellation RPC in the MVP.
+- No automatic conflict-of-interest block against the original finalising manager because current audit rows do not expose a stable per-participant finaliser lookup for enforcement.
+- Admin/support creation of requests is not added; support can resolve existing requests.
+- UI deadline is advisory and uses scheduled end; database remains authoritative.
+
+## Recommended Phase 4 PR 09
+
+Add a focused database harness for correction RPC/RLS/concurrency, expose historical read-only correction decisions on the rehearsal surface, and add an explicit per-participant finaliser reference for stronger conflict-of-interest enforcement.

--- a/src/components/social/ParticipantStatusList.tsx
+++ b/src/components/social/ParticipantStatusList.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle, Users } from "lucide-react";
+import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import {
@@ -28,6 +29,7 @@ import {
 import { supabase } from "@/integrations/supabase/client";
 import {
   getGigLineupStatusDisplay,
+  getRehearsalAttendanceCorrectionStatusDisplay,
   getRehearsalParticipantStatusDisplay,
 } from "@/lib/participationStatus";
 import {
@@ -39,8 +41,10 @@ import { useToast } from "@/hooks/use-toast";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import {
   useGigPerformers,
+  useRehearsalAttendanceCorrectionRequests,
   useRehearsalParticipants,
   type GigPerformer,
+  type RehearsalAttendanceCorrectionRequest,
   type RehearsalParticipant,
 } from "@/hooks/useParticipationDetails";
 
@@ -69,16 +73,21 @@ function ParticipantRow({
   activeProfileId,
   rehearsalStatus,
   scheduledStart,
+  scheduledEnd,
+  correction,
 }: {
   row: RehearsalParticipant | GigPerformer;
   kind: Kind;
   activeProfileId?: string | null;
   rehearsalStatus?: string;
   scheduledStart?: string;
+  scheduledEnd?: string;
+  correction?: RehearsalAttendanceCorrectionRequest;
 }) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const [message, setMessage] = useState<string | null>(null);
+  const [correctionReason, setCorrectionReason] = useState("");
   const status =
     kind === "rehearsal"
       ? getRehearsalParticipantStatusDisplay(
@@ -93,6 +102,14 @@ function ParticipantRow({
   const deadline = scheduledStart
     ? getRehearsalRsvpDeadline(scheduledStart)
     : null;
+  const correctionDeadline = scheduledEnd ? new Date(new Date(scheduledEnd).getTime() + 24 * 60 * 60 * 1000) : null;
+  const canRequestCorrection =
+    isOwnRehearsalRow &&
+    FINAL_REHEARSAL_STATUSES.has((row as RehearsalParticipant).participation_status) &&
+    !correction &&
+    correctionDeadline !== null &&
+    Date.now() <= correctionDeadline.getTime();
+  const oppositeStatus = (row as RehearsalParticipant).participation_status === "attended" ? "missed" : "attended";
   const canRespond =
     isOwnRehearsalRow &&
     scheduledStart &&
@@ -101,6 +118,28 @@ function ParticipantRow({
       (row as RehearsalParticipant).participation_status,
       scheduledStart,
     );
+
+  const correctionMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await (supabase as any).rpc(
+        "request_rehearsal_attendance_correction",
+        { participant_id: row.id, requested_status: oppositeStatus, reason: correctionReason },
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      setMessage("Correction request submitted for manager review.");
+      setCorrectionReason("");
+      toast({ title: "Correction requested", description: "A manager will review your attendance correction." });
+      queryClient.invalidateQueries({ queryKey: ["rehearsal-attendance-corrections", (row as RehearsalParticipant).rehearsal_id] });
+    },
+    onError: (error: any) => {
+      const description = error?.message || "Please try again later.";
+      setMessage(description);
+      toast({ title: "Unable to request correction", description, variant: "destructive" });
+    },
+  });
 
   const mutation = useMutation({
     mutationFn: async (response: "confirmed" | "declined") => {
@@ -181,6 +220,42 @@ function ParticipantRow({
         >
           {status.label}
         </Badge>
+
+        {correction ? (
+          <div className="max-w-sm rounded-md border border-dashed p-2 text-xs text-muted-foreground" role="status" aria-live="polite">
+            Correction request: {getRehearsalAttendanceCorrectionStatusDisplay(correction.status).label}
+            {correction.status === "pending" ? ` — ${correction.current_status} → ${correction.requested_status}` : ""}
+          </div>
+        ) : null}
+        {canRequestCorrection ? (
+          <div className="space-y-2 rounded-md border p-2" aria-busy={correctionMutation.isPending}>
+            <p className="text-xs text-muted-foreground">Correction window closes {correctionDeadline?.toLocaleString()}.</p>
+            <Label htmlFor={`${row.id}-correction-reason`}>Correction reason (optional)</Label>
+            <Textarea
+              id={`${row.id}-correction-reason`}
+              value={correctionReason}
+              onChange={(event) => setCorrectionReason(event.target.value)}
+              maxLength={280}
+              placeholder={`Request change to ${oppositeStatus}`}
+              disabled={correctionMutation.isPending}
+            />
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button size="sm" variant="outline" disabled={correctionMutation.isPending || correctionReason.includes("<") || correctionReason.includes(">")}>Request correction</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Request attendance correction?</AlertDialogTitle>
+                  <AlertDialogDescription>This asks a manager to review changing your final status to {oppositeStatus}. Attendance will not change immediately.</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={correctionMutation.isPending}>Cancel</AlertDialogCancel>
+                  <AlertDialogAction disabled={correctionMutation.isPending} onClick={(event) => { event.preventDefault(); correctionMutation.mutate(); }}>Submit request</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        ) : null}
         {canRespond ? (
           <div
             className="flex flex-col gap-2 sm:flex-row"
@@ -448,6 +523,77 @@ function ManagerAttendanceFinalisation({
   );
 }
 
+
+function ManagerCorrectionRequests({ rehearsalId, requests }: { rehearsalId: string; requests: RehearsalAttendanceCorrectionRequest[] }) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [message, setMessage] = useState<string | null>(null);
+  const pending = requests.filter((request) => request.status === "pending");
+  const mutation = useMutation({
+    mutationFn: async ({ id, decision }: { id: string; decision: "approve" | "reject" }) => {
+      const { data, error } = await (supabase as any).rpc("resolve_rehearsal_attendance_correction", {
+        correction_request_id: id,
+        decision,
+        resolution_note: notes[id] || null,
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      setMessage(`Correction ${variables.decision === "approve" ? "approved" : "rejected"}.`);
+      toast({ title: "Correction resolved", description: "The requester was notified." });
+      queryClient.invalidateQueries({ queryKey: ["rehearsal-attendance-corrections", rehearsalId] });
+      queryClient.invalidateQueries({ queryKey: ["rehearsal-participants", rehearsalId] });
+      queryClient.invalidateQueries({ queryKey: ["band-contribution-events"] });
+    },
+    onError: (error: any) => {
+      const description = error?.message || "Please try again later.";
+      setMessage(description);
+      toast({ title: "Unable to resolve correction", description, variant: "destructive" });
+    },
+  });
+
+  if (requests.length === 0) return null;
+
+  return (
+    <section className="space-y-3 rounded-lg border p-3" aria-label="Attendance correction requests" aria-busy={mutation.isPending}>
+      <div className="space-y-1">
+        <h4 className="font-medium">Attendance correction requests</h4>
+        <p className="text-sm text-muted-foreground">Private correction reasons are visible only to the requester, authorised resolvers, and support.</p>
+      </div>
+      {message ? <p className="text-sm text-muted-foreground" role="status" aria-live="polite">{message}</p> : null}
+      {pending.length === 0 ? <p className="text-sm text-muted-foreground">No pending correction requests.</p> : null}
+      <ul className="space-y-2">
+        {pending.map((request) => {
+          const requesterName = nameFor({ profiles: request.profiles ?? null });
+          return (
+            <li key={request.id} className="space-y-2 rounded-md bg-muted/30 p-3">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="break-words text-sm font-medium">{requesterName}</p>
+                  <p className="text-xs text-muted-foreground">{request.current_status} → {request.requested_status} · submitted {new Date(request.created_at).toLocaleString()}</p>
+                </div>
+                <Badge variant={getRehearsalAttendanceCorrectionStatusDisplay(request.status).badgeVariant}>{getRehearsalAttendanceCorrectionStatusDisplay(request.status).label}</Badge>
+              </div>
+              {request.request_reason ? <p className="break-words rounded border bg-background p-2 text-sm">{request.request_reason}</p> : <p className="text-sm text-muted-foreground">No reason provided.</p>}
+              <Label htmlFor={`${request.id}-resolution-note`}>Private resolution note (optional)</Label>
+              <Textarea id={`${request.id}-resolution-note`} value={notes[request.id] ?? ""} maxLength={280} disabled={mutation.isPending} onChange={(event) => setNotes((current) => ({ ...current, [request.id]: event.target.value }))} />
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild><Button size="sm" disabled={mutation.isPending}>Approve</Button></AlertDialogTrigger>
+                  <AlertDialogContent><AlertDialogHeader><AlertDialogTitle>Approve correction?</AlertDialogTitle><AlertDialogDescription>This updates final attendance and applies contribution correction semantics.</AlertDialogDescription></AlertDialogHeader><AlertDialogFooter><AlertDialogCancel disabled={mutation.isPending}>Cancel</AlertDialogCancel><AlertDialogAction disabled={mutation.isPending} onClick={(event) => { event.preventDefault(); mutation.mutate({ id: request.id, decision: "approve" }); }}>Approve correction</AlertDialogAction></AlertDialogFooter></AlertDialogContent>
+                </AlertDialog>
+                <Button size="sm" variant="outline" disabled={mutation.isPending} onClick={() => mutation.mutate({ id: request.id, decision: "reject" })}>Reject</Button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
 function ParticipantStatusCard({
   title,
   description,
@@ -462,6 +608,7 @@ function ParticipantStatusCard({
   scheduledStart,
   scheduledEnd,
   isManager,
+  corrections = [],
 }: {
   title: string;
   description: string;
@@ -476,6 +623,7 @@ function ParticipantStatusCard({
   scheduledStart?: string;
   scheduledEnd?: string;
   isManager?: boolean;
+  corrections?: RehearsalAttendanceCorrectionRequest[];
 }) {
   if (isLoading)
     return (
@@ -525,20 +673,26 @@ function ParticipantStatusCard({
                 activeProfileId={activeProfileId}
                 rehearsalStatus={rehearsalStatus}
                 scheduledStart={scheduledStart}
+                scheduledEnd={scheduledEnd}
+                correction={corrections.find((correction) => correction.participant_id === row.id && correction.status === "pending")}
               />
             ))}
           </ul>
         )}
         {kind === "rehearsal" && isManager ? (
-          <ManagerAttendanceFinalisation
-            rehearsalId={
-              (rows[0] as RehearsalParticipant | undefined)?.rehearsal_id ?? ""
-            }
-            status={rehearsalStatus}
-            scheduledStart={scheduledStart}
-            scheduledEnd={scheduledEnd}
-            rows={rows as RehearsalParticipant[]}
-          />
+          <>
+            <ManagerCorrectionRequests
+              rehearsalId={(rows[0] as RehearsalParticipant | undefined)?.rehearsal_id ?? ""}
+              requests={corrections}
+            />
+            <ManagerAttendanceFinalisation
+              rehearsalId={(rows[0] as RehearsalParticipant | undefined)?.rehearsal_id ?? ""}
+              status={rehearsalStatus}
+              scheduledStart={scheduledStart}
+              scheduledEnd={scheduledEnd}
+              rows={rows as RehearsalParticipant[]}
+            />
+          </>
         ) : null}
       </CardContent>
     </Card>
@@ -552,6 +706,7 @@ export function RehearsalParticipantsSection({
   scheduledStart,
   scheduledEnd,
   isManager,
+  corrections = [],
 }: {
   rehearsalId: string;
   completed?: boolean;
@@ -559,8 +714,10 @@ export function RehearsalParticipantsSection({
   scheduledStart?: string;
   scheduledEnd?: string;
   isManager?: boolean;
+  corrections?: RehearsalAttendanceCorrectionRequest[];
 }) {
   const query = useRehearsalParticipants(rehearsalId);
+  const correctionsQuery = useRehearsalAttendanceCorrectionRequests(rehearsalId);
   const { profileId } = useActiveProfile();
   return (
     <ParticipantStatusCard
@@ -581,6 +738,7 @@ export function RehearsalParticipantsSection({
       scheduledStart={scheduledStart}
       scheduledEnd={scheduledEnd}
       isManager={isManager}
+      corrections={correctionsQuery.data ?? []}
     />
   );
 }

--- a/src/hooks/useBandContributions.ts
+++ b/src/hooks/useBandContributions.ts
@@ -10,9 +10,10 @@ export function useBandContributions(bandId: string, limit = BAND_CONTRIBUTION_L
       const { data, error } = await (supabase as any)
         .from("band_contribution_events")
         .select(
-          "id, band_id, profile_id, contribution_type, source_entity_type, source_entity_id, occurred_at, metadata, created_at, profiles:profiles!band_contribution_events_profile_id_fkey(id, username, display_name, avatar_url)",
+          "id, band_id, profile_id, contribution_type, source_entity_type, source_entity_id, occurred_at, metadata, created_at, voided_at, voided_by_correction_request_id, profiles:profiles!band_contribution_events_profile_id_fkey(id, username, display_name, avatar_url)",
         )
         .eq("band_id", bandId)
+        .is("voided_at", null)
         .order("occurred_at", { ascending: false })
         .order("created_at", { ascending: false })
         .limit(limit);

--- a/src/hooks/useParticipationDetails.ts
+++ b/src/hooks/useParticipationDetails.ts
@@ -65,3 +65,36 @@ export function useGigPerformers(gigId: string | null | undefined, enabled = tru
     },
   });
 }
+
+export type RehearsalAttendanceCorrectionRequest = {
+  id: string;
+  rehearsal_id: string;
+  participant_id: string;
+  band_id: string;
+  requester_profile_id: string;
+  current_status: "attended" | "missed";
+  requested_status: "attended" | "missed";
+  request_reason: string | null;
+  status: "pending" | "approved" | "rejected" | "cancelled";
+  created_at: string;
+  resolved_at: string | null;
+  resolved_by_profile_id: string | null;
+  resolution_note: string | null;
+  profiles?: PublicParticipantProfile | null;
+};
+
+export function useRehearsalAttendanceCorrectionRequests(rehearsalId: string | null | undefined, enabled = true) {
+  return useQuery({
+    queryKey: ["rehearsal-attendance-corrections", rehearsalId],
+    enabled: enabled && !!rehearsalId,
+    queryFn: async (): Promise<RehearsalAttendanceCorrectionRequest[]> => {
+      const { data, error } = await (supabase as any)
+        .from("rehearsal_attendance_correction_requests")
+        .select(`id, rehearsal_id, participant_id, band_id, requester_profile_id, current_status, requested_status, request_reason, status, created_at, resolved_at, resolved_by_profile_id, resolution_note, profiles:profiles!rehearsal_attendance_correction_requests_requester_profile_id_fkey(${profileSelect})`)
+        .eq("rehearsal_id", rehearsalId)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as RehearsalAttendanceCorrectionRequest[];
+    },
+  });
+}

--- a/src/lib/bandContributions.ts
+++ b/src/lib/bandContributions.ts
@@ -20,6 +20,8 @@ export type BandContributionEvent = {
   occurred_at: string;
   metadata: { label?: string; accuracy?: string; source_detail?: string; [key: string]: unknown } | null;
   created_at: string;
+  voided_at?: string | null;
+  voided_by_correction_request_id?: string | null;
   profiles: {
     id: string;
     username: string | null;
@@ -61,7 +63,7 @@ export function summarizeContributions(events: BandContributionEvent[]) {
   const byMember = new Map<string, { profile: BandContributionEvent["profiles"]; count: number }>();
   const byType = new Map<string, number>();
 
-  events.forEach((event) => {
+  events.filter((event) => !event.voided_at).forEach((event) => {
     const member = byMember.get(event.profile_id) ?? { profile: event.profiles, count: 0 };
     member.count += 1;
     byMember.set(event.profile_id, member);
@@ -69,7 +71,7 @@ export function summarizeContributions(events: BandContributionEvent[]) {
   });
 
   return {
-    total: events.length,
+    total: events.filter((event) => !event.voided_at).length,
     byMember: Array.from(byMember.entries()).map(([profileId, value]) => ({ profileId, ...value })),
     byType: Array.from(byType.entries()).map(([type, count]) => ({ type: type as BandContributionType, count })),
   };

--- a/src/lib/participationStatus.test.ts
+++ b/src/lib/participationStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getGigLineupStatusDisplay, getRehearsalParticipantStatusDisplay } from "./participationStatus";
+import { getGigLineupStatusDisplay, getRehearsalAttendanceCorrectionStatusDisplay, getRehearsalParticipantStatusDisplay } from "./participationStatus";
 
 describe("participation status mappings", () => {
   it("maps rehearsal statuses", () => {
@@ -16,8 +16,16 @@ describe("participation status mappings", () => {
     expect(getGigLineupStatusDisplay("missed")).toMatchObject({ label: "Missed", final: true });
   });
 
+  it("maps correction request statuses", () => {
+    expect(getRehearsalAttendanceCorrectionStatusDisplay("pending")).toMatchObject({ label: "Pending review", final: false, actionable: true });
+    expect(getRehearsalAttendanceCorrectionStatusDisplay("approved")).toMatchObject({ label: "Approved", final: true });
+    expect(getRehearsalAttendanceCorrectionStatusDisplay("rejected")).toMatchObject({ label: "Rejected", final: true });
+    expect(getRehearsalAttendanceCorrectionStatusDisplay("cancelled")).toMatchObject({ label: "Cancelled", final: true });
+  });
+
   it("returns a safe fallback for unsupported values", () => {
     expect(getRehearsalParticipantStatusDisplay("future")).toMatchObject({ label: "Status unavailable", semantic: "unknown" });
     expect(getGigLineupStatusDisplay(undefined)).toMatchObject({ label: "Status unavailable", semantic: "unknown" });
+    expect(getRehearsalAttendanceCorrectionStatusDisplay("future")).toMatchObject({ label: "Status unavailable", actionable: false });
   });
 });

--- a/src/lib/participationStatus.ts
+++ b/src/lib/participationStatus.ts
@@ -38,3 +38,19 @@ export function getRehearsalParticipantStatusDisplay(status: string | null | und
 export function getGigLineupStatusDisplay(status: string | null | undefined): StatusDisplay {
   return status ? gigLineupStatus[status] ?? fallback : fallback;
 }
+
+
+export type CorrectionRequestStatus = "pending" | "approved" | "rejected" | "cancelled";
+
+export const rehearsalAttendanceCorrectionStatus = {
+  pending: { label: "Pending review", final: false, actionable: true, badgeVariant: "secondary" },
+  approved: { label: "Approved", final: true, actionable: false, badgeVariant: "default" },
+  rejected: { label: "Rejected", final: true, actionable: false, badgeVariant: "destructive" },
+  cancelled: { label: "Cancelled", final: true, actionable: false, badgeVariant: "outline" },
+} satisfies Record<CorrectionRequestStatus, { label: string; final: boolean; actionable: boolean; badgeVariant: ParticipationBadgeVariant }>;
+
+export function getRehearsalAttendanceCorrectionStatusDisplay(status: string | null | undefined) {
+  return status && status in rehearsalAttendanceCorrectionStatus
+    ? rehearsalAttendanceCorrectionStatus[status as CorrectionRequestStatus]
+    : { label: "Status unavailable", final: false, actionable: false, badgeVariant: "outline" as ParticipationBadgeVariant };
+}

--- a/supabase/migrations/20260711110000_rehearsal_attendance_corrections.sql
+++ b/supabase/migrations/20260711110000_rehearsal_attendance_corrections.sql
@@ -1,0 +1,185 @@
+-- Phase 4 PR 08: rehearsal attendance correction request MVP.
+
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'rehearsal_attendance_correction_requested';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'rehearsal_attendance_correction_approved';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'rehearsal_attendance_correction_rejected';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'rehearsal_attendance_corrected';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'rehearsal_attendance_correction_denied';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'band_contribution_correction_created';
+
+CREATE TABLE IF NOT EXISTS public.rehearsal_attendance_correction_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rehearsal_id uuid NOT NULL REFERENCES public.band_rehearsals(id) ON DELETE CASCADE,
+  participant_id uuid NOT NULL REFERENCES public.band_rehearsal_participants(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  requester_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  current_status text NOT NULL CHECK (current_status IN ('attended', 'missed')),
+  requested_status text NOT NULL CHECK (requested_status IN ('attended', 'missed')),
+  request_reason text,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz,
+  resolved_by_profile_id uuid REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  resolution_note text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT rehearsal_attendance_correction_status_change CHECK (current_status <> requested_status),
+  CONSTRAINT rehearsal_attendance_correction_metadata_object CHECK (jsonb_typeof(metadata) = 'object')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS rehearsal_attendance_correction_one_pending_idx
+  ON public.rehearsal_attendance_correction_requests(participant_id)
+  WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS rehearsal_attendance_correction_rehearsal_idx
+  ON public.rehearsal_attendance_correction_requests(rehearsal_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS rehearsal_attendance_correction_band_idx
+  ON public.rehearsal_attendance_correction_requests(band_id, status, created_at DESC);
+
+ALTER TABLE public.rehearsal_attendance_correction_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.rehearsal_attendance_correction_window()
+RETURNS interval LANGUAGE sql IMMUTABLE SET search_path = public AS $$ SELECT interval '24 hours'; $$;
+
+CREATE OR REPLACE FUNCTION public.rehearsal_attendance_correction_deadline(p_completed_at timestamptz, p_scheduled_end timestamptz)
+RETURNS timestamptz LANGUAGE sql IMMUTABLE SET search_path = public AS $$
+  SELECT COALESCE(p_completed_at, p_scheduled_end) + public.rehearsal_attendance_correction_window();
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_rehearsal_attendance_correction_open(p_completed_at timestamptz, p_scheduled_end timestamptz)
+RETURNS boolean LANGUAGE sql STABLE SET search_path = public AS $$
+  SELECT COALESCE(p_completed_at, p_scheduled_end) IS NOT NULL
+    AND now() <= public.rehearsal_attendance_correction_deadline(p_completed_at, p_scheduled_end);
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_read_rehearsal_attendance_correction(p_band_id uuid, p_requester_profile_id uuid, p_actor_user_id uuid DEFAULT auth.uid())
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT p_actor_user_id IS NOT NULL AND (
+    EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = p_requester_profile_id AND p.user_id = p_actor_user_id)
+    OR public.is_band_leader_or_manager(p_band_id, p_actor_user_id)
+    OR public.has_role(p_actor_user_id, 'admin'::public.app_role)
+  );
+$$;
+
+CREATE POLICY "Requester and authorised resolvers can view rehearsal corrections"
+ON public.rehearsal_attendance_correction_requests FOR SELECT TO authenticated
+USING (public.can_read_rehearsal_attendance_correction(band_id, requester_profile_id, auth.uid()));
+
+CREATE OR REPLACE FUNCTION public.safe_correction_text(p_text text, p_max integer)
+RETURNS text LANGUAGE plpgsql IMMUTABLE SET search_path = public AS $$
+DECLARE v text;
+BEGIN
+  v := nullif(btrim(COALESCE(p_text, '')), '');
+  IF v IS NULL THEN RETURN NULL; END IF;
+  IF length(v) > p_max OR v ~ '[<>]' THEN
+    RAISE EXCEPTION 'Correction notes must be plain text under % characters.', p_max USING ERRCODE = '22023';
+  END IF;
+  RETURN v;
+END;
+$$;
+
+ALTER TABLE public.band_contribution_events
+  ADD COLUMN IF NOT EXISTS voided_at timestamptz,
+  ADD COLUMN IF NOT EXISTS voided_by_profile_id uuid REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS voided_by_correction_request_id uuid REFERENCES public.rehearsal_attendance_correction_requests(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS band_contribution_events_effective_idx
+  ON public.band_contribution_events(band_id, profile_id, contribution_type, source_entity_type, source_entity_id)
+  WHERE voided_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.request_rehearsal_attendance_correction(participant_id uuid, requested_status text, reason text DEFAULT NULL)
+RETURNS public.rehearsal_attendance_correction_requests
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_user_id uuid; actor_profile_id uuid; participant_row public.band_rehearsal_participants; rehearsal_row public.band_rehearsals; normalized_status text; cleaned_reason text; request_row public.rehearsal_attendance_correction_requests; manager_record record;
+BEGIN
+  actor_user_id := auth.uid();
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = actor_user_id ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Sign in before requesting an attendance correction.' USING ERRCODE = '28000'; END IF;
+  normalized_status := lower(btrim(COALESCE(requested_status, '')));
+  cleaned_reason := public.safe_correction_text(reason, 280);
+
+  SELECT * INTO participant_row FROM public.band_rehearsal_participants brp WHERE brp.id = participant_id FOR UPDATE;
+  IF participant_row.id IS NULL THEN RAISE EXCEPTION 'That attendance row could not be found.' USING ERRCODE = '22023'; END IF;
+  SELECT * INTO rehearsal_row FROM public.band_rehearsals br WHERE br.id = participant_row.rehearsal_id FOR UPDATE;
+
+  IF participant_row.profile_id <> actor_profile_id THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id, participant_row.profile_id, 'rehearsal_attendance_correction_denied'::public.social_action_audit_kind, 'band_rehearsal_participant', participant_row.id, jsonb_build_object('reason','not_own_participant','rehearsal_id',participant_row.rehearsal_id,'created_at',now()));
+    RAISE EXCEPTION 'You can only request correction for your own attendance.' USING ERRCODE = '42501';
+  END IF;
+  IF participant_row.participation_status NOT IN ('attended','missed') OR normalized_status NOT IN ('attended','missed') OR participant_row.participation_status = normalized_status THEN
+    RAISE EXCEPTION 'Corrections only switch final attended and missed statuses.' USING ERRCODE = '22023';
+  END IF;
+  IF NOT public.is_rehearsal_attendance_correction_open(rehearsal_row.completed_at, rehearsal_row.scheduled_end) THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id,'rehearsal_attendance_correction_denied'::public.social_action_audit_kind,'band_rehearsal_participant',participant_row.id,jsonb_build_object('reason','late_request','band_id',participant_row.band_id,'rehearsal_id',participant_row.rehearsal_id,'deadline',public.rehearsal_attendance_correction_deadline(rehearsal_row.completed_at,rehearsal_row.scheduled_end),'created_at',now()));
+    RAISE EXCEPTION 'The attendance correction window has closed.' USING ERRCODE = '55000';
+  END IF;
+
+  INSERT INTO public.rehearsal_attendance_correction_requests(rehearsal_id, participant_id, band_id, requester_profile_id, current_status, requested_status, request_reason, metadata)
+  VALUES (participant_row.rehearsal_id, participant_row.id, participant_row.band_id, actor_profile_id, participant_row.participation_status, normalized_status, cleaned_reason, jsonb_build_object('deadline', public.rehearsal_attendance_correction_deadline(rehearsal_row.completed_at,rehearsal_row.scheduled_end)))
+  ON CONFLICT (participant_id) WHERE status = 'pending' DO UPDATE SET metadata = public.rehearsal_attendance_correction_requests.metadata || jsonb_build_object('duplicate_request_at', now())
+  RETURNING * INTO request_row;
+
+  INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata)
+  VALUES (actor_profile_id, actor_profile_id, 'rehearsal_attendance_correction_requested'::public.social_action_audit_kind, 'band_rehearsal_participant', participant_row.id, jsonb_build_object('band_id',participant_row.band_id,'rehearsal_id',participant_row.rehearsal_id,'correction_request_id',request_row.id,'previous_status',participant_row.participation_status,'requested_status',normalized_status,'created_at',now()));
+
+  FOR manager_record IN SELECT DISTINCT bm.user_id, bm.profile_id FROM public.band_members bm WHERE bm.band_id = participant_row.band_id AND COALESCE(bm.member_status,'active')='active' AND bm.user_id IS NOT NULL AND bm.profile_id IS NOT NULL AND lower(COALESCE(bm.role,'')) IN ('leader','founder','co-leader','manager') LOOP
+    INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+    SELECT manager_record.user_id, manager_record.profile_id, 'band', 'rehearsal_attendance_correction_requested', 'Attendance correction requested', 'A rehearsal attendance correction needs review.', '/rehearsals', jsonb_build_object('rehearsal_id',participant_row.rehearsal_id,'participant_id',participant_row.id,'correction_request_id',request_row.id,'band_id',participant_row.band_id)
+    WHERE NOT EXISTS (SELECT 1 FROM public.notifications n WHERE n.user_id = manager_record.user_id AND n.type = 'rehearsal_attendance_correction_requested' AND n.metadata->>'correction_request_id' = request_row.id::text);
+  END LOOP;
+  RETURN request_row;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.resolve_rehearsal_attendance_correction(correction_request_id uuid, decision text, resolution_note text DEFAULT NULL)
+RETURNS public.rehearsal_attendance_correction_requests
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_user_id uuid; actor_profile_id uuid; request_row public.rehearsal_attendance_correction_requests; participant_row public.band_rehearsal_participants; rehearsal_row public.band_rehearsals; normalized_decision text; cleaned_note text; requester_user_id uuid; event_id uuid;
+BEGIN
+  actor_user_id := auth.uid();
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = actor_user_id ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Sign in before resolving an attendance correction.' USING ERRCODE = '28000'; END IF;
+  normalized_decision := lower(btrim(COALESCE(decision,'')));
+  cleaned_note := public.safe_correction_text(resolution_note, 280);
+  IF normalized_decision NOT IN ('approve','reject') THEN RAISE EXCEPTION 'Choose approve or reject.' USING ERRCODE = '22023'; END IF;
+
+  SELECT * INTO request_row FROM public.rehearsal_attendance_correction_requests r WHERE r.id = correction_request_id FOR UPDATE;
+  IF request_row.id IS NULL THEN RAISE EXCEPTION 'Correction request not found.' USING ERRCODE = '22023'; END IF;
+  IF request_row.status <> 'pending' THEN RETURN request_row; END IF;
+  SELECT * INTO participant_row FROM public.band_rehearsal_participants brp WHERE brp.id = request_row.participant_id FOR UPDATE;
+  SELECT * INTO rehearsal_row FROM public.band_rehearsals br WHERE br.id = request_row.rehearsal_id FOR UPDATE;
+  IF NOT (public.is_band_leader_or_manager(request_row.band_id, actor_user_id) OR public.has_role(actor_user_id, 'admin'::public.app_role)) THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id, request_row.requester_profile_id, 'rehearsal_attendance_correction_denied'::public.social_action_audit_kind, 'band_rehearsal_participant', request_row.participant_id, jsonb_build_object('reason','unauthorised_resolution','band_id',request_row.band_id,'rehearsal_id',request_row.rehearsal_id,'correction_request_id',request_row.id,'created_at',now()));
+    RAISE EXCEPTION 'Only current authorised managers or support can resolve attendance corrections.' USING ERRCODE = '42501';
+  END IF;
+  IF participant_row.participation_status <> request_row.current_status THEN RAISE EXCEPTION 'Attendance changed since this correction was requested.' USING ERRCODE = '40001'; END IF;
+
+  UPDATE public.rehearsal_attendance_correction_requests SET status = CASE WHEN normalized_decision='approve' THEN 'approved' ELSE 'rejected' END, resolved_at = now(), resolved_by_profile_id = actor_profile_id, resolution_note = cleaned_note WHERE id = request_row.id AND status = 'pending' RETURNING * INTO request_row;
+
+  IF normalized_decision = 'approve' THEN
+    UPDATE public.band_rehearsal_participants SET participation_status = request_row.requested_status, attended_at = CASE WHEN request_row.requested_status = 'attended' THEN COALESCE(attended_at, now()) ELSE attended_at END, updated_at = now() WHERE id = request_row.participant_id;
+    IF request_row.requested_status = 'attended' THEN
+      event_id := public.insert_band_contribution_event(request_row.band_id, request_row.requester_profile_id, 'rehearsal_attendance', 'band_rehearsal', request_row.rehearsal_id, COALESCE(rehearsal_row.completed_at, rehearsal_row.scheduled_end, now()), jsonb_build_object('label','Corrected rehearsal attendance','accuracy','corrected_participant','correction_request_id',request_row.id));
+    ELSE
+      UPDATE public.band_contribution_events SET voided_at = COALESCE(voided_at, now()), voided_by_profile_id = actor_profile_id, voided_by_correction_request_id = request_row.id WHERE band_id = request_row.band_id AND profile_id = request_row.requester_profile_id AND contribution_type = 'rehearsal_attendance' AND source_entity_type = 'band_rehearsal' AND source_entity_id = request_row.rehearsal_id AND voided_at IS NULL RETURNING id INTO event_id;
+    END IF;
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id, request_row.requester_profile_id, 'rehearsal_attendance_corrected'::public.social_action_audit_kind, 'band_rehearsal_participant', request_row.participant_id, jsonb_build_object('band_id',request_row.band_id,'rehearsal_id',request_row.rehearsal_id,'correction_request_id',request_row.id,'previous_status',request_row.current_status,'resulting_status',request_row.requested_status,'contribution_event_id',event_id,'created_at',now()));
+  END IF;
+
+  INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id, request_row.requester_profile_id, CASE WHEN normalized_decision='approve' THEN 'rehearsal_attendance_correction_approved'::public.social_action_audit_kind ELSE 'rehearsal_attendance_correction_rejected'::public.social_action_audit_kind END, 'band_rehearsal_participant', request_row.participant_id, jsonb_build_object('band_id',request_row.band_id,'rehearsal_id',request_row.rehearsal_id,'correction_request_id',request_row.id,'previous_status',request_row.current_status,'requested_status',request_row.requested_status,'decision',normalized_decision,'resulting_status',CASE WHEN normalized_decision='approve' THEN request_row.requested_status ELSE request_row.current_status END,'created_at',now()));
+
+  SELECT p.user_id INTO requester_user_id FROM public.profiles p WHERE p.id = request_row.requester_profile_id;
+  IF requester_user_id IS NOT NULL THEN
+    INSERT INTO public.notifications(user_id, profile_id, category, type, title, message, action_path, metadata)
+    SELECT requester_user_id, request_row.requester_profile_id, 'band', 'rehearsal_attendance_correction_resolved', 'Attendance correction resolved', CASE WHEN normalized_decision='approve' THEN 'Your rehearsal attendance correction was approved.' ELSE 'Your rehearsal attendance correction was rejected.' END, '/rehearsals', jsonb_build_object('rehearsal_id',request_row.rehearsal_id,'participant_id',request_row.participant_id,'correction_request_id',request_row.id,'decision',normalized_decision,'band_id',request_row.band_id)
+    WHERE NOT EXISTS (SELECT 1 FROM public.notifications n WHERE n.user_id = requester_user_id AND n.type = 'rehearsal_attendance_correction_resolved' AND n.metadata->>'correction_request_id' = request_row.id::text);
+  END IF;
+  IF normalized_decision='approve' AND event_id IS NOT NULL THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES (actor_profile_id, request_row.requester_profile_id, 'band_contribution_correction_created'::public.social_action_audit_kind, 'band_rehearsal_participant', request_row.participant_id, jsonb_build_object('band_id',request_row.band_id,'rehearsal_id',request_row.rehearsal_id,'correction_request_id',request_row.id,'contribution_event_id',event_id,'created_at',now()));
+  END IF;
+  RETURN request_row;
+END; $$;
+
+REVOKE ALL ON FUNCTION public.request_rehearsal_attendance_correction(uuid, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.resolve_rehearsal_attendance_correction(uuid, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.request_rehearsal_attendance_correction(uuid, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_rehearsal_attendance_correction(uuid, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.rehearsal_attendance_correction_deadline(timestamptz, timestamptz) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_rehearsal_attendance_correction_open(timestamptz, timestamptz) TO authenticated;


### PR DESCRIPTION
### Motivation
- Provide a narrow, time-limited, auditable correction path for rehearsal final attendance (only `attended` ↔ `missed`) without letting managers directly rewrite final states.
- Preserve append-only audit history and keep contribution events auditable while correcting effective contribution summaries safely.
- Prevent abuse by limiting who may request or resolve corrections, enforcing a one-pending-request rule, and using a database-authoritative correction window.
- Keep the scope small for beta: rehearsal-only corrections, private reasons, vetted resolver roles, and no rewards/penalties/XP changes.

### Description
- Database: Add `rehearsal_attendance_correction_requests` table, RLS policy, partial-unique index for one pending request per participant, timing helpers (`rehearsal_attendance_correction_window`, `rehearsal_attendance_correction_deadline`, `is_rehearsal_attendance_correction_open`), and `safe_correction_text` validator in `supabase/migrations/20260711110000_rehearsal_attendance_corrections.sql`.
- RPCs & audit: Implement guarded RPCs `request_rehearsal_attendance_correction(...)` and `resolve_rehearsal_attendance_correction(...)`, add social audit kinds for request/approve/reject/correct events, and create deduped notifications for resolvers and requesters.
- Contribution model: Extend `band_contribution_events` with `voided_at`, `voided_by_profile_id`, and `voided_by_correction_request_id`, add a filtered index and adjust contribution reads/summaries to ignore voided events so effective summaries no longer count invalidated attendance.
- Frontend: Add requester UI on the existing rehearsal participant row and manager review UI in `src/components/social/ParticipantStatusList.tsx`, plus `useRehearsalAttendanceCorrectionRequests` hook in `src/hooks/useParticipationDetails.ts` and correction-status mappings in `src/lib/participationStatus.ts`.
- Docs: Add `docs/social/implementation/PHASE_4_PR_08.md` and update `docs/social/ATTENDANCE_AND_LINEUP_RULES.md`, `docs/social/SOCIAL_SYSTEM_AUDIT.md`, and `docs/social/SOCIAL_MMO_EXPANSION_PLAN.md` with implementation status and limitations.

### Testing
- Typecheck: ran `npm run typecheck` (`tsc --noEmit`) and it succeeded.
- Lint/build/unit/db tests: `npm run lint` (ESLint), `npm run build` (Vite), `npm run test:unit` (Vitest), and `npm run test:participants:db` (Supabase harness) were attempted but blocked by the environment or missing dev tooling (missing `@eslint/js`, `vite`, `vitest`, and Supabase CLI); these are noted as environment-dependent and not introduced by the change.
- Unit tests added: updated `src/lib/participationStatus.test.ts` to cover correction-status mappings; test files are present but could not be executed here due to missing `vitest`.
- Static checks: `git diff --check` was run and produced no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51d56bc8f08325997b0e842c72ff4d)