### PR TITLE
Phase 5 PR 01: Live gig experience audit and canonical event design (docs)

### DIFF
--- a/docs/gigs/LIVE_GIG_EXPERIENCE_PLAN.md
+++ b/docs/gigs/LIVE_GIG_EXPERIENCE_PLAN.md
@@ -1,0 +1,519 @@
+# Live Gig Experience Plan
+
+This plan defines the future lightweight Football Manager-style gig experience. It is documentation only: no viewer implementation, migration, balance change, or new dependency is introduced in Phase 5 PR 01.
+
+## Goals
+
+- Tell the story of a gig with simple 2D shapes, concise commentary, and a clear post-gig hierarchy.
+- Keep rewards and outcomes server-authoritative.
+- Make the viewer deterministic, reconnectable, seekable, replayable, and safe across tabs.
+- Replace the fixed ten-minute report delay with result availability based on authoritative completion.
+- Avoid 3D, game engines, heavy particles, or client-side reward recalculation.
+
+## Post-gig information hierarchy
+
+### Level 1 — Immediate result
+
+Displayed as soon as the authoritative outcome is ready.
+
+Must include:
+
+- large grade/rating;
+- one-sentence verdict;
+- attendance and capacity;
+- net profit;
+- fans/fame gained;
+- best-performing song;
+- biggest positive or negative moment;
+- `Continue` button;
+- `View full analysis` button.
+
+Existing cards to merge into this level:
+
+- Overall Performance;
+- the useful headline parts of Enhanced Metrics;
+- net profit from Financial Deep Dive;
+- fame/fans from Impact/Fan Growth/Member Rewards;
+- best song from Setlist Performance;
+- one canonical Moment Highlight.
+
+### Level 2 — Performance story
+
+Explains what happened:
+
+- timeline by phase;
+- setlist in performance order;
+- song scores and crowd response changes;
+- highlight moments;
+- band-member moments when canonical data exists;
+- encore/finale;
+- turning point.
+
+Existing cards to retain here with changes:
+
+- Setlist Performance, simplified by default;
+- Crowd Analytics, converted into momentum/story language;
+- Moment Highlights, backed by canonical event data;
+- selected performer/member moments when server-authored.
+
+### Level 3 — Detailed analysis
+
+Optional collapsible detail:
+
+- full financial breakdown;
+- equipment impact;
+- crew impact;
+- skill contribution;
+- chemistry;
+- venue relationship;
+- detailed fan conversion;
+- XP/rewards;
+- technical modifiers;
+- legacy warnings.
+
+Existing cards to move/collapse:
+
+- Financial Deep Dive;
+- Gear Bonuses Applied;
+- Band Chemistry;
+- Venue Relationship;
+- XP Rewards;
+- Member Rewards;
+- Performance Factors;
+- Stage Behavior Used.
+
+Existing cards to remove or replace:
+
+- Impact summary as a separate card, because it duplicates fame, chemistry, and merch;
+- client-derived Band Member Performance unless backed by performer outcome data;
+- zero-merch warning unless inventory data proves the cause.
+
+## Recommended 2D visual approach
+
+Use HTML Canvas for the first full viewer implementation, with a DOM event log and controls beside or below it.
+
+Rationale:
+
+- Canvas handles hundreds of simple circles better than large DOM/SVG trees on mobile.
+- The current app already uses React UI components for shell/controls and does not need a game engine.
+- Authoritative outcome data can remain separate from cosmetic interpolation.
+- Canvas can be paired with a reduced-motion DOM-only mode.
+
+SVG/DOM remains acceptable for PR 04 if prototype profiling shows entity counts below budget, but the safe default is Canvas.
+
+## Venue layer
+
+Represent venues with simple geometry:
+
+- entrance/doors;
+- audience area;
+- stage rectangle;
+- backstage entrance;
+- barriers/rail;
+- optional seating zones;
+- capacity-scaled dimensions;
+- label overlays for venue name, attendance, and current phase.
+
+### Venue presets
+
+| Preset | Capacity guide | Layout |
+|---|---:|---|
+| Tiny club | 0-150 | Narrow room, small stage, one entrance, dense standing floor. |
+| Small venue | 151-750 | Wider standing floor, stage rail, optional side bar/door. |
+| Theatre | 751-2,500 | Stage plus seated blocks/aisles. |
+| Arena | 2,501-20,000 | Large floor, tier rings represented as bands, multiple entrances. |
+| Stadium | 20,001+ | Aggregated crowd blocks, very low entity density, large stage. |
+| Festival stage | Any large outdoor venue | Wide stage, open field, multiple crowd zones. |
+
+First implementation may ship only small, medium, and large presets. Venue type and capacity choose the preset; attendance percentage determines fill; band size adjusts stage spacing.
+
+## Crowd aggregation rules
+
+Do not render one entity per attendee.
+
+Recommended caps:
+
+| Device/performance mode | Visual fan cap |
+|---|---:|
+| Reduced motion | 0-50 static dots or density blocks |
+| Mobile low-performance | 80 |
+| Mobile default | 150 |
+| Desktop default | 300 |
+| Desktop high | 500 |
+
+Each visual fan has `represents_attendees = ceil(actual_attendance / visualFanCount)`. Preserve perceived scale by changing density, crowd blocks, labels, and tier fill, not by unlimited entities.
+
+Fan states:
+
+- arriving;
+- waiting;
+- attentive;
+- warming;
+- engaged;
+- energetic;
+- ecstatic;
+- disappointed;
+- leaving.
+
+Inputs may include current song score, previous momentum, attendance density, band fame, venue fit, chemistry, equipment incidents, and canonical highlights. Crowd animation never feeds back into rewards.
+
+## Band entities and stage positions
+
+Band members are larger coloured circles with initials, instrument icon, or short label. Use `gig_performers` and band role/instrument data when available, falling back to band members and generic roles.
+
+Predictable positions:
+
+| Role | Position rule | Movement |
+|---|---|---|
+| Vocalist/frontperson | Front centre | Largest roaming zone. |
+| Lead guitar | Front left/right | Medium roaming, solos step forward. |
+| Rhythm guitar | Opposite side | Medium roaming. |
+| Bass | Front/mid opposite rhythm | Medium-low roaming. |
+| Drums | Rear centre | Mostly fixed. |
+| Keyboard | Rear/side | Low roaming. |
+| DJ/electronic | Rear/centre table | Low roaming. |
+| Backing vocals | Rear/side mic spots | Small zones. |
+| Other/unknown | Evenly spaced fallback slots | Conservative movement. |
+
+Large bands should use rings/rows and avoid overlap. Unknown roles should never break the layout.
+
+## Visual effects
+
+Keep effects simple and sparse:
+
+- pulse;
+- scale;
+- ring;
+- short trail;
+- spotlight cone;
+- colour/intensity change;
+- crowd wave;
+- floating commentary label;
+- confetti only for exceptional finale.
+
+Avoid heavy particles, physics, shaders, 3D, or external game engines.
+
+## Canonical gig phase model
+
+Default normal viewer duration should be configurable, initially 2-4 minutes. Fast mode target is about one minute. Skip-to-result should be immediate once outcome exists.
+
+| Phase | Trigger | Default duration | Visual behaviour | Required data | Commentary | Skippable | Reconnect/accessibility |
+|---|---|---:|---|---|---|---|---|
+| `venue_opening` | viewer starts or replay begins | 5s | Empty room, doors/lights on | venue, capacity | Doors open | yes | Log entry with timestamp. |
+| `crowd_entry` | after opening | 15-30s | Fan dots enter and fill zones | attendance, capacity | Room starts to fill | yes | Seek from offset. |
+| `pre_show` | crowd settled | 5-10s | Waiting crowd, stage lights | band/venue | Anticipation line | yes | Reduced-motion static state. |
+| `band_entrance` | pre-show ends | 8-12s | Band enters backstage path | performers/roles | Band walks on | yes | Text list of members. |
+| `song_intro` | each song starts | 3-5s | Highlight song title, members ready | setlist song | Opening riff line | yes | Announce song. |
+| `song_performance` | after intro | 15-35s per song | Movement, crowd energy | song score, response | 1-3 factual lines | skip to next | Derive exact offset from event sequence. |
+| `between_songs` | song ends | 3-8s | Applause/reset | score/response | Applause/banter if supported | yes | Event log line. |
+| `highlight_moment` | scheduled event | 4-8s | Ring/effect/label | canonical moment | Positive/negative highlight | yes | Important status update. |
+| `encore_decision` | after main set | 5-8s | Crowd chant or quiet | rating/crowd | Encore requested/declined | yes | Text equivalent. |
+| `finale` | final song/encore | 10-20s | Peak energy/end effects | final rating | Finale line | yes | No flashing. |
+| `band_exit` | after finale | 5-8s | Band leaves, crowd disperses | performers | Band exits | yes | Text summary. |
+| `result_reveal` | authoritative outcome exists | immediate | Headline result card | report summary | Verdict | no need | Always accessible. |
+| `completed` | result acknowledged | indefinite | Replay/report options | outcome id | None | replay | Versioned replay fallback. |
+
+## Canonical event contract
+
+Design TypeScript shape for PR 02/04 discussion:
+
+```ts
+export type GigViewerPhase =
+  | 'venue_opening'
+  | 'crowd_entry'
+  | 'pre_show'
+  | 'band_entrance'
+  | 'song_intro'
+  | 'song_performance'
+  | 'between_songs'
+  | 'highlight_moment'
+  | 'encore_decision'
+  | 'finale'
+  | 'band_exit'
+  | 'result_reveal'
+  | 'completed';
+
+export interface GigViewerEvent {
+  id: string;
+  gig_id: string;
+  sequence: number;
+  phase: GigViewerPhase;
+  event_type:
+    | 'doors_open'
+    | 'fans_enter'
+    | 'capacity_milestone'
+    | 'band_enters'
+    | 'member_takes_position'
+    | 'song_starts'
+    | 'crowd_warms'
+    | 'crowd_surges'
+    | 'crowd_drops'
+    | 'performer_highlight'
+    | 'performer_mistake'
+    | 'equipment_issue'
+    | 'recovery'
+    | 'singalong'
+    | 'encore_requested'
+    | 'encore_performed'
+    | 'finale'
+    | 'band_exits'
+    | 'result_ready';
+  scheduled_offset_ms: number;
+  duration_ms: number;
+  song_id?: string | null;
+  performer_profile_id?: string | null;
+  crowd_energy_before?: number | null;
+  crowd_energy_after?: number | null;
+  importance: 'ambient' | 'normal' | 'important' | 'critical';
+  title: string;
+  description: string;
+  visual_payload: Record<string, unknown>;
+  created_at: string;
+}
+```
+
+### Storage recommendation
+
+Use a hybrid model:
+
+1. Store authoritative outcome, `viewer_version`, `simulation_seed`, `result_ready_at`, and a canonical event payload JSON on the outcome or a related summary row.
+2. Later add a normalized event table only if querying individual events becomes necessary for analytics, moderation, public spectators, or very large payloads.
+
+This is safer than deriving events differently on each client and lighter than introducing a table before the final event shape stabilizes.
+
+Requirements:
+
+- generated once by server/edge code;
+- deterministic from outcome data plus seed;
+- versioned;
+- replayable after completion;
+- independent of frame rate;
+- seekable by `scheduled_offset_ms`;
+- safe if multiple tabs are open;
+- never client-authoritative for rewards.
+
+## Authority boundaries
+
+### Server-authoritative
+
+- gig start;
+- gig completion;
+- attendance;
+- song performance scores;
+- rewards;
+- profit;
+- fans;
+- fame;
+- chemistry;
+- member progression;
+- significant moments;
+- canonical event sequence or seed;
+- report summary DTO.
+
+### Client presentation
+
+- interpolation;
+- cosmetic movement;
+- crowd positioning;
+- animation timing;
+- camera/zoom;
+- visual effects;
+- speed;
+- pause;
+- sound settings;
+- reduced-motion presentation.
+
+Watching, skipping, pausing, replaying, closing, or opening multiple tabs must never alter rewards.
+
+## Reconnect, replay, and skipping
+
+| Scenario | Future behaviour |
+|---|---|
+| Browser closes | Server continues/finishes. Return uses stored outcome/events and viewer offset. |
+| Return during gig | Load current canonical phase from server time/result state; allow watch live or skip. |
+| Return after gig | Show immediate result if outcome exists; allow replay. |
+| Network interruption | Pause local playback, retry event/outcome fetch, resume by offset. |
+| Duplicate tabs | Tabs are read-only viewers. Server idempotency prevents duplicate completion/events. |
+| Late arrival | Start at current phase with option to rewind replayable events if permitted. |
+| Gig already complete | Show headline result first, with replay/full analysis options. |
+| Viewer version changes | Use stored `viewer_version`; if unsupported, show textual timeline and report. |
+
+Controls:
+
+- Play/Pause;
+- 1x, 2x, 4x/Fast;
+- Skip to next song;
+- Skip to highlights;
+- Skip to result;
+- Replay completed gig;
+- Mute visual/audio cues if audio is added later.
+
+Replace the fixed ten-minute report delay with:
+
+- result available when authoritative completion is ready;
+- viewer may continue cosmetically;
+- skip-to-result always available once outcome exists.
+
+## Commentary and storytelling
+
+Tone should be concise and factual:
+
+- “The room starts to fill.”
+- “The front rows recognise the opening riff.”
+- “The crowd loses interest during the breakdown.”
+- “A huge chorus pulls the room back in.”
+- “The audience demands one more song.”
+
+Rules:
+
+- 1 ambient line per phase maximum unless player opens full log;
+- 1-2 lines per song at normal importance;
+- critical moments always logged;
+- no unsupported claims about pyrotechnics, proposals, stockouts, camera crews, or injuries;
+- duplicate prevention by event type/song/performer;
+- localisation-ready message keys in future;
+- textual event log is the accessibility equivalent.
+
+## Performance and accessibility budgets
+
+- Target 60fps desktop, acceptable 30fps mobile.
+- Mobile default cap: 150 visual fans.
+- Desktop default cap: 300 visual fans.
+- Hard cap: 500 visual fans until profiling proves more is safe.
+- Pause expensive animation when tab hidden; advance logical playback by timestamps on return.
+- Cleanup `requestAnimationFrame`, timers, audio, and subscriptions on unmount.
+- Low-performance mode should reduce fan count, disable trails/confetti, and lower frame work.
+- Reduced-motion mode should use static positions, gentle opacity changes, and text timeline.
+
+Accessibility:
+
+- textual event log equivalent;
+- pause controls;
+- keyboard controls;
+- reduced motion;
+- colour-independent state labels;
+- screen-reader status summaries for phase/song/result;
+- no flashing effects;
+- no required audio;
+- result accessible without watching animation.
+
+## Analytics and engagement measurement
+
+Use existing analytics/event infrastructure only. Do not add a platform.
+
+Recommended event names:
+
+- `gig_viewer_opened`;
+- `gig_viewer_started`;
+- `viewer_speed_changed`;
+- `song_skipped`;
+- `highlights_skipped`;
+- `result_skipped_to`;
+- `viewer_completed`;
+- `viewer_abandoned`;
+- `viewer_replayed`;
+- `report_opened`;
+- `report_section_opened`.
+
+Success measures:
+
+- percentage opening viewer;
+- percentage watching at least one song;
+- median viewing time;
+- skip-to-result rate;
+- replay rate;
+- outcome report completion;
+- return to gig history.
+
+## Data migration assessment for later PRs
+
+| Addition | Classification | Reason |
+|---|---|---|
+| `viewer_version` | Required | Version renderer/event contracts. |
+| `simulation_seed` | Required | Deterministic cosmetic playback. |
+| canonical event payload JSON | Required | Reconnectable/replayable timeline without premature table design. |
+| `result_ready_at` | Required | Replace arbitrary ten-minute delay. |
+| structured report summary | Required | Stable Level 1 DTO and hierarchy. |
+| event sequence table | Useful/deferred | Needed only if JSON payload becomes too large or independently queried. |
+| `viewer_started_at` | Useful | Engagement analytics, not outcome authority. |
+| `viewer_completed_at` | Useful | Engagement analytics, not outcome authority. |
+| replay availability flag | Deferred | Product decision. |
+| public spectator ACL fields | Deferred | Product decision. |
+| client-written reward fields | Not recommended | Violates authority boundary. |
+
+## Proposed component architecture
+
+```text
+src/features/gig-experience/
+  components/
+    GigExperienceShell.tsx
+    GigTimeline.tsx
+    GigControls.tsx
+    GigHeadlineResult.tsx
+    GigDetailedReport.tsx
+  viewer/
+    GigCanvas.tsx
+    VenueRenderer.ts
+    CrowdRenderer.ts
+    PerformerRenderer.ts
+    EffectRenderer.ts
+    camera.ts
+  simulation/
+    eventTypes.ts
+    eventPlayer.ts
+    deterministicRandom.ts
+    crowdState.ts
+    stagePositions.ts
+  hooks/
+    useGigExperience.ts
+    useGigEventPlayback.ts
+  services/
+    gigExperienceService.ts
+  tests/
+```
+
+Use feature-folder boundaries for the rebuild and keep the existing report/viewer operational until replacement is ready.
+
+## Testing strategy
+
+Cover:
+
+- deterministic event generation;
+- same seed creates same sequence;
+- different frame rates do not change result;
+- reconnect resumes correct point;
+- skip produces no reward differences;
+- multiple tabs do not duplicate completion;
+- crowd entity caps;
+- stage placement;
+- unknown roles;
+- large bands;
+- zero/low attendance;
+- sold-out venue;
+- cancelled gig;
+- failed/poor performance;
+- excellent performance;
+- missing song data;
+- missing profile/avatar;
+- reduced motion;
+- mobile layout;
+- report hierarchy;
+- result available immediately when authoritative outcome exists.
+
+## Product decisions
+
+| Decision | Status | Safe default |
+|---|---|---|
+| Canvas versus SVG/DOM | Required before PR 04 | Canvas with DOM log. |
+| Expected viewer duration | Required before PR 04 | 2-4 minutes normal; ~1 minute fast. |
+| Speed options | Safe default available | 1x, 2x, 4x. |
+| Pause support | Safe default available | Support pause for accessibility. |
+| Replay availability duration | Deferred | Members can replay indefinitely for now. |
+| Venue layouts public? | Deferred | Use generic layouts only. |
+| Maximum visual fan entities | Safe default available | 300 desktop, 150 mobile, 500 hard cap. |
+| Outcome immediately skippable? | Required before PR 02 | Yes once outcome exists. |
+| Commentary textual only? | Safe default available | Textual first; audio deferred. |
+| Future audio planned? | Deferred | No required audio. |
+| Public spectators for other bands? | Deferred | Not in first implementation. |
+| Non-member replay of completed gigs? | Deferred | No until ACL defined. |
+| Hide setlist surprises until performed? | Required before PR 04 | Preserve hidden future songs if product wants surprise; otherwise show band-owned setlist. |

--- a/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
+++ b/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
@@ -1,0 +1,255 @@
+# Live Gig System Audit
+
+Phase 5 PR 01 documents the existing RockMundo gig journey, viewer, outcome report, and data model. It does not implement the future viewer, change balance, add migrations, or replace completion logic.
+
+## Repository evidence reviewed
+
+- `docs/realtime-gig-system.md`
+- `docs/social/implementation/PHASE_4_REVIEW.md`
+- `src/pages/PerformGig.tsx`
+- `src/components/gig-viewer/TopDownGigViewer.tsx`
+- `src/components/gig-viewer/GigAudioPlayer.tsx`
+- `src/components/gig/GigOutcomeReport.tsx`
+- `src/components/gig/*.tsx`
+- `src/hooks/useRealtimeGigAdvancement.ts`
+- `src/hooks/useManualGigStart.ts`
+- gig calculation and narrative utilities under `src/utils/`
+- gig edge functions under `supabase/functions/`
+- gig-related migrations under `supabase/migrations/`
+
+## Current player journey
+
+### Routes and entry points
+
+| Route / surface | Evidence | Current behaviour |
+|---|---|---|
+| `/gig-booking` | `src/App.tsx`, `src/pages/PerformGig.tsx` back links | Main schedule/booking return route. |
+| `/gig/:gigId` or equivalent routed page | `PerformGig` reads `gigId` from route params | Detailed gig page for preparation, live viewing, finalisation, and report modal. |
+| Band history | `src/components/band/GigHistoryTab.tsx` | Loads completed outcomes and can open the same report and replay-style viewer. |
+| News/other band outcomes | `src/components/news/LastNightGigs.tsx`, `src/components/news/OtherBandsGigOutcomes.tsx` | Reuses `GigOutcomeReport`, meaning report availability can differ from the ten-minute gate in `PerformGig`. |
+| Notifications/inbox | `useGameEventNotifications`, `complete-gig`, database trigger notes in version history | Gig outcome notifications point users back to gig booking rather than a dedicated report route. |
+
+### Upcoming gig
+
+1. `PerformGig` loads `gigs` with venue data, then checks `gig_outcomes` for an existing result.
+2. It loads band setlists, setlist song counts, current setlist songs, rehearsals, stage equipment count, crew count, and band chemistry/fame/fans.
+3. It shows the gig header, setlist selector/display, ticket-price adjustment when still scheduled and sales are poor, read-only performer section, and preparation checklist.
+4. The live viewer appears if the gig is within ten minutes of scheduled start, currently in progress, ready for completion, or completed less than ten minutes ago.
+
+### Preparation
+
+Preparation is represented as information and selectors, not an interactive performance simulation:
+
+- Setlist may be changed through `GigSetlistDisplay`; the comment in `PerformGig` says it is locked one hour before the gig.
+- Ticket price adjustment appears only for scheduled gigs with at least seven days remaining, low predicted sales, and no previous adjustment.
+- `GigPreparationChecklist` receives rehearsals, equipment count, crew count, chemistry, and gear effects.
+- `GigPerformersSection` displays the Phase 4 read-only performer/lineup data.
+
+### Manual and automatic start
+
+| Start path | Verified behaviour | Risk |
+|---|---|---|
+| Manual start | `useManualGigStart` checks status and setlist, then updates `gigs.status='in_progress'`, `started_at=now`, and `current_song_position=0`. `PerformGig` also checks current city and scheduling conflict before calling it. | Client can issue the status update directly through Supabase if policies allow it; no RPC lock is visible in the hook. |
+| Automatic start | `docs/realtime-gig-system.md` and `supabase/functions/auto-start-gigs` describe a cron/edge flow that starts due gigs. | Local UI still contains manual fallback. |
+
+### Live viewer and realtime advancement
+
+The current active viewer is `TopDownGigViewer`, not the older `RealtimeGigViewer` described in the realtime documentation.
+
+- `PerformGig` enables `useRealtimeGigAdvancement(gigId, shouldShowLiveViewer && !showOutcome)`.
+- `useRealtimeGigAdvancement` fetches `gigs`, setlist songs, and the outcome row; then it invokes `process-gig-song` for the current position and calls `advance_gig_song`.
+- It schedules follow-up checks based on song durations, subscribes to `gigs` updates for the current gig, and cleans up the timeout and realtime channel on unmount.
+- `TopDownGigViewer` separately polls gig data every eight seconds, polls song performances every five seconds, and subscribes to `gig_song_performances` inserts and `gigs` updates.
+
+### Completion and report delay
+
+Verified facts:
+
+- Outcomes can exist before the report is displayable. `PerformGig` queries `gig_outcomes`, but if `gigs.completed_at` is less than ten minutes ago it discards the loaded outcome and shows processing state.
+- The ten-minute delay is a client UI gate in `PerformGig`, implemented with `differenceInMinutes(now, completedAt) >= 10`, a refresh timeout for `completed_at + 10 minutes`, and a one-second countdown.
+- The viewer itself does not necessarily last ten real minutes. Song advancement uses actual setlist song durations from `started_at`; completed gigs stay in the live-viewer window for ten minutes after completion.
+- Closing the page can affect client-driven song-by-song progression because `useRealtimeGigAdvancement` only runs while the page is open; however `auto-complete-gigs` and `complete-gig` include server-side completion/backfill paths for unplayed songs.
+- `complete-gig` processes missing songs server-side before final calculations, so outcome generation is after or at completion and can recover from incomplete client playback.
+- Multiple browser tabs can call `process-gig-song`/`advance_gig_song` concurrently. There is a per-hook `completingGigsRef`, but it is tab-local. The later `complete-gig` function is documented and coded as idempotent, but song advancement still has duplicate-call risk unless database constraints/functions prevent it.
+- Reconnecting restores the stored `gigs.status`, `started_at`, `current_song_position`, and existing song performance rows, but there is no canonical viewer timeline state or deterministic event offset.
+- Players may see report data immediately through other routes that render `GigOutcomeReport` directly from `gig_outcomes` without the `PerformGig` ten-minute gate.
+
+### Loading, error, and recovery states
+
+| State | Current implementation |
+|---|---|
+| Initial load | Spinner card in `PerformGig`. |
+| Gig not found | Message and back button. |
+| Load failure | Toast and navigate to `/gig-booking`. |
+| Manual start failure | Toast from `useManualGigStart`; wrong-city and schedule-conflict toasts in page. |
+| Advancement failure | Toast on edge function errors; retries every ten seconds for unexpected errors. |
+| Completion failure | Toast from `handleFinalizeGig` or advancement hook. |
+| Recently completed | Processing card, countdown, refresh button. |
+| Stuck gig | Button invokes `fix-stuck-gigs`. |
+| Report open/close | Modal controlled by local `showOutcome`; no route state. |
+
+### Skip behaviour
+
+- `TopDownGigViewer` has a `Skip to Outcome` button.
+- It pauses audio, clears ambient commentary, and calls `onComplete`.
+- It does not complete the gig or unlock a delayed report by itself; `PerformGig` just reloads and will still hide the outcome inside the ten-minute window.
+- Skipping therefore changes only the local viewing experience, not rewards, but the label overpromises when the outcome is not yet available.
+
+### Mobile behaviour
+
+- `GigOutcomeReport` uses a `95vw`, `90vh`, scrollable dialog with responsive grids and smaller text.
+- `TopDownGigViewer` is card-based with a fixed `h-[500px]` scroll area and compact controls; it has no dedicated mobile performance cap because it renders text rather than a large entity field.
+- No explicit reduced-motion, keyboard shortcut, or screen-reader status model was found in the viewer.
+
+## Existing live viewer audit
+
+### Current visual model
+
+`TopDownGigViewer` is named like a spatial viewer but currently renders a live commentary card:
+
+- no canvas, SVG stage, or top-down map;
+- no venue geometry;
+- no fan entities;
+- no band-member entities;
+- progress is a song-count progress bar;
+- crowd mood is a label from latest `gig_song_performances.crowd_response`;
+- extensive random ambient commentary is generated in the browser;
+- optional song audio playback is attempted from `songs.audio_url`.
+
+### Rendering and animation
+
+| Area | Current approach | Category |
+|---|---|---|
+| Card shell/header | React + existing UI components | Reusable with changes |
+| Commentary feed | DOM list in scroll area | Reusable with changes as accessibility/event-log surface |
+| Progress bar | Song completion percentage | Reusable with changes |
+| Audio controls | HTMLAudioElement + volume slider | Deferred / unverified for future audio |
+| Random ambient comments | `Math.random`, local timers | Replace for canonical story; may keep as cosmetic only if labelled |
+| Realtime subscriptions | Supabase channels | Reusable with changes; filters need tightening for song inserts |
+| Polling | 8s gig reload + 5s performance reload | Replace or reduce after canonical event service |
+| Stage/crowd/band visuals | Not implemented | Replace / new implementation |
+| Skip button | Local callback | Reusable with semantic changes |
+| Pause/speed controls | Not present | New implementation |
+
+### Song progression and narration
+
+- Song performance rows drive song commentary once rows exist.
+- On first load, existing rows are replayed eight seconds apart even if the real gig is further along, which can misrepresent timing.
+- Ambient commentary is not authoritative and can claim events that have no supporting outcome data: proposals, pyrotechnics, camera crews, LED screens, crowd surfing, and merch stock claims.
+- Several `setTimeout` calls inside `processPerf` are not tracked for cleanup, creating stale-comment risk after unmount or skip.
+
+### CPU, memory, and mobile risks
+
+- Current viewer is lightweight compared with a canvas crowd, but it can keep adding unbounded commentary entries.
+- Polling plus realtime subscriptions duplicate work.
+- Untracked `setTimeout` callbacks can fire after unmount.
+- Audio playback can be blocked by browser autoplay rules and is not part of an accessibility-first control model.
+
+### Why players are likely to skip
+
+Verified usability problems:
+
+- The viewer does not show the promised spatial story of a performance.
+- `Skip to Outcome` does not reliably reveal the outcome due to the separate ten-minute gate.
+- There is no fast-forward, pause, skip-song, or highlights control.
+- The commentary feed gives equal prominence to random flavour and actual performance facts.
+- The fixed ten-minute post-completion delay blocks the report even when `gig_outcomes` already exists.
+
+Assumptions requiring player telemetry:
+
+- Players skip because they prefer immediate rewards.
+- Players distrust non-authoritative commentary.
+- Mobile users abandon because the scroll feed is too tall.
+
+## Outcome report audit
+
+### Sections rendered today
+
+| Section | Player question | Source | Authority | Recommendation |
+|---|---|---|---|---|
+| Overall Performance | Was it good? | `gig_outcomes.overall_rating`, grade utility | Authoritative score, client grade label | Retain as headline, larger and simpler. |
+| Stage Behavior Used | What behaviour modifiers applied? | `stage_behavior_used`, `stageBehaviors` utility | Mixed: stored behaviour key, client explanation | Move to detailed analysis/collapsed. |
+| Enhanced Metrics | What are key results? | Outcome + derived `overallRating * 4`, best/worst from song rows | Mixed; some client-derived | Merge into Level 1 summary and Level 2 story. |
+| Moment Highlights | What happened? | Optional prop; not loaded in `PerformGig` | Often absent | Replace with canonical event highlights. |
+| Crowd Analytics | How did crowd react? | attendance, song performances, rating | Partly authoritative | Move to Level 2 with clearer momentum. |
+| Financial Deep Dive | What did we earn? | flat outcome columns | Authoritative | Collapse under Level 3; headline only net profit. |
+| No Merch warning | Why zero merch? | merch fields defaulting to zero | Inferred | Retain only with inventory evidence. |
+| No Song Data warning | Why missing details? | song performance array | Authoritative absence | Retain as compatibility warning. |
+| XP Rewards | What XP did members get? | optional `xpSummary` prop | Usually absent in current page | Needs canonical DTO; otherwise collapse/omit. |
+| Fan Growth | How many fans converted? | optional prop or fallback fans | Often absent | Headline should use authoritative stored fields. |
+| Venue Relationship | Did venue like us? | optional prop | Often absent | Detailed only. |
+| Band Chemistry | Did chemistry change? | outcome/page props | Authoritative-ish; scale mismatch 0-100 vs 0-25 | Detailed analysis. |
+| Gear Bonuses Applied | What gear helped? | props or fallback mapping from flat columns | Mixed and legacy-transformed | Collapse; fix DTO naming first. |
+| Band Member Performances | Who performed well? | separate query by band | Client-derived from overall rating | Replace with canonical performer facts or label as estimate. |
+| Member Rewards | Who gained fame/fans? | separate query/fallback formulas | Mixed; fallback formulas | Use server-authored reward records only. |
+| Setlist Performance | Which songs worked? | `gig_song_performances` | Authoritative | Level 2, less modifier detail by default. |
+| Performance Factors | Why score happened? | flat averages / breakdown JSON | Authoritative but technical | Level 3 collapsed. |
+| Impact | Fame, chemistry, merch | outcome and transformed breakdown | Duplicates other cards | Merge/remove. |
+
+### Report problems
+
+- Too many cards receive equal visual weight.
+- Financial, impact, enhanced metrics, fan growth, XP, member rewards, and setlist cards duplicate player questions.
+- Rating uses a 0-25 scale while enhanced metrics converts to percentage and chemistry often uses 0-100 elsewhere.
+- `safeNumber` silently turns missing values into zero, hiding absent/legacy data.
+- `PerformGig` converts flat columns into `breakdown_data` and `gear_effects`, mixing authoritative database fields with compatibility presentation.
+- `GigOutcomeReport` may query song performances after outcome loading, and child cards query member/reward data separately, creating avoidable extra requests.
+- Several values are client-derived or fallback formulas rather than explicit server-authored report facts.
+- Moment highlights and fan/XP/venue relationship props are optional and usually absent from the `PerformGig` path.
+
+## Outcome data model audit
+
+### Core relationships
+
+- `gigs` belongs to `bands` and `venues`, optionally references a `setlist`, and stores schedule/status/start/completion progress fields.
+- `setlists` belongs to `bands`; `setlist_songs` orders songs within a setlist.
+- `gig_outcomes` is unique per gig and stores flat outcome totals, ratings, progression deltas, and legacy JSON breakdowns.
+- `gig_song_performances` stores one row per performed song/item and contribution components.
+- `gig_performers` stores selected/performed/missed profiles for a gig, but outcome scoring is still song/band-level rather than performer-event-level.
+- `band_stage_equipment` and `band_crew_members` are inputs to calculations.
+- Notifications/inbox are produced after outcome insert/completion and route back toward gig surfaces.
+
+### Important schema/UI mismatches
+
+| Finding | Impact |
+|---|---|
+| Contribution column names have legacy variants (`song_quality_contribution` vs UI `song_quality_contrib`, position vs setlist_position). | Requires compatibility transforms and increases breakage risk. |
+| `gig_outcomes.breakdown_data` and flat columns both represent factor breakdowns. | Duplicates source of truth. |
+| Gear-effect compatibility maps fields named `band_synergy_modifier`, `social_buzz_impact`, `audience_memory_impact`, `promoter_modifier`, `venue_loyalty_bonus` into unrelated gear concepts. | Naming is misleading for future contracts. |
+| `gigs.attendance` and `gig_outcomes.actual_attendance` can both exist. | Viewer/report need a canonical attendance source. |
+| `completed_at` exists on gigs and was also added historically to outcomes. | Result readiness should use an explicit `result_ready_at` rather than infer from completion. |
+| `gig_performers.role_or_instrument` exists, but there is no per-performer stage position, stage role, moment, or contribution row. | Future band-entity viewer lacks canonical movement/role data. |
+| No deterministic simulation seed, viewer version, canonical event sequence, event timestamps, per-song crowd energy before/after, or venue layout inputs. | Reconnect/replay/seek are impossible to make exact. |
+
+### Current authority boundaries
+
+Server/edge/database currently own:
+
+- final gig completion;
+- missing-song processing during completion;
+- outcome totals;
+- song performance rows;
+- band balance/fame/fans/chemistry/member progression side effects;
+- notifications/inbox.
+
+Client currently owns:
+
+- manual start status update;
+- live advancement scheduling while page is open;
+- random commentary;
+- report delay gate;
+- report compatibility transforms;
+- several report presentation fallbacks.
+
+## Explicit answers to requested verification questions
+
+| Question | Verified answer |
+|---|---|
+| Why is the outcome hidden for ten minutes after completion? | `PerformGig` discards existing outcomes until `differenceInMinutes(now, completedAt) >= 10` and shows a processing countdown. This is a client UI gate, not evidence of calculation need. |
+| Does the viewer itself last ten real minutes? | Not inherently. Song advancement follows real song durations; the page continues showing live/recent viewer state for ten minutes after completion. |
+| Does closing the page affect progression? | It can stop client advancement, but server auto-complete/complete-gig can complete and backfill missing song rows. |
+| Does the gig continue server-side? | Yes, there are `auto-start-gigs`, `auto-complete-gigs`, scheduled activity processing, and `complete-gig` server paths, but song-by-song live progression is still partly client driven. |
+| Does reconnect restore correct phase? | It restores coarse DB state and rows, not an exact canonical viewer phase. |
+| Can multiple tabs cause duplicate advancement? | Yes, duplicate client advancement calls are possible. Final completion is guarded/idempotent, but per-song advancement still needs server-side idempotency guarantees for the future. |
+| Can players see report immediately through another route? | Likely yes. Gig history/news components render `GigOutcomeReport` from `gig_outcomes` without the `PerformGig` ten-minute discard gate. |
+| Are outcomes generated before, during, or after viewer? | An outcome row may be found during live progression; final authoritative totals are generated/updated by `complete-gig` after songs are processed or backfilled. |

--- a/docs/gigs/implementation/PHASE_5_PR_01.md
+++ b/docs/gigs/implementation/PHASE_5_PR_01.md
@@ -1,0 +1,291 @@
+# Phase 5 PR 01 — Live Gig Experience Audit and Canonical Event Design
+
+## Objective
+
+Start Phase 5 with documentation only: audit the existing live gig journey and define the canonical data, UX, and delivery plan for a future lightweight 2D gig viewer and clearer outcome report.
+
+## Scope completed
+
+- Audited the current gig journey from scheduled gig through preparation, start, live viewer, advancement, completion, delayed report availability, report opening, and return routes.
+- Audited the current `TopDownGigViewer` and related gig-viewer components.
+- Audited `GigOutcomeReport` and its child card hierarchy.
+- Documented current data model relationships and naming/authority mismatches.
+- Defined a three-level post-gig information hierarchy.
+- Designed a lightweight 2D viewer concept based on simple shapes and deterministic playback.
+- Defined a canonical phase model and draft `GigViewerEvent` contract.
+- Defined authority boundaries, reconnect/replay/skip behaviour, venue scaling, crowd state, commentary, performance/accessibility budgets, analytics events, migration assessment, component architecture, tests, product decisions, and delivery plan.
+
+## Deliverables
+
+- [Live Gig System Audit](../LIVE_GIG_SYSTEM_AUDIT.md)
+- [Live Gig Experience Plan](../LIVE_GIG_EXPERIENCE_PLAN.md)
+
+## Key findings
+
+### Current gig journey
+
+- `PerformGig` is the central page for preparation, manual start, current viewer, finalisation, and report modal.
+- Automatic start and completion server paths exist, but live song-by-song advancement is still partly driven by a mounted client hook.
+- The ten-minute report delay is implemented in the client page by hiding an existing outcome until ten minutes after `gigs.completed_at`.
+- The viewer does not itself need to last ten real minutes; it follows song durations during the gig and remains visible during the post-completion delay window.
+- Closing the page can stop client advancement, but `complete-gig` and auto-complete paths can finish/backfill server-side.
+- Reconnect restores coarse DB progress, not a canonical visual phase/event offset.
+- Multiple tabs can duplicate advancement attempts; final completion has idempotency protections, but the future viewer should be read-only and server-authored.
+- Some other report surfaces can render `GigOutcomeReport` directly from `gig_outcomes`, bypassing the `PerformGig` delay.
+
+### Main engagement problems
+
+- The active viewer is a text commentary feed, not a spatial performance representation.
+- Random ambient commentary can claim unsupported events.
+- Skip-to-outcome does not reliably show an outcome because of the separate ten-minute gate.
+- There are no proper speed, pause, skip-song, highlights, or replay controls.
+- The outcome report has too many equally weighted cards and no immediate headline result hierarchy.
+
+### Existing viewer foundations
+
+Reusable with changes:
+
+- Supabase subscriptions and cleanup patterns;
+- existing card shell and progress display;
+- commentary feed as an accessible event log;
+- skip control concept;
+- audio control only as deferred optional enhancement.
+
+Replace/new:
+
+- deterministic event playback;
+- venue/stage/crowd/band renderers;
+- canonical commentary;
+- speed/pause/replay controls;
+- reconnectable phase state.
+
+### Outcome report problems
+
+- Duplicate metrics across Enhanced Metrics, Financial Deep Dive, Impact, Fan Growth, Member Rewards, and Setlist cards.
+- Conflicting scales: 0-25 stars, percentages, 0-100 chemistry/equipment inputs.
+- Missing values often become zero through `safeNumber`.
+- Client compatibility transforms convert flat DB columns into nested breakdown/gear-effect objects.
+- Several child cards fetch data separately after the outcome is loaded.
+- Some information is technical or not immediately actionable but appears with headline-level weight.
+
+### Data-model findings
+
+Future work likely needs:
+
+- `viewer_version`;
+- `simulation_seed`;
+- canonical event payload;
+- `result_ready_at`;
+- structured report summary;
+- optional event sequence table later.
+
+No migration is included in this PR.
+
+## Recommended 2D approach
+
+- Use Canvas plus DOM controls/event log as the safe default.
+- Render venue, fans, band members, and effects as simple geometry.
+- Cap visual fans and aggregate attendees.
+- Use deterministic seeded movement and server-authored events.
+- Keep cosmetic animation separate from outcome calculation.
+- Provide reduced-motion and text-only equivalents.
+
+## Canonical phase model
+
+Initial phases:
+
+1. `venue_opening`
+2. `crowd_entry`
+3. `pre_show`
+4. `band_entrance`
+5. `song_intro`
+6. `song_performance`
+7. `between_songs`
+8. `highlight_moment`
+9. `encore_decision`
+10. `finale`
+11. `band_exit`
+12. `result_reveal`
+13. `completed`
+
+Default timing should be configurable, with a first target of 2-4 minutes at normal speed and about one minute at fast speed.
+
+## Canonical event contract
+
+Use a versioned `GigViewerEvent` sequence with:
+
+- stable id and sequence;
+- phase and event type;
+- scheduled offset/duration;
+- optional song and performer references;
+- crowd energy before/after;
+- importance;
+- title/description;
+- visual payload.
+
+The safest storage model is hybrid: generate once server-side, store outcome summary/version/seed/event payload as JSON first, and add normalized event rows later only if needed.
+
+## Authority boundaries
+
+Server authoritative:
+
+- start/completion;
+- attendance;
+- song scores;
+- rewards/profit/fans/fame/chemistry;
+- member progression;
+- significant moments;
+- canonical event sequence or seed.
+
+Client presentation only:
+
+- interpolation;
+- movement;
+- camera;
+- visual effects;
+- speed/pause;
+- audio/mute;
+- reduced-motion display.
+
+## Report information hierarchy
+
+- Level 1: immediate headline result.
+- Level 2: performance story.
+- Level 3: detailed analysis.
+
+The current `GigOutcomeReport` should be rebuilt around a canonical DTO rather than continuing to patch flat/nested compatibility transforms in the page and report.
+
+## Performance/accessibility targets
+
+- 60fps desktop target, 30fps mobile acceptable.
+- 300 default desktop fans, 150 default mobile fans, 500 hard cap initially.
+- Pause animation work when hidden.
+- Cleanup animation frames, timers, subscriptions, and audio.
+- Reduced motion, keyboard controls, screen-reader summaries, colour-independent state, no flashing, no required audio.
+
+## Analytics plan
+
+Use existing analytics infrastructure only. Track viewer open/start, speed changes, song/highlight/result skips, completion, abandonment, replay, report opens, and section opens.
+
+Success measures include viewer open rate, at-least-one-song watch rate, median viewing time, skip-to-result rate, replay rate, report completion, and return to gig history.
+
+## Product decisions
+
+Required soon:
+
+- approve Canvas as first implementation default or choose SVG/DOM;
+- approve expected viewer duration;
+- confirm result is immediately skippable when outcome exists;
+- decide setlist surprise visibility.
+
+Safe defaults exist for speed options, pause, fan caps, textual commentary, and no required audio.
+
+Deferred decisions include public spectators, non-member replay, venue layout publicity, and future audio.
+
+## Delivery sequence
+
+### Phase 5 PR 02 — Canonical outcome DTO and report-summary service
+
+- Objective: define server/client DTO for headline result and report summary.
+- Scope: map current `gig_outcomes`, `gig_song_performances`, performers, venue, and rewards into one read model; remove page-level compatibility transforms from new code path.
+- Likely files: `src/features/gig-experience/services/`, shared types, tests, `GigOutcomeReport` adapter.
+- Database impact: none or read-only; migration design only.
+- Security impact: ensure no client reward recalculation.
+- Dependencies: PR 01 decisions on immediate result fields.
+- Acceptance: one DTO answers Level 1 without extra child-card queries.
+- Tests: unit mapping for legacy/current outcomes, missing song data, zero attendance.
+- Risk: medium.
+
+### Phase 5 PR 03 — Outcome report information-architecture rebuild
+
+- Objective: rebuild report into Level 1/2/3 hierarchy.
+- Scope: headline card, performance story, collapsible details.
+- Likely files: `src/features/gig-experience/components/`, existing gig report wrappers.
+- Database impact: none.
+- Security impact: none if DTO remains read-only.
+- Dependencies: PR 02.
+- Acceptance: immediate result is clear in seconds; detailed cards are collapsed/ordered.
+- Tests: component tests for hierarchy and missing data.
+- Risk: medium.
+
+### Phase 5 PR 04 — 2D viewer shell, venue layout, deterministic entity engine
+
+- Objective: add non-authoritative visual shell and deterministic renderer foundation.
+- Scope: Canvas shell, venue presets, seeded random, entity caps, reduced-motion fallback.
+- Likely files: `src/features/gig-experience/viewer/`, `simulation/`, tests.
+- Database impact: none initially; use mock/derived event data.
+- Security impact: renderer must not mutate outcome.
+- Dependencies: Canvas/product duration decision.
+- Acceptance: static/replay demo from existing outcome data.
+- Tests: deterministic seed, caps, layout presets.
+- Risk: medium-high.
+
+### Phase 5 PR 05 — Crowd entrance and venue filling
+
+- Objective: show venue opening and audience arrival.
+- Scope: fan aggregation, fill zones, density scaling.
+- Database impact: none.
+- Security impact: none.
+- Dependencies: PR 04.
+- Acceptance: 50/500/50,000 attendance feels different within caps.
+- Tests: low/sold-out attendance, mobile caps.
+- Risk: medium.
+
+### Phase 5 PR 06 — Band entrance, stage positions, and movement
+
+- Objective: render performers and role-based positions.
+- Scope: role mapping from `gig_performers`/band members, fallback placement, movement zones.
+- Database impact: possible future role enrichment design only.
+- Security impact: respect member visibility/RLS.
+- Dependencies: PR 04.
+- Acceptance: unknown roles and large bands do not overlap/break.
+- Tests: role mapping, large bands, missing profile.
+- Risk: medium.
+
+### Phase 5 PR 07 — Song timeline, crowd-state changes, and commentary
+
+- Objective: drive playback from setlist/song performance facts.
+- Scope: song events, crowd energy states, factual commentary log.
+- Database impact: design for canonical events may begin.
+- Security impact: no outcome mutation.
+- Dependencies: PR 02/04.
+- Acceptance: story follows setlist order and score changes.
+- Tests: deterministic sequence, missing song data, poor/excellent gigs.
+- Risk: medium-high.
+
+### Phase 5 PR 08 — Highlights, finale, and viewer controls
+
+- Objective: add highlights, encore/finale, play/pause/speed/skip controls.
+- Scope: controls, result skip, highlight navigation, replay entry.
+- Database impact: possibly event payload fields if approved.
+- Security impact: skipping must not affect rewards.
+- Dependencies: PR 07.
+- Acceptance: skip-to-result works once outcome exists.
+- Tests: skip no reward changes, controls keyboard support.
+- Risk: medium.
+
+### Phase 5 PR 09 — Reconnect, replay, skip, and analytics
+
+- Objective: persist/recover viewer state and measure engagement.
+- Scope: event offsets, replay completed gigs, analytics events using existing infra.
+- Database impact: likely `result_ready_at`, `viewer_version`, `simulation_seed`, event payload.
+- Security impact: multi-tab/read-only safety.
+- Dependencies: migration approval and PR 08.
+- Acceptance: reconnect resumes correct phase; duplicate tabs do not duplicate completion.
+- Tests: reconnect, hidden tab, duplicate tab, analytics emission.
+- Risk: high.
+
+### Phase 5 PR 10 — Performance, accessibility, testing, and Phase 5 review
+
+- Objective: harden and close Phase 5.
+- Scope: profiling, reduced motion, mobile, cleanup, docs/review.
+- Database impact: none expected.
+- Security impact: final RLS/read-path review.
+- Dependencies: PR 04-09.
+- Acceptance: budgets met and accessibility checklist passes.
+- Tests: full unit/component/e2e where available, typecheck/lint/build.
+- Risk: medium.
+
+## Recommended Phase 5 PR 02
+
+Build the canonical outcome DTO and report-summary service first. This unlocks the immediate result, removes fragile client transforms, and gives the future viewer a stable read model without touching balance or migrations.


### PR DESCRIPTION
### Motivation

- Provide a repository-backed audit of the current live gig journey, viewer, outcome report and data model to unblock a phased redesign of the gig experience. 
- Define a lightweight, deterministic 2D viewer concept and a canonical event contract so future work can be reconnectable, replayable and safe across multiple tabs without changing game authority or rewards. 
- Deliver a clear delivery plan and next-step (PR 02 — canonical outcome DTO/report summary) without modifying runtime code, migrations, balance, or server-side reward logic.

### Description

- Added three documentation artifacts under `docs/gigs/`: `LIVE_GIG_SYSTEM_AUDIT.md`, `LIVE_GIG_EXPERIENCE_PLAN.md`, and `implementation/PHASE_5_PR_01.md` that together (a) audit current behaviour and code, (b) specify the three-level post-gig information hierarchy, and (c) define the canonical phase model, event contract, authority boundaries and delivery roadmap. 
- The audit explicitly inspected and references key files and server functions such as `src/pages/PerformGig.tsx`, `src/components/gig-viewer/TopDownGigViewer.tsx`, `src/components/gig/GigOutcomeReport.tsx`, `src/hooks/useRealtimeGigAdvancement.ts`, `src/hooks/useManualGigStart.ts`, and related Supabase functions under `supabase/functions/` and migrations under `supabase/migrations/`. 
- The plan prescribes a Canvas-first safe-default viewer architecture, crowd aggregation rules, band/stage position rules, simple visual effects, accessibility targets, analytics events, and a phased sequence of Phase 5 PRs (PR 02..PR 10) so implementation work can proceed incrementally and safely. 
- This PR is documentation-only: no runtime code, no migrations, no reward/balance changes, and no addition of new runtime dependencies or game engines were introduced.

### Testing

- Ran `git diff --cached --check` to validate staged changes for whitespace/conflicts; the check completed successfully. 
- Executed an internal link/reference verification script (Python) that confirms the new docs link to each other and referenced files exist; the script reported no missing links. 
- Noted that no repository Markdown linter is configured (no `markdownlint`/`remark` script found in `package.json`), and no typecheck/lint/build was run because this PR contains only documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e10d92b88325847a12a51c5f0dd0)