### PR TITLE
feat: add immersive live gig presentation and audience reactions

### DIFF
--- a/docs/gigs/live-gig-presentation.md
+++ b/docs/gigs/live-gig-presentation.md
@@ -1,0 +1,56 @@
+# Live gig presentation and audience experience
+
+This phase adds a presentation layer above the server-authoritative live gig timeline. It does not replace live session, segment, song-result, incident, tactical-decision, or completion calculations.
+
+## Existing implementation inspected
+
+- Live lifecycle is documented in `docs/gigs/live-gig-timeline.md`: sessions move through scheduled, preshow, ready, live, paused-for-decision, resolving, completed, cancelled, and failed states.
+- Authoritative types and deterministic helpers live in `src/utils/gigLive.ts`.
+- `LiveGigTimelineDashboard` already renders session metrics, timeline rows, highlights, incidents, and tactical decisions.
+- `TopDownGigViewer` is an older client-heavy viewer with local commentary/audio behaviours; the new presentation layer avoids relying on it for authoritative live facts.
+- Completed gig replay lives under `src/features/gig-experience/viewer`, with reduced-motion and canvas conventions suitable for future reuse.
+- Completed gig reports use `GigOutcomeReport` and the `GigExperienceDTO` read model, with legacy fallback behaviour for older gigs.
+
+## Architecture
+
+`buildLiveGigPresentationState` consumes persisted live state and maps it to display state:
+
+- current segment and scene;
+- current song profile;
+- crowd energy, fan satisfaction, stamina, and momentum;
+- venue tier and density;
+- production plan, lighting state, and active effects;
+- performer roles, instruments, stamina, and incident involvement;
+- tactical decision state;
+- commentary derived from persisted highlights, incidents, and decision metadata.
+
+The output is deterministic and can be rebuilt after refresh, reconnect, app backgrounding, or SSE/polling recovery without replaying old animations.
+
+## Stage layouts and performer positioning
+
+Initial layouts are solo, duo, three-piece, four-piece, five-piece, six-plus, festival stage, and small club. Positioning is role-based: lead vocalists at centre-front, drums rear-centre, bass/guitar near front sides, keys/DJ side or rear, and fallback performers spread across the stage. Existing explicit stage positions take precedence.
+
+## Venue, crowd, lighting, and effects
+
+Venue tiers are small bar, local club, theatre, music hall, large venue, arena, stadium, and festival stage. Crowd density is capped and derived from attendance/capacity, so low-attendance gigs look sparse and sell-outs are dense without one DOM node per fan.
+
+Crowd states map from authoritative crowd energy with attendance and incident overrides. Lighting reflects segment type, song tempo/mood, package labels, crowd intensity, and production incidents. Effects only render from the supplied production plan and are filtered when disabled or when reduced-motion/data-only modes are active.
+
+## Accessibility and performance
+
+The React presentation component provides reduced, minimal, and data-only modes; a screen-reader summary; labelled metric bars; keyboard-accessible decision buttons; no unsafe rapid flashing; bounded crowd elements; and no continuous simulation loop.
+
+## End-of-show and reports
+
+This PR establishes the state mapping needed by a polished completion sequence and immediate summary. The existing completed report remains the authoritative detailed surface and older gigs continue to use existing fallbacks. Future work can persist final presentation snapshots/highlight records if product requirements demand historical share cards.
+
+## Spectator extension points
+
+The presentation state separates view-only display from management controls. Tactical option submission remains controlled by existing permissions and callbacks; future spectator modes can consume the same display state while omitting private crew, health, and finance details.
+
+## Known limitations
+
+- No new database migration is included.
+- The first stage view is DOM/CSS based rather than WebGL or a game engine.
+- Highlight persistence and venue/band history records are foundations only; automatic public sharing is intentionally out of scope.
+- Older `TopDownGigViewer` remains available until the live route is fully migrated to the server timeline dashboard.

--- a/src/components/gig/LiveGigPresentation.tsx
+++ b/src/components/gig/LiveGigPresentation.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import type { GigLiveSegment, LiveGigSessionState, LiveIncident, LiveSongResult, TacticalDecision } from '@/utils/gigLive';
+import { buildLiveGigPresentationState, type LiveGigPerformerInput, type LiveGigProductionInput, type LiveGigSongPresentationInput, type LiveGigVenueInput } from '@/utils/gigLivePresentation';
+
+interface Props {
+  session: LiveGigSessionState;
+  segments: GigLiveSegment[];
+  songResults: Array<LiveSongResult & { segmentIndex: number; title?: string; song?: LiveGigSongPresentationInput }>;
+  incidents?: LiveIncident[];
+  activeDecision?: TacticalDecision | null;
+  canDecide?: boolean;
+  onSelectDecision?: (optionKey: string) => void;
+  venue?: LiveGigVenueInput | null;
+  production?: LiveGigProductionInput | null;
+  performers?: LiveGigPerformerInput[];
+}
+
+export function LiveGigPresentation({ session, segments, songResults, incidents = [], activeDecision, canDecide = false, onSelectDecision, venue, production, performers = [] }: Props) {
+  const [quality, setQuality] = useState<'full' | 'reduced' | 'minimal' | 'data'>('full');
+  const current = segments.find((s) => s.segmentIndex === session.currentSegmentIndex) ?? segments.find((s) => s.status === 'active') ?? segments[0];
+  const currentSong = current?.songId ? songResults.find((r) => r.segmentIndex === current.segmentIndex)?.song ?? { id: current.songId, title: songResults.find((r) => r.segmentIndex === current.segmentIndex)?.title } : null;
+  const presentation = useMemo(() => buildLiveGigPresentationState({ session, segments, songResults, incidents, activeDecision, venue, production, performers, currentSong, reducedMotion: quality !== 'full', dataOnly: quality === 'data' }), [session, segments, songResults, incidents, activeDecision, venue, production, performers, currentSong, quality]);
+
+  return (
+    <Card className="overflow-hidden border-primary/30">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle className="text-xl">Live stage presentation</CardTitle>
+            <p className="text-sm text-muted-foreground">Server-authoritative concert view · {presentation.stageLayout.replaceAll('_', ' ')} · {presentation.venueTier.replaceAll('_', ' ')}</p>
+          </div>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Presentation quality settings">
+            {(['full', 'reduced', 'minimal', 'data'] as const).map((mode) => <Button key={mode} type="button" size="sm" variant={quality === mode ? 'default' : 'outline'} onClick={() => setQuality(mode)}>{mode === 'data' ? 'Data-only' : mode}</Button>)}
+          </div>
+        </div>
+        <p className="sr-only" aria-live="polite">{presentation.accessibilitySummary}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {quality !== 'data' ? (
+          <div className="relative min-h-[330px] overflow-hidden rounded-2xl border bg-slate-950 text-white shadow-inner" data-scene={presentation.scene}>
+            <div className="absolute inset-0 bg-gradient-to-b from-indigo-950 via-slate-900 to-black" />
+            <div className={`absolute inset-0 opacity-70 ${presentation.lightingState === 'warm_wash' ? 'bg-amber-500/20' : presentation.lightingState === 'cool_wash' ? 'bg-cyan-500/20' : presentation.lightingState === 'failure_state' ? 'bg-red-950/40' : presentation.lightingState.includes('spot') ? 'bg-yellow-200/10' : 'bg-purple-500/10'}`} aria-hidden="true" />
+            <div className="absolute left-4 right-4 top-4 flex flex-wrap items-center justify-between gap-2">
+              <Badge>{presentation.scene}</Badge>
+              <Badge variant="secondary">{presentation.currentSongProfile.performanceLabel}</Badge>
+            </div>
+            <div className="absolute left-[8%] right-[8%] top-[24%] h-[44%] rounded-t-[48%] border border-white/15 bg-black/40 shadow-2xl">
+              <div className="absolute inset-x-[12%] top-3 h-10 rounded-full bg-white/10 blur-lg" />
+              {presentation.activeEffects.map((effect, index) => <span key={effect} className="absolute rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs" style={{ left: `${16 + index * 15}%`, top: `${18 + (index % 2) * 44}%` }}>{effect}</span>)}
+              {presentation.performerStates.map((performer) => (
+                <div key={performer.id} className="absolute -translate-x-1/2 -translate-y-1/2 text-center" style={{ left: `${performer.x}%`, top: `${performer.y}%` }}>
+                  <div className={`mx-auto flex h-14 w-10 items-center justify-center rounded-t-full border text-xl shadow-lg ${performer.visualState === 'incident_affected' ? 'border-red-300 bg-red-600/70' : performer.visualState === 'standout_performance' ? 'border-yellow-200 bg-yellow-500/60' : 'border-white/30 bg-slate-700/80'}`} aria-hidden="true">{performer.instrumentLabel.includes('Drum') ? '🥁' : performer.instrumentLabel.includes('Bass') ? '🎸' : performer.instrumentLabel.includes('guitar') ? '🎸' : performer.instrumentLabel.includes('Keyboard') ? '🎹' : performer.instrumentLabel.includes('Microphone') ? '🎤' : '🎵'}</div>
+                  <div className="mt-1 max-w-24 rounded bg-black/60 px-1 text-[10px]">{performer.name}<br />{performer.visualState.replaceAll('_', ' ')}</div>
+                </div>
+              ))}
+            </div>
+            <div className="absolute bottom-0 left-0 right-0 h-[28%] border-t border-white/10 bg-gradient-to-t from-black via-slate-900/95 to-transparent">
+              <div className="absolute inset-x-3 bottom-3 grid grid-cols-8 gap-1" aria-hidden="true">
+                {Array.from({ length: Math.max(2, Math.min(24, Math.round(presentation.crowdDensity / 4))) }).map((_, index) => <div key={index} className={`rounded-t-full bg-white/30 ${quality === 'full' && presentation.intensity > 65 ? 'animate-pulse' : ''}`} style={{ height: index % 3 === 0 ? '3rem' : '2.25rem' }} />)}
+              </div>
+              <div className="absolute bottom-2 left-4 rounded bg-black/60 px-2 py-1 text-xs">Crowd: {presentation.crowdState.replaceAll('_', ' ')} · density {presentation.crowdDensity}%</div>
+            </div>
+            <div className="absolute bottom-4 right-4 max-w-xs rounded-lg bg-black/70 p-3 text-sm">
+              <div className="font-semibold">{presentation.headline}</div>
+              <div className="text-white/75">{presentation.currentSongProfile.genre} · {presentation.currentSongProfile.tempoLabel}</div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-3 md:grid-cols-4">
+          <Metric label="Crowd energy" value={session.crowdEnergy} note={presentation.crowdState.replaceAll('_', ' ')} />
+          <Metric label="Fan satisfaction" value={session.fanSatisfaction} note={session.fanSatisfaction >= 70 ? 'strong response' : 'building'} />
+          <Metric label="Band stamina" value={session.bandStamina} note={session.bandStamina < 30 ? 'fatigue risk' : 'available'} />
+          <Metric label="Momentum" value={session.momentum} note={session.momentum >= 0 ? 'positive flow' : 'recovery needed'} signed />
+        </div>
+
+        {activeDecision ? (
+          <div className="rounded-lg border border-amber-400 bg-amber-50 p-3 text-sm dark:bg-amber-950/20" role="region" aria-label="Tactical decision presentation">
+            <div className="font-semibold">Decision open · fallback {activeDecision.recommendedFallback.replaceAll('_', ' ')}</div>
+            <p className="text-muted-foreground">Deadline window: {Math.round(activeDecision.deadlineSeconds / 60)} min game time. Visual distraction is reduced while options are available.</p>
+            <div className="mt-2 grid gap-2 sm:grid-cols-3">
+              {activeDecision.options.map((option) => <Button key={option.key} type="button" variant={option.safeFallback ? 'default' : 'outline'} disabled={!canDecide} onClick={() => onSelectDecision?.(option.key)} aria-label={`${option.label}. ${option.safeFallback ? 'Automatic fallback option.' : 'Tactical option.'}`}>{option.label}</Button>)}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="rounded-lg border p-3">
+            <h4 className="font-semibold">Visual setlist timeline</h4>
+            <div className="mt-3 flex gap-2 overflow-x-auto pb-2" role="list" aria-label="Live setlist timeline">
+              {segments.map((segment) => <div key={segment.segmentIndex} className="min-w-32 rounded-md border p-2 text-xs" role="listitem"><div className="font-medium">{segment.segmentType.replaceAll('_', ' ')}</div><Badge variant={segment.segmentIndex === current?.segmentIndex ? 'default' : segment.status === 'resolved' ? 'secondary' : 'outline'}>{segment.status}</Badge></div>)}
+            </div>
+          </div>
+          <div className="rounded-lg border p-3">
+            <h4 className="font-semibold">Live commentary</h4>
+            <ul className="mt-2 space-y-2 text-sm" aria-label="Presentation commentary feed">
+              {presentation.commentary.slice(-5).map((line) => <li key={line}>{line}</li>)}
+            </ul>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value, note, signed = false }: { label: string; value: number; note: string; signed?: boolean }) {
+  const pct = signed ? Math.min(100, Math.max(0, 50 + value * 4)) : value;
+  return <div className="rounded-lg border p-3"><div className="flex items-center justify-between gap-2"><span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span><span className="font-semibold">{signed && value > 0 ? '+' : ''}{value}</span></div><Progress value={pct} aria-label={label} /><p className="mt-1 text-xs text-muted-foreground">{note}</p></div>;
+}

--- a/src/components/gig/LiveGigTimelineDashboard.tsx
+++ b/src/components/gig/LiveGigTimelineDashboard.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import type { GigLiveSegment, LiveGigSessionState, LiveIncident, LiveSongResult, TacticalDecision } from '@/utils/gigLive';
+import { LiveGigPresentation } from './LiveGigPresentation';
 
 export interface LiveGigTimelineDashboardProps {
   session: LiveGigSessionState;
@@ -20,6 +21,15 @@ export function LiveGigTimelineDashboard({ session, segments, songResults, incid
 
   return (
     <div className="space-y-4" aria-live="polite">
+      <LiveGigPresentation
+        session={session}
+        segments={segments}
+        songResults={songResults}
+        incidents={incidents}
+        activeDecision={activeDecision}
+        canDecide={canDecide}
+        onSelectDecision={onSelectDecision}
+      />
       <Card>
         <CardHeader className="space-y-2">
           <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/utils/__tests__/gigLivePresentation.test.ts
+++ b/src/utils/__tests__/gigLivePresentation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { GigLiveSegment, LiveGigSessionState } from '../gigLive';
+import { buildLiveGigPresentationState, buildStageLayout, calculateCrowdDensity, mapCrowdEnergyToPresentation, mapLightingState, mapProductionPlanToVisualEffects, mapVenueToTier } from '../gigLivePresentation';
+
+const session: LiveGigSessionState = { gigId: 'gig-1', bandId: 'band-1', status: 'live', startedAt: '2026-01-01T20:00:00Z', currentSegmentIndex: 1, crowdEnergy: 74, fanSatisfaction: 68, performanceQuality: 70, bandStamina: 82, momentum: 5, incidentRisk: 12, simulationVersion: 1 };
+const segments: GigLiveSegment[] = [
+  { segmentIndex: 0, segmentType: 'intro', plannedStartAt: session.startedAt, plannedDurationSeconds: 90, status: 'resolved' },
+  { segmentIndex: 1, segmentType: 'song', songId: 'song-1', plannedStartAt: session.startedAt, plannedDurationSeconds: 210, status: 'active' },
+  { segmentIndex: 2, segmentType: 'outro', plannedStartAt: session.startedAt, plannedDurationSeconds: 90, status: 'pending' },
+];
+
+describe('gig live presentation mapping', () => {
+  it('builds deterministic song presentation state from authoritative live values', () => {
+    const input = { session, segments, venue: { name: 'Ruby Club', capacity: 300, attendance: 240 }, production: { lightingPackage: 'cool led', effects: ['haze', 'confetti'] }, performers: [{ id: 'p1', name: 'Ari', role: 'lead vocalist', instrument: 'microphone', isLead: true }, { id: 'p2', name: 'Bo', role: 'drummer', instrument: 'drums' }], currentSong: { id: 'song-1', title: 'Neon Hearts', genre: 'rock', tempo: 142, popularity: 78 } };
+    expect(buildLiveGigPresentationState(input)).toEqual(buildLiveGigPresentationState(input));
+    const state = buildLiveGigPresentationState(input);
+    expect(state.scene).toBe('song');
+    expect(state.crowdState).toBe('clapping');
+    expect(state.venueTier).toBe('local_club');
+    expect(state.activeEffects).toEqual(['haze', 'confetti']);
+    expect(state.performerStates[0]).toMatchObject({ x: 50, y: 70, instrumentLabel: 'Microphone' });
+    expect(state.performerStates[1]).toMatchObject({ x: 50, y: 32, instrumentLabel: 'Drum kit' });
+  });
+
+  it('maps crowd energy and attendance density without overfilling low-attendance gigs', () => {
+    expect(mapCrowdEnergyToPresentation(18, 10, 200)).toBe('sparse');
+    expect(mapCrowdEnergyToPresentation(95, 195, 200)).toBe('ecstatic');
+    expect(calculateCrowdDensity(10, 200)).toBe(5);
+    expect(calculateCrowdDensity(250, 200)).toBe(96);
+  });
+
+  it('supports venue tiers and reusable band-size layouts', () => {
+    expect(mapVenueToTier({ capacity: 90 })).toBe('small_bar');
+    expect(mapVenueToTier({ capacity: 18000 })).toBe('arena');
+    expect(mapVenueToTier({ capacity: 40000, isFestival: true })).toBe('festival_stage');
+    expect(buildStageLayout([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }])).toBe('three_piece');
+    expect(buildStageLayout(new Array(7).fill(null).map((_, i) => ({ id: String(i), name: `P${i}` })))).toBe('six_plus');
+  });
+
+  it('respects production incidents and reduced motion for lighting and effects', () => {
+    const incident = { incidentType: 'production_cue_failure', category: 'production' as const, severity: 'moderate' as const, title: 'Lighting cue fails', generationSnapshot: {}, resultSnapshot: {} };
+    const base = { session, segments, incidents: [incident], currentSong: { title: 'Ballad', tempo: 70 }, production: { lightingPackage: 'dramatic', effects: ['haze', 'pyro_burst', 'projection'] } };
+    expect(mapLightingState(base, 'song')).toBe('failure_state');
+    expect(mapProductionPlanToVisualEffects(base.production, [incident], 'song', true)).toEqual(['haze', 'projection']);
+  });
+
+  it('surfaces decisions, fallback copy, and incident-affected performers', () => {
+    const state = buildLiveGigPresentationState({ session: { ...session, status: 'paused_for_decision' }, segments, activeDecision: { decisionType: 'equipment_response', deadlineSeconds: 420, recommendedFallback: 'use_spare', options: [] }, incidents: [{ incidentType: 'equipment_fault', category: 'equipment', severity: 'major', title: 'Amp failure', generationSnapshot: {}, resultSnapshot: {} }], performers: [{ id: 'g', name: 'Gale', instrument: 'electric guitar' }] });
+    expect(state.scene).toBe('decision');
+    expect(state.headline).toBe('Tactical decision available');
+    expect(state.performerStates[0].visualState).toBe('incident_affected');
+    expect(state.commentary.join(' ')).toContain('Decision fallback');
+  });
+});

--- a/src/utils/gigLivePresentation.ts
+++ b/src/utils/gigLivePresentation.ts
@@ -1,0 +1,143 @@
+import type { GigLiveSegment, LiveGigSessionState, LiveIncident, LiveSegmentType, LiveSongResult, TacticalDecision } from './gigLive';
+
+export type LivePresentationScene = 'intro' | 'song' | 'transition' | 'incident' | 'decision' | 'encore' | 'outro';
+export type CrowdPresentationState = 'sparse' | 'waiting' | 'bored' | 'passive' | 'swaying' | 'engaged' | 'clapping' | 'hands_raised' | 'jumping' | 'singing' | 'wild' | 'ecstatic' | 'disappointed' | 'leaving_early';
+export type LightingPresentationState = 'house_lights' | 'basic_wash' | 'warm_wash' | 'cool_wash' | 'spotlights' | 'pulsing' | 'dramatic_silhouette' | 'encore_lighting' | 'finale_lighting' | 'failure_state';
+export type VenuePresentationTier = 'small_bar' | 'local_club' | 'theatre' | 'music_hall' | 'large_venue' | 'arena' | 'stadium' | 'festival_stage';
+export type StageLayoutKey = 'solo' | 'duo' | 'three_piece' | 'four_piece' | 'five_piece' | 'six_plus' | 'festival_stage' | 'small_club';
+export type PerformerVisualState = 'waiting' | 'performing' | 'energetic' | 'focused' | 'struggling' | 'recovering' | 'celebrating' | 'incident_affected' | 'standout_performance' | 'absent';
+
+export interface LiveGigPerformerInput { id: string; name: string; role?: string | null; instrument?: string | null; isLead?: boolean | null; stamina?: number | null; available?: boolean | null; avatarUrl?: string | null; portraitUrl?: string | null; stagePosition?: { x: number; y: number } | null; }
+export interface LiveGigVenueInput { name?: string | null; capacity?: number | null; venueType?: string | null; isOutdoor?: boolean | null; stageSize?: string | null; quality?: number | null; productionCapability?: number | null; isFestival?: boolean | null; attendance?: number | null; }
+export interface LiveGigProductionInput { lightingPackage?: string | null; effects?: string[] | null; disabledEffects?: string[] | null; productionQuality?: number | null; soundQuality?: number | null; }
+export interface LiveGigSongPresentationInput { id?: string | null; title?: string | null; genre?: string | null; tempo?: number | null; mood?: string | null; popularity?: number | null; quality?: number | null; durationSeconds?: number | null; position?: number | null; isEncore?: boolean | null; }
+export interface BuildLiveGigPresentationInput { session: LiveGigSessionState; segments: GigLiveSegment[]; songResults?: Array<LiveSongResult & { segmentIndex: number; title?: string; song?: LiveGigSongPresentationInput }>; incidents?: LiveIncident[]; activeDecision?: TacticalDecision | null; venue?: LiveGigVenueInput | null; production?: LiveGigProductionInput | null; performers?: LiveGigPerformerInput[]; currentSong?: LiveGigSongPresentationInput | null; canManage?: boolean; reducedMotion?: boolean; dataOnly?: boolean; }
+
+export interface PerformerPresentationState extends LiveGigPerformerInput { visualState: PerformerVisualState; x: number; y: number; instrumentLabel: string; representation: 'full_body_avatar' | 'portrait_avatar' | 'role_silhouette' | 'generic_fallback'; focusReason?: string; }
+export interface LiveGigPresentationState { scene: LivePresentationScene; intensity: number; crowdState: CrowdPresentationState; crowdDensity: number; venueTier: VenuePresentationTier; stageLayout: StageLayoutKey; lightingState: LightingPresentationState; productionState: string; performerStates: PerformerPresentationState[]; activeEffects: string[]; headline: string; commentary: string[]; currentSongProfile: { title: string; phase: string; genre: string; tempoLabel: string; moodLabel: string; isCrowdFavourite: boolean; performanceLabel: string; }; accessibilitySummary: string; }
+
+const clamp = (n: number, min = 0, max = 100) => Math.max(min, Math.min(max, n));
+
+export function mapLiveSegmentToScene(type?: LiveSegmentType, hasDecision = false, hasIncident = false): LivePresentationScene {
+  if (hasDecision) return 'decision';
+  if (hasIncident || type === 'incident') return 'incident';
+  if (type === 'encore_break' || type === 'encore_song') return 'encore';
+  if (type === 'song') return 'song';
+  if (type === 'intro' || !type) return 'intro';
+  if (type === 'outro') return 'outro';
+  return 'transition';
+}
+
+export function mapCrowdEnergyToPresentation(energy: number, attendance = 0, capacity = 0, incident?: LiveIncident | null): CrowdPresentationState {
+  const sellThrough = capacity > 0 ? attendance / capacity : 0.5;
+  if (incident?.category === 'crowd' && incident.severity !== 'minor') return 'disappointed';
+  if (sellThrough < 0.15) return energy < 35 ? 'sparse' : 'passive';
+  if (energy < 20) return 'leaving_early';
+  if (energy < 32) return 'bored';
+  if (energy < 45) return 'passive';
+  if (energy < 56) return 'swaying';
+  if (energy < 66) return 'engaged';
+  if (energy < 76) return 'clapping';
+  if (energy < 84) return 'hands_raised';
+  if (energy < 92) return 'wild';
+  return 'ecstatic';
+}
+
+export function mapVenueToTier(venue?: LiveGigVenueInput | null): VenuePresentationTier {
+  if (venue?.isFestival || /festival/i.test(venue?.venueType ?? '')) return 'festival_stage';
+  const capacity = venue?.capacity ?? 120;
+  if (capacity <= 120) return 'small_bar';
+  if (capacity <= 450) return 'local_club';
+  if (capacity <= 1000) return 'theatre';
+  if (capacity <= 2500) return 'music_hall';
+  if (capacity <= 8000) return 'large_venue';
+  if (capacity <= 22000) return 'arena';
+  return 'stadium';
+}
+
+export function calculateCrowdDensity(attendance = 0, capacity = 0): number {
+  if (capacity <= 0) return 45;
+  return Math.round(clamp((attendance / capacity) * 100, 4, 96));
+}
+
+export function buildStageLayout(performers: LiveGigPerformerInput[], venue?: LiveGigVenueInput | null): StageLayoutKey {
+  if (venue?.isFestival || /festival/i.test(venue?.venueType ?? '')) return 'festival_stage';
+  if ((venue?.capacity ?? 999) <= 180) return 'small_club';
+  if (performers.length <= 1) return 'solo';
+  if (performers.length === 2) return 'duo';
+  if (performers.length === 3) return 'three_piece';
+  if (performers.length === 4) return 'four_piece';
+  if (performers.length === 5) return 'five_piece';
+  return 'six_plus';
+}
+
+function positionFor(performer: LiveGigPerformerInput, index: number, total: number): { x: number; y: number } {
+  if (performer.stagePosition) return performer.stagePosition;
+  const role = `${performer.role ?? ''} ${performer.instrument ?? ''}`.toLowerCase();
+  if (performer.isLead || /lead|vocal|singer|front/.test(role)) return { x: 50, y: 70 };
+  if (/drum|percussion/.test(role)) return { x: 50, y: 32 };
+  if (/bass/.test(role)) return { x: 72, y: 58 };
+  if (/guitar/.test(role)) return { x: index % 2 ? 28 : 68, y: 60 };
+  if (/key|synth|piano|turntable|dj/.test(role)) return { x: 18 + (index % 2) * 64, y: 44 };
+  const spread = total <= 1 ? 0 : (index / (total - 1)) * 64;
+  return { x: 18 + spread, y: index % 2 ? 54 : 64 };
+}
+
+export function buildPerformerPresentation(performers: LiveGigPerformerInput[], session: LiveGigSessionState, incidents: LiveIncident[] = []): PerformerPresentationState[] {
+  const activeIncident = incidents.find((i) => i.category !== 'positive');
+  return performers.map((performer, index) => {
+    const stamina = performer.stamina ?? session.bandStamina;
+    const roleText = `${performer.role ?? ''} ${performer.instrument ?? ''}`.toLowerCase();
+    const affected = activeIncident && (activeIncident.category === 'performance' || (activeIncident.category === 'equipment' && /guitar|bass|key|drum|mic|vocal/.test(roleText)));
+    const pos = positionFor(performer, index, performers.length);
+    const representation = performer.avatarUrl ? 'full_body_avatar' : performer.portraitUrl ? 'portrait_avatar' : performer.role || performer.instrument ? 'role_silhouette' : 'generic_fallback';
+    return { ...performer, ...pos, instrumentLabel: instrumentLabel(performer.instrument ?? performer.role), representation, visualState: performer.available === false ? 'absent' : affected ? 'incident_affected' : stamina < 28 ? 'struggling' : session.momentum >= 7 ? 'standout_performance' : session.crowdEnergy >= 78 ? 'energetic' : session.status === 'paused_for_decision' ? 'recovering' : 'performing', focusReason: affected ? activeIncident.title : session.momentum >= 7 ? 'Momentum is carrying this performer.' : undefined };
+  });
+}
+
+function instrumentLabel(value?: string | null) { const v = (value ?? '').toLowerCase(); if (/drum/.test(v)) return 'Drum kit'; if (/bass/.test(v)) return 'Bass'; if (/acoustic/.test(v)) return 'Acoustic guitar'; if (/guitar/.test(v)) return 'Electric guitar'; if (/key|piano|synth/.test(v)) return 'Keyboard'; if (/turntable|dj/.test(v)) return 'Turntables'; if (/vocal|sing|mic/.test(v)) return 'Microphone'; return value || 'Live rig'; }
+
+export function mapLightingState(input: BuildLiveGigPresentationInput, scene: LivePresentationScene): LightingPresentationState {
+  if (input.incidents?.some((i) => i.category === 'production' && /light|cue|production/i.test(i.incidentType))) return 'failure_state';
+  if (scene === 'outro') return 'finale_lighting';
+  if (scene === 'encore') return 'encore_lighting';
+  if (scene === 'intro' || scene === 'transition') return 'house_lights';
+  const pkg = input.production?.lightingPackage?.toLowerCase() ?? '';
+  const song = input.currentSong;
+  if ((song?.tempo ?? 0) < 85 || /ballad|slow|intimate/i.test(song?.mood ?? song?.genre ?? '')) return 'spotlights';
+  if (/dramatic|silhouette/.test(pkg)) return 'dramatic_silhouette';
+  if (/cool|led|projection/.test(pkg)) return 'cool_wash';
+  if (/warm/.test(pkg)) return 'warm_wash';
+  if ((input.session.crowdEnergy + input.session.momentum) > 80) return input.reducedMotion ? 'spotlights' : 'pulsing';
+  return 'basic_wash';
+}
+
+export function mapProductionPlanToVisualEffects(production?: LiveGigProductionInput | null, incidents: LiveIncident[] = [], scene: LivePresentationScene = 'song', reducedMotion = false): string[] {
+  if (scene === 'intro' || scene === 'transition') return [];
+  const disabled = new Set([...(production?.disabledEffects ?? []), ...incidents.filter((i) => i.category === 'production').map((i) => i.incidentType)]);
+  return (production?.effects ?? []).filter((effect) => !disabled.has(effect)).filter((effect) => !(reducedMotion && /pyro|confetti|strobe|burst/i.test(effect))).slice(0, 5);
+}
+
+export function buildSongPresentationProfile(song?: LiveGigSongPresentationInput | null, result?: LiveSongResult) {
+  const tempo = song?.tempo ?? 110;
+  const isBallad = tempo < 85 || /ballad|slow|intimate/i.test(`${song?.mood ?? ''} ${song?.genre ?? ''}`);
+  return { title: song?.title ?? 'Current segment', phase: result ? `Resolved: ${result.rating}` : song?.isEncore ? 'Encore performance' : 'Live performance', genre: song?.genre ?? 'Unknown genre', tempoLabel: isBallad ? 'Slow / ballad' : tempo >= 140 ? 'Fast' : tempo >= 110 ? 'Up-tempo' : 'Mid-tempo', moodLabel: song?.mood ?? (isBallad ? 'Focused' : 'High energy'), isCrowdFavourite: (song?.popularity ?? 0) >= 70, performanceLabel: result ? `${result.score}/100 · ${result.rating}` : 'Awaiting server result' };
+}
+
+export function buildLiveGigPresentationState(input: BuildLiveGigPresentationInput): LiveGigPresentationState {
+  const current = input.segments.find((s) => s.segmentIndex === input.session.currentSegmentIndex) ?? input.segments.find((s) => s.status === 'active') ?? input.segments[0];
+  const unresolvedIncident = input.incidents?.find((i) => i.category !== 'positive');
+  const scene = mapLiveSegmentToScene(current?.segmentType, !!input.activeDecision, !!unresolvedIncident);
+  const result = input.songResults?.find((r) => r.segmentIndex === current?.segmentIndex);
+  const venueTier = mapVenueToTier(input.venue);
+  const crowdDensity = calculateCrowdDensity(input.venue?.attendance ?? 0, input.venue?.capacity ?? 0);
+  const crowdState = mapCrowdEnergyToPresentation(input.session.crowdEnergy, input.venue?.attendance, input.venue?.capacity, unresolvedIncident);
+  const lightingState = mapLightingState(input, scene);
+  const activeEffects = mapProductionPlanToVisualEffects(input.production, input.incidents, scene, !!input.reducedMotion || !!input.dataOnly);
+  const songProfile = buildSongPresentationProfile(input.currentSong, result);
+  const intensity = input.dataOnly ? 0 : Math.round(clamp(input.session.crowdEnergy * 0.45 + Math.max(0, input.session.momentum) * 3 + (input.currentSong?.tempo ?? 100) * 0.18 + (result?.audienceResponse ?? 50) * 0.25));
+  const performers = buildPerformerPresentation(input.performers ?? [], input.session, input.incidents);
+  const headline = input.activeDecision ? 'Tactical decision available' : scene === 'outro' ? 'The show is wrapping up' : `${songProfile.title} · ${crowdState.replaceAll('_', ' ')} crowd`;
+  const commentary = [ `${input.venue?.name ?? 'The venue'} is presented as ${venueTier.replaceAll('_', ' ')} with ${crowdDensity}% visible density.`, `Lighting: ${lightingState.replaceAll('_', ' ')}. Effects: ${activeEffects.length ? activeEffects.join(', ') : 'none active'}.`, ...(result?.highlights ?? []), ...(input.incidents ?? []).slice(-2).map((i) => i.title), ...(input.activeDecision ? [`Decision fallback: ${input.activeDecision.recommendedFallback.replaceAll('_', ' ')}.`] : []) ];
+  return { scene, intensity, crowdState, crowdDensity, venueTier, stageLayout: buildStageLayout(input.performers ?? [], input.venue), lightingState, productionState: activeEffects.length ? 'effects_active' : 'clean_stage', performerStates: performers, activeEffects, headline, commentary, currentSongProfile: songProfile, accessibilitySummary: `${headline}. Crowd energy ${input.session.crowdEnergy}, fan satisfaction ${input.session.fanSatisfaction}, band stamina ${input.session.bandStamina}, momentum ${input.session.momentum}.` };
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, server-driven presentation layer that maps authoritative live gig state to a polished stage view without changing server-side simulation or outcome logic.
- Improve the live gig UX by adding role-based stage layouts, performer presentation, crowd and lighting visuals, production effects, timeline and commentary while keeping presentation extendable and accessible.

### Description

- Added a mapping service `buildLiveGigPresentationState` and helpers in `src/utils/gigLivePresentation.ts` to translate persisted session/segment/song-result/incident/decision/venue/production/performer inputs into a deterministic display state (scene, intensity, crowd state/density, lighting, active effects, performer states, commentary, accessibility summary).
- Implemented a responsive DOM/CSS stage presentation component `LiveGigPresentation` at `src/components/gig/LiveGigPresentation.tsx` that renders venue/stage background, performer markers (avatar/portrait/silhouette fallbacks), instrument icons, lighting/effects layer, bounded crowd foreground, current-song panel, metrics, timeline and commentary, plus presentation quality modes (`full|reduced|minimal|data`).
- Wired the presentation into the existing control UI by embedding `LiveGigPresentation` into `LiveGigTimelineDashboard` while preserving the existing timeline, metrics, highlights, incident and decision UI paths.
- Added deterministic unit tests at `src/utils/__tests__/gigLivePresentation.test.ts` and documentation `docs/gigs/live-gig-presentation.md` describing architecture, mapping rules, layouts, accessibility, performance and known limitations.

### Testing

- Added unit tests for presentation mapping, crowd density, venue tiers, stage layouts, reduced-motion filtering, incident handling and decision scenes (`src/utils/__tests__/gigLivePresentation.test.ts`), but the test run could not be executed in this environment because `vitest` was not available and dependency installation failed.\
- Attempted `npm run test:unit` which failed with `vitest: not found`.\
- Attempted `npm install` and `npm run typecheck`, but the install was blocked by a registry `403 Forbidden` for `@react-three/fiber`, preventing full dependency install and subsequent lint/typecheck/build steps.
- The presentation logic and component are covered by deterministic unit assertions (added) and the code is committed so CI in the proper environment should run `npm ci`, `npm run test:unit`, `npm run test:gig-experience:viewer`, `npm run typecheck` and a production build to validate runtime and typings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a533139dc2c83258ccbcdc320f3e174)