### PR TITLE
feat: add server-driven live gig timeline and tactical decisions

### DIFF
--- a/docs/gigs/live-gig-timeline.md
+++ b/docs/gigs/live-gig-timeline.md
@@ -1,0 +1,86 @@
+# Live gig timeline and tactical decisions
+
+Phase 6 adds the first server-driven live performance foundation. A scheduled gig can create one `gig_live_sessions` row, persist a deterministic `gig_live_segments` timeline, resolve songs into `gig_live_song_results`, persist incidents and tactical decisions, and finalize a result from the resolved timeline rather than rerolling a separate whole-gig simulation.
+
+## Architecture inspected
+
+The implementation builds on the existing gig preparation stack:
+
+- Scheduled gigs and historical outcomes already live in `gigs`, `gig_performances`, and `gig_outcomes`.
+- Setlists are stored in `gig_setlists` and ordered `gig_setlist_items` with an encore flag.
+- Readiness is calculated by `calculateGigReadiness`, including setlist completeness, duration fit, song practice, rehearsal recency, chemistry, health/fatigue, and required performers.
+- Crew/equipment preparation exposes `calculateCrewEffectiveness` and `calculateEquipmentReliability`.
+- Stage production/soundcheck exposes production quality and `SOUNDCHECK_TYPES` sound benefits.
+- Forecasting combines readiness, crew, equipment, production, venue, fan demand, revenue, and pre-show consequences.
+- Pre-show incidents already use persisted sessions, incident rows, option rows, idempotent decision commits, deadline expiry, and automatic fallback decisions.
+- Existing viewer/replay components establish the UI pattern for low-frequency timeline updates rather than high-frequency action rendering.
+
+## Lifecycle
+
+Live state is intentionally small and server-owned: `scheduled`, `preshow`, `ready_to_start`, `live`, `paused_for_decision`, `resolving`, `completed`, `cancelled`, and `failed`. A session can start only after the scheduled start time, for non-terminal gigs, with no blocking readiness issues and at least one setlist item. The database enforces one live session per gig.
+
+## Session and segment models
+
+`gig_live_sessions` stores current live totals: crowd energy, fan satisfaction, performance quality, band stamina, momentum, incident risk, current segment, simulation version, idempotency keys, final snapshots, and projection snapshots.
+
+`gig_live_segments` stores the immutable generated timeline. Segment types include intro, song, transition, encore break, encore song, outro, incident, decision, and crowd interaction. Segments resolve sequentially and are guarded by `(session_id, segment_index)` uniqueness.
+
+## Timeline generation
+
+The first version generates:
+
+1. Intro.
+2. Each normal song from ordered setlist items.
+3. Transitions between songs.
+4. Encore break before the first encore item.
+5. Encore song segments for encore items.
+6. Outro.
+
+The generated timeline is deterministic for a start timestamp and setlist. It is inserted only when the session has no segments, so refreshes or duplicate workers do not create a different show.
+
+## Scheduled and catch-up progression
+
+The schema and service helpers support two processing modes:
+
+- Scheduled workers start eligible sessions, resolve due segments, expire decisions, and complete finished sessions.
+- Lazy catch-up can safely process overdue segments in order from live page reads, gig status reads, or world tick processing.
+
+`mark_gig_live_segment_resolved` is conditional and idempotent. Decision expiry is also idempotent through one decision per incident.
+
+## Song-resolution formula
+
+`resolveLiveSong` combines song quality, popularity, familiarity/rehearsal, readiness, performer skill, stage presence, band chemistry, health-derived stamina, current momentum, current crowd energy, crew effectiveness, equipment reliability, soundcheck, production, venue acoustics, genre fit, setlist position, pre-show consequences, and deterministic bounded variance. The output includes score, rating, technical score, performance score, audience response, energy/satisfaction/stamina/momentum deltas, highlights, incidents, and an explainable breakdown.
+
+## Crowd energy, fan satisfaction, stamina, and momentum
+
+Crowd energy is 0-100 and changes from audience response, setlist position, decay, incidents, and tactical choices. Fan satisfaction is separate and responds to quality, sound, professionalism, encore value, incidents, and final ending. Band stamina starts from health/fatigue and falls per song based on duration, difficulty, tempo/intensity, and low-intensity tags. Momentum is capped and reflects show flow from song quality, transitions, incidents, and tactical choices.
+
+## Incidents and tactical decisions
+
+The first incident set covers performance mistakes, equipment faults, production cue failures, flat crowd moments, and positive standout moments. Probability considers equipment reliability, crew coverage, production setup risk, stamina, momentum, and pre-show consequences. At most one incident is generated per processed segment by the helper.
+
+Decision types include equipment response, crowd response, and performance/production recovery. Each has a server-owned deadline, a recommended automatic fallback, and capped consequences. Offline defaults prioritize continuing the gig, health, essential equipment, curfew safety, and avoiding catastrophic loss.
+
+## Live setlist changes, encore, and curfew
+
+Only pending song or encore-song segments can be changed. Completed or active segments are immutable. Supported changes are represented in `gig_live_setlist_changes` for skip, swap, replace, move favourite, add/remove encore, and shorten set. Encore requires valid remaining encore songs, crowd demand, satisfaction, stamina, and curfew room.
+
+## Final result, rewards, and finances
+
+`finalizeLiveGig` derives final quality and satisfaction from persisted song results, peak performance, final live state, positive moments, and incident penalties. It emits reward and finance idempotency keys so downstream progression and ledger systems can process exactly once.
+
+## Realtime and UI
+
+`LiveGigTimelineDashboard` renders the authoritative live session, progress, timeline, metrics, recent highlights, incidents, and active tactical decisions. It is compatible with existing SSE/realtime/polling patterns because reconnecting clients only need to fetch persisted session, segment, incident, decision, and result rows.
+
+## Admin and observability
+
+The migration adds indexed session status, due segment, incident deadline, and decision views suitable for admin diagnostics. Admin recovery should trigger overdue processing or mark specific segments resolved through service-role functions without rerolling persisted results.
+
+## Balancing configuration
+
+`DEFAULT_LIVE_GIG_CONFIG` centralizes initial energy/satisfaction/stamina, energy decay, momentum caps, position caps, stamina base, incident probabilities, decision windows, encore thresholds, curfew warning, and tactical modifier caps.
+
+## Known limitations
+
+This PR intentionally does not add a high-frequency renderer, browser-dependent progression, detailed support-act simulation, or advanced delegated permissions UI. The next PR should wire the helpers into the production scheduler and existing gig pages, add database harness tests against a seeded Supabase instance, and connect reward/finance processors to existing ledgers.

--- a/src/components/gig/LiveGigTimelineDashboard.tsx
+++ b/src/components/gig/LiveGigTimelineDashboard.tsx
@@ -1,0 +1,92 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import type { GigLiveSegment, LiveGigSessionState, LiveIncident, LiveSongResult, TacticalDecision } from '@/utils/gigLive';
+
+export interface LiveGigTimelineDashboardProps {
+  session: LiveGigSessionState;
+  segments: GigLiveSegment[];
+  songResults: Array<LiveSongResult & { segmentIndex: number; title?: string }>;
+  incidents?: LiveIncident[];
+  activeDecision?: TacticalDecision | null;
+  canDecide?: boolean;
+  onSelectDecision?: (optionKey: string) => void;
+}
+
+export function LiveGigTimelineDashboard({ session, segments, songResults, incidents = [], activeDecision, canDecide = false, onSelectDecision }: LiveGigTimelineDashboardProps) {
+  const resolved = segments.filter((segment) => segment.status === 'resolved').length;
+  const progress = segments.length ? Math.round((resolved / segments.length) * 100) : 0;
+  const current = segments.find((segment) => segment.segmentIndex === session.currentSegmentIndex) ?? segments.find((segment) => segment.status === 'active') ?? segments.find((segment) => segment.status === 'pending');
+
+  return (
+    <div className="space-y-4" aria-live="polite">
+      <Card>
+        <CardHeader className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle>Live gig control room</CardTitle>
+            <Badge variant={session.status === 'paused_for_decision' ? 'destructive' : 'default'}>{session.status.replaceAll('_', ' ')}</Badge>
+          </div>
+          <Progress value={progress} aria-label="Live gig progress" />
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-5">
+          <Metric label="Crowd energy" value={session.crowdEnergy} />
+          <Metric label="Fan satisfaction" value={session.fanSatisfaction} />
+          <Metric label="Band stamina" value={session.bandStamina} />
+          <Metric label="Momentum" value={session.momentum} signed />
+          <Metric label="Incident risk" value={session.incidentRisk} />
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-[1.35fr_0.85fr]">
+        <Card>
+          <CardHeader><CardTitle className="text-base">Performance timeline</CardTitle></CardHeader>
+          <CardContent className="space-y-2">
+            {segments.map((segment) => (
+              <div key={segment.segmentIndex} className="flex items-center justify-between rounded-md border p-3 text-sm">
+                <div>
+                  <div className="font-medium">{segment.segmentType.replaceAll('_', ' ')}</div>
+                  <div className="text-muted-foreground">{Math.round(segment.plannedDurationSeconds / 60)} min planned</div>
+                </div>
+                <Badge variant={segment.segmentIndex === current?.segmentIndex ? 'default' : segment.status === 'resolved' ? 'secondary' : 'outline'}>{segment.status}</Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          {activeDecision ? (
+            <Card className="border-amber-400">
+              <CardHeader><CardTitle className="text-base">Tactical decision required</CardTitle></CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-sm text-muted-foreground">Fallback: {activeDecision.recommendedFallback.replaceAll('_', ' ')}. Window: {Math.round(activeDecision.deadlineSeconds / 60)} min game time.</p>
+                {activeDecision.options.map((option) => (
+                  <button key={option.key} type="button" disabled={!canDecide} onClick={() => onSelectDecision?.(option.key)} className="w-full rounded-md border p-2 text-left text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60">
+                    {option.label}{option.safeFallback ? ' · safe fallback' : ''}
+                  </button>
+                ))}
+              </CardContent>
+            </Card>
+          ) : null}
+
+          <Card>
+            <CardHeader><CardTitle className="text-base">Recent highlights</CardTitle></CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {songResults.flatMap((result) => result.highlights.map((highlight) => `${result.title ?? 'Song'}: ${highlight}`)).slice(-4).map((highlight) => <p key={highlight}>{highlight}</p>)}
+              {incidents.slice(-3).map((incident) => <p key={`${incident.incidentType}-${incident.title}`}>{incident.title}</p>)}
+              {songResults.length === 0 && incidents.length === 0 ? <p className="text-muted-foreground">The show is just getting started.</p> : null}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value, signed = false }: { label: string; value: number; signed?: boolean }) {
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 text-2xl font-semibold">{signed && value > 0 ? '+' : ''}{value}</div>
+    </div>
+  );
+}

--- a/src/utils/__tests__/gigLive.test.ts
+++ b/src/utils/__tests__/gigLive.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { applySongResultToSession, buildInitialLiveSession, buildLiveTimeline, buildTacticalDecision, canApplyLiveSetlistChange, canStartLiveGig, evaluateEncore, finalizeLiveGig, maybeGenerateLiveIncident, resolveLiveSong, type GigLiveContext } from '../gigLive';
+import { calculateGigReadiness } from '../gigReadiness';
+
+const readiness = calculateGigReadiness({ setlistSongs: [{ id: 'song-1', durationSeconds: 180, rehearsalLevel: 85 }, { id: 'song-2', durationSeconds: 210, rehearsalLevel: 90 }], bandChemistry: 78, fatigueScore: 80, healthScore: 82, assignedPerformers: 4, requiredPerformers: 4 });
+const ctx: GigLiveContext = { gigId: 'gig-1', bandId: 'band-1', scheduledAt: '2026-07-11T12:00:00Z', capacity: 100, ticketsSold: 88, venueAcoustics: 72, venueQuality: 70, genreAffinity: 68, performerSkill: 76, stagePresence: 74, bandChemistry: 80, fatigueScore: 78, healthScore: 82, readiness, crew: [{ role: 'sound_engineer', workerType: 'npc_staff', relevantSkill: 80, attendance: 'confirmed', status: 'accepted' }], equipment: [{ equipmentRole: 'amplifier', quality: 82, condition: 86, isSpare: false }, { equipmentRole: 'amplifier', quality: 70, condition: 90, isSpare: true }], productionQuality: { score: 76, rating: 'impressive', audienceImpact: 12, reliability: 78, setupRisk: 16, costEfficiency: 70, factors: [] }, soundcheckType: 'full_production_soundcheck', setlist: [{ id: 'item-1', position: 1, song: { id: 'song-1', title: 'Opener', durationSeconds: 180, quality: 82, popularity: 78, familiarity: 88, tempo: 132, difficulty: 58, genre: 'rock' } }, { id: 'item-2', position: 2, song: { id: 'song-2', title: 'Closer', durationSeconds: 210, quality: 86, popularity: 84, familiarity: 90, tempo: 118, difficulty: 64, genre: 'rock' }, isEncore: true }] };
+
+describe('gig live simulation', () => {
+  it('starts eligible gigs once inputs are ready', () => {
+    expect(canStartLiveGig(ctx, new Date('2026-07-11T12:01:00Z'))).toBe(true);
+    expect(canStartLiveGig({ ...ctx, status: 'completed' }, new Date('2026-07-11T12:01:00Z'))).toBe(false);
+    expect(canStartLiveGig({ ...ctx, setlist: [] }, new Date('2026-07-11T12:01:00Z'))).toBe(false);
+  });
+
+  it('generates a stable persisted timeline with encore and transitions', () => {
+    const first = buildLiveTimeline(ctx, new Date('2026-07-11T12:00:00Z'));
+    const second = buildLiveTimeline(ctx, new Date('2026-07-11T12:00:00Z'));
+    expect(first).toEqual(second);
+    expect(first.map(s => s.segmentType)).toEqual(['intro', 'song', 'transition', 'encore_break', 'encore_song', 'outro']);
+  });
+
+  it('resolves songs deterministically and persists bounded state changes', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const result = resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'seed');
+    expect(resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'seed')).toEqual(result);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+    const next = applySongResultToSession(session, result, ctx.setlist[0]);
+    expect(next.crowdEnergy).toBeGreaterThanOrEqual(0);
+    expect(next.fanSatisfaction).toBeGreaterThanOrEqual(0);
+    expect(next.bandStamina).toBeLessThan(session.bandStamina);
+  });
+
+  it('rewards stronger preparation and penalizes low familiarity', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const strong = resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'prep');
+    const weak = resolveLiveSong({ ...ctx, readiness: calculateGigReadiness({ setlistSongs: [{ id: 'song-1', durationSeconds: 180, rehearsalLevel: 10 }], assignedPerformers: 1, requiredPerformers: 1 }) }, session, { ...ctx.setlist[0], song: { ...ctx.setlist[0].song, familiarity: 10 } }, 1, 'prep');
+    expect(strong.score).toBeGreaterThan(weak.score);
+  });
+
+  it('supports tactical decisions, automatic fallbacks, encore checks and immutable completed segments', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const incident = maybeGenerateLiveIncident({ ...ctx, equipment: [{ equipmentRole: 'amplifier', quality: 20, condition: 20, isSpare: false }] }, { ...session, bandStamina: 20 }, { ...buildLiveTimeline(ctx)[1], segmentIndex: 1 }, 'likely-incident') ?? { incidentType: 'equipment_fault', category: 'equipment' as const, severity: 'moderate' as const, title: 'Equipment fault', decisionType: 'equipment_response', generationSnapshot: {}, resultSnapshot: {} };
+    const decision = buildTacticalDecision(incident);
+    expect(decision?.recommendedFallback).toBe('use_spare');
+    expect(evaluateEncore({ ...session, crowdEnergy: 80, fanSatisfaction: 78, bandStamina: 60 }, 1, 2000).allowed).toBe(true);
+    expect(evaluateEncore({ ...session, crowdEnergy: 20 }, 1, 2000).outcome).toBe('no_encore_requested');
+    expect(canApplyLiveSetlistChange([{ ...buildLiveTimeline(ctx)[1], status: 'resolved' }], 1, 'skip').allowed).toBe(false);
+  });
+
+  it('finalizes from persisted song results with idempotency keys', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const song = resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'final');
+    const final = finalizeLiveGig(applySongResultToSession(session, song, ctx.setlist[0]), [song], []);
+    expect(final.finalQuality).toBeGreaterThan(0);
+    expect(final.rewardsIdempotencyKey).toContain('gig-1:live-gig');
+    expect(final.financeIdempotencyKey).toContain('finance');
+  });
+});

--- a/src/utils/gigLive.ts
+++ b/src/utils/gigLive.ts
@@ -1,0 +1,162 @@
+import { calculateCrewEffectiveness, calculateEquipmentReliability, type CrewAssignmentInput, type EquipmentLoadoutInput } from './gigCrewEquipment';
+import { calculateReadinessPerformanceModifier, type ReadinessResult } from './gigReadiness';
+import { SOUNDCHECK_TYPES, type ProductionQualityResult, type SoundcheckType } from './gigStageProduction';
+import { summarizePreshowPerformanceModifiers, type PreshowConsequence } from './gigPreshow';
+
+export type LiveGigStatus = 'scheduled' | 'preshow' | 'ready_to_start' | 'live' | 'paused_for_decision' | 'resolving' | 'completed' | 'cancelled' | 'failed';
+export type LiveSegmentType = 'intro' | 'song' | 'transition' | 'crowd_interaction' | 'incident' | 'decision' | 'encore_break' | 'encore_song' | 'outro';
+export type LiveSegmentStatus = 'pending' | 'active' | 'resolved' | 'skipped' | 'blocked';
+export type LiveDecisionPolicy = 'balanced' | 'protect_quality' | 'protect_finances' | 'protect_health' | 'maximise_energy' | 'manager_decides';
+export type LiveIncidentCategory = 'performance' | 'equipment' | 'production' | 'crowd' | 'venue' | 'positive';
+export type LiveIncidentSeverity = 'minor' | 'moderate' | 'major' | 'critical';
+export type LiveSongRating = 'disaster' | 'poor' | 'average' | 'good' | 'great' | 'outstanding';
+
+export interface LiveGigSong { id: string; title: string; durationSeconds?: number | null; quality?: number | null; popularity?: number | null; familiarity?: number | null; rehearsalLevel?: number | null; genre?: string | null; tempo?: number | null; difficulty?: number | null; tags?: string[] | null; }
+export interface LiveSetlistItem { id: string; song: LiveGigSong; position: number; isEncore?: boolean; }
+export interface GigLiveSegment { id?: string; segmentIndex: number; segmentType: LiveSegmentType; setlistItemId?: string | null; songId?: string | null; plannedStartAt: string; plannedDurationSeconds: number; status: LiveSegmentStatus; resultSnapshot?: Record<string, unknown>; }
+export interface LiveGigSessionState { gigId: string; bandId: string; status: LiveGigStatus; startedAt: string; expectedEndAt?: string; currentSegmentIndex: number; currentSongItemId?: string | null; crowdEnergy: number; fanSatisfaction: number; performanceQuality: number; bandStamina: number; momentum: number; incidentRisk: number; simulationVersion: number; lastProcessedAt?: string; }
+export interface GigLiveContext { gigId: string; bandId: string; scheduledAt: string | Date; status?: string | null; slotDurationSeconds?: number | null; capacity?: number | null; ticketsSold?: number | null; venueAcoustics?: number | null; venueQuality?: number | null; genreAffinity?: number | null; ticketPrice?: number | null; curfewAt?: string | Date | null; performerSkill?: number | null; stagePresence?: number | null; bandChemistry?: number | null; healthScore?: number | null; fatigueScore?: number | null; readiness: ReadinessResult; crew?: CrewAssignmentInput[]; equipment?: EquipmentLoadoutInput[]; productionQuality?: ProductionQualityResult | null; soundcheckType?: SoundcheckType; preShowConsequences?: PreshowConsequence[]; setlist: LiveSetlistItem[]; }
+export interface LiveBreakdownItem { key: string; label: string; modifier: number; explanation: string; }
+export interface LiveSongResult { score: number; rating: LiveSongRating; technicalScore: number; performanceScore: number; audienceResponse: number; energyChange: number; satisfactionChange: number; staminaCost: number; momentumChange: number; incidents: string[]; highlights: string[]; breakdown: LiveBreakdownItem[]; }
+export interface LiveIncident { incidentType: string; category: LiveIncidentCategory; severity: LiveIncidentSeverity; title: string; decisionType?: string; generationSnapshot: Record<string, unknown>; resultSnapshot: Record<string, unknown>; }
+export interface TacticalDecisionOption { key: string; label: string; consequence: { crowdEnergy?: number; fanSatisfaction?: number; momentum?: number; bandStamina?: number; incidentRisk?: number; durationSeconds?: number }; safeFallback?: boolean; }
+export interface TacticalDecision { decisionType: string; options: TacticalDecisionOption[]; deadlineSeconds: number; recommendedFallback: string; }
+
+export const GIG_LIVE_SIMULATION_VERSION = 1;
+export const DEFAULT_LIVE_GIG_CONFIG = { initialCrowdEnergy: 52, initialFanSatisfaction: 58, initialStamina: 86, initialMomentum: 0, introSeconds: 90, transitionSeconds: 45, encoreBreakSeconds: 120, outroSeconds: 90, energyDecayPerSegment: 1.2, momentumCap: 12, songPositionBonusCap: 8, staminaCostBase: 4, incidentBaseProbability: 0.055, positiveMomentProbability: 0.045, decisionWindowSeconds: 420, encoreEnergyThreshold: 66, encoreSatisfactionThreshold: 60, curfewWarningSeconds: 900, tacticalModifierCap: 12 } as const;
+
+const clamp = (n: number, min = 0, max = 100) => Math.max(min, Math.min(max, n));
+const signedClamp = (n: number, max: number) => Math.max(-max, Math.min(max, n));
+const hash = (seed: string) => Array.from(seed).reduce((h, ch) => Math.imul(31, h) + ch.charCodeAt(0) | 0, 2166136261) >>> 0;
+export const deterministicRandom = (seed: string) => (hash(seed) % 10000) / 10000;
+const ratingFor = (score: number): LiveSongRating => score < 25 ? 'disaster' : score < 40 ? 'poor' : score < 58 ? 'average' : score < 72 ? 'good' : score < 86 ? 'great' : 'outstanding';
+
+export function canStartLiveGig(ctx: GigLiveContext, now = new Date()) {
+  const status = ctx.status ?? 'scheduled';
+  const blockingIssues = ctx.readiness.blockingIssues ?? [];
+  return !['completed', 'cancelled', 'failed'].includes(status) && new Date(ctx.scheduledAt) <= now && blockingIssues.length === 0 && ctx.setlist.length > 0;
+}
+
+export function buildInitialLiveSession(ctx: GigLiveContext, now = new Date()): LiveGigSessionState {
+  const preshow = summarizePreshowPerformanceModifiers(ctx.preShowConsequences ?? []);
+  const density = ctx.capacity ? ((ctx.ticketsSold ?? 0) / ctx.capacity) * 100 : 45;
+  const stamina = clamp(DEFAULT_LIVE_GIG_CONFIG.initialStamina + ((ctx.healthScore ?? 75) - 70) * 0.18 - Math.max(0, 65 - (ctx.fatigueScore ?? 75)) * 0.32);
+  const crowdEnergy = clamp(DEFAULT_LIVE_GIG_CONFIG.initialCrowdEnergy + density * 0.12 + (ctx.productionQuality?.audienceImpact ?? 0) * 0.18 + preshow.crowdEnergyModifier * 100);
+  const fanSatisfaction = clamp(DEFAULT_LIVE_GIG_CONFIG.initialFanSatisfaction + ctx.readiness.score * 0.12 + (ctx.venueQuality ?? 55) * 0.06 + preshow.fanSatisfactionModifier * 100);
+  const duration = buildLiveTimeline(ctx, now).reduce((sum, s) => sum + s.plannedDurationSeconds, 0);
+  return { gigId: ctx.gigId, bandId: ctx.bandId, status: 'live', startedAt: now.toISOString(), expectedEndAt: new Date(now.getTime() + duration * 1000).toISOString(), currentSegmentIndex: 0, currentSongItemId: null, crowdEnergy: Math.round(crowdEnergy), fanSatisfaction: Math.round(fanSatisfaction), performanceQuality: 0, bandStamina: Math.round(stamina), momentum: 0, incidentRisk: Math.round(calculateIncidentRisk(ctx, stamina, 0)), simulationVersion: GIG_LIVE_SIMULATION_VERSION, lastProcessedAt: now.toISOString() };
+}
+
+export function buildLiveTimeline(ctx: GigLiveContext, startAt = new Date()): GigLiveSegment[] {
+  const sorted = [...ctx.setlist].sort((a, b) => a.position - b.position);
+  const segments: GigLiveSegment[] = [];
+  let offset = 0, index = 0;
+  const add = (segmentType: LiveSegmentType, duration: number, item?: LiveSetlistItem) => { segments.push({ segmentIndex: index++, segmentType, setlistItemId: item?.id ?? null, songId: item?.song.id ?? null, plannedStartAt: new Date(startAt.getTime() + offset * 1000).toISOString(), plannedDurationSeconds: Math.max(15, Math.round(duration)), status: 'pending' }); offset += Math.max(15, Math.round(duration)); };
+  add('intro', DEFAULT_LIVE_GIG_CONFIG.introSeconds);
+  sorted.forEach((item, idx) => { if (item.isEncore && (idx === 0 || !sorted[idx - 1].isEncore)) add('encore_break', DEFAULT_LIVE_GIG_CONFIG.encoreBreakSeconds); add(item.isEncore ? 'encore_song' : 'song', item.song.durationSeconds ?? 210, item); if (idx < sorted.length - 1) add('transition', DEFAULT_LIVE_GIG_CONFIG.transitionSeconds); });
+  add('outro', DEFAULT_LIVE_GIG_CONFIG.outroSeconds);
+  return segments;
+}
+
+function setlistPositionModifier(item: LiveSetlistItem, total: number, previous?: LiveSetlistItem) {
+  const song = item.song; let modifier = 0; const notes: string[] = [];
+  const quality = song.quality ?? 55, popularity = song.popularity ?? 45, tempo = song.tempo ?? 110, difficulty = song.difficulty ?? 50;
+  if (item.position === 1) { modifier += (quality + popularity + (tempo >= 110 ? 8 : -6) - 110) * 0.08; notes.push('Opening slot rewards familiar, energetic songs.'); }
+  if (item.position >= total - 1) { modifier += (quality + popularity - difficulty - 45) * 0.06; notes.push('Closing slot rewards strong, popular material.'); }
+  if (item.isEncore) { modifier += popularity >= 65 ? 5 : -3; notes.push('Encore crowd expectation is applied.'); }
+  if (previous && previous.song.genre && previous.song.genre === song.genre) { modifier -= 2.5; notes.push('Consecutive similar songs reduce variety.'); }
+  if ((song.tags ?? []).some(t => /ballad|slow/i.test(t)) || tempo < 85) { modifier -= 1.5; notes.push('Lower-intensity songs trade energy for stamina control.'); }
+  return { modifier: signedClamp(modifier, DEFAULT_LIVE_GIG_CONFIG.songPositionBonusCap), notes };
+}
+
+export function resolveLiveSong(ctx: GigLiveContext, session: LiveGigSessionState, item: LiveSetlistItem, position: number, seed: string): LiveSongResult {
+  const crewAvg = (ctx.crew ?? []).length ? (ctx.crew ?? []).reduce((s, c) => s + calculateCrewEffectiveness(c), 0) / (ctx.crew ?? []).length : 45;
+  const reliability = calculateEquipmentReliability(ctx.equipment ?? [], ctx.crew ?? []);
+  const sound = SOUNDCHECK_TYPES[ctx.soundcheckType ?? 'none'];
+  const preshow = summarizePreshowPerformanceModifiers(ctx.preShowConsequences ?? []);
+  const song = item.song, total = ctx.setlist.length, previous = ctx.setlist.find(s => s.position === item.position - 1);
+  const positionMod = setlistPositionModifier(item, total, previous);
+  const staminaPenalty = Math.max(0, 55 - session.bandStamina) * 0.28;
+  const crowdLift = signedClamp((session.crowdEnergy - 55) * 0.08, 4);
+  const momentumLift = signedClamp(session.momentum * 0.18, 4);
+  const venueFit = ((ctx.venueAcoustics ?? 55) - 55) * 0.07 + ((ctx.genreAffinity ?? 55) - 55) * 0.06;
+  const boundedRandom = (deterministicRandom(`${seed}:${item.id}:song`) - 0.5) * 8;
+  const familiarity = song.familiarity ?? song.rehearsalLevel ?? 45;
+  const technicalScore = clamp((song.quality ?? 55) * 0.24 + familiarity * 0.2 + (ctx.performerSkill ?? 55) * 0.17 + reliability.quality * 0.12 + crewAvg * 0.08 + (ctx.venueAcoustics ?? 55) * 0.08 + sound.soundBenefit * 0.11 - staminaPenalty + preshow.soundQualityModifier * 45);
+  const performanceScore = clamp(ctx.readiness.score * 0.22 + (ctx.bandChemistry ?? 55) * 0.14 + (ctx.stagePresence ?? ctx.performerSkill ?? 55) * 0.16 + (song.popularity ?? 45) * 0.11 + (ctx.productionQuality?.score ?? 55) * 0.09 + session.bandStamina * 0.08 + 50 * 0.08 + positionMod.modifier + crowdLift + momentumLift + preshow.performanceModifier * 100);
+  const audienceResponse = clamp(performanceScore * 0.45 + technicalScore * 0.28 + (song.popularity ?? 45) * 0.17 + session.crowdEnergy * 0.10 + venueFit);
+  const score = Math.round(clamp(technicalScore * 0.38 + performanceScore * 0.39 + audienceResponse * 0.23 + boundedRandom));
+  const intensity = clamp(((song.tempo ?? 110) - 70) / 90 * 100) / 100;
+  const staminaCost = Math.round(clamp(DEFAULT_LIVE_GIG_CONFIG.staminaCostBase + (song.durationSeconds ?? 210) / 90 + (song.difficulty ?? 50) / 22 + intensity * 3 - ((song.tags ?? []).some(t => /ballad|slow/i.test(t)) ? 2 : 0), 1, 18));
+  const energyChange = Math.round(signedClamp((audienceResponse - 55) * 0.18 + positionMod.modifier * 0.35 - DEFAULT_LIVE_GIG_CONFIG.energyDecayPerSegment, 16));
+  const satisfactionChange = Math.round(signedClamp((score - 58) * 0.12 + (technicalScore - 55) * 0.06 + (item.isEncore ? 3 : 0), 12));
+  const momentumChange = Math.round(signedClamp((score - 55) * 0.11 + positionMod.modifier * 0.2, 8));
+  const highlights = score >= 82 ? [`${song.title} became a standout live moment.`] : audienceResponse >= 78 ? [`The crowd lifted ${song.title}.`] : [];
+  return { score, rating: ratingFor(score), technicalScore: Math.round(technicalScore), performanceScore: Math.round(performanceScore), audienceResponse: Math.round(audienceResponse), energyChange, satisfactionChange, staminaCost, momentumChange, incidents: [], highlights, breakdown: [ { key: 'readiness', label: 'Final readiness', modifier: Math.round(calculateReadinessPerformanceModifier(ctx.readiness.score) * 100), explanation: `Readiness score ${ctx.readiness.score} anchors the performance.` }, { key: 'familiarity', label: 'Song familiarity', modifier: Math.round(familiarity - 55), explanation: 'Saved setlist familiarity/rehearsal affects accuracy.' }, { key: 'equipment_crew', label: 'Equipment and crew', modifier: Math.round((reliability.score + crewAvg) / 2 - 55), explanation: 'Loadout reliability and crew effectiveness reduce mistakes.' }, { key: 'sound_production', label: 'Soundcheck and production', modifier: Math.round(sound.soundBenefit * 0.6 + ((ctx.productionQuality?.score ?? 55) - 55) * 0.12), explanation: 'Soundcheck and production quality shape technical/audience response.' }, { key: 'position', label: 'Setlist position', modifier: Math.round(positionMod.modifier), explanation: positionMod.notes.join(' ') || 'Neutral setlist position.' }, { key: 'live_state', label: 'Crowd, stamina and momentum', modifier: Math.round(crowdLift + momentumLift - staminaPenalty), explanation: 'Current live state modestly influences this song.' }, { key: 'bounded_randomness', label: 'Bounded live variance', modifier: Math.round(boundedRandom), explanation: 'Deterministic per-song variance prevents refresh rerolls.' } ] };
+}
+
+export function applySongResultToSession(session: LiveGigSessionState, result: LiveSongResult, item: LiveSetlistItem): LiveGigSessionState {
+  return { ...session, currentSongItemId: item.id, crowdEnergy: Math.round(clamp(session.crowdEnergy + result.energyChange)), fanSatisfaction: Math.round(clamp(session.fanSatisfaction + result.satisfactionChange)), bandStamina: Math.round(clamp(session.bandStamina - result.staminaCost)), momentum: Math.round(signedClamp(session.momentum + result.momentumChange, DEFAULT_LIVE_GIG_CONFIG.momentumCap)), performanceQuality: Math.round(session.performanceQuality ? (session.performanceQuality + result.score) / 2 : result.score), incidentRisk: Math.round(clamp(session.incidentRisk + (result.score < 45 ? 4 : -2))) };
+}
+
+export function calculateIncidentRisk(ctx: GigLiveContext, stamina: number, momentum: number) {
+  const reliability = calculateEquipmentReliability(ctx.equipment ?? [], ctx.crew ?? []);
+  const crewAvg = (ctx.crew ?? []).length ? (ctx.crew ?? []).reduce((s, c) => s + calculateCrewEffectiveness(c), 0) / (ctx.crew ?? []).length : 45;
+  return clamp(8 + reliability.failureRisk * 0.22 + Math.max(0, 55 - crewAvg) * 0.16 + (ctx.productionQuality?.setupRisk ?? 20) * 0.12 + Math.max(0, 45 - stamina) * 0.22 - Math.max(0, momentum) * 0.18 + (ctx.preShowConsequences ?? []).length * 2);
+}
+
+export function maybeGenerateLiveIncident(ctx: GigLiveContext, session: LiveGigSessionState, segment: GigLiveSegment, seed: string): LiveIncident | null {
+  if (!['song', 'encore_song', 'transition'].includes(segment.segmentType)) return null;
+  const risk = calculateIncidentRisk(ctx, session.bandStamina, session.momentum);
+  const roll = deterministicRandom(`${seed}:${segment.segmentIndex}:incident`);
+  const positiveRoll = deterministicRandom(`${seed}:${segment.segmentIndex}:positive`);
+  if (positiveRoll < DEFAULT_LIVE_GIG_CONFIG.positiveMomentProbability + Math.max(0, session.momentum) / 900) return { incidentType: 'standout_moment', category: 'positive', severity: 'minor', title: 'Standout live moment', generationSnapshot: { roll: positiveRoll, momentum: session.momentum }, resultSnapshot: { crowdEnergy: 4, fanSatisfaction: 3, momentum: 3 } };
+  if (roll > DEFAULT_LIVE_GIG_CONFIG.incidentBaseProbability + risk / 1000) return null;
+  const hasSpare = (ctx.equipment ?? []).some(e => e.isSpare);
+  const equipmentWeak = calculateEquipmentReliability(ctx.equipment ?? [], ctx.crew ?? []).score < 62;
+  const productionComplex = (ctx.productionQuality?.setupRisk ?? 0) > 45;
+  const severe = risk > 55 && deterministicRandom(`${seed}:${segment.segmentIndex}:severity`) < 0.08;
+  if (equipmentWeak) return { incidentType: 'equipment_fault', category: 'equipment', severity: severe ? 'major' : 'moderate', title: hasSpare ? 'Equipment fault with spare available' : 'Equipment fault threatens the set', decisionType: 'equipment_response', generationSnapshot: { risk, equipmentWeak, hasSpare }, resultSnapshot: { incidentRisk: 6, momentum: -4 } };
+  if (productionComplex) return { incidentType: 'production_cue_failure', category: 'production', severity: severe ? 'major' : 'minor', title: 'Production cue misfires', decisionType: 'production_response', generationSnapshot: { risk, setupRisk: ctx.productionQuality?.setupRisk }, resultSnapshot: { crowdEnergy: -3, fanSatisfaction: -2 } };
+  if (session.crowdEnergy < 34) return { incidentType: 'crowd_goes_flat', category: 'crowd', severity: 'minor', title: 'Crowd energy drops', decisionType: 'crowd_response', generationSnapshot: { risk, crowdEnergy: session.crowdEnergy }, resultSnapshot: { momentum: -3 } };
+  return { incidentType: 'missed_cue', category: 'performance', severity: severe ? 'major' : 'minor', title: 'Missed cue on stage', decisionType: 'performance_response', generationSnapshot: { risk, stamina: session.bandStamina }, resultSnapshot: { performanceQuality: -3, momentum: -2 } };
+}
+
+export function buildTacticalDecision(incident: LiveIncident, policy: LiveDecisionPolicy = 'balanced'): TacticalDecision | null {
+  if (!incident.decisionType) return null;
+  const common = { deadlineSeconds: DEFAULT_LIVE_GIG_CONFIG.decisionWindowSeconds, decisionType: incident.decisionType };
+  if (incident.decisionType === 'equipment_response') return { ...common, recommendedFallback: policy === 'protect_finances' ? 'technician_repair' : 'use_spare', options: [ { key: 'use_spare', label: 'Use spare equipment', safeFallback: true, consequence: { momentum: 1, incidentRisk: -7, durationSeconds: 60 } }, { key: 'technician_repair', label: 'Let technician repair it', consequence: { fanSatisfaction: -1, incidentRisk: -4, durationSeconds: 180 } }, { key: 'push_through', label: 'Push through carefully', consequence: { crowdEnergy: -3, momentum: -3, incidentRisk: 4 } } ] };
+  if (incident.decisionType === 'crowd_response') return { ...common, recommendedFallback: 'address_crowd', options: [ { key: 'address_crowd', label: 'Address the crowd', safeFallback: true, consequence: { crowdEnergy: 5, fanSatisfaction: 2, momentum: 2, durationSeconds: 90 } }, { key: 'move_favourite', label: 'Move a favourite earlier', consequence: { crowdEnergy: 8, momentum: 3 } }, { key: 'shorten_banter', label: 'Shorten banter', consequence: { crowdEnergy: 2, durationSeconds: -60 } } ] };
+  return { ...common, recommendedFallback: 'safe_recovery', options: [ { key: 'safe_recovery', label: 'Take a brief recovery beat', safeFallback: true, consequence: { bandStamina: 4, momentum: 1, durationSeconds: 60 } }, { key: 'push_through', label: 'Push through', consequence: { crowdEnergy: 2, bandStamina: -5, momentum: -1 } }, { key: 'reduce_complexity', label: 'Reduce production complexity', consequence: { incidentRisk: -5, fanSatisfaction: -1 } } ] };
+}
+
+export function applyTacticalConsequence(session: LiveGigSessionState, option: TacticalDecisionOption): LiveGigSessionState {
+  const cap = DEFAULT_LIVE_GIG_CONFIG.tacticalModifierCap;
+  return { ...session, crowdEnergy: Math.round(clamp(session.crowdEnergy + signedClamp(option.consequence.crowdEnergy ?? 0, cap))), fanSatisfaction: Math.round(clamp(session.fanSatisfaction + signedClamp(option.consequence.fanSatisfaction ?? 0, cap))), momentum: Math.round(signedClamp(session.momentum + signedClamp(option.consequence.momentum ?? 0, cap), DEFAULT_LIVE_GIG_CONFIG.momentumCap)), bandStamina: Math.round(clamp(session.bandStamina + signedClamp(option.consequence.bandStamina ?? 0, cap))), incidentRisk: Math.round(clamp(session.incidentRisk + signedClamp(option.consequence.incidentRisk ?? 0, cap))) };
+}
+
+export function canApplyLiveSetlistChange(segments: GigLiveSegment[], targetSegmentIndex: number, change: 'skip' | 'swap' | 'replace' | 'encore_toggle') {
+  const target = segments.find(s => s.segmentIndex === targetSegmentIndex);
+  if (!target) return { allowed: false, reason: 'Segment not found.' };
+  if (target.status !== 'pending') return { allowed: false, reason: 'Already performed or active segments are immutable.' };
+  if (!['song', 'encore_song'].includes(target.segmentType)) return { allowed: false, reason: 'Only unperformed song segments can be changed.' };
+  return { allowed: true, reason: `${change} can be applied transactionally to an upcoming song.` };
+}
+
+export function evaluateEncore(session: LiveGigSessionState, remainingEncoreSongs: number, secondsToCurfew?: number | null) {
+  const curfewAllows = secondsToCurfew == null || secondsToCurfew > DEFAULT_LIVE_GIG_CONFIG.curfewWarningSeconds;
+  const demand = session.crowdEnergy >= DEFAULT_LIVE_GIG_CONFIG.encoreEnergyThreshold && session.fanSatisfaction >= DEFAULT_LIVE_GIG_CONFIG.encoreSatisfactionThreshold;
+  const staminaAllows = session.bandStamina >= 28;
+  const allowed = remainingEncoreSongs > 0 && curfewAllows && demand && staminaAllows;
+  return { allowed, outcome: allowed ? 'planned_encore_available' : !demand ? 'no_encore_requested' : !curfewAllows ? 'curfew_blocks_encore' : !staminaAllows ? 'band_too_exhausted' : 'no_valid_encore_song' };
+}
+
+export function finalizeLiveGig(session: LiveGigSessionState, songResults: LiveSongResult[], incidents: LiveIncident[]) {
+  const avg = songResults.length ? songResults.reduce((s, r) => s + r.score, 0) / songResults.length : session.performanceQuality;
+  const peak = songResults.length ? Math.max(...songResults.map(r => r.score)) : avg;
+  const incidentPenalty = incidents.filter(i => i.category !== 'positive').length * 2;
+  const positiveLift = incidents.filter(i => i.category === 'positive').length * 2;
+  const finalQuality = Math.round(clamp(avg * 0.72 + peak * 0.12 + session.momentum * 0.35 + positiveLift - incidentPenalty));
+  const finalSatisfaction = Math.round(clamp(session.fanSatisfaction + (finalQuality - 60) * 0.12 + positiveLift - incidentPenalty));
+  return { finalQuality, finalSatisfaction, finalCrowdEnergy: session.crowdEnergy, songsPerformed: songResults.length, averageSongScore: Math.round(avg), peakSongScore: Math.round(peak), incidents: incidents.length, rating: ratingFor(finalQuality), rewardsIdempotencyKey: `${session.gigId}:live-gig:${session.simulationVersion}:completion`, financeIdempotencyKey: `${session.gigId}:live-gig:${session.simulationVersion}:finance` };
+}

--- a/supabase/migrations/20260711223000_gig_live_timeline.sql
+++ b/supabase/migrations/20260711223000_gig_live_timeline.sql
@@ -1,0 +1,227 @@
+-- Gig Preparation Phase 6: server-driven live gig timeline and tactical decisions.
+CREATE TABLE IF NOT EXISTS public.gig_live_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled','preshow','ready_to_start','live','paused_for_decision','resolving','completed','cancelled','failed')),
+  started_at timestamptz,
+  expected_end_at timestamptz,
+  completed_at timestamptz,
+  current_segment_index integer NOT NULL DEFAULT 0 CHECK (current_segment_index >= 0),
+  current_song_item_id uuid REFERENCES public.gig_setlist_items(id) ON DELETE SET NULL,
+  crowd_energy integer NOT NULL DEFAULT 50 CHECK (crowd_energy BETWEEN 0 AND 100),
+  fan_satisfaction integer NOT NULL DEFAULT 50 CHECK (fan_satisfaction BETWEEN 0 AND 100),
+  performance_quality integer NOT NULL DEFAULT 0 CHECK (performance_quality BETWEEN 0 AND 100),
+  band_stamina integer NOT NULL DEFAULT 85 CHECK (band_stamina BETWEEN 0 AND 100),
+  momentum integer NOT NULL DEFAULT 0 CHECK (momentum BETWEEN -25 AND 25),
+  incident_risk integer NOT NULL DEFAULT 0 CHECK (incident_risk BETWEEN 0 AND 100),
+  simulation_version integer NOT NULL DEFAULT 1,
+  last_processed_at timestamptz,
+  completion_idempotency_key text,
+  finance_idempotency_key text,
+  final_result_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  projection_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  config_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(gig_id),
+  UNIQUE(completion_idempotency_key),
+  UNIQUE(finance_idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_live_segments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  segment_index integer NOT NULL CHECK (segment_index >= 0),
+  segment_type text NOT NULL CHECK (segment_type IN ('intro','song','transition','crowd_interaction','incident','decision','encore_break','encore_song','outro')),
+  setlist_item_id uuid REFERENCES public.gig_setlist_items(id) ON DELETE SET NULL,
+  song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  planned_start_at timestamptz NOT NULL,
+  planned_duration_seconds integer NOT NULL CHECK (planned_duration_seconds > 0),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','active','resolved','skipped','blocked')),
+  started_at timestamptz,
+  resolved_at timestamptz,
+  result_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(session_id, segment_index)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_live_song_results (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  segment_id uuid NOT NULL REFERENCES public.gig_live_segments(id) ON DELETE CASCADE,
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  setlist_item_id uuid REFERENCES public.gig_setlist_items(id) ON DELETE SET NULL,
+  song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  position integer NOT NULL CHECK (position > 0),
+  score integer NOT NULL CHECK (score BETWEEN 0 AND 100),
+  rating text NOT NULL CHECK (rating IN ('disaster','poor','average','good','great','outstanding')),
+  technical_score integer NOT NULL CHECK (technical_score BETWEEN 0 AND 100),
+  performance_score integer NOT NULL CHECK (performance_score BETWEEN 0 AND 100),
+  audience_response integer NOT NULL CHECK (audience_response BETWEEN 0 AND 100),
+  energy_before integer NOT NULL CHECK (energy_before BETWEEN 0 AND 100),
+  energy_after integer NOT NULL CHECK (energy_after BETWEEN 0 AND 100),
+  satisfaction_before integer NOT NULL CHECK (satisfaction_before BETWEEN 0 AND 100),
+  satisfaction_after integer NOT NULL CHECK (satisfaction_after BETWEEN 0 AND 100),
+  stamina_before integer NOT NULL CHECK (stamina_before BETWEEN 0 AND 100),
+  stamina_after integer NOT NULL CHECK (stamina_after BETWEEN 0 AND 100),
+  momentum_before integer NOT NULL CHECK (momentum_before BETWEEN -25 AND 25),
+  momentum_after integer NOT NULL CHECK (momentum_after BETWEEN -25 AND 25),
+  breakdown jsonb NOT NULL DEFAULT '[]'::jsonb,
+  highlights jsonb NOT NULL DEFAULT '[]'::jsonb,
+  incidents jsonb NOT NULL DEFAULT '[]'::jsonb,
+  resolved_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(segment_id),
+  UNIQUE(session_id, position)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_live_incidents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  segment_id uuid REFERENCES public.gig_live_segments(id) ON DELETE SET NULL,
+  incident_type text NOT NULL,
+  category text NOT NULL CHECK (category IN ('performance','equipment','production','crowd','venue','positive')),
+  severity text NOT NULL CHECK (severity IN ('minor','moderate','major','critical')),
+  status text NOT NULL DEFAULT 'open' CHECK (status IN ('open','awaiting_decision','resolved','expired','automatic','cancelled')),
+  decision_deadline timestamptz,
+  generation_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(session_id, segment_id, incident_type)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_live_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  incident_id uuid REFERENCES public.gig_live_incidents(id) ON DELETE SET NULL,
+  decision_type text NOT NULL,
+  selected_option text NOT NULL,
+  decided_by_player_id uuid REFERENCES public.profiles(user_id) ON DELETE SET NULL,
+  decision_source text NOT NULL CHECK (decision_source IN ('player','delegated_staff','automatic_fallback','system')),
+  requirements_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  outcome_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  decided_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(incident_id),
+  UNIQUE(session_id, decision_type, decided_at)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_live_setlist_changes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  change_type text NOT NULL CHECK (change_type IN ('skip','swap','replace','move_favourite','add_encore','remove_encore','shorten_set')),
+  requested_by_player_id uuid REFERENCES public.profiles(user_id) ON DELETE SET NULL,
+  change_source text NOT NULL CHECK (change_source IN ('player','automatic_fallback','system')),
+  before_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  after_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  validation_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  applied_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_live_sessions_band_status ON public.gig_live_sessions(band_id, status, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gig_live_segments_due ON public.gig_live_segments(status, planned_start_at, segment_index);
+CREATE INDEX IF NOT EXISTS idx_gig_live_song_results_gig ON public.gig_live_song_results(gig_id, position);
+CREATE INDEX IF NOT EXISTS idx_gig_live_incidents_session_status ON public.gig_live_incidents(session_id, status, decision_deadline);
+CREATE INDEX IF NOT EXISTS idx_gig_live_decisions_session ON public.gig_live_decisions(session_id, decided_at DESC);
+
+ALTER TABLE public.gig_live_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_live_segments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_live_song_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_live_incidents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_live_decisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_live_setlist_changes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Band members can view live sessions" ON public.gig_live_sessions FOR SELECT USING (EXISTS (SELECT 1 FROM public.band_members bm WHERE bm.band_id = gig_live_sessions.band_id AND bm.user_id = auth.uid()));
+CREATE POLICY "Band managers can manage live sessions" ON public.gig_live_sessions FOR ALL USING (public.is_band_leader_or_manager(band_id, auth.uid())) WITH CHECK (public.is_band_leader_or_manager(band_id, auth.uid()));
+CREATE POLICY "Band members can view live segments" ON public.gig_live_segments FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_live_sessions s JOIN public.band_members bm ON bm.band_id = s.band_id WHERE s.id = gig_live_segments.session_id AND bm.user_id = auth.uid()));
+CREATE POLICY "Band members can view live song results" ON public.gig_live_song_results FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_live_sessions s JOIN public.band_members bm ON bm.band_id = s.band_id WHERE s.id = gig_live_song_results.session_id AND bm.user_id = auth.uid()));
+CREATE POLICY "Band members can view live incidents" ON public.gig_live_incidents FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_live_sessions s JOIN public.band_members bm ON bm.band_id = s.band_id WHERE s.id = gig_live_incidents.session_id AND bm.user_id = auth.uid()));
+CREATE POLICY "Band members can view live decisions" ON public.gig_live_decisions FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_live_sessions s JOIN public.band_members bm ON bm.band_id = s.band_id WHERE s.id = gig_live_decisions.session_id AND bm.user_id = auth.uid()));
+CREATE POLICY "Band managers can insert live decisions" ON public.gig_live_decisions FOR INSERT WITH CHECK (EXISTS (SELECT 1 FROM public.gig_live_sessions s LEFT JOIN public.gig_live_incidents i ON i.id = gig_live_decisions.incident_id WHERE s.id = gig_live_decisions.session_id AND public.is_band_leader_or_manager(s.band_id, auth.uid()) AND (i.id IS NULL OR (i.status = 'awaiting_decision' AND i.decision_deadline > now()))));
+CREATE POLICY "Band members can view live setlist changes" ON public.gig_live_setlist_changes FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_live_sessions s JOIN public.band_members bm ON bm.band_id = s.band_id WHERE s.id = gig_live_setlist_changes.session_id AND bm.user_id = auth.uid()));
+
+CREATE OR REPLACE FUNCTION public.start_gig_live_session(p_gig_id uuid, p_initial_state jsonb, p_segments jsonb)
+RETURNS public.gig_live_sessions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_gig record; v_session public.gig_live_sessions; v_segment jsonb;
+BEGIN
+  SELECT id, band_id, status, scheduled_date INTO v_gig FROM public.gigs WHERE id = p_gig_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Gig not found'; END IF;
+  IF v_gig.status IN ('completed','cancelled','failed') THEN RAISE EXCEPTION 'Gig cannot start live session from terminal state'; END IF;
+  INSERT INTO public.gig_live_sessions(gig_id, band_id, status, started_at, expected_end_at, current_segment_index, crowd_energy, fan_satisfaction, performance_quality, band_stamina, momentum, incident_risk, simulation_version, last_processed_at, config_snapshot)
+  VALUES (p_gig_id, v_gig.band_id, COALESCE(p_initial_state->>'status','live'), COALESCE((p_initial_state->>'startedAt')::timestamptz, now()), (p_initial_state->>'expectedEndAt')::timestamptz, COALESCE((p_initial_state->>'currentSegmentIndex')::integer,0), COALESCE((p_initial_state->>'crowdEnergy')::integer,50), COALESCE((p_initial_state->>'fanSatisfaction')::integer,50), COALESCE((p_initial_state->>'performanceQuality')::integer,0), COALESCE((p_initial_state->>'bandStamina')::integer,85), COALESCE((p_initial_state->>'momentum')::integer,0), COALESCE((p_initial_state->>'incidentRisk')::integer,0), COALESCE((p_initial_state->>'simulationVersion')::integer,1), now(), COALESCE(p_initial_state->'configSnapshot','{}'::jsonb))
+  ON CONFLICT (gig_id) DO UPDATE SET gig_id = EXCLUDED.gig_id
+  RETURNING * INTO v_session;
+
+  IF NOT EXISTS (SELECT 1 FROM public.gig_live_segments WHERE session_id = v_session.id) THEN
+    FOR v_segment IN SELECT * FROM jsonb_array_elements(p_segments) LOOP
+      INSERT INTO public.gig_live_segments(session_id, segment_index, segment_type, setlist_item_id, song_id, planned_start_at, planned_duration_seconds, status, result_snapshot)
+      VALUES (v_session.id, (v_segment->>'segmentIndex')::integer, v_segment->>'segmentType', NULLIF(v_segment->>'setlistItemId','')::uuid, NULLIF(v_segment->>'songId','')::uuid, (v_segment->>'plannedStartAt')::timestamptz, (v_segment->>'plannedDurationSeconds')::integer, COALESCE(v_segment->>'status','pending'), COALESCE(v_segment->'resultSnapshot','{}'::jsonb))
+      ON CONFLICT (session_id, segment_index) DO NOTHING;
+    END LOOP;
+  END IF;
+  RETURN v_session;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.commit_gig_live_decision(p_incident_id uuid, p_option_key text, p_outcome jsonb DEFAULT '{}'::jsonb)
+RETURNS public.gig_live_decisions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_incident public.gig_live_incidents; v_session public.gig_live_sessions; v_decision public.gig_live_decisions;
+BEGIN
+  SELECT * INTO v_incident FROM public.gig_live_incidents WHERE id = p_incident_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Live incident not found'; END IF;
+  SELECT * INTO v_session FROM public.gig_live_sessions WHERE id = v_incident.session_id FOR UPDATE;
+  IF NOT public.is_band_leader_or_manager(v_session.band_id, auth.uid()) THEN RAISE EXCEPTION 'Not authorised to decide this live incident'; END IF;
+  IF v_incident.status <> 'awaiting_decision' OR v_incident.decision_deadline <= now() THEN RAISE EXCEPTION 'Live decision window is closed'; END IF;
+  INSERT INTO public.gig_live_decisions(session_id, incident_id, decision_type, selected_option, decided_by_player_id, decision_source, requirements_snapshot, outcome_snapshot)
+  VALUES (v_session.id, p_incident_id, COALESCE(v_incident.generation_snapshot->>'decisionType','incident_response'), p_option_key, auth.uid(), 'player', COALESCE(v_incident.generation_snapshot->'requirements','{}'::jsonb), p_outcome)
+  ON CONFLICT (incident_id) DO UPDATE SET incident_id = EXCLUDED.incident_id
+  RETURNING * INTO v_decision;
+  UPDATE public.gig_live_incidents SET status = 'resolved', result_snapshot = result_snapshot || p_outcome, updated_at = now() WHERE id = p_incident_id;
+  UPDATE public.gig_live_sessions SET status = 'live', updated_at = now() WHERE id = v_session.id AND status = 'paused_for_decision';
+  RETURN v_decision;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.expire_gig_live_decisions(p_now timestamptz DEFAULT now())
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_count integer;
+BEGIN
+  WITH expired AS (
+    UPDATE public.gig_live_incidents SET status = 'expired', updated_at = now()
+    WHERE status = 'awaiting_decision' AND decision_deadline <= p_now
+    RETURNING *
+  ), inserted AS (
+    INSERT INTO public.gig_live_decisions(session_id, incident_id, decision_type, selected_option, decision_source, requirements_snapshot, outcome_snapshot)
+    SELECT session_id, id, COALESCE(generation_snapshot->>'decisionType','incident_response'), COALESCE(generation_snapshot->>'recommendedFallback','automatic_fallback'), 'automatic_fallback', COALESCE(generation_snapshot->'requirements','{}'::jsonb), jsonb_build_object('fallbackAppliedAt', p_now, 'reason', 'Live decision deadline expired') FROM expired
+    ON CONFLICT (incident_id) DO NOTHING RETURNING id
+  ) SELECT count(*) INTO v_count FROM inserted;
+  UPDATE public.gig_live_sessions s SET status = 'live', updated_at = now() WHERE status = 'paused_for_decision' AND NOT EXISTS (SELECT 1 FROM public.gig_live_incidents i WHERE i.session_id = s.id AND i.status = 'awaiting_decision');
+  RETURN v_count;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.mark_gig_live_segment_resolved(p_segment_id uuid, p_result jsonb DEFAULT '{}'::jsonb)
+RETURNS public.gig_live_segments
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_segment public.gig_live_segments;
+BEGIN
+  UPDATE public.gig_live_segments SET status = 'resolved', started_at = COALESCE(started_at, now()), resolved_at = COALESCE(resolved_at, now()), result_snapshot = CASE WHEN status = 'resolved' THEN result_snapshot ELSE p_result END, updated_at = now()
+  WHERE id = p_segment_id AND status IN ('pending','active')
+  RETURNING * INTO v_segment;
+  IF NOT FOUND THEN SELECT * INTO v_segment FROM public.gig_live_segments WHERE id = p_segment_id; END IF;
+  RETURN v_segment;
+END; $$;
+
+REVOKE ALL ON FUNCTION public.start_gig_live_session(uuid,jsonb,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.start_gig_live_session(uuid,jsonb,jsonb) TO service_role;
+REVOKE ALL ON FUNCTION public.commit_gig_live_decision(uuid,text,jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.commit_gig_live_decision(uuid,text,jsonb) TO authenticated;
+REVOKE ALL ON FUNCTION public.expire_gig_live_decisions(timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.expire_gig_live_decisions(timestamptz) TO service_role;
+REVOKE ALL ON FUNCTION public.mark_gig_live_segment_resolved(uuid,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_gig_live_segment_resolved(uuid,jsonb) TO service_role;
+
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS live_session_id uuid REFERENCES public.gig_live_sessions(id) ON DELETE SET NULL;
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS live_result_snapshot jsonb;
+ALTER TABLE public.gig_outcomes ADD COLUMN IF NOT EXISTS live_simulation_version integer;

--- a/supabase/tests/gig_live_timeline_harness.sql
+++ b/supabase/tests/gig_live_timeline_harness.sql
@@ -1,0 +1,22 @@
+-- Harness assertions for Gig Preparation Phase 6 live timeline schema.
+BEGIN;
+
+SELECT plan(14);
+
+SELECT has_table('public', 'gig_live_sessions', 'live sessions table exists');
+SELECT has_table('public', 'gig_live_segments', 'live segments table exists');
+SELECT has_table('public', 'gig_live_song_results', 'live song results table exists');
+SELECT has_table('public', 'gig_live_incidents', 'live incidents table exists');
+SELECT has_table('public', 'gig_live_decisions', 'live decisions table exists');
+SELECT has_table('public', 'gig_live_setlist_changes', 'live setlist changes table exists');
+SELECT col_is_unique('public', 'gig_live_sessions', ARRAY['gig_id'], 'one live session per gig');
+SELECT col_is_unique('public', 'gig_live_segments', ARRAY['session_id', 'segment_index'], 'segments generate once per index');
+SELECT col_is_unique('public', 'gig_live_song_results', ARRAY['segment_id'], 'song result cannot reroll per segment');
+SELECT col_is_unique('public', 'gig_live_incidents', ARRAY['session_id', 'segment_id', 'incident_type'], 'incident cannot reroll per segment/type');
+SELECT has_function('public', 'start_gig_live_session', ARRAY['uuid', 'jsonb', 'jsonb'], 'idempotent live session starter exists');
+SELECT has_function('public', 'commit_gig_live_decision', ARRAY['uuid', 'text', 'jsonb'], 'decision commit function exists');
+SELECT has_function('public', 'expire_gig_live_decisions', ARRAY['timestamp with time zone'], 'decision expiry function exists');
+SELECT has_function('public', 'mark_gig_live_segment_resolved', ARRAY['uuid', 'jsonb'], 'idempotent segment resolve function exists');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Implement the Phase 6 server-authoritative live gig experience so scheduled performances progress song-by-song using persisted timeline state rather than a second, client-driven resolution engine. 
- Make live gigs continue when players are offline, persist every song result and incident, and allow a small set of meaningful tactical decisions with automatic fallback and idempotent processing. 
- Lay foundations for later visual presentation and replay by providing deterministic per-song resolution, incident/decision models, projection snapshots, and admin/diagnostic RPCs. 

### Description
- Added a backend simulation library `src/utils/gigLive.ts` implementing lifecycle checks (`canStartLiveGig`), deterministic timeline generation (`buildLiveTimeline`), per-song resolution (`resolveLiveSong`), incident generation (`maybeGenerateLiveIncident`), tactical decision builders (`buildTacticalDecision`), tactical consequence application (`applyTacticalConsequence`), live setlist change validation, encore/curfew checks, and finalization (`finalizeLiveGig`). 
- Introduced a database migration `supabase/migrations/20260711223000_gig_live_timeline.sql` creating `gig_live_sessions`, `gig_live_segments`, `gig_live_song_results`, `gig_live_incidents`, `gig_live_decisions`, and `gig_live_setlist_changes` with RLS, indexes and idempotency-guard columns, plus server RPCs `start_gig_live_session`, `commit_gig_live_decision`, `expire_gig_live_decisions`, and `mark_gig_live_segment_resolved`. 
- Added a lightweight UI component `src/components/gig/LiveGigTimelineDashboard.tsx` to render authoritative session state, timeline, metrics, recent highlights, and active tactical decisions without requiring a real-time game engine. 
- Included determinism and balancing constants via `DEFAULT_LIVE_GIG_CONFIG`, deterministic seeding helper `deterministicRandom`, explainable breakdowns for song results, and idempotency keys for downstream reward/finance processing. 
- Added unit tests `src/utils/__tests__/gigLive.test.ts`, a Supabase harness `supabase/tests/gig_live_timeline_harness.sql`, and documentation `docs/gigs/live-gig-timeline.md` describing inspected architecture, timeline rules, formulas, scheduling/catch-up approach, and limitations. 

### Testing
- Attempted to run unit tests with `npm run test:unit -- src/utils/__tests__/gigLive.test.ts`, but the runner failed because `vitest` was not available in the environment so the unit suite could not execute (failed). 
- Attempted `npm install` to provision dev tooling, but install failed due to a `403 Forbidden` response for `@react-three/fiber` from the npm registry which prevented running the full test matrix (failed). 
- Added a database test harness `supabase/tests/gig_live_timeline_harness.sql` asserting table and RPC presence and uniqueness constraints, but the harness was not executed in this environment (not run). 
- All new DB functions and schema include uniqueness and idempotency guards so scheduled workers and lazy catch-up processing can be exercised by CI or local Supabase tests when dependencies and the DB harness are available (manual/CI verification required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52d68a00008325800f8aea2f25952c)