### PR TITLE
Add canonical GigExperienceDTO, ReportMetric and GigExperienceService (Phase 5 PR 02)

### DIFF
--- a/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
+++ b/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
@@ -1,6 +1,6 @@
 # Live Gig System Audit
 
-Phase 5 PR 01 documents the existing RockMundo gig journey, viewer, outcome report, and data model. It does not implement the future viewer, change balance, add migrations, or replace completion logic.
+Phase 5 PR 01 documented the existing RockMundo gig journey, viewer, outcome report, and data model. Phase 5 PR 02 adds a canonical `GigExperienceDTO` and summary service without changing balance, adding migrations, redesigning the viewer, or replacing completion logic.
 
 ## Repository evidence reviewed
 
@@ -191,9 +191,9 @@ Assumptions requiring player telemetry:
 - Too many cards receive equal visual weight.
 - Financial, impact, enhanced metrics, fan growth, XP, member rewards, and setlist cards duplicate player questions.
 - Rating uses a 0-25 scale while enhanced metrics converts to percentage and chemistry often uses 0-100 elsewhere.
-- `safeNumber` silently turns missing values into zero, hiding absent/legacy data.
-- `PerformGig` converts flat columns into `breakdown_data` and `gear_effects`, mixing authoritative database fields with compatibility presentation.
-- `GigOutcomeReport` may query song performances after outcome loading, and child cards query member/reward data separately, creating avoidable extra requests.
+- Historically, `safeNumber` silently turned missing values into zero, hiding absent/legacy data; Phase 5 PR 02 introduces `ReportMetric<T>` for the canonical DTO while the preserved report UI still has temporary adapter fallbacks.
+- Historically, `PerformGig` converted flat columns into `breakdown_data` and `gear_effects`; Phase 5 PR 02 moves the new canonical compatibility mapping into `GigExperienceService`.
+- `GigOutcomeReport` can now consume `GigExperienceDTO`, but some child cards still own legacy member/reward fetching until PR 03 removes or replaces them.
 - Several values are client-derived or fallback formulas rather than explicit server-authored report facts.
 - Moment highlights and fan/XP/venue relationship props are optional and usually absent from the `PerformGig` path.
 
@@ -253,3 +253,13 @@ Client currently owns:
 | Can multiple tabs cause duplicate advancement? | Yes, duplicate client advancement calls are possible. Final completion is guarded/idempotent, but per-song advancement still needs server-side idempotency guarantees for the future. |
 | Can players see report immediately through another route? | Likely yes. Gig history/news components render `GigOutcomeReport` from `gig_outcomes` without the `PerformGig` ten-minute discard gate. |
 | Are outcomes generated before, during, or after viewer? | An outcome row may be found during live progression; final authoritative totals are generated/updated by `complete-gig` after songs are processed or backfilled. |
+
+
+## Phase 5 PR 02 implementation status
+
+- Added `GigExperienceDTO` with `gig`, `headline`, `songs`, `performers`, `finances`, `progression`, `analysis`, `lessons`, and `viewer` sections.
+- Added `ReportMetric<T>` states for `available`, `processing`, `legacy_missing`, and `not_applicable`.
+- Added `GigExperienceService` as the canonical outcome summary assembler and validator.
+- `PerformGig` now requests the canonical DTO with a stable React Query key and passes it to the existing report.
+- `GigOutcomeReport` retains its current layout through a temporary DTO-to-legacy adapter pending PR 03.
+- Remaining factual gap: member reward cards and the broader report card wall are not yet fully DTO-native.

--- a/docs/gigs/ROCKMUNDO_LIVE_GIG_IMPLEMENTATION_ROADMAP.md
+++ b/docs/gigs/ROCKMUNDO_LIVE_GIG_IMPLEMENTATION_ROADMAP.md
@@ -933,6 +933,8 @@ Deferred post-beta:
 
 ## Phase 5 PR 02 — Canonical Outcome DTO and Summary Service
 
+**Status: Complete in Phase 5 PR 02.**
+
 ### Objective
 Create one typed, authoritative read model for the gig result.
 
@@ -1384,8 +1386,8 @@ The phase is complete when:
 
 The next implementation PR should be:
 
-> **Phase 5 PR 02 — Canonical Outcome DTO and Summary Service**
+> **Phase 5 PR 03 — Outcome Report Information Architecture Rebuild**
 
-This should be completed before any new viewer rendering work.
+Phase 5 PR 02 is complete; the next step is to rebuild the report hierarchy on top of the canonical DTO before adding new viewer rendering work.
 
 The new 2D viewer will only be trustworthy if it is driven by a stable, typed, authoritative gig outcome model.

--- a/docs/gigs/implementation/PHASE_5_PR_02.md
+++ b/docs/gigs/implementation/PHASE_5_PR_02.md
@@ -1,0 +1,182 @@
+# Phase 5 PR 02 — Canonical Outcome DTO and Summary Service
+
+## Purpose
+
+Build the first canonical gig outcome read model for Phase 5. The intent is to make one typed DTO the foundation for the current report, future headline result, performance story, detailed report, replay, live viewer, tour history, sharing, and spectator surfaces.
+
+This PR does not redesign the report UI, add Canvas, add replay, rebalance gigs, change rewards, edit historical migrations, or rewrite existing gig calculations.
+
+## Existing loading issues
+
+### Current flow before this PR
+
+1. `PerformGig` loaded `gigs` with `venues`.
+2. It separately loaded `gig_outcomes` and nested `gig_song_performances`.
+3. It loaded setlists, then counted setlist songs with one query per setlist.
+4. It loaded current setlist songs, rehearsals, equipment count, crew count, and band summary fields.
+5. It reconstructed `breakdown_data`, `gear_effects`, chemistry aliases, and equipment-cost aliases in the page.
+6. `GigOutcomeReport` ran additional compatibility mapping and could refetch song performances if nested rows were absent.
+7. Child report cards still owned additional presentation fallbacks and member/reward fetching.
+
+### Problems found
+
+- Outcome data was loaded through multiple paths rather than one canonical report path.
+- Page-level transforms rebuilt nested objects from flat outcome columns.
+- `safeNumber` semantics hid missing legacy values by converting them to `0`.
+- Compatibility aliases existed in both `PerformGig` and `GigOutcomeReport`.
+- Missing song data could trigger an extra outcome lookup plus child song query.
+- Song and performer data were not represented in one future-proof outcome shape.
+- Client-side fallback values were not clearly distinguished from authoritative values.
+
+### Target flow introduced
+
+`PerformGig` now requests `GigExperienceDTO` through `useGigExperience(gigId)`. `GigExperienceService` owns outcome, song, setlist-title, performer, venue, legacy compatibility, normalisation, validation, and report-summary mapping. `GigOutcomeReport` can consume the DTO while retaining the existing visual layout through a temporary adapter.
+
+## Architecture
+
+```text
+PerformGig
+  └─ useGigExperience(["gig-experience", gigId])
+       └─ getGigExperience(gigId)
+            ├─ gigs + venue narrow select
+            ├─ gig_outcomes narrow select
+            ├─ gig_song_performances by outcome id
+            ├─ setlist_songs + song titles by setlist id
+            └─ gig_performers + profile display fields
+                 ↓
+              mapGigExperience()
+                 ↓
+              validateGigExperience()
+                 ↓
+              GigExperienceDTO
+                 ↓
+              GigOutcomeReport temporary adapter
+```
+
+## DTO diagram
+
+```text
+GigExperienceDTO
+├─ gig
+│  ├─ ids/status/timing
+│  ├─ ticketPrice: ReportMetric<number>
+│  └─ venue
+├─ headline
+│  ├─ overallRating/grade/verdict
+│  ├─ attendance/capacity
+│  ├─ netProfit/fame/fans
+│  └─ bestSongTitle
+├─ songs[]
+│  ├─ position/title/score/crowdResponse
+│  └─ contribution metrics
+├─ performers[]
+├─ finances
+├─ progression
+├─ analysis
+│  ├─ technical factor metrics
+│  ├─ stage behavior
+│  ├─ gearEffects compatibility mapping
+│  └─ warnings[]
+├─ lessons
+└─ viewer
+```
+
+## Interfaces
+
+The DTO interfaces live in `src/features/gig-experience/types.ts`:
+
+- `GigExperienceDTO`
+- `GigExperienceGigDTO`
+- `GigExperienceHeadlineDTO`
+- `GigExperienceSongDTO`
+- `GigExperiencePerformerDTO`
+- `GigExperienceFinancesDTO`
+- `GigExperienceProgressionDTO`
+- `GigExperienceAnalysisDTO`
+- `GigExperienceValidationError`
+
+No raw database rows are exposed from the DTO.
+
+## ReportMetric
+
+`ReportMetric<T>` supports:
+
+- `available` — authoritative, legacy, or derived value exists;
+- `processing` — value is expected but not ready;
+- `legacy_missing` — old outcome does not contain this value;
+- `not_applicable` — value does not apply to this gig.
+
+An actual zero is represented as `available` with value `0`. Missing data is never silently converted into zero inside the canonical DTO.
+
+## Legacy compatibility
+
+Centralised compatibility in `GigExperienceService` includes:
+
+- flat outcome financial columns mapped into `finances`;
+- legacy fan-gain columns combined into one progression metric;
+- missing breakdowns represented as `legacy_missing`;
+- gear modifier columns mapped into the existing gear-effect presentation shape;
+- missing song rows and performer rows surfaced as warnings;
+- absent stage behaviour represented as `not_applicable`.
+
+## Query improvements
+
+- Added one `getGigExperience()` query path for report outcome data.
+- Uses narrow selects for gig, outcome, song performance, setlist-title, and performer data.
+- Batches setlist-title and performer loading rather than putting title/profile lookups in child cards.
+- Uses stable React Query key `['gig-experience', gigId]` and `staleTime` for memoised outcome reads.
+- The report adapter avoids the previous report-level fallback song fetch when DTO song data is present.
+
+## Validation
+
+`validateGigExperience()` rejects:
+
+- missing gig id;
+- invalid venue name/capacity;
+- negative attendance;
+- attendance greater than venue capacity;
+- rating outside `0..25`;
+- duplicate performer profile IDs;
+- duplicate song positions.
+
+## Files changed
+
+- `src/features/gig-experience/types.ts`
+- `src/features/gig-experience/reportMetric.ts`
+- `src/features/gig-experience/hooks.ts`
+- `src/features/gig-experience/services/GigExperienceService.ts`
+- `src/features/gig-experience/components/ReportMetricValue.tsx`
+- `src/features/gig-experience/__tests__/GigExperienceService.test.ts`
+- `src/pages/PerformGig.tsx`
+- `src/components/gig/GigOutcomeReport.tsx`
+- `docs/gigs/implementation/PHASE_5_PR_02.md`
+- `docs/gigs/ROCKMUNDO_LIVE_GIG_IMPLEMENTATION_ROADMAP.md`
+- `docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md`
+
+## Tests
+
+Added unit coverage for:
+
+- current gig outcome mapping;
+- legacy missing metrics;
+- missing songs;
+- missing performers;
+- zero attendance;
+- sold-out attendance;
+- negative profit;
+- validation of impossible attendance;
+- validation of rating limits;
+- duplicate performer IDs;
+- duplicate song positions;
+- `ReportMetric` rendering semantics.
+
+## Known limitations
+
+- The current report UI is intentionally preserved and still contains legacy card-level fallbacks that should be removed during PR 03.
+- Member reward presentation still has legacy child-card behaviour until the information architecture rebuild replaces it with DTO-native sections.
+- The DTO has a viewer descriptor but not a canonical event timeline yet.
+- Result readiness still relies on existing `completed_at` fields until a future authoritative `result_ready_at` exists.
+
+## Recommended next PR
+
+Phase 5 PR 03 should rebuild the outcome report information architecture around this DTO: headline result first, performance story second, detailed analysis collapsed third, and lessons/actions last.

--- a/src/components/gig/GigOutcomeReport.tsx
+++ b/src/components/gig/GigOutcomeReport.tsx
@@ -28,6 +28,8 @@ import type { ChemistryMoment } from "@/utils/bandChemistryEffects";
 import { getBehavior } from "@/utils/stageBehaviors";
 import { BandMemberPerformanceCard } from "./BandMemberPerformanceCard";
 import { MemberRewardsCard } from "./MemberRewardsCard";
+import type { GigExperienceDTO } from "@/features/gig-experience/types";
+import { metricValue } from "@/features/gig-experience/reportMetric";
 const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 
 interface SongPerformance {
@@ -110,6 +112,7 @@ interface Props {
   stageBehaviorUsed?: string | null;
   bandId?: string | null;
   gigId?: string | null;
+  experience?: GigExperienceDTO | null;
 }
 
 export const GigOutcomeReport = ({
@@ -133,10 +136,23 @@ export const GigOutcomeReport = ({
   stageBehaviorUsed,
   bandId,
   gigId,
+  experience,
 }: Props) => {
-  if (!outcome) return null;
+  const adaptedOutcome = experience ? adaptExperienceForLegacyReport(experience) : outcome;
+  const effectiveVenueName = experience?.gig.venue.name ?? venueName;
+  const effectiveVenueCapacity = experience?.gig.venue.capacity ?? venueCapacity;
+  const effectiveSongs = experience ? experience.songs.map((song) => ({ id: song.songId ?? song.id, title: song.title })) : songs;
+  const effectiveBandId = experience?.gig.bandId ?? bandId;
+  const effectiveGigId = experience?.gig.id ?? gigId;
+  if (!adaptedOutcome) return null;
+  outcome = adaptedOutcome;
+  venueName = effectiveVenueName;
+  venueCapacity = effectiveVenueCapacity;
+  songs = effectiveSongs;
+  bandId = effectiveBandId;
+  gigId = effectiveGigId;
 
-  const safeNumber = (value: number | string | null | undefined) => {
+  const legacyDisplayNumber = (value: number | string | null | undefined) => {
     if (typeof value === "number" && Number.isFinite(value)) {
       return value;
     }
@@ -152,38 +168,38 @@ export const GigOutcomeReport = ({
   };
 
   const formatCurrency = (value: number | string | null | undefined) => {
-    const numericValue = safeNumber(value);
+    const numericValue = legacyDisplayNumber(value);
     return integerFormatter.format(numericValue);
   };
 
-  const overallRating = safeNumber(outcome.overall_rating);
-  const ticketRevenue = safeNumber(outcome.ticket_revenue);
-  const merchSales = safeNumber(outcome.merch_sales);
-  const totalRevenue = safeNumber(outcome.total_revenue);
-  const crewCosts = safeNumber(outcome.crew_costs);
-  const equipmentWearCost = safeNumber(outcome.equipment_wear_cost);
-  const netProfit = safeNumber(outcome.net_profit);
-  const actualAttendance = safeNumber(outcome.actual_attendance);
-  const attendancePercentage = safeNumber(outcome.attendance_percentage);
-  const fameGained = safeNumber(outcome.fame_gained);
-  const chemistryImpact = safeNumber(outcome.chemistry_impact);
+  const overallRating = legacyDisplayNumber(outcome.overall_rating);
+  const ticketRevenue = legacyDisplayNumber(outcome.ticket_revenue);
+  const merchSales = legacyDisplayNumber(outcome.merch_sales);
+  const totalRevenue = legacyDisplayNumber(outcome.total_revenue);
+  const crewCosts = legacyDisplayNumber(outcome.crew_costs);
+  const equipmentWearCost = legacyDisplayNumber(outcome.equipment_wear_cost);
+  const netProfit = legacyDisplayNumber(outcome.net_profit);
+  const actualAttendance = legacyDisplayNumber(outcome.actual_attendance);
+  const attendancePercentage = legacyDisplayNumber(outcome.attendance_percentage);
+  const fameGained = legacyDisplayNumber(outcome.fame_gained);
+  const chemistryImpact = legacyDisplayNumber(outcome.chemistry_impact);
 
   const breakdown = {
-    equipment_quality: safeNumber(outcome.breakdown_data?.equipment_quality ?? outcome.equipment_quality_avg),
-    crew_skill: safeNumber(outcome.breakdown_data?.crew_skill ?? outcome.crew_skill_avg),
-    band_chemistry: safeNumber(outcome.breakdown_data?.band_chemistry ?? outcome.band_chemistry_level),
-    member_skills: safeNumber(outcome.breakdown_data?.member_skills ?? outcome.member_skill_avg),
-    merch_items_sold: safeNumber(outcome.breakdown_data?.merch_items_sold ?? outcome.merch_items_sold),
+    equipment_quality: legacyDisplayNumber(outcome.breakdown_data?.equipment_quality ?? outcome.equipment_quality_avg),
+    crew_skill: legacyDisplayNumber(outcome.breakdown_data?.crew_skill ?? outcome.crew_skill_avg),
+    band_chemistry: legacyDisplayNumber(outcome.breakdown_data?.band_chemistry ?? outcome.band_chemistry_level),
+    member_skills: legacyDisplayNumber(outcome.breakdown_data?.member_skills ?? outcome.member_skill_avg),
+    merch_items_sold: legacyDisplayNumber(outcome.breakdown_data?.merch_items_sold ?? outcome.merch_items_sold),
   };
 
 
   const buildFallbackGearEffects = (): GearModifierEffects => {
-    const attendanceBonus = safeNumber(outcome.social_buzz_impact);
-    const reliabilityBonus = safeNumber(outcome.audience_memory_impact);
-    const revenueBonus = safeNumber(outcome.promoter_modifier);
-    const fameBonus = safeNumber(outcome.venue_loyalty_bonus);
-    const equipmentBonus = safeNumber(outcome.band_synergy_modifier);
-    const breakdownRisk = safeNumber(outcome.gear_effects?.breakdownRiskPercent);
+    const attendanceBonus = legacyDisplayNumber(outcome.social_buzz_impact);
+    const reliabilityBonus = legacyDisplayNumber(outcome.audience_memory_impact);
+    const revenueBonus = legacyDisplayNumber(outcome.promoter_modifier);
+    const fameBonus = legacyDisplayNumber(outcome.venue_loyalty_bonus);
+    const equipmentBonus = legacyDisplayNumber(outcome.band_synergy_modifier);
+    const breakdownRisk = legacyDisplayNumber(outcome.gear_effects?.breakdownRiskPercent);
 
     const derived: GearModifierEffects = {
       ...EMPTY_GEAR_EFFECTS,
@@ -625,7 +641,7 @@ export const GigOutcomeReport = ({
               gigId={gigId}
               bandId={bandId}
               fameGained={fameGained}
-              newFansTotal={safeNumber(fanConversion?.newFansGained ?? (outcome as any).fans_gained ?? 0)}
+              newFansTotal={legacyDisplayNumber(fanConversion?.newFansGained ?? (outcome as any).fans_gained ?? 0)}
             />
           )}
 
@@ -785,3 +801,48 @@ export const GigOutcomeReport = ({
     </Dialog>
   );
 };
+
+
+function adaptExperienceForLegacyReport(experience: GigExperienceDTO): GigOutcome {
+  return {
+    overall_rating: metricValue(experience.headline.overallRating, 0),
+    actual_attendance: metricValue(experience.headline.attendance, 0),
+    attendance_percentage: experience.gig.venue.capacity > 0 ? (metricValue(experience.headline.attendance, 0) / experience.gig.venue.capacity) * 100 : 0,
+    ticket_revenue: metricValue(experience.finances.ticketRevenue, 0),
+    merch_sales: metricValue(experience.finances.merchRevenue, 0),
+    total_revenue: metricValue(experience.finances.totalRevenue, 0),
+    crew_costs: metricValue(experience.finances.crewCosts, 0),
+    equipment_wear_cost: metricValue(experience.finances.equipmentWearCost, 0),
+    net_profit: metricValue(experience.finances.netProfit, 0),
+    fame_gained: metricValue(experience.progression.fameGained, 0),
+    chemistry_impact: metricValue(experience.progression.chemistryChange, 0),
+    equipment_quality_avg: metricValue(experience.analysis.equipmentQuality, 0),
+    crew_skill_avg: metricValue(experience.analysis.crewSkill, 0),
+    band_chemistry_level: metricValue(experience.analysis.bandChemistry, 0),
+    member_skill_avg: metricValue(experience.analysis.memberSkills, 0),
+    merch_items_sold: metricValue(experience.finances.merchItemsSold, 0),
+    stage_behavior_used: experience.analysis.stageBehaviorUsed.status === "available" ? experience.analysis.stageBehaviorUsed.value : null,
+    gear_effects: experience.analysis.gearEffects ? {
+      equipmentQualityBonus: experience.analysis.gearEffects.equipmentQualityBonus,
+      attendanceBonusPercent: experience.analysis.gearEffects.attendanceBonusPercent,
+      reliabilitySwingReductionPercent: experience.analysis.gearEffects.reliabilitySwingReductionPercent,
+      breakdownRiskPercent: experience.analysis.gearEffects.breakdownRiskPercent,
+      revenueBonusPercent: experience.analysis.gearEffects.revenueBonusPercent,
+      fameBonusPercent: experience.analysis.gearEffects.fameBonusPercent,
+      breakdown: experience.analysis.gearEffects.breakdown,
+    } : undefined,
+    gig_song_performances: experience.songs.map((song) => ({
+      song_id: song.songId ?? song.id,
+      position: song.position,
+      performance_score: metricValue(song.performanceScore, 0),
+      song_quality_contrib: metricValue(song.contributions.songQuality, 0),
+      rehearsal_contrib: metricValue(song.contributions.rehearsal, 0),
+      chemistry_contrib: metricValue(song.contributions.chemistry, 0),
+      equipment_contrib: metricValue(song.contributions.equipment, 0),
+      crew_contrib: metricValue(song.contributions.crew, 0),
+      member_skill_contrib: metricValue(song.contributions.memberSkill, 0),
+      crowd_response: metricValue(song.crowdResponse, "mixed"),
+      song_title: song.title,
+    })),
+  };
+}

--- a/src/features/gig-experience/__tests__/GigExperienceService.test.ts
+++ b/src/features/gig-experience/__tests__/GigExperienceService.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { mapGigExperience, validateGigExperience } from "../services/GigExperienceService";
+import { metricAvailable, metricLegacyMissing, renderMetricValue } from "../reportMetric";
+
+const gig = { id: "gig-1", band_id: "band-1", status: "completed", scheduled_date: "2026-07-11T20:00:00Z", started_at: null, completed_at: "2026-07-11T22:00:00Z", ticket_price: 20, venues: { id: "venue-1", name: "Club Test", location: "NYC", capacity: 100 } } as any;
+const outcome = { id: "out-1", gig_id: "gig-1", band_id: "band-1", venue_id: "venue-1", venue_name: "Club Test", venue_capacity: 100, completed_at: "2026-07-11T22:00:00Z", created_at: "2026-07-11T22:00:00Z", overall_rating: 20, performance_grade: null, actual_attendance: 100, attendance_percentage: 100, ticket_revenue: 2000, merch_revenue: 100, total_revenue: 2100, crew_cost: 300, equipment_cost: 50, venue_cost: 500, total_costs: 850, net_profit: 1250, fame_gained: 10, new_followers: 5, casual_fans_gained: 1, dedicated_fans_gained: 2, superfans_gained: 3, fan_conversions: 11, chemistry_change: -1, total_xp_awarded: 75, equipment_quality_avg: 13, crew_skill_avg: 12, band_chemistry_level: 14, member_skill_avg: 15, merch_items_sold: 4, crowd_energy_peak: 90, stage_behavior_used: "balanced", band_synergy_modifier: 1, social_buzz_impact: 2, audience_memory_impact: 3, promoter_modifier: 4, venue_loyalty_bonus: 5 } as any;
+const song = (overrides = {}) => ({ id: "sp-1", song_id: "song-1", position: 1, performance_score: 23, crowd_response: "ecstatic", song_quality_contrib: 20, rehearsal_contrib: 18, chemistry_contrib: 15, equipment_contrib: 12, crew_contrib: 11, member_skill_contrib: 19, song_title: "Opener", performance_item_name: null, ...overrides } as any);
+
+describe("GigExperienceService", () => {
+  it("maps current gig outcomes into one canonical DTO", () => {
+    const dto = mapGigExperience({ gig, outcome, songPerformances: [song()], setlistSongs: [], performers: [{ id: "gp-1", profile_id: "p-1", role_or_instrument: "Vocals", lineup_status: "performed", profiles: { display_name: "Alex" } }] });
+    expect(dto.headline.attendance).toEqual(metricAvailable(100));
+    expect(dto.headline.bestSongTitle).toEqual(metricAvailable("Opener", "authoritative"));
+    expect(dto.finances.netProfit).toEqual(metricAvailable(1250));
+    expect(dto.performers).toHaveLength(1);
+  });
+
+  it("preserves zero attendance as available rather than missing", () => {
+    const dto = mapGigExperience({ gig, outcome: { ...outcome, actual_attendance: 0, attendance_percentage: 0 }, songPerformances: [song()], performers: [] });
+    expect(dto.headline.attendance).toEqual(metricAvailable(0));
+  });
+
+  it("keeps negative profit available", () => {
+    const dto = mapGigExperience({ gig, outcome: { ...outcome, net_profit: -250 }, songPerformances: [song()], performers: [] });
+    expect(dto.finances.netProfit).toEqual(metricAvailable(-250));
+  });
+
+  it("marks missing breakdown fields as legacy metrics", () => {
+    const dto = mapGigExperience({ gig, outcome: { ...outcome, equipment_quality_avg: null }, songPerformances: [song()], performers: [] });
+    expect(dto.analysis.equipmentQuality.status).toBe("legacy_missing");
+  });
+
+  it("supports missing songs and performers with compatibility warnings", () => {
+    const dto = mapGigExperience({ gig, outcome, songPerformances: [], performers: [] });
+    expect(dto.songs).toEqual([]);
+    expect(dto.analysis.warnings).toContain("No song performance rows were found for this outcome.");
+    expect(dto.analysis.warnings).toContain("No performer lineup rows were found; legacy performer details are unavailable.");
+  });
+
+  it("rejects impossible attendance over capacity", () => {
+    expect(() => mapGigExperience({ gig, outcome: { ...outcome, actual_attendance: 101 }, songPerformances: [song()], performers: [] })).toThrow(/attendance/);
+  });
+
+  it("validates rating limits, duplicate performers, and duplicate song positions", () => {
+    const dto = mapGigExperience({ gig, outcome, songPerformances: [song({ id: "sp-1", position: 1 }), song({ id: "sp-2", position: 2, song_id: "song-2" })], performers: [{ id: "gp-1", profile_id: "p-1", role_or_instrument: null, lineup_status: "performed" }] });
+    dto.headline.overallRating = metricAvailable(30);
+    dto.performers.push({ id: "gp-2", profileId: "p-1", displayName: "Dup", roleOrInstrument: null, lineupStatus: "performed" });
+    dto.songs[1].position = 1;
+    expect(validateGigExperience(dto).map((e) => e.field)).toEqual(expect.arrayContaining(["headline.overallRating", "performers", "songs"]));
+  });
+
+  it("renders ReportMetric statuses without coercing missing values to zero", () => {
+    expect(renderMetricValue(metricAvailable(0))).toBe("0");
+    expect(renderMetricValue(metricLegacyMissing<number>("legacy"))).toBe("Legacy data unavailable");
+  });
+});

--- a/src/features/gig-experience/components/ReportMetricValue.tsx
+++ b/src/features/gig-experience/components/ReportMetricValue.tsx
@@ -1,0 +1,6 @@
+import type { ReportMetric } from "../types";
+import { renderMetricValue } from "../reportMetric";
+
+export function ReportMetricValue<T>({ metric, format = String }: { metric: ReportMetric<T>; format?: (value: T) => string }) {
+  return <>{renderMetricValue(metric, format)}</>;
+}

--- a/src/features/gig-experience/hooks.ts
+++ b/src/features/gig-experience/hooks.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getGigExperience } from "./services/GigExperienceService";
+
+export function useGigExperience(gigId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ["gig-experience", gigId],
+    enabled: enabled && !!gigId,
+    queryFn: () => getGigExperience(gigId as string),
+    staleTime: 30_000,
+  });
+}

--- a/src/features/gig-experience/reportMetric.ts
+++ b/src/features/gig-experience/reportMetric.ts
@@ -1,0 +1,25 @@
+import type { ReportMetric } from "./types";
+
+export const metricAvailable = <T>(value: T, source: "authoritative" | "legacy" | "derived" = "authoritative"): ReportMetric<T> => ({ status: "available", value, source });
+export const metricProcessing = <T>(reason: string): ReportMetric<T> => ({ status: "processing", reason });
+export const metricLegacyMissing = <T>(reason: string): ReportMetric<T> => ({ status: "legacy_missing", reason });
+export const metricNotApplicable = <T>(reason: string): ReportMetric<T> => ({ status: "not_applicable", reason });
+
+export function nullableNumberMetric(value: unknown, missingReason: string, source: "authoritative" | "legacy" | "derived" = "authoritative"): ReportMetric<number> {
+  if (typeof value === "number" && Number.isFinite(value)) return metricAvailable(value, source);
+  if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) return metricAvailable(Number(value), source);
+  return metricLegacyMissing(missingReason);
+}
+
+export function metricValue<T>(metric: ReportMetric<T>, fallback: T): T {
+  return metric.status === "available" ? metric.value : fallback;
+}
+
+export function renderMetricValue<T>(metric: ReportMetric<T>, format: (value: T) => string = String): string {
+  switch (metric.status) {
+    case "available": return format(metric.value);
+    case "processing": return "Processing";
+    case "legacy_missing": return "Legacy data unavailable";
+    case "not_applicable": return "Not applicable";
+  }
+}

--- a/src/features/gig-experience/services/GigExperienceService.ts
+++ b/src/features/gig-experience/services/GigExperienceService.ts
@@ -1,0 +1,123 @@
+import { supabase } from "@/integrations/supabase/client";
+import { getPerformanceGrade } from "@/utils/gigPerformanceCalculator";
+import { EMPTY_GEAR_EFFECTS, type GearModifierEffects } from "@/utils/gearModifiers";
+import type { Database } from "@/lib/supabase-types";
+import type { GigExperienceDTO, GigExperienceValidationError } from "../types";
+import { metricAvailable, metricLegacyMissing, metricNotApplicable, nullableNumberMetric, metricValue } from "../reportMetric";
+
+type GigRow = Database["public"]["Tables"]["gigs"]["Row"] & { venues?: Database["public"]["Tables"]["venues"]["Row"] | null };
+type OutcomeRow = Database["public"]["Tables"]["gig_outcomes"]["Row"];
+type SongPerfRow = Database["public"]["Tables"]["gig_song_performances"]["Row"];
+type SetlistSongRow = { song_id: string; position: number; songs?: { id: string; title: string | null; genre?: string | null; quality_score?: number | null } | null };
+type PerformerRow = { id: string; profile_id: string; role_or_instrument: string | null; lineup_status: string | null; profiles?: { display_name?: string | null; username?: string | null } | null };
+
+const outcomeSelect = "id,gig_id,band_id,venue_id,venue_name,venue_capacity,completed_at,created_at,overall_rating,performance_grade,actual_attendance,attendance_percentage,ticket_revenue,merch_revenue,total_revenue,crew_cost,equipment_cost,venue_cost,total_costs,net_profit,fame_gained,new_followers,casual_fans_gained,dedicated_fans_gained,superfans_gained,fan_conversions,chemistry_change,total_xp_awarded,equipment_quality_avg,crew_skill_avg,band_chemistry_level,member_skill_avg,merch_items_sold,crowd_energy_peak,stage_behavior_used,band_synergy_modifier,social_buzz_impact,audience_memory_impact,promoter_modifier,venue_loyalty_bonus,highlight_moments,xp_breakdown";
+
+export async function getGigExperience(gigId: string): Promise<GigExperienceDTO | null> {
+  const { data: gig, error: gigError } = await supabase
+    .from("gigs")
+    .select("id,band_id,venue_id,setlist_id,status,scheduled_date,started_at,completed_at,ticket_price,venues!gigs_venue_id_fkey(id,name,location,capacity,city_id)")
+    .eq("id", gigId)
+    .single();
+  if (gigError) throw gigError;
+
+  const { data: outcome, error: outcomeError } = await supabase
+    .from("gig_outcomes")
+    .select(outcomeSelect)
+    .eq("gig_id", gigId)
+    .maybeSingle();
+  if (outcomeError) throw outcomeError;
+
+  const outcomeId = outcome?.id ?? null;
+  const [songPerfsRes, setlistSongsRes, performersRes] = await Promise.all([
+    outcomeId
+      ? supabase.from("gig_song_performances").select("id,song_id,position,performance_score,crowd_response,song_quality_contrib,rehearsal_contrib,chemistry_contrib,equipment_contrib,crew_contrib,member_skill_contrib,song_title,performance_item_name,item_type").eq("gig_outcome_id", outcomeId).order("position")
+      : Promise.resolve({ data: [] as SongPerfRow[], error: null }),
+    gig?.setlist_id
+      ? supabase.from("setlist_songs").select("song_id,position,songs(id,title,genre,quality_score)").eq("setlist_id", gig.setlist_id).order("position")
+      : Promise.resolve({ data: [] as SetlistSongRow[], error: null }),
+    (supabase as any).from("gig_performers").select("id,profile_id,role_or_instrument,lineup_status,profiles:profiles!gig_performers_profile_id_fkey(display_name,username)").eq("gig_id", gigId).order("created_at", { ascending: true }),
+  ]);
+  if (songPerfsRes.error) throw songPerfsRes.error;
+  if (setlistSongsRes.error) throw setlistSongsRes.error;
+  if (performersRes.error) throw performersRes.error;
+
+  return mapGigExperience({
+    gig: gig as unknown as GigRow,
+    outcome: outcome as OutcomeRow | null,
+    songPerformances: (songPerfsRes.data ?? []) as SongPerfRow[],
+    setlistSongs: (setlistSongsRes.data ?? []) as unknown as SetlistSongRow[],
+    performers: (performersRes.data ?? []) as PerformerRow[],
+  });
+}
+
+export function mapGigExperience(input: { gig: GigRow; outcome: OutcomeRow | null; songPerformances?: SongPerfRow[]; setlistSongs?: SetlistSongRow[]; performers?: PerformerRow[] }): GigExperienceDTO {
+  const { gig, outcome } = input;
+  const venue = gig.venues;
+  const capacity = venue?.capacity ?? outcome?.venue_capacity ?? 0;
+  const setlistTitles = new Map((input.setlistSongs ?? []).map((row) => [row.song_id, row.songs?.title ?? "Unknown Song"]));
+  const songPerformances = [...(input.songPerformances ?? [])].sort((a, b) => a.position - b.position);
+  const songs = songPerformances.map((row) => ({
+    id: row.id,
+    songId: row.song_id ?? null,
+    position: row.position,
+    title: row.song_title ?? (row.song_id ? setlistTitles.get(row.song_id) : undefined) ?? row.performance_item_name ?? "Unknown Song",
+    performanceScore: nullableNumberMetric(row.performance_score, "Song score missing from legacy performance row"),
+    crowdResponse: row.crowd_response ? metricAvailable(row.crowd_response) : metricLegacyMissing("Crowd response missing from legacy performance row"),
+    contributions: {
+      songQuality: nullableNumberMetric(row.song_quality_contrib, "Song quality contribution missing from legacy row"),
+      rehearsal: nullableNumberMetric(row.rehearsal_contrib, "Rehearsal contribution missing from legacy row"),
+      chemistry: nullableNumberMetric(row.chemistry_contrib, "Chemistry contribution missing from legacy row"),
+      equipment: nullableNumberMetric(row.equipment_contrib, "Equipment contribution missing from legacy row"),
+      crew: nullableNumberMetric(row.crew_contrib, "Crew contribution missing from legacy row"),
+      memberSkill: nullableNumberMetric(row.member_skill_contrib, "Member skill contribution missing from legacy row"),
+    },
+  }));
+  const bestSong = songs.reduce<typeof songs[number] | null>((best, song) => !best || metricValue(song.performanceScore, -Infinity) > metricValue(best.performanceScore, -Infinity) ? song : best, null);
+  const fans = (outcome?.new_followers ?? outcome?.casual_fans_gained ?? null) !== null
+    ? metricAvailable((outcome?.new_followers ?? 0) + (outcome?.casual_fans_gained ?? 0) + (outcome?.dedicated_fans_gained ?? 0) + (outcome?.superfans_gained ?? 0))
+    : metricLegacyMissing<number>("Fan-gain columns are absent on this legacy outcome");
+  const rating = outcome ? nullableNumberMetric(outcome.overall_rating, "Overall rating is still processing") : metricLegacyMissing<number>("No outcome row exists yet");
+  const dto: GigExperienceDTO = {
+    schemaVersion: 1,
+    gig: { id: gig.id, bandId: gig.band_id, status: gig.status, scheduledDate: gig.scheduled_date, startedAt: gig.started_at, completedAt: gig.completed_at, ticketPrice: nullableNumberMetric(gig.ticket_price, "Ticket price missing"), venue: { id: venue?.id ?? outcome?.venue_id ?? null, name: venue?.name ?? outcome?.venue_name ?? "Unknown Venue", location: venue?.location ?? null, capacity } },
+    headline: { overallRating: rating, performanceGrade: outcome?.performance_grade ? metricAvailable(outcome.performance_grade) : rating.status === "available" ? metricAvailable(getPerformanceGrade(rating.value).grade, "derived") : metricLegacyMissing("Grade unavailable until rating exists"), verdict: buildVerdict(metricValue(rating, 0)), attendance: outcome ? nullableNumberMetric(outcome.actual_attendance, "Attendance missing from outcome") : metricLegacyMissing("Outcome is not ready"), capacity: capacity > 0 ? metricAvailable(capacity) : metricLegacyMissing("Venue capacity missing"), netProfit: outcome ? nullableNumberMetric(outcome.net_profit, "Net profit missing from outcome") : metricLegacyMissing("Outcome is not ready"), fameGained: outcome ? nullableNumberMetric(outcome.fame_gained, "Fame gain missing from outcome") : metricLegacyMissing("Outcome is not ready"), fansGained: fans, bestSongTitle: bestSong ? metricAvailable(bestSong.title, bestSong.performanceScore.status === "available" ? "authoritative" : "legacy") : metricLegacyMissing("No song performance rows available") },
+    songs,
+    performers: (input.performers ?? []).map((row) => ({ id: row.id, profileId: row.profile_id, displayName: row.profiles?.display_name ?? row.profiles?.username ?? "Unknown Performer", roleOrInstrument: row.role_or_instrument, lineupStatus: row.lineup_status ?? "unknown" })),
+    finances: { ticketRevenue: outcome ? nullableNumberMetric(outcome.ticket_revenue, "Ticket revenue missing") : metricLegacyMissing("Outcome is not ready"), merchRevenue: outcome ? nullableNumberMetric(outcome.merch_revenue, "Merch revenue missing") : metricLegacyMissing("Outcome is not ready"), totalRevenue: outcome ? nullableNumberMetric(outcome.total_revenue, "Total revenue missing") : metricLegacyMissing("Outcome is not ready"), crewCosts: outcome ? nullableNumberMetric(outcome.crew_cost, "Crew cost missing") : metricLegacyMissing("Outcome is not ready"), equipmentWearCost: outcome ? nullableNumberMetric(outcome.equipment_cost, "Equipment wear cost missing") : metricLegacyMissing("Outcome is not ready"), venueCost: outcome ? nullableNumberMetric(outcome.venue_cost, "Venue cost missing") : metricLegacyMissing("Outcome is not ready"), totalCosts: outcome ? nullableNumberMetric(outcome.total_costs, "Total costs missing") : metricLegacyMissing("Outcome is not ready"), netProfit: outcome ? nullableNumberMetric(outcome.net_profit, "Net profit missing") : metricLegacyMissing("Outcome is not ready"), merchItemsSold: outcome ? nullableNumberMetric(outcome.merch_items_sold, "Merch item count missing") : metricLegacyMissing("Outcome is not ready") },
+    progression: { fameGained: outcome ? nullableNumberMetric(outcome.fame_gained, "Fame gain missing") : metricLegacyMissing("Outcome is not ready"), chemistryChange: outcome ? nullableNumberMetric(outcome.chemistry_change, "Chemistry change missing") : metricLegacyMissing("Outcome is not ready"), totalXpAwarded: outcome ? nullableNumberMetric(outcome.total_xp_awarded, "XP summary missing") : metricLegacyMissing("Outcome is not ready"), fansGained: fans, fanConversions: outcome ? nullableNumberMetric(outcome.fan_conversions, "Fan conversion count missing") : metricLegacyMissing("Outcome is not ready") },
+    analysis: { equipmentQuality: outcome ? nullableNumberMetric(outcome.equipment_quality_avg, "Equipment breakdown missing") : metricLegacyMissing("Outcome is not ready"), crewSkill: outcome ? nullableNumberMetric(outcome.crew_skill_avg, "Crew breakdown missing") : metricLegacyMissing("Outcome is not ready"), bandChemistry: outcome ? nullableNumberMetric(outcome.band_chemistry_level, "Band chemistry breakdown missing") : metricLegacyMissing("Outcome is not ready"), memberSkills: outcome ? nullableNumberMetric(outcome.member_skill_avg, "Member skills breakdown missing") : metricLegacyMissing("Outcome is not ready"), crowdEnergyPeak: outcome ? nullableNumberMetric(outcome.crowd_energy_peak, "Crowd energy peak missing") : metricLegacyMissing("Outcome is not ready"), stageBehaviorUsed: outcome?.stage_behavior_used ? metricAvailable(outcome.stage_behavior_used) : metricNotApplicable("No stage behaviour was recorded"), gearEffects: outcome ? mapGearEffects(outcome) : null, warnings: buildWarnings(outcome, songs.length, input.performers?.length ?? 0) },
+    lessons: buildLessons(metricValue(rating, 0), metricValue(outcome ? nullableNumberMetric(outcome.actual_attendance, "") : metricAvailable(0), 0), capacity, metricValue(outcome ? nullableNumberMetric(outcome.net_profit, "") : metricAvailable(0), 0)),
+    viewer: { ready: !!outcome, outcomeId: outcome?.id ?? null, resultReadyAt: outcome?.completed_at ?? gig.completed_at ?? null, replayAvailable: songs.length > 0 },
+  };
+  const validationErrors = validateGigExperience(dto);
+  if (validationErrors.length > 0) throw new Error(`Invalid gig experience DTO: ${validationErrors.map((e) => `${e.field} ${e.message}`).join(", ")}`);
+  return dto;
+}
+
+export function validateGigExperience(dto: GigExperienceDTO): GigExperienceValidationError[] {
+  const errors: GigExperienceValidationError[] = [];
+  if (!dto.gig.id) errors.push({ field: "gig.id", message: "is required" });
+  if (!dto.gig.venue.name || dto.gig.venue.capacity < 0) errors.push({ field: "gig.venue", message: "is invalid" });
+  const attendance = dto.headline.attendance;
+  if (attendance.status === "available" && (attendance.value < 0 || attendance.value > dto.gig.venue.capacity)) errors.push({ field: "headline.attendance", message: "must be between 0 and capacity" });
+  const rating = dto.headline.overallRating;
+  if (rating.status === "available" && (rating.value < 0 || rating.value > 25)) errors.push({ field: "headline.overallRating", message: "must be between 0 and 25" });
+  const performerIds = new Set<string>();
+  dto.performers.forEach((p) => performerIds.has(p.profileId) ? errors.push({ field: "performers", message: `duplicate performer ${p.profileId}` }) : performerIds.add(p.profileId));
+  const positions = new Set<number>();
+  dto.songs.forEach((song) => positions.has(song.position) ? errors.push({ field: "songs", message: `duplicate position ${song.position}` }) : positions.add(song.position));
+  return errors;
+}
+
+function mapGearEffects(outcome: OutcomeRow): GearModifierEffects {
+  const attendanceBonus = outcome.social_buzz_impact ?? 0;
+  const reliabilityBonus = outcome.audience_memory_impact ?? 0;
+  const revenueBonus = outcome.promoter_modifier ?? 0;
+  const fameBonus = outcome.venue_loyalty_bonus ?? 0;
+  const equipmentBonus = outcome.band_synergy_modifier ?? 0;
+  return { ...EMPTY_GEAR_EFFECTS, equipmentQualityBonus: equipmentBonus, crowdEngagementMultiplier: 1 + attendanceBonus / 100, attendanceBonusPercent: attendanceBonus, reliabilityStability: reliabilityBonus / 100, reliabilitySwingReductionPercent: reliabilityBonus, revenueMultiplier: 1 + revenueBonus / 100, revenueBonusPercent: revenueBonus, fameMultiplier: 1 + fameBonus / 100, fameBonusPercent: fameBonus, breakdown: [] };
+}
+function buildVerdict(rating: number) { if (rating >= 22) return "A landmark performance that the crowd will remember."; if (rating >= 17) return "A strong show with clear momentum."; if (rating >= 10) return "A mixed gig with useful lessons for next time."; return "A rough night that exposed areas to improve."; }
+function buildWarnings(outcome: OutcomeRow | null, songCount: number, performerCount: number) { const warnings: string[] = []; if (!outcome) warnings.push("Outcome is still processing or unavailable."); if (outcome && songCount === 0) warnings.push("No song performance rows were found for this outcome."); if (outcome && performerCount === 0) warnings.push("No performer lineup rows were found; legacy performer details are unavailable."); if (outcome && outcome.merch_items_sold === null) warnings.push("Merch item details are missing on this legacy outcome."); return warnings; }
+function buildLessons(rating: number, attendance: number, capacity: number, profit: number) { return { worked: [rating >= 17 ? "Overall performance quality was strong." : "The outcome was recorded and can be reviewed."], heldBack: [attendance < capacity * 0.5 ? "Attendance was below half capacity." : profit < 0 ? "Costs outweighed revenue." : "No major blocker was identified in the canonical summary."], recommendations: [attendance < capacity * 0.5 ? "Book a smaller venue or build local demand before returning." : profit < 0 ? "Review ticket price, crew costs, and venue fit before the next gig." : "Use the song breakdown to refine the next setlist."] }; }

--- a/src/features/gig-experience/types.ts
+++ b/src/features/gig-experience/types.ts
@@ -1,0 +1,103 @@
+import type { GearModifierEffects } from "@/utils/gearModifiers";
+
+export type ReportMetricStatus = "available" | "processing" | "legacy_missing" | "not_applicable";
+
+export type ReportMetric<T> =
+  | { status: "available"; value: T; source?: "authoritative" | "legacy" | "derived" }
+  | { status: "processing"; reason: string }
+  | { status: "legacy_missing"; reason: string }
+  | { status: "not_applicable"; reason: string };
+
+export interface GigExperienceGigDTO {
+  id: string;
+  bandId: string | null;
+  status: string;
+  scheduledDate: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  ticketPrice: ReportMetric<number>;
+  venue: { id: string | null; name: string; location: string | null; capacity: number };
+}
+
+export interface GigExperienceHeadlineDTO {
+  overallRating: ReportMetric<number>;
+  performanceGrade: ReportMetric<string>;
+  verdict: string;
+  attendance: ReportMetric<number>;
+  capacity: ReportMetric<number>;
+  netProfit: ReportMetric<number>;
+  fameGained: ReportMetric<number>;
+  fansGained: ReportMetric<number>;
+  bestSongTitle: ReportMetric<string>;
+}
+
+export interface GigExperienceSongDTO {
+  id: string;
+  songId: string | null;
+  position: number;
+  title: string;
+  performanceScore: ReportMetric<number>;
+  crowdResponse: ReportMetric<string>;
+  contributions: {
+    songQuality: ReportMetric<number>;
+    rehearsal: ReportMetric<number>;
+    chemistry: ReportMetric<number>;
+    equipment: ReportMetric<number>;
+    crew: ReportMetric<number>;
+    memberSkill: ReportMetric<number>;
+  };
+}
+
+export interface GigExperiencePerformerDTO {
+  id: string;
+  profileId: string;
+  displayName: string;
+  roleOrInstrument: string | null;
+  lineupStatus: string;
+}
+
+export interface GigExperienceFinancesDTO {
+  ticketRevenue: ReportMetric<number>;
+  merchRevenue: ReportMetric<number>;
+  totalRevenue: ReportMetric<number>;
+  crewCosts: ReportMetric<number>;
+  equipmentWearCost: ReportMetric<number>;
+  venueCost: ReportMetric<number>;
+  totalCosts: ReportMetric<number>;
+  netProfit: ReportMetric<number>;
+  merchItemsSold: ReportMetric<number>;
+}
+
+export interface GigExperienceProgressionDTO {
+  fameGained: ReportMetric<number>;
+  chemistryChange: ReportMetric<number>;
+  totalXpAwarded: ReportMetric<number>;
+  fansGained: ReportMetric<number>;
+  fanConversions: ReportMetric<number>;
+}
+
+export interface GigExperienceAnalysisDTO {
+  equipmentQuality: ReportMetric<number>;
+  crewSkill: ReportMetric<number>;
+  bandChemistry: ReportMetric<number>;
+  memberSkills: ReportMetric<number>;
+  crowdEnergyPeak: ReportMetric<number>;
+  stageBehaviorUsed: ReportMetric<string>;
+  gearEffects: GearModifierEffects | null;
+  warnings: string[];
+}
+
+export interface GigExperienceDTO {
+  schemaVersion: 1;
+  gig: GigExperienceGigDTO;
+  headline: GigExperienceHeadlineDTO;
+  songs: GigExperienceSongDTO[];
+  performers: GigExperiencePerformerDTO[];
+  finances: GigExperienceFinancesDTO;
+  progression: GigExperienceProgressionDTO;
+  analysis: GigExperienceAnalysisDTO;
+  lessons: { worked: string[]; heldBack: string[]; recommendations: string[] };
+  viewer: { ready: boolean; outcomeId: string | null; resultReadyAt: string | null; replayAvailable: boolean };
+}
+
+export interface GigExperienceValidationError { field: string; message: string }

--- a/src/pages/PerformGig.tsx
+++ b/src/pages/PerformGig.tsx
@@ -23,6 +23,7 @@ import { buildGearOutcomeNarrative } from '@/utils/gigNarrative';
 import { calculateDailySalesRate } from '@/utils/ticketSalesSimulation';
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { GigPerformersSection } from "@/components/social/ParticipantStatusList";
+import { useGigExperience } from "@/features/gig-experience/hooks";
 
 type GigWithVenue = Database['public']['Tables']['gigs']['Row'] & {
   venues: Database['public']['Tables']['venues']['Row'] | null;
@@ -51,6 +52,9 @@ export default function PerformGig() {
   const [timeUntilReport, setTimeUntilReport] = useState<string | null>(null);
   const [bandSetlists, setBandSetlists] = useState<any[]>([]);
   // Viewer mode removed — single top-down viewer
+
+  const gigExperienceQuery = useGigExperience(gigId || null, !!gigId && !!profileId);
+  const gigExperience = gigExperienceQuery.data ?? null;
 
   const { data: bandGearData, isLoading: bandGearLoading } = useBandGearEffects(gig?.band_id ?? null, {
     enabled: !!gig?.band_id,
@@ -151,27 +155,7 @@ export default function PerformGig() {
         const canShowOutcome = completedAt && differenceInMinutes(now, completedAt) >= 10;
         
         if (canShowOutcome) {
-          const transformedOutcome = {
-            ...existingOutcome,
-            breakdown_data: {
-              equipment_quality: existingOutcome.equipment_quality_avg || 0,
-              crew_skill: existingOutcome.crew_skill_avg || 0,
-              band_chemistry: existingOutcome.band_chemistry_level || 0,
-              member_skills: existingOutcome.member_skill_avg || 0,
-              merch_items_sold: existingOutcome.merch_items_sold || 0
-            },
-            chemistry_impact: existingOutcome.chemistry_change || 0,
-            equipment_wear_cost: existingOutcome.equipment_cost || 0,
-            gear_effects: {
-              equipmentQualityBonus: existingOutcome.band_synergy_modifier || 0,
-              attendanceBonusPercent: existingOutcome.social_buzz_impact || 0,
-              reliabilitySwingReductionPercent: existingOutcome.audience_memory_impact || 0,
-              revenueBonusPercent: existingOutcome.promoter_modifier || 0,
-              fameBonusPercent: existingOutcome.venue_loyalty_bonus || 0,
-              breakdown: (existingOutcome as any).gear_effects?.breakdown,
-            }
-          };
-          setOutcome(transformedOutcome);
+          setOutcome(existingOutcome);
           setShowOutcome(false); // Don't auto-show, let user click to view
         } else {
           // Outcome exists but it's too soon - keep showing live view
@@ -709,6 +693,7 @@ export default function PerformGig() {
         isOpen={!!outcome && showOutcome}
         onClose={() => setShowOutcome(false)}
         outcome={outcome}
+        experience={gigExperience}
         venueName={gig.venues?.name || 'Unknown Venue'}
         venueCapacity={gig.venues?.capacity || 0}
         songs={setlistSongs.map(s => ({ id: s.song_id, title: s.songs?.title || 'Unknown' }))}


### PR DESCRIPTION
### Motivation
- Provide one authoritative, typed read model for gig outcomes so all report and viewer surfaces consume the same DTO and stop reconstructing/duplicating outcome logic.
- Replace silent legacy-coercion semantics (previous `safeNumber` behaviour) with explicit `ReportMetric<T>` states so missing/processing/legacy values are surfaced correctly.
- Centralise legacy compatibility, narrow selects and N+1 prevention into one service to simplify future viewer/replay work and reduce duplicate queries.

### Description
- Introduces `GigExperienceDTO` and sectioned interfaces under `src/features/gig-experience/types.ts` with explicit sections `gig`, `headline`, `songs`, `performers`, `finances`, `progression`, `analysis`, `lessons`, and `viewer`.
- Adds `ReportMetric<T>` and helpers (`metricAvailable`, `metricProcessing`, `metricLegacyMissing`, `metricNotApplicable`, `nullableNumberMetric`, `metricValue`, `renderMetricValue`) in `src/features/gig-experience/reportMetric.ts` and a small `ReportMetricValue` component for DTO-native UI rendering.
- Implements the canonical assembler `getGigExperience()` + mapping/validation in `src/features/gig-experience/services/GigExperienceService.ts` that loads gigs, outcome, song performances, setlist titles and performers with narrow selects and maps legacy fields into the DTO, plus `validateGigExperience()` to reject impossible values.
- Adds a React Query hook `useGigExperience` (`src/features/gig-experience/hooks.ts`) and wires `PerformGig` to request the DTO and pass it into `GigOutcomeReport` via a temporary adapter, preserving the existing report UI while components are migrated (`src/pages/PerformGig.tsx`, `src/components/gig/GigOutcomeReport.tsx`).
- Documents the change and status in `docs/gigs/implementation/PHASE_5_PR_02.md` and updates roadmap/audit docs to mark PR 02 complete and recommend Phase 5 PR 03.

### Testing
- Type-check: ran `npm run typecheck` (`tsc --noEmit`) and it passed.
- Unit tests: added `src/features/gig-experience/__tests__/GigExperienceService.test.ts` covering mapping, zero/negative values, legacy-missing metrics, missing songs/performers, and validation; tests could not be executed in this environment because `vitest` was not available (`vitest: not found`).
- Lint/build: `npm run lint` and `npm run build` were not executed successfully in this environment due to missing dev dependencies (`@eslint/js`, `vite`) and an attempted `npm install` failing with a registry `403` for a dependency; these steps should be green in CI once dependencies are restored.
- Notes: the code preserves the current report rendering by adapting the DTO to the legacy report shape so behavior remains unchanged for users while enabling an incremental migration in the next PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e67885b4832597fa130e3064af05)