### PR TITLE
Implement typed gig viewer replay storage

### DIFF
--- a/docs/gigs/LIVE_GIG_EXPERIENCE_PLAN.md
+++ b/docs/gigs/LIVE_GIG_EXPERIENCE_PLAN.md
@@ -521,3 +521,8 @@ Cover:
 ## Phase 5 PR 04 implemented model update
 
 The live viewer plan should assume that browser sessions do not advance songs or complete gigs. Viewer surfaces read canonical gig status, current song position, song-performance rows, and `result_ready_at`. “Skip” actions are presentation-only until the server exposes a ready result.
+
+
+## Phase 5 PR 05 update
+
+Implemented event contract: viewer version 1/event schema version 1 stores typed replay events in `gig_viewer_replays`, using message keys/params plus discriminated visual payloads rather than final English commentary.

--- a/docs/gigs/LIVE_GIG_IMPLEMENTATION_ROADMAP.md
+++ b/docs/gigs/LIVE_GIG_IMPLEMENTATION_ROADMAP.md
@@ -1397,3 +1397,8 @@ The new 2D viewer will only be trustworthy if it is driven by a stable, typed, a
 ## Phase 5 PR 04 implementation status
 
 Phase 5 PR 04 is implemented in this branch: gig viewing has been converted to a read-only observer model, manual starts route through a guarded server RPC, song rows are protected by authoritative per-position uniqueness, the scheduled worker catches up due positions without a mounted viewer, completion uses a server-side claim step, and result access is controlled by `gigs.result_ready_at` instead of a fixed ten-minute UI delay.
+
+
+## Phase 5 PR 05 update
+
+Phase 5 PR 05 — Typed Gig Event Schema and Replay Storage: complete. Canonical replay events, storage, service-role generation, typed validation, frontend replay read service, and documentation are implemented.

--- a/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
+++ b/docs/gigs/LIVE_GIG_SYSTEM_AUDIT.md
@@ -271,3 +271,8 @@ Phase 5 PR 03 rebuilds `GigOutcomeReport` around the canonical `GigExperienceDTO
 ## Phase 5 PR 04 factual update
 
 The current implementation now includes a server-authoritative gig lifecycle hardening pass. `start_gig_authoritative` owns guarded manual starts, `auto-complete-gigs` advances due setlist positions, `process-gig-song` is idempotent per outcome position, `claim_gig_completion` serializes completion, and `result_ready_at` determines report availability. The former realtime advancement hook is retained only as a compatibility alias to a read-only subscription/refetch hook.
+
+
+## Phase 5 PR 05 update
+
+Phase 5 PR 05 status: completed gigs now request an idempotent service-role canonical viewer replay after `result_ready_at`; replay payloads are stored separately from outcomes and can fail without blocking reports.

--- a/docs/gigs/implementation/PHASE_5_PR_05.md
+++ b/docs/gigs/implementation/PHASE_5_PR_05.md
@@ -1,0 +1,88 @@
+# Phase 5 PR 05 — Typed Gig Event Schema and Replay Storage
+
+## Recommendation source
+
+This PR builds on Phase 5 PR 04's server-authoritative lifecycle: server start/progression, exactly-once song rows, idempotent completion, and `result_ready_at` as the report availability gate.
+
+## Generation point
+
+Replay generation is requested by `complete-gig` immediately after the authoritative gig update writes `status = completed`, `completed_at`, and `result_ready_at`. The canonical generation implementation is the service-role Edge Function `generate-gig-viewer-replay`.
+
+## Transaction boundary
+
+Outcome and reward completion remain authoritative and independent. Replay generation is post-completion, synchronous from the caller's perspective, idempotent, and non-critical. A replay failure writes a controlled failure status/error code and does not roll back rewards, song scores, outcome totals, notifications, or result access.
+
+## Event schema
+
+The implemented schema lives in `src/features/gig-experience/events/`. Events use a strict envelope with sequence, phase, event type, offset, duration, importance, optional song/performer IDs, bounded crowd-energy values, `messageKey`, `messageParams`, and factual visual payload data.
+
+## Visual payload union
+
+`GigVisualPayload` is a discriminated union covering venue opening, crowd fill/reaction, performer entrance/movement, song starts, spotlights, moment effects, band exit, and result reveal. Validation rejects unknown discriminators and event-type/payload mismatches.
+
+## Replay envelope and versioning
+
+`GigViewerReplay` stores `viewerVersion`, `eventSchemaVersion`, `simulationSeed`, generated timestamp, duration, status, checksum, and events. Current versions are viewer `1` and event schema `1`. Unsupported versions return `unsupported_version` in the frontend service so clients can fall back to report/text-only mode.
+
+## Storage model
+
+A new `gig_viewer_replays` table stores the full replay payload separately from `gig_outcomes`. It includes foreign keys to `gigs` and `gig_outcomes`, status/version/duration/event-count checks, JSON shape checks, indexes, and partial unique indexes for one ready and one generating replay per gig/viewer version.
+
+## Deterministic seed
+
+The seed is derived from gig ID, outcome ID, completed timestamp, and viewer version. The generator provides a deterministic PRNG for cosmetic choices and never uses browser time, frame timing, client UUIDs, or `Math.random`.
+
+## Duration allocation
+
+The first schema targets approximately three minutes using fixed phase budgets plus weighted song budgets. Opening, final, best, and worst/turning-point songs receive emphasis. Very long setlists mark lower-emphasis songs as montage events without changing authoritative facts.
+
+## Crowd energy model
+
+Crowd energy uses a documented 0–100 presentation scale derived from attendance percentage, song performance score, previous momentum, and final rating. It is deterministic, bounded, follows song order, and does not alter the original outcome.
+
+## Performer mapping
+
+The generator reads `gig_performers` and public profile display names/usernames only. It stores profile IDs, display names, public role/instrument strings, and safe stage positions. Missing performers use a safe legacy entrance fallback; hidden stats, health, energy, auth identifiers, and private attendance data are not exposed.
+
+## Encore representation
+
+The current outcome model has no reward-bearing encore decision. PR 05 stores a presentation-only encore narrative derived from final rating, attendance percentage, and final crowd energy. The stored event is canonical for replay and does not alter rewards or outcome values.
+
+## Validation
+
+Replay validation checks versions, statuses, phases, event types, payload discriminators, event-type/payload mapping, increasing sequences, non-decreasing offsets, duration bounds, crowd-energy bounds, message params, duplicate event IDs, required result reveal, and completed-last ordering. Invalid payloads fail generation with a controlled error.
+
+## RLS and access
+
+Replay reads mirror existing outcome visibility by requiring the referenced `gig_outcomes` row to be visible. Direct client insert/update/delete is denied. Replay generation claim is a `SECURITY DEFINER` RPC with fixed `search_path`, revoked from anon/authenticated, and granted only to `service_role`.
+
+## Failure and retry behaviour
+
+The function returns existing ready rows on retry, refuses incomplete gigs, records controlled `failed` rows for validation/generation failures, and uses database uniqueness/row locking to protect concurrent claims. Result reports remain available without a replay.
+
+## Files changed
+
+- Event constants/types/schema/generator under `src/features/gig-experience/events/`.
+- Replay frontend service and hook under `src/features/gig-experience/`.
+- Edge Function `supabase/functions/generate-gig-viewer-replay/` and shared replay code.
+- `complete-gig` post-completion replay generation request.
+- New migration and SQL harness.
+
+## Migration
+
+`20260711140000_phase_5_pr_05_gig_viewer_replays.sql` creates replay storage, constraints, RLS, grants, trigger, and the guarded claim RPC.
+
+## Tests
+
+Vitest schema/determinism tests cover valid generation, invalid discriminators, unknown phases, duplicate sequences, invalid energy, missing reveal, completed-last enforcement, identical output/checksum, and deterministic random streams. A pgTAP-style SQL harness validates storage shape, RLS policies, and claim RPC grants when a Supabase test database is available.
+
+## Known limitations
+
+- No Canvas renderer, spectator mode, audio sync, or animation is implemented.
+- Legacy gigs without replay show unavailable; there is no bulk backfill.
+- Replay generation is invoked synchronously after completion rather than via a durable queue.
+- Edge Function tests require Supabase/Deno tooling in the target environment.
+
+## Recommended Phase 5 PR 06
+
+Build the viewer/reconnect read path on top of the canonical replay descriptor, including a protected replay-opening UI and text/timeline fallback for unsupported versions, without changing the stored canonical events.

--- a/src/features/gig-experience/events/__tests__/schema.test.ts
+++ b/src/features/gig-experience/events/__tests__/schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildGigViewerReplay, createDeterministicRandom, createDeterministicSeed } from "../generator";
+import { validateGigViewerReplay } from "../schema";
+
+const input = { replayId: "replay-1", outcomeId: "outcome-1", generatedAt: "2026-07-11T14:00:00.000Z", gig: { id: "gig-1", completedAt: "2026-07-11T13:59:00.000Z", resultReadyAt: "2026-07-11T14:00:00.000Z", venueCapacity: 100, actualAttendance: 80, overallRating: 18, netProfit: 250 }, songs: [{ id: "perf-1", songId: "song-1", position: 0, title: "One", performanceScore: 17 }, { id: "perf-2", songId: "song-2", position: 1, title: "Two", performanceScore: 21 }], performers: [{ profileId: "profile-1", displayName: "A", roleOrInstrument: "vocals", lineupStatus: "performed" }] };
+
+describe("gig viewer replay schema", () => {
+  it("validates a generated replay with all required terminal events", async () => {
+    const replay = await buildGigViewerReplay(input);
+    expect(validateGigViewerReplay(replay)).toEqual({ valid: true, errors: [] });
+    expect(replay.events.some((e) => e.eventType === "result_revealed")).toBe(true);
+    expect(replay.events.at(-1)?.eventType).toBe("replay_completed");
+  });
+
+  it("rejects invalid payload discriminators, unknown phases, duplicate sequence, out-of-order offsets, invalid energy, missing reveal, and non-last completed", async () => {
+    const replay = await buildGigViewerReplay(input);
+    replay.events[0] = { ...replay.events[0], visualPayload: { type: "pyrotechnics" } as never, phase: "bad_phase" as never, sequence: 1, crowdEnergyAfter: 101 };
+    replay.events[1] = { ...replay.events[1], scheduledOffsetMs: 0 };
+    const withoutReveal = { ...replay, events: replay.events.filter((e) => e.eventType !== "result_revealed") };
+    const result = validateGigViewerReplay(withoutReveal);
+    expect(result.valid).toBe(false);
+    expect(result.errors.join("|")).toContain("invalid payload");
+    expect(result.errors.join("|")).toContain("invalid phase");
+    expect(result.errors.join("|")).toContain("duplicate sequence");
+    expect(result.errors.join("|")).toContain("invalid crowd energy");
+    expect(result.errors.join("|")).toContain("result reveal event is required");
+    expect(result.errors.join("|")).toContain("completed event must be last");
+  });
+});
+
+describe("gig viewer replay determinism", () => {
+  it("generates identical output and checksum for identical inputs", async () => {
+    await expect(buildGigViewerReplay(input)).resolves.toEqual(await buildGigViewerReplay(input));
+  });
+
+  it("changes deterministic cosmetic random stream only when seed changes", () => {
+    const a = createDeterministicRandom(createDeterministicSeed(["gig", "outcome", "done", 1]));
+    const b = createDeterministicRandom(createDeterministicSeed(["gig", "outcome", "done", 1]));
+    const c = createDeterministicRandom(createDeterministicSeed(["gig", "outcome", "done", 2]));
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+    expect([a(), a(), a()]).not.toEqual([c(), c(), c()]);
+  });
+});

--- a/src/features/gig-experience/events/constants.ts
+++ b/src/features/gig-experience/events/constants.ts
@@ -1,0 +1,40 @@
+export const GIG_VIEWER_VERSION = 1;
+export const GIG_EVENT_SCHEMA_VERSION = 1;
+export const GIG_REPLAY_TARGET_DURATION_MS = 180_000;
+export const GIG_REPLAY_TARGET_TOLERANCE_MS = 15_000;
+
+export const GIG_VIEWER_PHASES = [
+  "venue_opening",
+  "crowd_entry",
+  "pre_show",
+  "band_entrance",
+  "song_intro",
+  "song_performance",
+  "between_songs",
+  "highlight_moment",
+  "encore_decision",
+  "finale",
+  "band_exit",
+  "result_reveal",
+  "completed",
+] as const;
+
+export const GIG_VIEWER_EVENT_TYPES = [
+  "venue_opened",
+  "crowd_arrived",
+  "pre_show_started",
+  "performer_entered",
+  "performer_moved",
+  "song_started",
+  "song_crowd_reaction",
+  "song_highlight",
+  "song_montage",
+  "between_song_transition",
+  "encore_decided",
+  "finale_started",
+  "band_exited",
+  "result_revealed",
+  "replay_completed",
+] as const;
+
+export const GIG_REPLAY_STATUSES = ["generating", "ready", "failed", "legacy_unavailable"] as const;

--- a/src/features/gig-experience/events/generator.ts
+++ b/src/features/gig-experience/events/generator.ts
@@ -1,0 +1,86 @@
+import { GIG_EVENT_SCHEMA_VERSION, GIG_REPLAY_TARGET_DURATION_MS, GIG_VIEWER_VERSION } from "./constants";
+import { validateGigViewerReplay } from "./schema";
+import type { GigViewerEvent, GigViewerReplay, StagePosition } from "./types";
+
+export interface ReplayGigInput { id: string; completedAt: string | null; resultReadyAt?: string | null; venueCapacity?: number | null; actualAttendance?: number | null; overallRating?: number | null; netProfit?: number | null }
+export interface ReplaySongInput { id: string; songId: string | null; position: number; title: string; performanceScore: number | null; crowdResponse?: string | null }
+export interface ReplayPerformerInput { profileId: string; displayName?: string | null; roleOrInstrument?: string | null; lineupStatus?: string | null }
+export interface BuildGigViewerReplayInput { replayId: string; gig: ReplayGigInput; outcomeId: string; songs: ReplaySongInput[]; performers: ReplayPerformerInput[]; generatedAt: string; viewerVersion?: number }
+
+export function createDeterministicSeed(parts: Array<string | number | null | undefined>): string {
+  return fnv1a64(parts.map((p) => String(p ?? "")).join("|"));
+}
+
+export function createDeterministicRandom(seed: string) {
+  let state = BigInt(`0x${fnv1a64([seed, "rng"].join("|"))}`);
+  return () => {
+    state = (state * 6364136223846793005n + 1442695040888963407n) & ((1n << 64n) - 1n);
+    return Number(state >> 11n) / Number(1n << 53n);
+  };
+}
+
+export async function checksumReplayEvents(events: GigViewerEvent[]): Promise<string> {
+  const text = JSON.stringify(events);
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  return fnv1a64(text);
+}
+
+export async function buildGigViewerReplay(input: BuildGigViewerReplayInput): Promise<GigViewerReplay> {
+  const viewerVersion = input.viewerVersion ?? GIG_VIEWER_VERSION;
+  const sortedSongs = [...input.songs].sort((a, b) => a.position - b.position);
+  const performed = input.performers.filter((p) => (p.lineupStatus ?? "performed") === "performed");
+  const seed = createDeterministicSeed([input.gig.id, input.outcomeId, input.gig.completedAt, viewerVersion]);
+  const random = createDeterministicRandom(seed);
+  const durationBySong = allocateSongDurations(sortedSongs);
+  const events: GigViewerEvent[] = [];
+  let offset = 0;
+  let energy = initialEnergy(input.gig);
+  const push = (event: Omit<GigViewerEvent, "id" | "gigId" | "sequence" | "scheduledOffsetMs">) => {
+    events.push({ ...event, id: `${input.gig.id}:viewer:${events.length}`, gigId: input.gig.id, sequence: events.length, scheduledOffsetMs: offset });
+    offset += event.durationMs;
+  };
+  push({ phase: "venue_opening", eventType: "venue_opened", durationMs: 8_000, importance: "normal", messageKey: "gig.viewer.venue_opened", messageParams: {}, visualPayload: { type: "venue_open", entranceIds: ["main"], lightLevel: 0.35 } });
+  push({ phase: "crowd_entry", eventType: "crowd_arrived", durationMs: 12_000, importance: "normal", crowdEnergyBefore: energy, crowdEnergyAfter: energy + 4, messageKey: "gig.viewer.crowd_arrived", messageParams: { attendance: input.gig.actualAttendance ?? 0 }, visualPayload: { type: "crowd_fill", targetDensity: attendancePct(input.gig), zoneIds: ["floor", "balcony"], enteringCount: input.gig.actualAttendance ?? 0 } });
+  energy = clamp(energy + 4);
+  push({ phase: "pre_show", eventType: "pre_show_started", durationMs: 8_000, importance: "ambient", crowdEnergyBefore: energy, crowdEnergyAfter: energy, messageKey: "gig.viewer.pre_show", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "still", intensity: energy / 100 } });
+  for (const [index, performer] of performed.slice(0, 8).entries()) {
+    push({ phase: "band_entrance", eventType: "performer_entered", durationMs: index === 0 ? 6_000 : 2_000, importance: "normal", performerProfileId: performer.profileId, messageKey: "gig.viewer.performer_entered", messageParams: { performer: performer.displayName ?? "Performer", role: performer.roleOrInstrument ?? "performer" }, visualPayload: { type: "performer_enter", performerId: performer.profileId, displayName: performer.displayName ?? "Performer", roleOrInstrument: performer.roleOrInstrument ?? "performer", startPosition: positionForRole(performer.roleOrInstrument, index) } });
+  }
+  if (performed.length === 0) push({ phase: "band_entrance", eventType: "performer_moved", durationMs: 6_000, importance: "ambient", messageKey: "gig.viewer.band_entrance_legacy", messageParams: {}, visualPayload: { type: "performer_move", performerId: "unknown", targetPosition: positionForRole(null, 0), movementStyle: "walk" } });
+  const bestScore = Math.max(...sortedSongs.map((s) => s.performanceScore ?? -1));
+  const worstScore = Math.min(...sortedSongs.map((s) => s.performanceScore ?? 999));
+  sortedSongs.forEach((song, i) => {
+    const songBudget = durationBySong.get(song.position) ?? 16_000;
+    const isEmphasis = i === 0 || i === sortedSongs.length - 1 || song.performanceScore === bestScore || song.performanceScore === worstScore;
+    const after = nextEnergy(energy, song, input.gig);
+    push({ phase: "song_intro", eventType: sortedSongs.length > 14 && !isEmphasis ? "song_montage" : "song_started", durationMs: Math.round(songBudget * 0.2), importance: isEmphasis ? "important" : "normal", songId: song.songId, messageKey: "gig.viewer.song_started", messageParams: { title: song.title, position: song.position + 1 }, visualPayload: { type: "song_start", songId: song.songId, title: song.title, position: song.position, montage: sortedSongs.length > 14 && !isEmphasis } });
+    push({ phase: "song_performance", eventType: "song_crowd_reaction", durationMs: Math.round(songBudget * 0.55), importance: isEmphasis ? "important" : "normal", songId: song.songId, crowdEnergyBefore: energy, crowdEnergyAfter: after, messageKey: "gig.viewer.song_reaction", messageParams: { title: song.title, score: song.performanceScore ?? 0 }, visualPayload: { type: "crowd_reaction", reaction: reactionForEnergy(after), intensity: after / 100, zoneIds: ["floor"] } });
+    if (isEmphasis) push({ phase: "highlight_moment", eventType: "song_highlight", durationMs: Math.round(songBudget * 0.15), importance: "important", songId: song.songId, crowdEnergyBefore: energy, crowdEnergyAfter: after, messageKey: "gig.viewer.song_highlight", messageParams: { title: song.title }, visualPayload: { type: "moment_effect", effect: random() > 0.5 ? "pulse" : "ring", targetId: song.songId ?? undefined, intensity: after / 100 } });
+    energy = after;
+    if (i < sortedSongs.length - 1) push({ phase: "between_songs", eventType: "between_song_transition", durationMs: Math.max(2_000, Math.round(songBudget * 0.1)), importance: "ambient", crowdEnergyBefore: energy, crowdEnergyAfter: energy, messageKey: "gig.viewer.between_songs", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "wave", intensity: energy / 120 } });
+  });
+  const encore = deriveEncoreDecision(input.gig, energy);
+  push({ phase: "encore_decision", eventType: "encore_decided", durationMs: 8_000, importance: "important", crowdEnergyBefore: energy, crowdEnergyAfter: encore ? clamp(energy + 5) : energy, messageKey: encore ? "gig.viewer.encore_requested" : "gig.viewer.encore_declined", messageParams: { narrative: "presentation_only" }, visualPayload: { type: "crowd_reaction", reaction: encore ? "jump" : "wave", intensity: energy / 100 } });
+  push({ phase: "finale", eventType: "finale_started", durationMs: 10_000, importance: "critical", crowdEnergyBefore: energy, crowdEnergyAfter: clamp(energy + (encore ? 8 : 2)), messageKey: "gig.viewer.finale", messageParams: {}, visualPayload: { type: "moment_effect", effect: "confetti", intensity: Math.min(1, energy / 90) } });
+  push({ phase: "band_exit", eventType: "band_exited", durationMs: 8_000, importance: "normal", messageKey: "gig.viewer.band_exit", messageParams: {}, visualPayload: { type: "band_exit", exitStyle: encore ? "encore_bow" : "wave", performerIds: performed.map((p) => p.profileId) } });
+  push({ phase: "result_reveal", eventType: "result_revealed", durationMs: 8_000, importance: "critical", messageKey: "gig.viewer.result_reveal", messageParams: { rating: input.gig.overallRating ?? 0 }, visualPayload: { type: "result_reveal", overallRating: input.gig.overallRating ?? null, attendance: input.gig.actualAttendance ?? null, netProfit: input.gig.netProfit ?? null, verdictKey: verdictKey(input.gig.overallRating) } });
+  push({ phase: "completed", eventType: "replay_completed", durationMs: 1_000, importance: "ambient", messageKey: "gig.viewer.completed", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "disperse", intensity: 0.1 } });
+  const replay: GigViewerReplay = { id: input.replayId, gigId: input.gig.id, gigOutcomeId: input.outcomeId, viewerVersion, eventSchemaVersion: GIG_EVENT_SCHEMA_VERSION, simulationSeed: seed, durationMs: offset, generatedAt: input.generatedAt, events, checksum: await checksumReplayEvents(events), status: "ready" };
+  const validation = validateGigViewerReplay(replay);
+  if (!validation.valid) throw new Error(`INVALID_REPLAY:${validation.errors.join(";")}`);
+  return replay;
+}
+
+function allocateSongDurations(songs: ReplaySongInput[]) { const out = new Map<number, number>(); if (!songs.length) return out; const base = Math.max(8_000, (GIG_REPLAY_TARGET_DURATION_MS - 71_000) / songs.length); const best = songs.reduce((a, b) => (b.performanceScore ?? -1) > (a.performanceScore ?? -1) ? b : a, songs[0]); const worst = songs.reduce((a, b) => (b.performanceScore ?? 999) < (a.performanceScore ?? 999) ? b : a, songs[0]); let totalWeight = 0; const weights = songs.map((s, i) => { let w = 1; if (i === 0 || i === songs.length - 1) w += 0.35; if (s === best || s === worst) w += 0.25; totalWeight += w; return w; }); songs.forEach((s, i) => out.set(s.position, Math.max(6_000, Math.round(base * songs.length * weights[i] / totalWeight)))); return out; }
+function attendancePct(gig: ReplayGigInput) { return clamp((gig.actualAttendance ?? 0) / Math.max(1, gig.venueCapacity ?? 1), 0, 1); }
+function initialEnergy(gig: ReplayGigInput) { return clamp(25 + attendancePct(gig) * 35 + ((gig.overallRating ?? 10) / 25) * 15); }
+function nextEnergy(current: number, song: ReplaySongInput, gig: ReplayGigInput) { return clamp(current * 0.65 + ((song.performanceScore ?? gig.overallRating ?? 10) / 25) * 35 + attendancePct(gig) * 10); }
+function reactionForEnergy(e: number) { return e > 80 ? "jump" : e > 60 ? "bounce" : e > 38 ? "wave" : "still"; }
+function deriveEncoreDecision(gig: ReplayGigInput, energy: number) { return (gig.overallRating ?? 0) >= 18 || energy >= 75 || (attendancePct(gig) >= 0.9 && (gig.overallRating ?? 0) >= 15); }
+function verdictKey(r?: number | null) { return (r ?? 0) >= 20 ? "excellent" : (r ?? 0) >= 15 ? "strong" : (r ?? 0) >= 8 ? "mixed" : "rough"; }
+function positionForRole(role: string | null | undefined, index: number): StagePosition { const r = (role ?? "").toLowerCase(); if (r.includes("drum")) return { x: 0.5, y: 0.8, zone: "back_center" }; if (r.includes("bass")) return { x: 0.25, y: 0.45, zone: "mid_left" }; if (r.includes("guitar")) return { x: 0.75, y: 0.45, zone: "mid_right" }; if (r.includes("vocal")) return { x: 0.5, y: 0.2, zone: "front_center" }; const zones: StagePosition["zone"][] = ["front_left", "front_center", "front_right", "mid_left", "mid_center", "mid_right"]; return { x: 0.15 + (index % 3) * 0.35, y: index < 3 ? 0.25 : 0.55, zone: zones[index % zones.length] }; }
+function clamp(value: number, min = 0, max = 100) { return Math.max(min, Math.min(max, Math.round(value))); }
+function fnv1a64(value: string) { let h = 0xcbf29ce484222325n; for (let i = 0; i < value.length; i++) { h ^= BigInt(value.charCodeAt(i)); h = (h * 0x100000001b3n) & 0xffffffffffffffffn; } return h.toString(16).padStart(16, "0"); }

--- a/src/features/gig-experience/events/schema.ts
+++ b/src/features/gig-experience/events/schema.ts
@@ -1,0 +1,92 @@
+import { GIG_EVENT_SCHEMA_VERSION, GIG_REPLAY_STATUSES, GIG_VIEWER_EVENT_TYPES, GIG_VIEWER_PHASES, GIG_VIEWER_VERSION } from "./constants";
+import type { GigViewerEvent, GigViewerEventType, GigVisualPayload, GigViewerReplay } from "./types";
+
+export interface GigReplayValidationResult { valid: boolean; errors: string[] }
+
+const eventTypes = new Set<string>(GIG_VIEWER_EVENT_TYPES);
+const phases = new Set<string>(GIG_VIEWER_PHASES);
+const statuses = new Set<string>(GIG_REPLAY_STATUSES);
+const eventPayloadTypes: Record<GigViewerEventType, GigVisualPayload["type"][]> = {
+  venue_opened: ["venue_open"],
+  crowd_arrived: ["crowd_fill"],
+  pre_show_started: ["crowd_reaction"],
+  performer_entered: ["performer_enter"],
+  performer_moved: ["performer_move"],
+  song_started: ["song_start"],
+  song_crowd_reaction: ["crowd_reaction"],
+  song_highlight: ["spotlight", "moment_effect", "performer_move"],
+  song_montage: ["song_start", "crowd_reaction"],
+  between_song_transition: ["crowd_reaction"],
+  encore_decided: ["crowd_reaction", "moment_effect"],
+  finale_started: ["moment_effect", "spotlight"],
+  band_exited: ["band_exit"],
+  result_revealed: ["result_reveal"],
+  replay_completed: ["crowd_reaction"],
+};
+
+export function isSupportedReplayVersion(viewerVersion: number, eventSchemaVersion: number) {
+  return viewerVersion === GIG_VIEWER_VERSION && eventSchemaVersion === GIG_EVENT_SCHEMA_VERSION;
+}
+
+export function validateGigViewerReplay(replay: GigViewerReplay): GigReplayValidationResult {
+  const errors: string[] = [];
+  if (!isSupportedReplayVersion(replay.viewerVersion, replay.eventSchemaVersion)) errors.push("unsupported version");
+  if (!statuses.has(replay.status)) errors.push("invalid status");
+  if (replay.durationMs <= 0) errors.push("duration must be positive");
+  if (!Array.isArray(replay.events)) errors.push("events must be an array");
+  if (replay.events.length === 0) errors.push("events are required");
+  const seenIds = new Set<string>();
+  const seenSequences = new Set<number>();
+  let previousOffset = -1;
+  let hasResultReveal = false;
+  replay.events.forEach((event, index) => {
+    validateEvent(event, errors, index);
+    if (seenIds.has(event.id)) errors.push(`duplicate event id ${event.id}`);
+    seenIds.add(event.id);
+    if (seenSequences.has(event.sequence)) errors.push(`duplicate sequence ${event.sequence}`);
+    seenSequences.add(event.sequence);
+    if (event.sequence !== index) errors.push(`sequence ${event.sequence} must equal array index ${index}`);
+    if (event.scheduledOffsetMs < previousOffset) errors.push(`offset out of order at sequence ${event.sequence}`);
+    previousOffset = event.scheduledOffsetMs;
+    if (event.eventType === "result_revealed") hasResultReveal = true;
+  });
+  const last = replay.events.at(-1);
+  if (!hasResultReveal) errors.push("result reveal event is required");
+  if (last?.eventType !== "replay_completed" || last.phase !== "completed") errors.push("completed event must be last");
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateEvent(event: GigViewerEvent, errors: string[] = [], index = 0): GigReplayValidationResult {
+  if (!event.id) errors.push(`event ${index} missing id`);
+  if (!event.gigId) errors.push(`event ${index} missing gigId`);
+  if (!Number.isInteger(event.sequence) || event.sequence < 0) errors.push(`event ${index} invalid sequence`);
+  if (!phases.has(event.phase)) errors.push(`event ${index} invalid phase`);
+  if (!eventTypes.has(event.eventType)) errors.push(`event ${index} invalid event type`);
+  if (!Number.isFinite(event.scheduledOffsetMs) || event.scheduledOffsetMs < 0) errors.push(`event ${index} invalid offset`);
+  if (!Number.isFinite(event.durationMs) || event.durationMs < 0) errors.push(`event ${index} invalid duration`);
+  if (!["ambient", "normal", "important", "critical"].includes(event.importance)) errors.push(`event ${index} invalid importance`);
+  for (const value of [event.crowdEnergyBefore, event.crowdEnergyAfter]) if (value != null && (value < 0 || value > 100)) errors.push(`event ${index} invalid crowd energy`);
+  if (!event.messageKey) errors.push(`event ${index} missing message key`);
+  if (!event.messageParams || Object.values(event.messageParams).some((v) => typeof v !== "string" && typeof v !== "number")) errors.push(`event ${index} invalid message params`);
+  if (!isPayloadValid(event.visualPayload)) errors.push(`event ${index} invalid payload`);
+  const allowed = eventTypes.has(event.eventType) ? eventPayloadTypes[event.eventType] : [];
+  if (event.visualPayload && allowed && !allowed.includes(event.visualPayload.type)) errors.push(`event ${index} payload ${event.visualPayload.type} not allowed for ${event.eventType}`);
+  return { valid: errors.length === 0, errors };
+}
+
+function isPayloadValid(payload: GigVisualPayload | undefined): payload is GigVisualPayload {
+  if (!payload || typeof payload !== "object" || !("type" in payload)) return false;
+  switch (payload.type) {
+    case "venue_open": return Array.isArray(payload.entranceIds) && payload.lightLevel >= 0 && payload.lightLevel <= 1;
+    case "crowd_fill": return payload.targetDensity >= 0 && payload.targetDensity <= 1 && Array.isArray(payload.zoneIds) && payload.enteringCount >= 0;
+    case "crowd_reaction": return ["still", "bounce", "jump", "wave", "disperse"].includes(payload.reaction) && payload.intensity >= 0 && payload.intensity <= 1;
+    case "performer_enter": return !!payload.performerId && !!payload.displayName && !!payload.startPosition;
+    case "performer_move": return !!payload.performerId && !!payload.targetPosition && ["walk", "rush", "step_forward"].includes(payload.movementStyle);
+    case "song_start": return typeof payload.title === "string" && Number.isInteger(payload.position) && typeof payload.montage === "boolean";
+    case "spotlight": return payload.intensity >= 0 && payload.intensity <= 1;
+    case "moment_effect": return ["pulse", "ring", "trail", "confetti"].includes(payload.effect) && payload.intensity >= 0 && payload.intensity <= 1;
+    case "band_exit": return ["wave", "quick", "encore_bow"].includes(payload.exitStyle) && Array.isArray(payload.performerIds);
+    case "result_reveal": return typeof payload.verdictKey === "string";
+    default: return false;
+  }
+}

--- a/src/features/gig-experience/events/types.ts
+++ b/src/features/gig-experience/events/types.ts
@@ -1,0 +1,55 @@
+import type { GIG_REPLAY_STATUSES, GIG_VIEWER_EVENT_TYPES, GIG_VIEWER_PHASES } from "./constants";
+
+export type GigViewerPhase = (typeof GIG_VIEWER_PHASES)[number];
+export type GigViewerEventType = (typeof GIG_VIEWER_EVENT_TYPES)[number];
+export type GigReplayStatus = (typeof GIG_REPLAY_STATUSES)[number];
+export type GigEventImportance = "ambient" | "normal" | "important" | "critical";
+
+export interface StagePosition { x: number; y: number; zone: "front_left" | "front_center" | "front_right" | "mid_left" | "mid_center" | "mid_right" | "back_left" | "back_center" | "back_right" }
+
+export type GigVisualPayload =
+  | { type: "venue_open"; entranceIds: string[]; lightLevel: number }
+  | { type: "crowd_fill"; targetDensity: number; zoneIds: string[]; enteringCount: number }
+  | { type: "crowd_reaction"; reaction: "still" | "bounce" | "jump" | "wave" | "disperse"; intensity: number; zoneIds?: string[] }
+  | { type: "performer_enter"; performerId: string; displayName: string; roleOrInstrument: string; startPosition: StagePosition }
+  | { type: "performer_move"; performerId: string; targetPosition: StagePosition; movementStyle: "walk" | "rush" | "step_forward" }
+  | { type: "song_start"; songId: string | null; title: string; position: number; montage: boolean }
+  | { type: "spotlight"; performerId?: string; stageZone?: string; intensity: number }
+  | { type: "moment_effect"; effect: "pulse" | "ring" | "trail" | "confetti"; targetId?: string; intensity: number }
+  | { type: "band_exit"; exitStyle: "wave" | "quick" | "encore_bow"; performerIds: string[] }
+  | { type: "result_reveal"; overallRating: number | null; attendance: number | null; netProfit: number | null; verdictKey: string };
+
+export interface GigViewerEventBase {
+  id: string;
+  gigId: string;
+  sequence: number;
+  phase: GigViewerPhase;
+  eventType: GigViewerEventType;
+  scheduledOffsetMs: number;
+  durationMs: number;
+  importance: GigEventImportance;
+  songId?: string | null;
+  performerProfileId?: string | null;
+  crowdEnergyBefore?: number | null;
+  crowdEnergyAfter?: number | null;
+  messageKey: string;
+  messageParams: Record<string, string | number>;
+}
+
+export type GigViewerEvent = GigViewerEventBase & { visualPayload: GigVisualPayload };
+
+export interface GigViewerReplay {
+  id: string;
+  gigId: string;
+  gigOutcomeId: string;
+  viewerVersion: number;
+  eventSchemaVersion: number;
+  simulationSeed: string;
+  durationMs: number;
+  generatedAt: string;
+  events: GigViewerEvent[];
+  checksum: string | null;
+  status: GigReplayStatus;
+}
+
+export type GigViewerReplayLoadState = "loading" | "ready" | "unavailable" | "generating" | "failed" | "unsupported_version";

--- a/src/features/gig-experience/hooks.ts
+++ b/src/features/gig-experience/hooks.ts
@@ -1,11 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGigExperience } from "./services/GigExperienceService";
+import { getGigViewerReplay } from "./services/GigViewerReplayService";
 
 export function useGigExperience(gigId: string | null, enabled = true) {
   return useQuery({
     queryKey: ["gig-experience", gigId],
     enabled: enabled && !!gigId,
     queryFn: () => getGigExperience(gigId as string),
+    staleTime: 30_000,
+  });
+}
+
+
+export function useGigViewerReplay(gigId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ["gig-viewer-replay", gigId],
+    enabled: enabled && !!gigId,
+    queryFn: () => getGigViewerReplay(gigId as string),
     staleTime: 30_000,
   });
 }

--- a/src/features/gig-experience/services/GigExperienceService.ts
+++ b/src/features/gig-experience/services/GigExperienceService.ts
@@ -29,7 +29,7 @@ export async function getGigExperience(gigId: string): Promise<GigExperienceDTO 
   if (outcomeError) throw outcomeError;
 
   const outcomeId = outcome?.id ?? null;
-  const [songPerfsRes, setlistSongsRes, performersRes] = await Promise.all([
+  const [songPerfsRes, setlistSongsRes, performersRes, replayDescriptorRes] = await Promise.all([
     outcomeId
       ? supabase.from("gig_song_performances").select("id,song_id,position,performance_score,crowd_response,song_quality_contrib,rehearsal_contrib,chemistry_contrib,equipment_contrib,crew_contrib,member_skill_contrib,song_title,performance_item_name,item_type").eq("gig_outcome_id", outcomeId).order("position")
       : Promise.resolve({ data: [] as SongPerfRow[], error: null }),
@@ -37,10 +37,12 @@ export async function getGigExperience(gigId: string): Promise<GigExperienceDTO 
       ? supabase.from("setlist_songs").select("song_id,position,songs(id,title,genre,quality_score)").eq("setlist_id", gig.setlist_id).order("position")
       : Promise.resolve({ data: [] as SetlistSongRow[], error: null }),
     (supabase as any).from("gig_performers").select("id,profile_id,role_or_instrument,lineup_status,profiles:profiles!gig_performers_profile_id_fkey(display_name,username)").eq("gig_id", gigId).order("created_at", { ascending: true }),
+    (supabase as any).from("gig_viewer_replays").select("viewer_version,duration_ms,generation_status").eq("gig_id", gigId).order("generated_at", { ascending: false }).limit(1).maybeSingle(),
   ]);
   if (songPerfsRes.error) throw songPerfsRes.error;
   if (setlistSongsRes.error) throw setlistSongsRes.error;
   if (performersRes.error) throw performersRes.error;
+  if (replayDescriptorRes.error && replayDescriptorRes.error.code !== "42P01") throw replayDescriptorRes.error;
 
   return mapGigExperience({
     gig: gig as unknown as GigRow,
@@ -48,10 +50,11 @@ export async function getGigExperience(gigId: string): Promise<GigExperienceDTO 
     songPerformances: (songPerfsRes.data ?? []) as SongPerfRow[],
     setlistSongs: (setlistSongsRes.data ?? []) as unknown as SetlistSongRow[],
     performers: (performersRes.data ?? []) as PerformerRow[],
+    replayDescriptor: replayDescriptorRes.data ?? null,
   });
 }
 
-export function mapGigExperience(input: { gig: GigRow; outcome: OutcomeRow | null; songPerformances?: SongPerfRow[]; setlistSongs?: SetlistSongRow[]; performers?: PerformerRow[] }): GigExperienceDTO {
+export function mapGigExperience(input: { gig: GigRow; outcome: OutcomeRow | null; songPerformances?: SongPerfRow[]; setlistSongs?: SetlistSongRow[]; performers?: PerformerRow[]; replayDescriptor?: { viewer_version: number; duration_ms: number; generation_status: string } | null }): GigExperienceDTO {
   const { gig, outcome } = input;
   const venue = gig.venues;
   const capacity = venue?.capacity ?? outcome?.venue_capacity ?? 0;
@@ -88,7 +91,7 @@ export function mapGigExperience(input: { gig: GigRow; outcome: OutcomeRow | nul
     progression: { fameGained: outcome ? nullableNumberMetric(outcome.fame_gained, "Fame gain missing") : metricLegacyMissing("Outcome is not ready"), chemistryChange: outcome ? nullableNumberMetric(outcome.chemistry_change, "Chemistry change missing") : metricLegacyMissing("Outcome is not ready"), totalXpAwarded: outcome ? nullableNumberMetric(outcome.total_xp_awarded, "XP summary missing") : metricLegacyMissing("Outcome is not ready"), fansGained: fans, fanConversions: outcome ? nullableNumberMetric(outcome.fan_conversions, "Fan conversion count missing") : metricLegacyMissing("Outcome is not ready") },
     analysis: { equipmentQuality: outcome ? nullableNumberMetric(outcome.equipment_quality_avg, "Equipment breakdown missing") : metricLegacyMissing("Outcome is not ready"), crewSkill: outcome ? nullableNumberMetric(outcome.crew_skill_avg, "Crew breakdown missing") : metricLegacyMissing("Outcome is not ready"), bandChemistry: outcome ? nullableNumberMetric(outcome.band_chemistry_level, "Band chemistry breakdown missing") : metricLegacyMissing("Outcome is not ready"), memberSkills: outcome ? nullableNumberMetric(outcome.member_skill_avg, "Member skills breakdown missing") : metricLegacyMissing("Outcome is not ready"), crowdEnergyPeak: outcome ? nullableNumberMetric(outcome.crowd_energy_peak, "Crowd energy peak missing") : metricLegacyMissing("Outcome is not ready"), stageBehaviorUsed: outcome?.stage_behavior_used ? metricAvailable(outcome.stage_behavior_used) : metricNotApplicable("No stage behaviour was recorded"), gearEffects: outcome ? mapGearEffects(outcome) : null, warnings: buildWarnings(outcome, songs.length, input.performers?.length ?? 0) },
     lessons: buildLessons(metricValue(rating, 0), metricValue(outcome ? nullableNumberMetric(outcome.actual_attendance, "") : metricAvailable(0), 0), capacity, metricValue(outcome ? nullableNumberMetric(outcome.net_profit, "") : metricAvailable(0), 0)),
-    viewer: { ready: !!outcome, outcomeId: outcome?.id ?? null, resultReadyAt: outcome?.completed_at ?? gig.completed_at ?? null, replayAvailable: songs.length > 0 },
+    viewer: { ready: !!outcome, outcomeId: outcome?.id ?? null, resultReadyAt: outcome?.completed_at ?? gig.completed_at ?? null, replayAvailable: input.replayDescriptor?.generation_status === "ready", replay: input.replayDescriptor ? { viewerVersion: input.replayDescriptor.viewer_version, durationMs: input.replayDescriptor.duration_ms, generationStatus: input.replayDescriptor.generation_status } : { viewerVersion: null, durationMs: null, generationStatus: outcome ? "legacy_unavailable" : null } },
   };
   const validationErrors = validateGigExperience(dto);
   if (validationErrors.length > 0) throw new Error(`Invalid gig experience DTO: ${validationErrors.map((e) => `${e.field} ${e.message}`).join(", ")}`);

--- a/src/features/gig-experience/services/GigViewerReplayService.ts
+++ b/src/features/gig-experience/services/GigViewerReplayService.ts
@@ -1,0 +1,32 @@
+import { supabase } from "@/integrations/supabase/client";
+import { GIG_EVENT_SCHEMA_VERSION, GIG_VIEWER_VERSION } from "../events/constants";
+import { isSupportedReplayVersion, validateGigViewerReplay } from "../events/schema";
+import type { GigReplayStatus, GigViewerReplay, GigViewerReplayLoadState } from "../events/types";
+
+type ReplayRow = { id: string; gig_id: string; gig_outcome_id: string; viewer_version: number; event_schema_version: number; simulation_seed: string; duration_ms: number; event_payload: { events?: unknown[] } | unknown[]; generated_at: string; generation_status: GigReplayStatus; checksum: string | null };
+export interface GigViewerReplayResult { state: GigViewerReplayLoadState; replay: GigViewerReplay | null; reason?: string }
+
+export async function getGigViewerReplay(gigId: string): Promise<GigViewerReplayResult> {
+  const { data, error } = await (supabase as any)
+    .from("gig_viewer_replays")
+    .select("id,gig_id,gig_outcome_id,viewer_version,event_schema_version,simulation_seed,duration_ms,event_payload,generated_at,generation_status,checksum")
+    .eq("gig_id", gigId)
+    .eq("viewer_version", GIG_VIEWER_VERSION)
+    .order("generated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return { state: "unavailable", replay: null, reason: "legacy_unavailable" };
+  const row = data as ReplayRow;
+  if (row.generation_status === "generating") return { state: "generating", replay: null };
+  if (row.generation_status === "failed") return { state: "failed", replay: null };
+  if (row.generation_status === "legacy_unavailable") return { state: "unavailable", replay: null, reason: "legacy_unavailable" };
+  if (!isSupportedReplayVersion(row.viewer_version, row.event_schema_version)) return { state: "unsupported_version", replay: null };
+  const events = Array.isArray(row.event_payload) ? row.event_payload : (row.event_payload as { events?: unknown[] })?.events;
+  const replay: GigViewerReplay = { id: row.id, gigId: row.gig_id, gigOutcomeId: row.gig_outcome_id, viewerVersion: row.viewer_version, eventSchemaVersion: row.event_schema_version, simulationSeed: row.simulation_seed, durationMs: row.duration_ms, generatedAt: row.generated_at, events: (events ?? []) as GigViewerReplay["events"], checksum: row.checksum, status: row.generation_status };
+  if (replay.eventSchemaVersion !== GIG_EVENT_SCHEMA_VERSION) return { state: "unsupported_version", replay: null };
+  const validation = validateGigViewerReplay(replay);
+  if (!validation.valid) return { state: "failed", replay: null, reason: "malformed_replay" };
+  console.info("[gig-viewer-replay] loaded", { gigId, replayId: row.id, eventCount: replay.events.length, durationMs: replay.durationMs });
+  return { state: "ready", replay };
+}

--- a/src/features/gig-experience/types.ts
+++ b/src/features/gig-experience/types.ts
@@ -97,7 +97,7 @@ export interface GigExperienceDTO {
   progression: GigExperienceProgressionDTO;
   analysis: GigExperienceAnalysisDTO;
   lessons: { worked: string[]; heldBack: string[]; recommendations: string[] };
-  viewer: { ready: boolean; outcomeId: string | null; resultReadyAt: string | null; replayAvailable: boolean };
+  viewer: { ready: boolean; outcomeId: string | null; resultReadyAt: string | null; replayAvailable: boolean; replay?: { viewerVersion: number | null; durationMs: number | null; generationStatus: string | null } };
 }
 
 export interface GigExperienceValidationError { field: string; message: string }

--- a/supabase/functions/_shared/gig-viewer-replay/constants.ts
+++ b/supabase/functions/_shared/gig-viewer-replay/constants.ts
@@ -1,0 +1,40 @@
+export const GIG_VIEWER_VERSION = 1;
+export const GIG_EVENT_SCHEMA_VERSION = 1;
+export const GIG_REPLAY_TARGET_DURATION_MS = 180_000;
+export const GIG_REPLAY_TARGET_TOLERANCE_MS = 15_000;
+
+export const GIG_VIEWER_PHASES = [
+  "venue_opening",
+  "crowd_entry",
+  "pre_show",
+  "band_entrance",
+  "song_intro",
+  "song_performance",
+  "between_songs",
+  "highlight_moment",
+  "encore_decision",
+  "finale",
+  "band_exit",
+  "result_reveal",
+  "completed",
+] as const;
+
+export const GIG_VIEWER_EVENT_TYPES = [
+  "venue_opened",
+  "crowd_arrived",
+  "pre_show_started",
+  "performer_entered",
+  "performer_moved",
+  "song_started",
+  "song_crowd_reaction",
+  "song_highlight",
+  "song_montage",
+  "between_song_transition",
+  "encore_decided",
+  "finale_started",
+  "band_exited",
+  "result_revealed",
+  "replay_completed",
+] as const;
+
+export const GIG_REPLAY_STATUSES = ["generating", "ready", "failed", "legacy_unavailable"] as const;

--- a/supabase/functions/_shared/gig-viewer-replay/generator.ts
+++ b/supabase/functions/_shared/gig-viewer-replay/generator.ts
@@ -1,0 +1,86 @@
+import { GIG_EVENT_SCHEMA_VERSION, GIG_REPLAY_TARGET_DURATION_MS, GIG_VIEWER_VERSION } from "./constants";
+import { validateGigViewerReplay } from "./schema";
+import type { GigViewerEvent, GigViewerReplay, StagePosition } from "./types";
+
+export interface ReplayGigInput { id: string; completedAt: string | null; resultReadyAt?: string | null; venueCapacity?: number | null; actualAttendance?: number | null; overallRating?: number | null; netProfit?: number | null }
+export interface ReplaySongInput { id: string; songId: string | null; position: number; title: string; performanceScore: number | null; crowdResponse?: string | null }
+export interface ReplayPerformerInput { profileId: string; displayName?: string | null; roleOrInstrument?: string | null; lineupStatus?: string | null }
+export interface BuildGigViewerReplayInput { replayId: string; gig: ReplayGigInput; outcomeId: string; songs: ReplaySongInput[]; performers: ReplayPerformerInput[]; generatedAt: string; viewerVersion?: number }
+
+export function createDeterministicSeed(parts: Array<string | number | null | undefined>): string {
+  return fnv1a64(parts.map((p) => String(p ?? "")).join("|"));
+}
+
+export function createDeterministicRandom(seed: string) {
+  let state = BigInt(`0x${fnv1a64([seed, "rng"].join("|"))}`);
+  return () => {
+    state = (state * 6364136223846793005n + 1442695040888963407n) & ((1n << 64n) - 1n);
+    return Number(state >> 11n) / Number(1n << 53n);
+  };
+}
+
+export async function checksumReplayEvents(events: GigViewerEvent[]): Promise<string> {
+  const text = JSON.stringify(events);
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  return fnv1a64(text);
+}
+
+export async function buildGigViewerReplay(input: BuildGigViewerReplayInput): Promise<GigViewerReplay> {
+  const viewerVersion = input.viewerVersion ?? GIG_VIEWER_VERSION;
+  const sortedSongs = [...input.songs].sort((a, b) => a.position - b.position);
+  const performed = input.performers.filter((p) => (p.lineupStatus ?? "performed") === "performed");
+  const seed = createDeterministicSeed([input.gig.id, input.outcomeId, input.gig.completedAt, viewerVersion]);
+  const random = createDeterministicRandom(seed);
+  const durationBySong = allocateSongDurations(sortedSongs);
+  const events: GigViewerEvent[] = [];
+  let offset = 0;
+  let energy = initialEnergy(input.gig);
+  const push = (event: Omit<GigViewerEvent, "id" | "gigId" | "sequence" | "scheduledOffsetMs">) => {
+    events.push({ ...event, id: `${input.gig.id}:viewer:${events.length}`, gigId: input.gig.id, sequence: events.length, scheduledOffsetMs: offset });
+    offset += event.durationMs;
+  };
+  push({ phase: "venue_opening", eventType: "venue_opened", durationMs: 8_000, importance: "normal", messageKey: "gig.viewer.venue_opened", messageParams: {}, visualPayload: { type: "venue_open", entranceIds: ["main"], lightLevel: 0.35 } });
+  push({ phase: "crowd_entry", eventType: "crowd_arrived", durationMs: 12_000, importance: "normal", crowdEnergyBefore: energy, crowdEnergyAfter: energy + 4, messageKey: "gig.viewer.crowd_arrived", messageParams: { attendance: input.gig.actualAttendance ?? 0 }, visualPayload: { type: "crowd_fill", targetDensity: attendancePct(input.gig), zoneIds: ["floor", "balcony"], enteringCount: input.gig.actualAttendance ?? 0 } });
+  energy = clamp(energy + 4);
+  push({ phase: "pre_show", eventType: "pre_show_started", durationMs: 8_000, importance: "ambient", crowdEnergyBefore: energy, crowdEnergyAfter: energy, messageKey: "gig.viewer.pre_show", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "still", intensity: energy / 100 } });
+  for (const [index, performer] of performed.slice(0, 8).entries()) {
+    push({ phase: "band_entrance", eventType: "performer_entered", durationMs: index === 0 ? 6_000 : 2_000, importance: "normal", performerProfileId: performer.profileId, messageKey: "gig.viewer.performer_entered", messageParams: { performer: performer.displayName ?? "Performer", role: performer.roleOrInstrument ?? "performer" }, visualPayload: { type: "performer_enter", performerId: performer.profileId, displayName: performer.displayName ?? "Performer", roleOrInstrument: performer.roleOrInstrument ?? "performer", startPosition: positionForRole(performer.roleOrInstrument, index) } });
+  }
+  if (performed.length === 0) push({ phase: "band_entrance", eventType: "performer_moved", durationMs: 6_000, importance: "ambient", messageKey: "gig.viewer.band_entrance_legacy", messageParams: {}, visualPayload: { type: "performer_move", performerId: "unknown", targetPosition: positionForRole(null, 0), movementStyle: "walk" } });
+  const bestScore = Math.max(...sortedSongs.map((s) => s.performanceScore ?? -1));
+  const worstScore = Math.min(...sortedSongs.map((s) => s.performanceScore ?? 999));
+  sortedSongs.forEach((song, i) => {
+    const songBudget = durationBySong.get(song.position) ?? 16_000;
+    const isEmphasis = i === 0 || i === sortedSongs.length - 1 || song.performanceScore === bestScore || song.performanceScore === worstScore;
+    const after = nextEnergy(energy, song, input.gig);
+    push({ phase: "song_intro", eventType: sortedSongs.length > 14 && !isEmphasis ? "song_montage" : "song_started", durationMs: Math.round(songBudget * 0.2), importance: isEmphasis ? "important" : "normal", songId: song.songId, messageKey: "gig.viewer.song_started", messageParams: { title: song.title, position: song.position + 1 }, visualPayload: { type: "song_start", songId: song.songId, title: song.title, position: song.position, montage: sortedSongs.length > 14 && !isEmphasis } });
+    push({ phase: "song_performance", eventType: "song_crowd_reaction", durationMs: Math.round(songBudget * 0.55), importance: isEmphasis ? "important" : "normal", songId: song.songId, crowdEnergyBefore: energy, crowdEnergyAfter: after, messageKey: "gig.viewer.song_reaction", messageParams: { title: song.title, score: song.performanceScore ?? 0 }, visualPayload: { type: "crowd_reaction", reaction: reactionForEnergy(after), intensity: after / 100, zoneIds: ["floor"] } });
+    if (isEmphasis) push({ phase: "highlight_moment", eventType: "song_highlight", durationMs: Math.round(songBudget * 0.15), importance: "important", songId: song.songId, crowdEnergyBefore: energy, crowdEnergyAfter: after, messageKey: "gig.viewer.song_highlight", messageParams: { title: song.title }, visualPayload: { type: "moment_effect", effect: random() > 0.5 ? "pulse" : "ring", targetId: song.songId ?? undefined, intensity: after / 100 } });
+    energy = after;
+    if (i < sortedSongs.length - 1) push({ phase: "between_songs", eventType: "between_song_transition", durationMs: Math.max(2_000, Math.round(songBudget * 0.1)), importance: "ambient", crowdEnergyBefore: energy, crowdEnergyAfter: energy, messageKey: "gig.viewer.between_songs", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "wave", intensity: energy / 120 } });
+  });
+  const encore = deriveEncoreDecision(input.gig, energy);
+  push({ phase: "encore_decision", eventType: "encore_decided", durationMs: 8_000, importance: "important", crowdEnergyBefore: energy, crowdEnergyAfter: encore ? clamp(energy + 5) : energy, messageKey: encore ? "gig.viewer.encore_requested" : "gig.viewer.encore_declined", messageParams: { narrative: "presentation_only" }, visualPayload: { type: "crowd_reaction", reaction: encore ? "jump" : "wave", intensity: energy / 100 } });
+  push({ phase: "finale", eventType: "finale_started", durationMs: 10_000, importance: "critical", crowdEnergyBefore: energy, crowdEnergyAfter: clamp(energy + (encore ? 8 : 2)), messageKey: "gig.viewer.finale", messageParams: {}, visualPayload: { type: "moment_effect", effect: "confetti", intensity: Math.min(1, energy / 90) } });
+  push({ phase: "band_exit", eventType: "band_exited", durationMs: 8_000, importance: "normal", messageKey: "gig.viewer.band_exit", messageParams: {}, visualPayload: { type: "band_exit", exitStyle: encore ? "encore_bow" : "wave", performerIds: performed.map((p) => p.profileId) } });
+  push({ phase: "result_reveal", eventType: "result_revealed", durationMs: 8_000, importance: "critical", messageKey: "gig.viewer.result_reveal", messageParams: { rating: input.gig.overallRating ?? 0 }, visualPayload: { type: "result_reveal", overallRating: input.gig.overallRating ?? null, attendance: input.gig.actualAttendance ?? null, netProfit: input.gig.netProfit ?? null, verdictKey: verdictKey(input.gig.overallRating) } });
+  push({ phase: "completed", eventType: "replay_completed", durationMs: 1_000, importance: "ambient", messageKey: "gig.viewer.completed", messageParams: {}, visualPayload: { type: "crowd_reaction", reaction: "disperse", intensity: 0.1 } });
+  const replay: GigViewerReplay = { id: input.replayId, gigId: input.gig.id, gigOutcomeId: input.outcomeId, viewerVersion, eventSchemaVersion: GIG_EVENT_SCHEMA_VERSION, simulationSeed: seed, durationMs: offset, generatedAt: input.generatedAt, events, checksum: await checksumReplayEvents(events), status: "ready" };
+  const validation = validateGigViewerReplay(replay);
+  if (!validation.valid) throw new Error(`INVALID_REPLAY:${validation.errors.join(";")}`);
+  return replay;
+}
+
+function allocateSongDurations(songs: ReplaySongInput[]) { const out = new Map<number, number>(); if (!songs.length) return out; const base = Math.max(8_000, (GIG_REPLAY_TARGET_DURATION_MS - 71_000) / songs.length); const best = songs.reduce((a, b) => (b.performanceScore ?? -1) > (a.performanceScore ?? -1) ? b : a, songs[0]); const worst = songs.reduce((a, b) => (b.performanceScore ?? 999) < (a.performanceScore ?? 999) ? b : a, songs[0]); let totalWeight = 0; const weights = songs.map((s, i) => { let w = 1; if (i === 0 || i === songs.length - 1) w += 0.35; if (s === best || s === worst) w += 0.25; totalWeight += w; return w; }); songs.forEach((s, i) => out.set(s.position, Math.max(6_000, Math.round(base * songs.length * weights[i] / totalWeight)))); return out; }
+function attendancePct(gig: ReplayGigInput) { return clamp((gig.actualAttendance ?? 0) / Math.max(1, gig.venueCapacity ?? 1), 0, 1); }
+function initialEnergy(gig: ReplayGigInput) { return clamp(25 + attendancePct(gig) * 35 + ((gig.overallRating ?? 10) / 25) * 15); }
+function nextEnergy(current: number, song: ReplaySongInput, gig: ReplayGigInput) { return clamp(current * 0.65 + ((song.performanceScore ?? gig.overallRating ?? 10) / 25) * 35 + attendancePct(gig) * 10); }
+function reactionForEnergy(e: number) { return e > 80 ? "jump" : e > 60 ? "bounce" : e > 38 ? "wave" : "still"; }
+function deriveEncoreDecision(gig: ReplayGigInput, energy: number) { return (gig.overallRating ?? 0) >= 18 || energy >= 75 || (attendancePct(gig) >= 0.9 && (gig.overallRating ?? 0) >= 15); }
+function verdictKey(r?: number | null) { return (r ?? 0) >= 20 ? "excellent" : (r ?? 0) >= 15 ? "strong" : (r ?? 0) >= 8 ? "mixed" : "rough"; }
+function positionForRole(role: string | null | undefined, index: number): StagePosition { const r = (role ?? "").toLowerCase(); if (r.includes("drum")) return { x: 0.5, y: 0.8, zone: "back_center" }; if (r.includes("bass")) return { x: 0.25, y: 0.45, zone: "mid_left" }; if (r.includes("guitar")) return { x: 0.75, y: 0.45, zone: "mid_right" }; if (r.includes("vocal")) return { x: 0.5, y: 0.2, zone: "front_center" }; const zones: StagePosition["zone"][] = ["front_left", "front_center", "front_right", "mid_left", "mid_center", "mid_right"]; return { x: 0.15 + (index % 3) * 0.35, y: index < 3 ? 0.25 : 0.55, zone: zones[index % zones.length] }; }
+function clamp(value: number, min = 0, max = 100) { return Math.max(min, Math.min(max, Math.round(value))); }
+function fnv1a64(value: string) { let h = 0xcbf29ce484222325n; for (let i = 0; i < value.length; i++) { h ^= BigInt(value.charCodeAt(i)); h = (h * 0x100000001b3n) & 0xffffffffffffffffn; } return h.toString(16).padStart(16, "0"); }

--- a/supabase/functions/_shared/gig-viewer-replay/schema.ts
+++ b/supabase/functions/_shared/gig-viewer-replay/schema.ts
@@ -1,0 +1,92 @@
+import { GIG_EVENT_SCHEMA_VERSION, GIG_REPLAY_STATUSES, GIG_VIEWER_EVENT_TYPES, GIG_VIEWER_PHASES, GIG_VIEWER_VERSION } from "./constants";
+import type { GigViewerEvent, GigViewerEventType, GigVisualPayload, GigViewerReplay } from "./types";
+
+export interface GigReplayValidationResult { valid: boolean; errors: string[] }
+
+const eventTypes = new Set<string>(GIG_VIEWER_EVENT_TYPES);
+const phases = new Set<string>(GIG_VIEWER_PHASES);
+const statuses = new Set<string>(GIG_REPLAY_STATUSES);
+const eventPayloadTypes: Record<GigViewerEventType, GigVisualPayload["type"][]> = {
+  venue_opened: ["venue_open"],
+  crowd_arrived: ["crowd_fill"],
+  pre_show_started: ["crowd_reaction"],
+  performer_entered: ["performer_enter"],
+  performer_moved: ["performer_move"],
+  song_started: ["song_start"],
+  song_crowd_reaction: ["crowd_reaction"],
+  song_highlight: ["spotlight", "moment_effect", "performer_move"],
+  song_montage: ["song_start", "crowd_reaction"],
+  between_song_transition: ["crowd_reaction"],
+  encore_decided: ["crowd_reaction", "moment_effect"],
+  finale_started: ["moment_effect", "spotlight"],
+  band_exited: ["band_exit"],
+  result_revealed: ["result_reveal"],
+  replay_completed: ["crowd_reaction"],
+};
+
+export function isSupportedReplayVersion(viewerVersion: number, eventSchemaVersion: number) {
+  return viewerVersion === GIG_VIEWER_VERSION && eventSchemaVersion === GIG_EVENT_SCHEMA_VERSION;
+}
+
+export function validateGigViewerReplay(replay: GigViewerReplay): GigReplayValidationResult {
+  const errors: string[] = [];
+  if (!isSupportedReplayVersion(replay.viewerVersion, replay.eventSchemaVersion)) errors.push("unsupported version");
+  if (!statuses.has(replay.status)) errors.push("invalid status");
+  if (replay.durationMs <= 0) errors.push("duration must be positive");
+  if (!Array.isArray(replay.events)) errors.push("events must be an array");
+  if (replay.events.length === 0) errors.push("events are required");
+  const seenIds = new Set<string>();
+  const seenSequences = new Set<number>();
+  let previousOffset = -1;
+  let hasResultReveal = false;
+  replay.events.forEach((event, index) => {
+    validateEvent(event, errors, index);
+    if (seenIds.has(event.id)) errors.push(`duplicate event id ${event.id}`);
+    seenIds.add(event.id);
+    if (seenSequences.has(event.sequence)) errors.push(`duplicate sequence ${event.sequence}`);
+    seenSequences.add(event.sequence);
+    if (event.sequence !== index) errors.push(`sequence ${event.sequence} must equal array index ${index}`);
+    if (event.scheduledOffsetMs < previousOffset) errors.push(`offset out of order at sequence ${event.sequence}`);
+    previousOffset = event.scheduledOffsetMs;
+    if (event.eventType === "result_revealed") hasResultReveal = true;
+  });
+  const last = replay.events.at(-1);
+  if (!hasResultReveal) errors.push("result reveal event is required");
+  if (last?.eventType !== "replay_completed" || last.phase !== "completed") errors.push("completed event must be last");
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateEvent(event: GigViewerEvent, errors: string[] = [], index = 0): GigReplayValidationResult {
+  if (!event.id) errors.push(`event ${index} missing id`);
+  if (!event.gigId) errors.push(`event ${index} missing gigId`);
+  if (!Number.isInteger(event.sequence) || event.sequence < 0) errors.push(`event ${index} invalid sequence`);
+  if (!phases.has(event.phase)) errors.push(`event ${index} invalid phase`);
+  if (!eventTypes.has(event.eventType)) errors.push(`event ${index} invalid event type`);
+  if (!Number.isFinite(event.scheduledOffsetMs) || event.scheduledOffsetMs < 0) errors.push(`event ${index} invalid offset`);
+  if (!Number.isFinite(event.durationMs) || event.durationMs < 0) errors.push(`event ${index} invalid duration`);
+  if (!["ambient", "normal", "important", "critical"].includes(event.importance)) errors.push(`event ${index} invalid importance`);
+  for (const value of [event.crowdEnergyBefore, event.crowdEnergyAfter]) if (value != null && (value < 0 || value > 100)) errors.push(`event ${index} invalid crowd energy`);
+  if (!event.messageKey) errors.push(`event ${index} missing message key`);
+  if (!event.messageParams || Object.values(event.messageParams).some((v) => typeof v !== "string" && typeof v !== "number")) errors.push(`event ${index} invalid message params`);
+  if (!isPayloadValid(event.visualPayload)) errors.push(`event ${index} invalid payload`);
+  const allowed = eventTypes.has(event.eventType) ? eventPayloadTypes[event.eventType] : [];
+  if (event.visualPayload && allowed && !allowed.includes(event.visualPayload.type)) errors.push(`event ${index} payload ${event.visualPayload.type} not allowed for ${event.eventType}`);
+  return { valid: errors.length === 0, errors };
+}
+
+function isPayloadValid(payload: GigVisualPayload | undefined): payload is GigVisualPayload {
+  if (!payload || typeof payload !== "object" || !("type" in payload)) return false;
+  switch (payload.type) {
+    case "venue_open": return Array.isArray(payload.entranceIds) && payload.lightLevel >= 0 && payload.lightLevel <= 1;
+    case "crowd_fill": return payload.targetDensity >= 0 && payload.targetDensity <= 1 && Array.isArray(payload.zoneIds) && payload.enteringCount >= 0;
+    case "crowd_reaction": return ["still", "bounce", "jump", "wave", "disperse"].includes(payload.reaction) && payload.intensity >= 0 && payload.intensity <= 1;
+    case "performer_enter": return !!payload.performerId && !!payload.displayName && !!payload.startPosition;
+    case "performer_move": return !!payload.performerId && !!payload.targetPosition && ["walk", "rush", "step_forward"].includes(payload.movementStyle);
+    case "song_start": return typeof payload.title === "string" && Number.isInteger(payload.position) && typeof payload.montage === "boolean";
+    case "spotlight": return payload.intensity >= 0 && payload.intensity <= 1;
+    case "moment_effect": return ["pulse", "ring", "trail", "confetti"].includes(payload.effect) && payload.intensity >= 0 && payload.intensity <= 1;
+    case "band_exit": return ["wave", "quick", "encore_bow"].includes(payload.exitStyle) && Array.isArray(payload.performerIds);
+    case "result_reveal": return typeof payload.verdictKey === "string";
+    default: return false;
+  }
+}

--- a/supabase/functions/_shared/gig-viewer-replay/types.ts
+++ b/supabase/functions/_shared/gig-viewer-replay/types.ts
@@ -1,0 +1,55 @@
+import type { GIG_REPLAY_STATUSES, GIG_VIEWER_EVENT_TYPES, GIG_VIEWER_PHASES } from "./constants";
+
+export type GigViewerPhase = (typeof GIG_VIEWER_PHASES)[number];
+export type GigViewerEventType = (typeof GIG_VIEWER_EVENT_TYPES)[number];
+export type GigReplayStatus = (typeof GIG_REPLAY_STATUSES)[number];
+export type GigEventImportance = "ambient" | "normal" | "important" | "critical";
+
+export interface StagePosition { x: number; y: number; zone: "front_left" | "front_center" | "front_right" | "mid_left" | "mid_center" | "mid_right" | "back_left" | "back_center" | "back_right" }
+
+export type GigVisualPayload =
+  | { type: "venue_open"; entranceIds: string[]; lightLevel: number }
+  | { type: "crowd_fill"; targetDensity: number; zoneIds: string[]; enteringCount: number }
+  | { type: "crowd_reaction"; reaction: "still" | "bounce" | "jump" | "wave" | "disperse"; intensity: number; zoneIds?: string[] }
+  | { type: "performer_enter"; performerId: string; displayName: string; roleOrInstrument: string; startPosition: StagePosition }
+  | { type: "performer_move"; performerId: string; targetPosition: StagePosition; movementStyle: "walk" | "rush" | "step_forward" }
+  | { type: "song_start"; songId: string | null; title: string; position: number; montage: boolean }
+  | { type: "spotlight"; performerId?: string; stageZone?: string; intensity: number }
+  | { type: "moment_effect"; effect: "pulse" | "ring" | "trail" | "confetti"; targetId?: string; intensity: number }
+  | { type: "band_exit"; exitStyle: "wave" | "quick" | "encore_bow"; performerIds: string[] }
+  | { type: "result_reveal"; overallRating: number | null; attendance: number | null; netProfit: number | null; verdictKey: string };
+
+export interface GigViewerEventBase {
+  id: string;
+  gigId: string;
+  sequence: number;
+  phase: GigViewerPhase;
+  eventType: GigViewerEventType;
+  scheduledOffsetMs: number;
+  durationMs: number;
+  importance: GigEventImportance;
+  songId?: string | null;
+  performerProfileId?: string | null;
+  crowdEnergyBefore?: number | null;
+  crowdEnergyAfter?: number | null;
+  messageKey: string;
+  messageParams: Record<string, string | number>;
+}
+
+export type GigViewerEvent = GigViewerEventBase & { visualPayload: GigVisualPayload };
+
+export interface GigViewerReplay {
+  id: string;
+  gigId: string;
+  gigOutcomeId: string;
+  viewerVersion: number;
+  eventSchemaVersion: number;
+  simulationSeed: string;
+  durationMs: number;
+  generatedAt: string;
+  events: GigViewerEvent[];
+  checksum: string | null;
+  status: GigReplayStatus;
+}
+
+export type GigViewerReplayLoadState = "loading" | "ready" | "unavailable" | "generating" | "failed" | "unsupported_version";

--- a/supabase/functions/complete-gig/index.ts
+++ b/supabase/functions/complete-gig/index.ts
@@ -970,6 +970,20 @@ serve(async (req) => {
 
     console.log(`Gig ${gigId} completed successfully. Rating: ${avgRating.toFixed(1)}, Profit: $${netProfit}, New Fans: ${newFansTotal}`);
 
+    // Phase 5 PR 05: generate the canonical viewer replay after the authoritative
+    // completion/result_ready_at update commits. Replay generation is idempotent and
+    // non-critical: a failure must not roll back rewards or block the result report.
+    try {
+      const { error: replayError } = await supabaseClient.functions.invoke('generate-gig-viewer-replay', { body: { gigId } });
+      if (replayError) {
+        console.error('[complete-gig] Viewer replay generation failed (non-critical):', replayError);
+      } else {
+        console.log('[complete-gig] Viewer replay generation requested', { gigId });
+      }
+    } catch (replayErr) {
+      console.error('[complete-gig] Viewer replay generation error (non-critical):', replayErr);
+    }
+
     // Create inbox messages for ALL active band members (not just the leader)
     try {
       const venueName = gig.venues?.name || 'Unknown Venue';

--- a/supabase/functions/generate-gig-viewer-replay/index.ts
+++ b/supabase/functions/generate-gig-viewer-replay/index.ts
@@ -1,0 +1,52 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { buildGigViewerReplay } from "../_shared/gig-viewer-replay/generator.ts";
+import { GIG_VIEWER_VERSION } from "../_shared/gig-viewer-replay/constants.ts";
+
+const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type" };
+const response = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  const supabase = createClient(Deno.env.get("SUPABASE_URL") ?? "", Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "");
+  let gigId = "";
+  let replayId: string | null = null;
+  try {
+    ({ gigId } = await req.json());
+    if (!gigId) return response({ error: "missing_gig_id" }, 400);
+    const { data: existing, error: existingError } = await supabase.from("gig_viewer_replays").select("id,generation_status,event_count,duration_ms,checksum").eq("gig_id", gigId).eq("viewer_version", GIG_VIEWER_VERSION).eq("generation_status", "ready").maybeSingle();
+    if (existingError) throw existingError;
+    if (existing) { console.log("[gig-viewer-replay] returned existing", { gigId, replayId: existing.id }); return response({ success: true, existing: true, replay: existing }); }
+
+    const { data: gig, error: gigError } = await supabase.from("gigs").select("id,status,completed_at,result_ready_at,venue_id,venues!gigs_venue_id_fkey(capacity)").eq("id", gigId).single();
+    if (gigError || !gig) return response({ error: "gig_not_found" }, 404);
+    if (gig.status !== "completed" || !gig.result_ready_at) return response({ error: "gig_not_completed" }, 409);
+    const { data: outcome, error: outcomeError } = await supabase.from("gig_outcomes").select("id,completed_at,actual_attendance,overall_rating,net_profit").eq("gig_id", gigId).single();
+    if (outcomeError || !outcome) return response({ error: "outcome_not_found" }, 409);
+
+    const { data: claim, error: claimError } = await supabase.rpc("claim_gig_viewer_replay_generation", { p_gig_id: gigId, p_gig_outcome_id: outcome.id, p_viewer_version: GIG_VIEWER_VERSION });
+    if (claimError) throw claimError;
+    if (claim?.alreadyReady || claim?.alreadyGenerating) return response({ success: true, existing: Boolean(claim.alreadyReady), generating: Boolean(claim.alreadyGenerating), replayId: claim.replayId });
+    replayId = claim.replayId;
+    console.log("[gig-viewer-replay] generation started", { gigId, outcomeId: outcome.id, replayId });
+
+    const [songsRes, performersRes] = await Promise.all([
+      supabase.from("gig_song_performances").select("id,song_id,position,performance_score,crowd_response,song_title,performance_item_name").eq("gig_outcome_id", outcome.id).order("position"),
+      supabase.from("gig_performers").select("profile_id,role_or_instrument,lineup_status,profiles:profiles!gig_performers_profile_id_fkey(display_name,username)").eq("gig_id", gigId).order("created_at", { ascending: true }),
+    ]);
+    if (songsRes.error) throw songsRes.error;
+    if (performersRes.error) throw performersRes.error;
+    if (!songsRes.data?.length) throw new Error("MISSING_SONGS");
+
+    const replay = await buildGigViewerReplay({ replayId, gig: { id: gig.id, completedAt: outcome.completed_at ?? gig.completed_at, resultReadyAt: gig.result_ready_at, venueCapacity: gig.venues?.capacity ?? null, actualAttendance: outcome.actual_attendance, overallRating: outcome.overall_rating, netProfit: outcome.net_profit }, outcomeId: outcome.id, generatedAt: new Date().toISOString(), songs: songsRes.data.map((s: any) => ({ id: s.id, songId: s.song_id, position: s.position, title: s.song_title ?? s.performance_item_name ?? "Unknown Song", performanceScore: s.performance_score, crowdResponse: s.crowd_response })), performers: (performersRes.data ?? []).map((p: any) => ({ profileId: p.profile_id, displayName: p.profiles?.display_name ?? p.profiles?.username ?? "Unknown Performer", roleOrInstrument: p.role_or_instrument, lineupStatus: p.lineup_status })) });
+    const { error: updateError } = await supabase.from("gig_viewer_replays").update({ event_payload: { events: replay.events }, event_count: replay.events.length, duration_ms: replay.durationMs, simulation_seed: replay.simulationSeed, event_schema_version: replay.eventSchemaVersion, generation_status: "ready", generation_error_code: null, checksum: replay.checksum, generated_at: replay.generatedAt }).eq("id", replayId);
+    if (updateError) throw updateError;
+    console.log("[gig-viewer-replay] generation succeeded", { gigId, outcomeId: outcome.id, replayId, eventCount: replay.events.length, durationMs: replay.durationMs });
+    return response({ success: true, existing: false, replayId, eventCount: replay.events.length, durationMs: replay.durationMs, checksum: replay.checksum });
+  } catch (error) {
+    const code = error instanceof Error && error.message.startsWith("INVALID_REPLAY") ? "validation_failed" : error instanceof Error ? error.message.slice(0, 64) : "unknown_error";
+    console.error("[gig-viewer-replay] generation failed", { gigId, replayId, code });
+    if (replayId) await supabase.from("gig_viewer_replays").update({ generation_status: "failed", generation_error_code: code }).eq("id", replayId);
+    return response({ error: "replay_generation_failed", code }, 500);
+  }
+});

--- a/supabase/migrations/20260711140000_phase_5_pr_05_gig_viewer_replays.sql
+++ b/supabase/migrations/20260711140000_phase_5_pr_05_gig_viewer_replays.sql
@@ -1,0 +1,110 @@
+-- Phase 5 PR 05: Typed gig viewer replay storage
+
+CREATE TABLE IF NOT EXISTS public.gig_viewer_replays (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE RESTRICT,
+  gig_outcome_id uuid NOT NULL REFERENCES public.gig_outcomes(id) ON DELETE RESTRICT,
+  viewer_version integer NOT NULL,
+  event_schema_version integer NOT NULL,
+  simulation_seed text NOT NULL,
+  duration_ms integer NOT NULL,
+  event_payload jsonb NOT NULL DEFAULT jsonb_build_object('events', jsonb_build_array()),
+  event_count integer NOT NULL DEFAULT 0,
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  generation_status text NOT NULL DEFAULT 'generating',
+  generation_error_code text,
+  checksum text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT gig_viewer_replays_duration_positive CHECK (duration_ms > 0),
+  CONSTRAINT gig_viewer_replays_event_count_nonnegative CHECK (event_count >= 0),
+  CONSTRAINT gig_viewer_replays_status_valid CHECK (generation_status IN ('generating','ready','failed','legacy_unavailable')),
+  CONSTRAINT gig_viewer_replays_version_positive CHECK (viewer_version > 0 AND event_schema_version > 0),
+  CONSTRAINT gig_viewer_replays_payload_object CHECK (jsonb_typeof(event_payload) = 'object' AND jsonb_typeof(event_payload->'events') = 'array')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS gig_viewer_replays_one_ready_per_gig_viewer
+  ON public.gig_viewer_replays(gig_id, viewer_version)
+  WHERE generation_status = 'ready';
+CREATE UNIQUE INDEX IF NOT EXISTS gig_viewer_replays_one_generating_per_gig_viewer
+  ON public.gig_viewer_replays(gig_id, viewer_version)
+  WHERE generation_status = 'generating';
+CREATE INDEX IF NOT EXISTS gig_viewer_replays_gig_idx ON public.gig_viewer_replays(gig_id, viewer_version, generation_status);
+CREATE INDEX IF NOT EXISTS gig_viewer_replays_outcome_idx ON public.gig_viewer_replays(gig_outcome_id);
+
+ALTER TABLE public.gig_viewer_replays ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS gig_viewer_replays_select_matches_outcome_visibility ON public.gig_viewer_replays;
+CREATE POLICY gig_viewer_replays_select_matches_outcome_visibility
+ON public.gig_viewer_replays FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1 FROM public.gig_outcomes go
+    WHERE go.id = gig_viewer_replays.gig_outcome_id
+  )
+);
+
+DROP POLICY IF EXISTS gig_viewer_replays_deny_insert ON public.gig_viewer_replays;
+CREATE POLICY gig_viewer_replays_deny_insert ON public.gig_viewer_replays FOR INSERT WITH CHECK (false);
+DROP POLICY IF EXISTS gig_viewer_replays_deny_update ON public.gig_viewer_replays;
+CREATE POLICY gig_viewer_replays_deny_update ON public.gig_viewer_replays FOR UPDATE USING (false) WITH CHECK (false);
+DROP POLICY IF EXISTS gig_viewer_replays_deny_delete ON public.gig_viewer_replays;
+CREATE POLICY gig_viewer_replays_deny_delete ON public.gig_viewer_replays FOR DELETE USING (false);
+
+CREATE OR REPLACE FUNCTION public.set_gig_viewer_replay_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_gig_viewer_replay_updated_at ON public.gig_viewer_replays;
+CREATE TRIGGER set_gig_viewer_replay_updated_at
+BEFORE UPDATE ON public.gig_viewer_replays
+FOR EACH ROW EXECUTE FUNCTION public.set_gig_viewer_replay_updated_at();
+
+CREATE OR REPLACE FUNCTION public.claim_gig_viewer_replay_generation(p_gig_id uuid, p_gig_outcome_id uuid, p_viewer_version integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_existing public.gig_viewer_replays%ROWTYPE;
+  v_replay_id uuid;
+BEGIN
+  PERFORM 1 FROM public.gigs g
+  WHERE g.id = p_gig_id AND g.status = 'completed' AND g.result_ready_at IS NOT NULL
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Gig is not completed or result_ready_at is missing' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_existing
+  FROM public.gig_viewer_replays
+  WHERE gig_id = p_gig_id AND viewer_version = p_viewer_version AND generation_status IN ('ready','generating')
+  ORDER BY CASE generation_status WHEN 'ready' THEN 0 ELSE 1 END, generated_at DESC
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object('claimed', false, 'alreadyReady', v_existing.generation_status = 'ready', 'alreadyGenerating', v_existing.generation_status = 'generating', 'replayId', v_existing.id);
+  END IF;
+
+  INSERT INTO public.gig_viewer_replays (gig_id, gig_outcome_id, viewer_version, event_schema_version, simulation_seed, duration_ms, event_payload, event_count, generation_status)
+  VALUES (p_gig_id, p_gig_outcome_id, p_viewer_version, 1, 'pending', 1, jsonb_build_object('events', jsonb_build_array()), 0, 'generating')
+  RETURNING id INTO v_replay_id;
+
+  RAISE LOG '[gig-viewer-replay] generation claimed gig_id=% outcome_id=% viewer_version=% replay_id=%', p_gig_id, p_gig_outcome_id, p_viewer_version, v_replay_id;
+  RETURN jsonb_build_object('claimed', true, 'replayId', v_replay_id);
+END;
+$$;
+
+REVOKE ALL ON TABLE public.gig_viewer_replays FROM PUBLIC, anon;
+GRANT SELECT ON TABLE public.gig_viewer_replays TO authenticated;
+GRANT ALL ON TABLE public.gig_viewer_replays TO service_role;
+REVOKE ALL ON FUNCTION public.claim_gig_viewer_replay_generation(uuid, uuid, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_gig_viewer_replay_generation(uuid, uuid, integer) TO service_role;

--- a/supabase/tests/phase_5_pr_05_gig_viewer_replays_harness.sql
+++ b/supabase/tests/phase_5_pr_05_gig_viewer_replays_harness.sql
@@ -1,0 +1,19 @@
+-- Phase 5 PR 05 replay storage/RLS harness (requires seeded Supabase test database).
+BEGIN;
+SELECT plan(7);
+
+SELECT has_table('public', 'gig_viewer_replays', 'stores canonical replay payloads outside gig_outcomes');
+SELECT col_is_pk('public', 'gig_viewer_replays', 'id', 'replay table has uuid primary key');
+SELECT has_index('public', 'gig_viewer_replays', 'gig_viewer_replays_one_ready_per_gig_viewer', 'one ready replay per gig/viewer version');
+SELECT policies_are('public', 'gig_viewer_replays', ARRAY[
+  'gig_viewer_replays_select_matches_outcome_visibility',
+  'gig_viewer_replays_deny_insert',
+  'gig_viewer_replays_deny_update',
+  'gig_viewer_replays_deny_delete'
+], 'replay RLS read and mutation-denial policies exist');
+SELECT function_privs_are('public', 'claim_gig_viewer_replay_generation', ARRAY['uuid','uuid','integer'], 'anon', ARRAY[]::text[], 'anon cannot claim replay generation');
+SELECT function_privs_are('public', 'claim_gig_viewer_replay_generation', ARRAY['uuid','uuid','integer'], 'authenticated', ARRAY[]::text[], 'authenticated cannot claim replay generation');
+SELECT function_privs_are('public', 'claim_gig_viewer_replay_generation', ARRAY['uuid','uuid','integer'], 'service_role', ARRAY['EXECUTE'], 'service role can claim replay generation');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Provide a canonical, deterministic replay timeline for completed gigs as a typed, server-authoritative artifact to power future viewer/reconnect/replay features.  
- Ensure replays are validated, versioned, and stored separately from `gig_outcomes` so outcome/report logic remains authoritative and replay generation is non-critical.  
- Make replay generation idempotent and safe under concurrent completion flows by claiming generation with a service-role RPC and storing generation status in the DB.  
- Expose a read model/hook so frontends can load replay descriptors cheaply and fetch full event payloads only when the viewer opens.  

### Description
- Added a typed event contract and validation under `src/features/gig-experience/events/`: `constants.ts`, `types.ts`, `schema.ts`, and `generator.ts` implementing a discriminated `GigVisualPayload`, strict `GigViewerEvent` envelope, deterministic seed/PRNG, checksuming, and replay validation.  
- Implemented a canonical generator and shared copy for Edge Functions at `supabase/functions/_shared/gig-viewer-replay/` and an Edge Function `supabase/functions/generate-gig-viewer-replay` that claims generation via `claim_gig_viewer_replay_generation` and writes one validated canonical replay row.  
- Created a migration `supabase/migrations/20260711140000_phase_5_pr_05_gig_viewer_replays.sql` to add `gig_viewer_replays` with constraints, partial unique indexes (one ready / one generating per gig+viewer), RLS (read tied to outcome visibility), a timestamp trigger, and a `SECURITY DEFINER` claim RPC granted only to `service_role`.  
- Integrated non-critical post-completion invocation of the generator from the authoritative completion flow in `complete-gig` so replays are requested after `status = 'completed'` and `result_ready_at` are written.  
- Added a read service and hook: `getGigViewerReplay` and `useGigViewerReplay`, and updated `GigExperienceDTO` to expose a small `replay` descriptor (viewerVersion/duration/generationStatus) without embedding full payloads.  
- Added tests and docs: Vitest schema/determinism tests under `src/features/gig-experience/events/__tests__/schema.test.ts`, a pgTAP-style SQL harness `supabase/tests/phase_5_pr_05_gig_viewer_replays_harness.sql`, and `docs/gigs/implementation/PHASE_5_PR_05.md` plus roadmap/plan/audit updates.  

### Testing
- Ran typecheck with `npx tsc --noEmit`, which passed.  
- Attempted unit tests with `npm run test:unit -- src/features/gig-experience/events/__tests__/schema.test.ts`, but `vitest` was unavailable in the environment so the tests were not executed.  
- `npm run lint` and `npm run build` were not run to completion in this environment due to missing dev dependencies (`eslint` / `vite` binaries), so lint/build results are unavailable.  
- SQL harness and Edge Function/integration tests were not executed because Supabase/Deno test tooling is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a522823e8d88325a9e7938eb9090901)