### PR TITLE
feat: add gig setlist management and preparation readiness

### DIFF
--- a/docs/gigs/gig-preparation-readiness.md
+++ b/docs/gigs/gig-preparation-readiness.md
@@ -1,0 +1,57 @@
+# Gig preparation readiness
+
+This phase adds gig-specific setlists and an explainable readiness score for upcoming performances.
+
+## Data model
+
+- `gig_setlists`: one persisted preparation setlist per scheduled gig, owned by `gig_id` and `band_id`, with cached `total_duration_seconds`.
+- `gig_setlist_items`: ordered setlist rows with `song_id`, `position`, and `is_encore`.
+- `gig_outcomes`: stores `readiness_score`, `readiness_modifier`, and `readiness_breakdown` so completed gigs can explain how preparation affected the result.
+
+## Validation rules
+
+Blocking errors prevent saving or resolving a gig:
+
+- Empty setlist.
+- Duplicate songs in the same setlist.
+- Songs not owned by the performing band.
+- Missing song duration.
+- Encore songs before normal-set songs.
+- Edits by users who are not band leaders or managers.
+- Edits to completed or cancelled gigs.
+
+Warnings do not block saving:
+
+- Total duration shorter than 85% of the booked slot.
+- Total duration longer than 108% of the booked slot.
+
+## Readiness calculation
+
+Readiness is a weighted 0–100 score:
+
+- Setlist completeness: 24%.
+- Booked slot duration fit: 14%.
+- Song familiarity/rehearsal: 18%.
+- Recent rehearsal: 14%.
+- Recent jam session: 8%.
+- Band chemistry: 10%.
+- Fatigue and health: 6%.
+- Required performers: 6%.
+
+Missing optional data falls back to neutral scores so historical and incomplete gigs remain readable.
+
+## Ratings
+
+- 0–29: poor.
+- 30–49: average.
+- 50–69: good.
+- 70–89: excellent.
+- 90–100: legendary.
+
+## Outcome impact
+
+Readiness applies a bounded modifier during gig execution. Scores above 70 can add up to +6%; low readiness can penalize by up to -10%. The modifier is intentionally modest so songs, rehearsal, chemistry, equipment, crew, performers, venue, weather, fatigue, and randomness remain meaningful.
+
+## Extension points
+
+Future crew, equipment, soundcheck, and stage setup systems should contribute additional readiness factors through the central readiness input rather than duplicating formulas in UI components or execution code.

--- a/src/components/gig/GigPreparationPanel.tsx
+++ b/src/components/gig/GigPreparationPanel.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useState } from 'react';
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, GripVertical, Music, Plus, Save, Trash2 } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/hooks/use-toast';
+import { calculateGigReadiness } from '@/utils/gigReadiness';
+import { validateGigSetlist } from '@/utils/gigSetlistValidation';
+
+interface DraftItem { id: string; song_id: string; title: string; duration_seconds: number | null; is_encore: boolean; rehearsal_level?: number | null }
+const fmt = (seconds: number | null | undefined) => seconds ? `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}` : 'Missing';
+
+function SortableSong({ item, index, onEncore, onRemove, onMove }: { item: DraftItem; index: number; onEncore: (id: string, value: boolean) => void; onRemove: (id: string) => void; onMove: (id: string, delta: number) => void }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.id });
+  return <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }} className="flex flex-col gap-2 rounded-md border bg-card p-3 sm:flex-row sm:items-center">
+    <button className="self-start text-muted-foreground" aria-label={`Drag ${item.title}`} {...attributes} {...listeners}><GripVertical className="h-4 w-4" /></button>
+    <div className="min-w-0 flex-1"><p className="font-medium">{index + 1}. {item.title}</p><p className="text-xs text-muted-foreground">{fmt(item.duration_seconds)} · rehearsal {Math.round(item.rehearsal_level ?? 0)}%</p></div>
+    <div className="flex items-center gap-2"><Button variant="outline" size="sm" onClick={() => onMove(item.id, -1)} disabled={index === 0}>Up</Button><Button variant="outline" size="sm" onClick={() => onMove(item.id, 1)}>Down</Button><label className="flex items-center gap-2 text-sm"><Switch checked={item.is_encore} onCheckedChange={(v) => onEncore(item.id, v)} /> Encore</label><Button variant="ghost" size="icon" onClick={() => onRemove(item.id)} aria-label={`Remove ${item.title}`}><Trash2 className="h-4 w-4" /></Button></div>
+  </div>;
+}
+
+export function GigPreparationPanel({ gigId, bandId, status, scheduledDate, slotDurationSeconds = 7200 }: { gigId: string; bandId: string; status?: string | null; scheduledDate?: string | null; slotDurationSeconds?: number }) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [draft, setDraft] = useState<DraftItem[]>([]);
+  const [selectedSong, setSelectedSong] = useState('');
+  const [saving, setSaving] = useState(false);
+  const locked = status === 'completed' || status === 'cancelled';
+
+  const songsQuery = useQuery({ queryKey: ['gig-prep-songs', bandId], enabled: !!bandId, queryFn: async () => {
+    const { data, error } = await supabase.from('songs').select('id,title,duration_seconds,band_id,status,archived').eq('band_id', bandId).eq('archived', false).order('title');
+    if (error) throw error;
+    const ids = (data || []).map((s) => s.id);
+    const { data: rehearsals } = ids.length ? await supabase.from('song_rehearsals').select('song_id,rehearsal_level').eq('band_id', bandId).in('song_id', ids) : { data: [] as any[] };
+    return (data || []).map((s: any) => ({ ...s, rehearsal_level: rehearsals?.find((r: any) => r.song_id === s.id)?.rehearsal_level ?? 0 }));
+  }});
+
+  const setlistQuery = useQuery({ queryKey: ['gig-prep-setlist', gigId], enabled: !!gigId, queryFn: async () => {
+    const { data, error } = await (supabase as any).from('gig_setlists').select('id,name,total_duration_seconds,gig_setlist_items(id,song_id,position,is_encore,songs(id,title,duration_seconds))').eq('gig_id', gigId).maybeSingle();
+    if (error) throw error;
+    return data;
+  }});
+
+  useEffect(() => {
+    const items = (setlistQuery.data?.gig_setlist_items || []).slice().sort((a: any, b: any) => a.position - b.position).map((item: any) => ({ id: item.id, song_id: item.song_id, title: item.songs?.title || 'Unknown song', duration_seconds: item.songs?.duration_seconds ?? null, is_encore: !!item.is_encore, rehearsal_level: songsQuery.data?.find((s: any) => s.id === item.song_id)?.rehearsal_level ?? 0 }));
+    setDraft(items);
+  }, [setlistQuery.data, songsQuery.data]);
+
+  const validation = useMemo(() => validateGigSetlist(draft.map((d) => ({ songId: d.song_id, bandId, durationSeconds: d.duration_seconds, isEncore: d.is_encore })), bandId, slotDurationSeconds), [draft, bandId, slotDurationSeconds]);
+  const readiness = useMemo(() => calculateGigReadiness({ setlistSongs: draft.map((d) => ({ id: d.song_id, durationSeconds: d.duration_seconds, rehearsalLevel: d.rehearsal_level })), slotDurationSeconds, bandChemistry: undefined }), [draft, slotDurationSeconds]);
+  const available = (songsQuery.data || []).filter((s: any) => !draft.some((d) => d.song_id === s.id));
+
+  const addSong = () => { const song: any = available.find((s: any) => s.id === selectedSong); if (!song) return; setDraft((d) => [...d, { id: `draft-${song.id}`, song_id: song.id, title: song.title, duration_seconds: song.duration_seconds, is_encore: false, rehearsal_level: song.rehearsal_level }]); setSelectedSong(''); };
+  const save = async () => { if (!validation.valid || saving) return; setSaving(true); try { const { error } = await (supabase as any).rpc('save_gig_setlist', { p_gig_id: gigId, p_name: 'Gig setlist', p_items: draft.map((d, i) => ({ song_id: d.song_id, position: i + 1, is_encore: d.is_encore })) }); if (error) throw error; toast({ title: 'Setlist saved', description: 'Gig preparation has been updated.' }); queryClient.invalidateQueries({ queryKey: ['gig-prep-setlist', gigId] }); queryClient.invalidateQueries({ queryKey: ['gig-details', gigId] }); } catch (e: any) { toast({ title: 'Could not save setlist', description: e.message, variant: 'destructive' }); } finally { setSaving(false); } };
+  const onDragEnd = (event: DragEndEvent) => { if (!event.over || event.active.id === event.over.id) return; setDraft((items) => arrayMove(items, items.findIndex((i) => i.id === event.active.id), items.findIndex((i) => i.id === event.over?.id))); };
+
+  return <Card><CardHeader><CardTitle className="flex items-center gap-2"><Music className="h-5 w-5" /> Gig preparation</CardTitle><CardDescription>Manage this gig's setlist and review readiness before showtime{scheduledDate ? ` (${new Date(scheduledDate).toLocaleString()})` : ''}.</CardDescription></CardHeader><CardContent className="space-y-4">
+    <div className="grid gap-3 md:grid-cols-[160px_1fr]"><div><div className="text-3xl font-bold">{readiness.score}</div><Badge className="capitalize">{readiness.rating}</Badge></div><div><Progress value={readiness.score} className="h-3" /><p className="mt-2 text-sm text-muted-foreground">Set duration {fmt(validation.totalDurationSeconds)} / booked {fmt(slotDurationSeconds)}.</p></div></div>
+    <div className="grid gap-2 md:grid-cols-2">{readiness.factors.slice(0, 6).map((f) => <div key={f.key} className="rounded-md border p-2 text-sm"><div className="flex justify-between"><span>{f.label}</span><Badge variant={f.status === 'critical' ? 'destructive' : 'outline'}>{f.score}</Badge></div><p className="text-xs text-muted-foreground">{f.explanation}</p></div>)}</div>
+    {[...validation.errors, ...readiness.blockingIssues].map((m) => <p key={m} className="flex gap-2 text-sm text-destructive"><AlertTriangle className="h-4 w-4" />{m}</p>)}
+    {[...validation.warnings, ...readiness.warnings].map((m) => <p key={m} className="flex gap-2 text-sm text-amber-600"><AlertTriangle className="h-4 w-4" />{m}</p>)}
+    {validation.valid && <p className="flex gap-2 text-sm text-emerald-600"><CheckCircle2 className="h-4 w-4" />Setlist is valid and ready to save.</p>}
+    <div className="flex gap-2"><Select value={selectedSong} onValueChange={setSelectedSong} disabled={locked}><SelectTrigger><SelectValue placeholder={songsQuery.isLoading ? 'Loading songs...' : 'Add an eligible band song'} /></SelectTrigger><SelectContent>{available.map((s: any) => <SelectItem key={s.id} value={s.id}>{s.title} · {fmt(s.duration_seconds)}</SelectItem>)}</SelectContent></Select><Button onClick={addSong} disabled={!selectedSong || locked}><Plus className="mr-2 h-4 w-4" />Add</Button></div>
+    <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}><SortableContext items={draft.map((d) => d.id)} strategy={verticalListSortingStrategy}><div className="space-y-2">{draft.length === 0 ? <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">No songs yet. Add songs to prepare the gig.</p> : draft.map((item, index) => <SortableSong key={item.id} item={item} index={index} onEncore={(id, v) => setDraft((d) => d.map((i) => i.id === id ? { ...i, is_encore: v } : i))} onRemove={(id) => setDraft((d) => d.filter((i) => i.id !== id))} onMove={(id, delta) => setDraft((d) => { const from = d.findIndex((i) => i.id === id); const to = Math.max(0, Math.min(d.length - 1, from + delta)); return arrayMove(d, from, to); })} />)}</div></SortableContext></DndContext>
+    <Button onClick={save} disabled={saving || locked || !validation.valid} className="w-full"><Save className="mr-2 h-4 w-4" />{saving ? 'Saving...' : 'Save gig setlist'}</Button>
+  </CardContent></Card>;
+}

--- a/src/components/schedule/GigDetailsDialog.tsx
+++ b/src/components/schedule/GigDetailsDialog.tsx
@@ -8,6 +8,7 @@ import { format, differenceInDays, differenceInHours } from "date-fns";
 import { MapPin, Clock, Users, Ticket, Music, DollarSign, Calendar, TrendingDown, AlertCircle } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { GigSetlistDisplay } from "@/components/gig/GigSetlistDisplay";
+import { GigPreparationPanel } from "@/components/gig/GigPreparationPanel";
 import { TicketPriceAdjuster } from "@/components/gig/TicketPriceAdjuster";
 import { TicketSalesDisplay } from "@/components/gig/TicketSalesDisplay";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -249,6 +250,16 @@ export function GigDetailsDialog({ open, onOpenChange, gigId, bandId: propBandId
                 <p className="text-sm text-muted-foreground">Loading setlist information...</p>
               )}
             </div>
+
+            <Separator />
+            {bandId && (
+              <GigPreparationPanel
+                gigId={gigId}
+                bandId={bandId}
+                status={gig.status}
+                scheduledDate={gig.scheduled_date}
+              />
+            )}
 
             {/* Action Button */}
             {hoursUntilGig <= 1 && hoursUntilGig > 0 && (

--- a/src/pages/PerformGig.tsx
+++ b/src/pages/PerformGig.tsx
@@ -13,6 +13,7 @@ import { GigOutcomeReport } from '@/components/gig/GigOutcomeReport';
 import { GigPreparationChecklist } from '@/components/gig/GigPreparationChecklist';
 import { useFixStuckGigs } from '@/hooks/useFixStuckGigs';
 import { GigSetlistDisplay } from '@/components/gig/GigSetlistDisplay';
+import { GigPreparationPanel } from '@/components/gig/GigPreparationPanel';
 import { TicketPriceAdjuster } from '@/components/gig/TicketPriceAdjuster';
 import { useLiveGigState } from '@/hooks/useLiveGigState';
 import { useManualGigStart } from '@/hooks/useManualGigStart';
@@ -255,6 +256,21 @@ export default function PerformGig() {
       }
     }
     
+    const { data: prepSetlist, error: prepError } = await (supabase as any)
+      .from('gig_setlists')
+      .select('id,gig_setlist_items(id)')
+      .eq('gig_id', gigId)
+      .maybeSingle();
+
+    if (prepError || !prepSetlist || (prepSetlist.gig_setlist_items || []).length === 0) {
+      toast({
+        title: 'Setlist required',
+        description: 'Save a valid gig preparation setlist before starting this performance.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
     startGigMutation.mutate(gigId, {
       onSuccess: () => {
         // Reload gig data after starting
@@ -403,6 +419,15 @@ export default function PerformGig() {
             />
           </CardContent>
         </Card>
+      )}
+
+      {gig.status === 'scheduled' && (
+        <GigPreparationPanel
+          gigId={gig.id}
+          bandId={gig.band_id}
+          status={gig.status}
+          scheduledDate={gig.scheduled_date}
+        />
       )}
 
       {/* Ticket Price Adjuster - shown for scheduled gigs with poor sales */}

--- a/src/utils/__tests__/gigReadiness.test.ts
+++ b/src/utils/__tests__/gigReadiness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { calculateGigReadiness, ratingForReadiness } from '../gigReadiness';
+import { validateGigSetlist } from '../gigSetlistValidation';
+
+const songs = [{ id: 's1', durationSeconds: 1800, rehearsalLevel: 90 }, { id: 's2', durationSeconds: 1800, rehearsalLevel: 80 }];
+
+describe('gig preparation setlist validation', () => {
+  it('creates valid setlists and warns on duration mismatch', () => {
+    const result = validateGigSetlist([{ songId: 's1', bandId: 'b1', durationSeconds: 180 }], 'b1', 3600);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toContain('Set duration is shorter than the booked performance slot.');
+  });
+  it('supports adding, reordering, removing and marking encores', () => {
+    const draft = [
+      { songId: 's1', bandId: 'b1', durationSeconds: 180, isEncore: false },
+      { songId: 's2', bandId: 'b1', durationSeconds: 200, isEncore: true },
+    ];
+    const reordered = [draft[1], draft[0]].map((s, i) => ({ ...s, isEncore: i === 1 }));
+    const removed = reordered.slice(0, 1);
+    expect(validateGigSetlist(removed, 'b1', 180).valid).toBe(true);
+  });
+  it('rejects duplicate songs, songs from another band, missing durations and misplaced encores', () => {
+    const result = validateGigSetlist([
+      { songId: 's1', bandId: 'b1', durationSeconds: 180, isEncore: true },
+      { songId: 's1', bandId: 'b2', durationSeconds: null, isEncore: false },
+    ], 'b1');
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      'Duplicate songs are not allowed in the same setlist.',
+      'Setlist songs must belong to the performing band.',
+      'Every setlist song needs an estimated duration.',
+      'Encore songs must appear after the normal set.',
+    ]));
+  });
+});
+
+describe('gig readiness', () => {
+  it('keeps score between 0 and 100 and applies rating thresholds', () => {
+    expect(calculateGigReadiness({ setlistSongs: songs, slotDurationSeconds: 3600 }).score).toBeGreaterThanOrEqual(0);
+    expect(calculateGigReadiness({ setlistSongs: songs, slotDurationSeconds: 3600 }).score).toBeLessThanOrEqual(100);
+    expect(ratingForReadiness(29)).toBe('poor');
+    expect(ratingForReadiness(30)).toBe('average');
+    expect(ratingForReadiness(50)).toBe('good');
+    expect(ratingForReadiness(70)).toBe('excellent');
+    expect(ratingForReadiness(90)).toBe('legendary');
+  });
+  it('penalizes empty setlists and missing performers', () => {
+    const result = calculateGigReadiness({ setlistSongs: [], requiredPerformers: 4, assignedPerformers: 2 });
+    expect(result.score).toBeLessThan(50);
+    expect(result.blockingIssues.length).toBeGreaterThan(0);
+  });
+  it('rewards well rehearsed valid setlists and handles missing optional data', () => {
+    const result = calculateGigReadiness({ setlistSongs: songs, slotDurationSeconds: 3600, recentRehearsalDaysAgo: 1, recentJamDaysAgo: 1, bandChemistry: 90, fatigueScore: 90, healthScore: 95, requiredPerformers: 4, assignedPerformers: 4 });
+    expect(result.score).toBeGreaterThanOrEqual(80);
+    expect(result.rating).toMatch(/excellent|legendary/);
+  });
+  it('reduces readiness for fatigue', () => {
+    const fresh = calculateGigReadiness({ setlistSongs: songs, fatigueScore: 95, healthScore: 95 });
+    const tired = calculateGigReadiness({ setlistSongs: songs, fatigueScore: 10, healthScore: 20 });
+    expect(tired.score).toBeLessThan(fresh.score);
+  });
+});

--- a/src/utils/gigExecution.ts
+++ b/src/utils/gigExecution.ts
@@ -37,6 +37,7 @@ import type { WeatherCondition } from "./weatherSystem";
 import { getFanSentiment } from "./fanSentiment";
 import { getMediaCycleState, applyMediaEvent } from "./mediaCycle";
 import { degradeEquipment } from "./equipmentDegradation";
+import { calculateGigReadiness, calculateReadinessPerformanceModifier } from "./gigReadiness";
 
 interface GigExecutionData {
   gigId: string;
@@ -59,6 +60,15 @@ export async function executeGigPerformance(data: GigExecutionData) {
   if (setlistError) throw setlistError;
   if (!setlistSongs || setlistSongs.length === 0) {
     throw new Error('No songs in setlist');
+  }
+
+  const { data: gigPrepSetlist } = await (supabase as any)
+    .from('gig_setlists')
+    .select('id,total_duration_seconds,gig_setlist_items(id)')
+    .eq('gig_id', gigId)
+    .maybeSingle();
+  if (!gigPrepSetlist || (gigPrepSetlist.gig_setlist_items || []).length === 0) {
+    throw new Error('A saved gig preparation setlist is required before resolving this performance.');
   }
 
   // Fetch all necessary data in parallel
@@ -248,6 +258,20 @@ export async function executeGigPerformance(data: GigExecutionData) {
     }
   }
 
+  const readiness = calculateGigReadiness({
+    setlistSongs: setlistSongs.map((song: any) => ({
+      id: song.song_id,
+      durationSeconds: song.songs?.duration_seconds ?? 180,
+      rehearsalLevel: rehearsals.find((r: any) => r.song_id === song.song_id)?.rehearsal_level || 0,
+    })),
+    slotDurationSeconds: 7200,
+    bandChemistry,
+    fatigueScore: fatigueState.performanceModifier * 100,
+    requiredPerformers: 1,
+    assignedPerformers: members.length,
+  });
+  const readinessModifier = calculateReadinessPerformanceModifier(readiness.score);
+
   const songPerformances = setlistSongs.map((song, index) => {
     const rehearsal = rehearsals.find(r => r.song_id === song.song_id);
     const rehearsalLevel = rehearsal?.rehearsal_level || 0;
@@ -275,8 +299,8 @@ export async function executeGigPerformance(data: GigExecutionData) {
     // Apply chemistry bonus to performance score
     let chemistryBoostedScore = applyChemistryToPerformance(result.score, bandChemistry);
     
-    // Apply tour fatigue modifier
-    chemistryBoostedScore = chemistryBoostedScore * fatigueState.performanceModifier;
+    // Apply tour fatigue and bounded gig preparation readiness modifiers.
+    chemistryBoostedScore = chemistryBoostedScore * fatigueState.performanceModifier * (1 + readinessModifier);
 
     // Apply encore fame bonus (last song = encore)
     const isEncore = index === setlistSongs.length - 1;
@@ -401,6 +425,9 @@ export async function executeGigPerformance(data: GigExecutionData) {
         promoter_modifier: Number(gearEffects.revenueBonusPercent.toFixed(2)),
         venue_loyalty_bonus: Number(gearEffects.fameBonusPercent.toFixed(2)),
         stage_behavior_used: stageBehavior,
+        readiness_score: readiness.score,
+        readiness_modifier: Number(readinessModifier.toFixed(4)),
+        readiness_breakdown: readiness as any,
       })
       .eq('id', existingOutcome.id)
       .select()
@@ -441,6 +468,9 @@ export async function executeGigPerformance(data: GigExecutionData) {
         promoter_modifier: Number(gearEffects.revenueBonusPercent.toFixed(2)),
         venue_loyalty_bonus: Number(gearEffects.fameBonusPercent.toFixed(2)),
         stage_behavior_used: stageBehavior,
+        readiness_score: readiness.score,
+        readiness_modifier: Number(readinessModifier.toFixed(4)),
+        readiness_breakdown: readiness as any,
       })
       .select()
       .single();

--- a/src/utils/gigReadiness.ts
+++ b/src/utils/gigReadiness.ts
@@ -1,0 +1,95 @@
+export type ReadinessRating = 'poor' | 'average' | 'good' | 'excellent' | 'legendary';
+export type ReadinessStatus = 'positive' | 'neutral' | 'warning' | 'critical';
+
+export interface ReadinessFactor { key: string; label: string; score: number; weight: number; status: ReadinessStatus; explanation: string }
+export interface ReadinessResult { score: number; rating: ReadinessRating; factors: ReadinessFactor[]; blockingIssues: string[]; warnings: string[] }
+export interface ReadinessSong { id: string; durationSeconds: number | null; rehearsalLevel?: number | null }
+export interface GigReadinessInput {
+  setlistSongs: ReadinessSong[];
+  slotDurationSeconds?: number | null;
+  recentRehearsalDaysAgo?: number | null;
+  recentJamDaysAgo?: number | null;
+  bandChemistry?: number | null;
+  fatigueScore?: number | null;
+  healthScore?: number | null;
+  requiredPerformers?: number | null;
+  assignedPerformers?: number | null;
+}
+
+export const GIG_READINESS_WEIGHTS = {
+  setlistCompleteness: 0.24,
+  durationFit: 0.14,
+  songPractice: 0.18,
+  recentRehearsal: 0.14,
+  recentJam: 0.08,
+  chemistry: 0.10,
+  fatigueHealth: 0.06,
+  performers: 0.06,
+} as const;
+
+export const READINESS_PERFORMANCE_MODIFIER = { maxBonus: 0.06, maxPenalty: -0.10 } as const;
+
+const clamp = (n: number, min = 0, max = 100) => Math.max(min, Math.min(max, n));
+
+export function ratingForReadiness(score: number): ReadinessRating {
+  if (score >= 90) return 'legendary';
+  if (score >= 70) return 'excellent';
+  if (score >= 50) return 'good';
+  if (score >= 30) return 'average';
+  return 'poor';
+}
+
+function statusFor(score: number): ReadinessStatus {
+  if (score < 30) return 'critical';
+  if (score < 60) return 'warning';
+  if (score >= 80) return 'positive';
+  return 'neutral';
+}
+
+export function calculateReadinessPerformanceModifier(score: number) {
+  const normalized = (clamp(score) - 70) / 30;
+  const raw = normalized >= 0 ? normalized * READINESS_PERFORMANCE_MODIFIER.maxBonus : (Math.abs(normalized) / (70 / 30)) * READINESS_PERFORMANCE_MODIFIER.maxPenalty;
+  return Math.max(READINESS_PERFORMANCE_MODIFIER.maxPenalty, Math.min(READINESS_PERFORMANCE_MODIFIER.maxBonus, raw));
+}
+
+export function calculateGigReadiness(input: GigReadinessInput): ReadinessResult {
+  const blockingIssues: string[] = [];
+  const warnings: string[] = [];
+  const songs = input.setlistSongs ?? [];
+  const totalDuration = songs.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0);
+  const missingDuration = songs.some((s) => !s.durationSeconds || s.durationSeconds <= 0);
+  if (songs.length === 0) blockingIssues.push('A saved setlist with at least one song is required.');
+  if (missingDuration) blockingIssues.push('Every setlist song needs an estimated duration.');
+
+  const slot = input.slotDurationSeconds ?? 7200;
+  const durationRatio = slot > 0 ? totalDuration / slot : 1;
+  if (songs.length > 0 && durationRatio < 0.85) warnings.push('Set duration is shorter than the booked performance slot.');
+  if (durationRatio > 1.08) warnings.push('Set duration is longer than the booked performance slot.');
+
+  const performerScore = input.requiredPerformers ? clamp(((input.assignedPerformers ?? 0) / input.requiredPerformers) * 100) : 75;
+  if (input.requiredPerformers && (input.assignedPerformers ?? 0) < input.requiredPerformers) blockingIssues.push('Required performers are missing from the gig lineup.');
+
+  const practiceAvg = songs.length ? songs.reduce((sum, s) => sum + (s.rehearsalLevel ?? 0), 0) / songs.length : 0;
+  const rehearsalDays = input.recentRehearsalDaysAgo;
+  const jamDays = input.recentJamDaysAgo;
+  const rehearsalScore = rehearsalDays == null ? 55 : clamp(100 - rehearsalDays * 8);
+  const jamScore = jamDays == null ? 55 : clamp(100 - jamDays * 6);
+  const chemistryScore = input.bandChemistry == null ? 60 : clamp(input.bandChemistry);
+  const fatigueHealthScore = clamp(((input.fatigueScore ?? 75) + (input.healthScore ?? 75)) / 2);
+  const durationScore = songs.length === 0 ? 0 : clamp(100 - Math.abs(1 - durationRatio) * 180);
+  const completeScore = songs.length === 0 ? 0 : missingDuration ? 45 : 100;
+
+  const defs: Array<[keyof typeof GIG_READINESS_WEIGHTS, string, number, string]> = [
+    ['setlistCompleteness', 'Setlist completeness', completeScore, songs.length ? `${songs.length} song(s) saved for this gig.` : 'No gig setlist has been saved yet.'],
+    ['durationFit', 'Booked slot fit', durationScore, `${Math.round(totalDuration / 60)} minutes planned for a ${Math.round(slot / 60)} minute slot.`],
+    ['songPractice', 'Song familiarity', practiceAvg, `Average rehearsal level is ${Math.round(practiceAvg)}%.`],
+    ['recentRehearsal', 'Recent rehearsal', rehearsalScore, rehearsalDays == null ? 'No recent rehearsal data found.' : `Last rehearsal was ${rehearsalDays} day(s) ago.`],
+    ['recentJam', 'Recent jam session', jamScore, jamDays == null ? 'No recent jam session data found.' : `Last jam was ${jamDays} day(s) ago.`],
+    ['chemistry', 'Band chemistry', chemistryScore, `Band chemistry contributes ${Math.round(chemistryScore)}%.`],
+    ['fatigueHealth', 'Fatigue and health', fatigueHealthScore, 'Current member condition is included when profile data is available.'],
+    ['performers', 'Required performers', performerScore, input.requiredPerformers ? `${input.assignedPerformers ?? 0}/${input.requiredPerformers} performers assigned.` : 'No required performer template is configured yet.'],
+  ];
+  const factors = defs.map(([key, label, score, explanation]) => ({ key, label, score: Math.round(clamp(score)), weight: GIG_READINESS_WEIGHTS[key], status: statusFor(score), explanation }));
+  const finalScore = Math.round(clamp(factors.reduce((sum, f) => sum + f.score * f.weight, 0)));
+  return { score: finalScore, rating: ratingForReadiness(finalScore), factors, blockingIssues, warnings };
+}

--- a/src/utils/gigSetlistValidation.ts
+++ b/src/utils/gigSetlistValidation.ts
@@ -1,0 +1,18 @@
+export interface GigSetlistValidationSong { songId: string; bandId?: string | null; durationSeconds?: number | null; isEncore?: boolean }
+export function validateGigSetlist(songs: GigSetlistValidationSong[], bandId: string, slotDurationSeconds = 7200) {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+  songs.forEach((song, index) => {
+    if (seen.has(song.songId)) errors.push('Duplicate songs are not allowed in the same setlist.');
+    seen.add(song.songId);
+    if (song.bandId && song.bandId !== bandId) errors.push('Setlist songs must belong to the performing band.');
+    if (!song.durationSeconds || song.durationSeconds <= 0) errors.push('Every setlist song needs an estimated duration.');
+    if (!song.isEncore && songs.slice(0, index).some((s) => s.isEncore)) errors.push('Encore songs must appear after the normal set.');
+  });
+  if (songs.length === 0) errors.push('Setlist must contain at least one song.');
+  const totalDurationSeconds = songs.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0);
+  if (songs.length && totalDurationSeconds < slotDurationSeconds * 0.85) warnings.push('Set duration is shorter than the booked performance slot.');
+  if (totalDurationSeconds > slotDurationSeconds * 1.08) warnings.push('Set duration is longer than the booked performance slot.');
+  return { valid: errors.length === 0, errors: Array.from(new Set(errors)), warnings, totalDurationSeconds };
+}

--- a/supabase/migrations/20260711123000_gig_setlists_readiness.sql
+++ b/supabase/migrations/20260711123000_gig_setlists_readiness.sql
@@ -1,0 +1,90 @@
+CREATE TABLE IF NOT EXISTS public.gig_setlists (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  name text NOT NULL DEFAULT 'Gig setlist',
+  total_duration_seconds integer NOT NULL DEFAULT 0 CHECK (total_duration_seconds >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (gig_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_setlist_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  setlist_id uuid NOT NULL REFERENCES public.gig_setlists(id) ON DELETE CASCADE,
+  song_id uuid NOT NULL REFERENCES public.songs(id) ON DELETE RESTRICT,
+  position integer NOT NULL CHECK (position > 0),
+  is_encore boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (setlist_id, song_id),
+  UNIQUE (setlist_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_setlists_band ON public.gig_setlists(band_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gig_setlist_items_setlist_position ON public.gig_setlist_items(setlist_id, position);
+CREATE INDEX IF NOT EXISTS idx_gig_setlist_items_song ON public.gig_setlist_items(song_id);
+
+ALTER TABLE public.gig_setlists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_setlist_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Band members can view gig setlists" ON public.gig_setlists FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.band_members bm WHERE bm.band_id = gig_setlists.band_id AND bm.user_id = auth.uid())
+);
+CREATE POLICY "Band managers can insert gig setlists" ON public.gig_setlists FOR INSERT WITH CHECK (public.is_band_leader_or_manager(band_id, auth.uid()));
+CREATE POLICY "Band managers can update gig setlists" ON public.gig_setlists FOR UPDATE USING (public.is_band_leader_or_manager(band_id, auth.uid())) WITH CHECK (public.is_band_leader_or_manager(band_id, auth.uid()));
+CREATE POLICY "Band managers can delete gig setlists" ON public.gig_setlists FOR DELETE USING (public.is_band_leader_or_manager(band_id, auth.uid()));
+
+CREATE POLICY "Band members can view gig setlist items" ON public.gig_setlist_items FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.gig_setlists gs JOIN public.band_members bm ON bm.band_id = gs.band_id WHERE gs.id = gig_setlist_items.setlist_id AND bm.user_id = auth.uid())
+);
+CREATE POLICY "Band managers can manage gig setlist items" ON public.gig_setlist_items FOR ALL USING (
+  EXISTS (SELECT 1 FROM public.gig_setlists gs WHERE gs.id = gig_setlist_items.setlist_id AND public.is_band_leader_or_manager(gs.band_id, auth.uid()))
+) WITH CHECK (
+  EXISTS (SELECT 1 FROM public.gig_setlists gs WHERE gs.id = gig_setlist_items.setlist_id AND public.is_band_leader_or_manager(gs.band_id, auth.uid()))
+);
+
+CREATE OR REPLACE FUNCTION public.save_gig_setlist(p_gig_id uuid, p_name text, p_items jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_gig record; v_setlist_id uuid; v_total integer := 0; v_count integer := 0; v_bad integer := 0; v_encore_seen boolean := false; v_item jsonb; v_pos integer := 1;
+BEGIN
+  SELECT id, band_id, status, scheduled_date INTO v_gig FROM public.gigs WHERE id = p_gig_id FOR UPDATE;
+  IF v_gig.id IS NULL THEN RAISE EXCEPTION 'Gig not found.' USING ERRCODE = '22023'; END IF;
+  IF v_gig.status IN ('completed','cancelled') THEN RAISE EXCEPTION 'Completed or cancelled gigs cannot be edited.' USING ERRCODE = '55000'; END IF;
+  IF NOT public.is_band_leader_or_manager(v_gig.band_id, auth.uid()) THEN RAISE EXCEPTION 'Only authorised band managers can edit gig setlists.' USING ERRCODE = '42501'; END IF;
+  IF jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN RAISE EXCEPTION 'Setlist must contain at least one song.' USING ERRCODE = '22023'; END IF;
+
+  CREATE TEMP TABLE tmp_gig_setlist_items(song_id uuid, position integer, is_encore boolean, duration integer) ON COMMIT DROP;
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    INSERT INTO tmp_gig_setlist_items(song_id, position, is_encore)
+    VALUES ((v_item->>'song_id')::uuid, COALESCE((v_item->>'position')::integer, v_pos), COALESCE((v_item->>'is_encore')::boolean, false));
+    v_pos := v_pos + 1;
+  END LOOP;
+  SELECT count(*), count(DISTINCT song_id) INTO v_count, v_bad FROM tmp_gig_setlist_items;
+  IF v_count <> v_bad THEN RAISE EXCEPTION 'Duplicate songs are not allowed in the same setlist.' USING ERRCODE = '23505'; END IF;
+
+  UPDATE tmp_gig_setlist_items t SET duration = s.duration_seconds FROM public.songs s WHERE s.id = t.song_id AND s.band_id = v_gig.band_id AND COALESCE(s.archived,false) = false;
+  SELECT count(*) INTO v_bad FROM tmp_gig_setlist_items WHERE duration IS NULL;
+  IF v_bad > 0 THEN RAISE EXCEPTION 'Songs must belong to this band and have an estimated duration.' USING ERRCODE = '22023'; END IF;
+
+  FOR v_item IN SELECT jsonb_build_object('is_encore', is_encore) FROM tmp_gig_setlist_items ORDER BY position LOOP
+    IF v_encore_seen AND NOT COALESCE((v_item->>'is_encore')::boolean,false) THEN RAISE EXCEPTION 'Encore songs must appear after the normal set.' USING ERRCODE = '22023'; END IF;
+    IF COALESCE((v_item->>'is_encore')::boolean,false) THEN v_encore_seen := true; END IF;
+  END LOOP;
+
+  SELECT COALESCE(sum(duration),0) INTO v_total FROM tmp_gig_setlist_items;
+  INSERT INTO public.gig_setlists(gig_id, band_id, name, total_duration_seconds) VALUES (p_gig_id, v_gig.band_id, COALESCE(NULLIF(p_name,''),'Gig setlist'), v_total)
+  ON CONFLICT (gig_id) DO UPDATE SET name = EXCLUDED.name, total_duration_seconds = EXCLUDED.total_duration_seconds, updated_at = now()
+  RETURNING id INTO v_setlist_id;
+  DELETE FROM public.gig_setlist_items WHERE setlist_id = v_setlist_id;
+  INSERT INTO public.gig_setlist_items(setlist_id, song_id, position, is_encore)
+  SELECT v_setlist_id, song_id, row_number() OVER (ORDER BY position), is_encore FROM tmp_gig_setlist_items ORDER BY position;
+  RETURN jsonb_build_object('setlist_id', v_setlist_id, 'total_duration_seconds', v_total);
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.save_gig_setlist(uuid, text, jsonb) TO authenticated;
+
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS readiness_score integer;
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS readiness_modifier numeric;
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS readiness_breakdown jsonb;


### PR DESCRIPTION
### Motivation

- Provide players persistent per-gig setlists and a single explainable readiness score so bands can prepare meaningfully before performances. 
- Reuse existing song, rehearsal and gig execution systems and add server-side validation to prevent invalid or unauthorized edits. 
- Surface preparation state on gig pages and ensure readiness can modestly influence performance outcomes without overriding existing systems. 

### Description

- Database: adds migration `20260711123000_gig_setlists_readiness.sql` to create `gig_setlists` and `gig_setlist_items`, indexes, RLS policies, a server RPC `save_gig_setlist(...)`, and three new columns on `gig_outcomes` (`readiness_score`, `readiness_modifier`, `readiness_breakdown`).
- Readiness & validation: new central calculation module `src/utils/gigReadiness.ts` with weighted factors and bounded performance modifier, and a setlist validator `src/utils/gigSetlistValidation.ts` enforcing duplicates, ownership, durations and encore ordering. 
- UI & integration: new responsive `GigPreparationPanel` (`src/components/gig/GigPreparationPanel.tsx`) with drag-and-drop reordering (`@dnd-kit`), accessible up/down controls, encore toggles, duration display, warnings/errors, and save RPC usage; the panel is embedded into `GigDetailsDialog` and `PerformGig` pages. 
- Execution & safety: `src/pages/PerformGig.tsx` now verifies a saved gig preparation setlist before starting a gig and `src/utils/gigExecution.ts` integrates readiness into outcome calculation (applies a bounded modifier and persists the breakdown on outcomes). 
- Tests & docs: adds unit tests `src/utils/__tests__/gigReadiness.test.ts` for validation and readiness behavior and documents the model and weights in `docs/gigs/gig-preparation-readiness.md`.

### Testing

- Type-check: ran `npm run typecheck` and it passed in the environment where the change was prepared. 
- Unit tests: test file `src/utils/__tests__/gigReadiness.test.ts` was added, but `npm test`/`vitest` could not be executed here because test tooling is not installed in the current environment. 
- Build & lint: `npm run build` and `npm run lint` were attempted but could not complete because `npm install` failed due to a registry access error for certain dependencies (environment constraint), so dependency-backed build/lint checks were not available. 
- Summary: logical unit coverage and type checks were exercised locally where possible, and the added server RPC and RLS are implemented to enforce validation and permissions server-side; full CI (install/build/test) is expected to run in the repository CI where `npm install` and `vitest` are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52892feb8c8325974123085f777f06)