### PR TITLE
feat: add live gig attendance and audience participation

### DIFF
--- a/docs/live-gig-audience-participation.md
+++ b/docs/live-gig-audience-participation.md
@@ -1,0 +1,58 @@
+# Live gig audience participation and social viewing
+
+This phase extends the server-driven live gig system with an audience layer. The existing live session, live segment, song result, incident, decision and replay architecture remains authoritative; audience actions create social atmosphere and modest capped modifiers only.
+
+## Architecture inspected
+
+- Live sessions are stored in `gig_live_sessions`, with immutable segment ordering in `gig_live_segments`, per-song authoritative results in `gig_live_song_results`, incident/decision tables and service-role lifecycle RPCs.
+- Live presentation currently uses `RealtimeGigViewer`, `GigViewerShell` and the gig experience DTOs to show public-facing show progress while the band-manager pages keep tactical decisions separate.
+- Ticketing for normal gigs is mostly aggregate (`gigs.tickets_sold` plus venue capacity); festivals already have `festival_tickets` and `festival_attendance`.
+- Visibility, memberships and social relationships are represented through band membership/manager guards, profile privacy settings, friendships, notifications, Twaater/community feed tables and RLS policies.
+- Location validation is city-level through `profiles.current_city_id` and `venues.city_id`; exact venue room/location attendance is not currently available.
+- Existing anti-abuse conventions prefer RLS denial for direct writes, SECURITY DEFINER RPCs, unique constraints, idempotency keys and bounded counters.
+
+## Eligibility and attending versus viewing
+
+`check_in_gig_audience` accepts server-side attendance types for ticket holders, invited/VIP guests, band friends, venue staff, crew, support acts, festival attendees, remote viewers and admin viewers. Physical attendance requires an authenticated profile, a non-terminal gig, venue capacity, and city-level location match where a venue city exists. Remote viewing creates a record but does not consume capacity or receive attendance rewards.
+
+Current limitation: normal gig tickets are aggregate in the existing schema, so the first implementation can store a nullable `ticket_id` but cannot verify an individual normal-gig ticket table that does not yet exist. Festival ticket ownership and richer invitation checks are extension points for future PRs.
+
+## Attendance records and presence
+
+`gig_audience_attendance` stores one row per player per gig with attendance type, status, ticket/invitation references, check-in time, last presence, watch duration, participation score and reward status. Rejoins update the existing row and preserve cooldown/reward state. Brief reconnects are tolerated by using bounded presence timestamps rather than high-frequency heartbeats.
+
+## Capacity and finances
+
+Real player check-ins are treated as a subset of existing sold/expected attendance. The RPC caps physical check-ins at `LEAST(gigs.tickets_sold, venues.capacity)` when sold tickets exist, or venue capacity as a fallback. Remote viewers and admins do not consume capacity. No ticket revenue or financial result is changed by audience check-in.
+
+## Audience view model
+
+Audience UI uses `LiveGigAudiencePanel` inside the live viewer. It displays public stage context, aggregate participation level, active participants, encore demand, capped atmosphere modifier, attendance status, reaction cooldown and reward progress. Private band readiness, crew details, health, finances, hidden probabilities, admin diagnostics and tactical options are not exposed by this panel.
+
+## Reactions, timing and limits
+
+Allowed reactions are positive/neutral: cheer, clap, sing along, hands up, dance, phone wave, chant, encore request, support performer and highlight. Timing is tied to the authoritative current live segment; client-provided current segment/timestamps are not trusted. Limits are one reaction every 4 seconds, 6 per segment/song, 40 per gig and one encore request per gig, with idempotency-key duplicate suppression.
+
+## Aggregation and influence
+
+`gig_audience_segment_aggregates` stores compact segment snapshots: reaction counts, unique participants, participation score/level, encore demand, singalong strength and an audience modifier. The client utility weights unique attendees, reaction variety and correct timing instead of raw reaction count. Influence is capped at +4 per segment and is intended to translate to at most +3 crowd energy/atmosphere and +2 support recovery. It cannot override curfew, stamina, preparation failure, invalid setlists or authoritative live decisions.
+
+## Requests, encore, polls and ratings
+
+Encore requests are aggregated as reaction data and may be surfaced as modest encore demand; they do not force an encore. `gig_audience_polls` and `gig_audience_poll_votes` support system/authorised predefined polls with one vote per attendance. `gig_audience_ratings` supports one structured post-gig rating per completed physical attendance, with favourite song and standout performer references for report aggregation.
+
+## Rewards
+
+`process_gig_audience_rewards` is service-role only and idempotent by attendance. It grants modest fan/social progression snapshots based on participation score to completed physical attendees only. Remote viewers, admin viewers, cancelled/removed rows and already processed rows receive no attendance reward.
+
+## Friend presence, social integration, moderation and privacy
+
+The first UI exposes aggregate presence only. Identity-level friend presence should be added by joining accepted friendships, profile privacy settings, blocking and mute/report tables before showing avatars. Predefined reactions avoid unrestricted public chat. RLS denies direct client writes; muting/removal can set attendance status to `removed` or add moderation snapshots without creating a separate moderation system.
+
+## Realtime and retention
+
+Realtime subscriptions listen to compact aggregate and attendance updates. Individual reaction events are persisted for audit/rate-limit windows but UI renders aggregate state only. Retention policy: preserve final attendance, reward, rating, poll vote and aggregate rows; raw reactions may be pruned after abuse-investigation windows once final aggregates are settled; low-value presence timestamps should not be expanded into indefinite heartbeat logs.
+
+## Spectator extension points
+
+The schema separates attendee, remote viewer, band-manager and admin concepts, keeps public presentation endpoints read-only, and uses aggregate broadcasts so festivals/large broadcasts can scale later without replacing the live gig simulation.

--- a/src/components/gig/LiveGigAudiencePanel.tsx
+++ b/src/components/gig/LiveGigAudiencePanel.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Users, Radio, ShieldCheck, Sparkles } from "lucide-react";
+import { AUDIENCE_REACTION_TYPES, aggregateAudienceResponse, checkAudienceReactionRateLimit, type AudienceReactionType } from "@/utils/gigAudience";
+
+interface LiveGigAudiencePanelProps { gigId: string; liveSessionId?: string | null; currentSegmentId?: string | null; isAudienceView?: boolean; }
+interface AttendanceRow { id: string; attendance_type: string; status: string; participation_score: number; watch_duration_seconds: number; reward_status: string; last_presence_at: string | null; }
+interface AggregateRow { participation_level: string; participation_score: number; reaction_counts: Record<string, number>; unique_participants: number; encore_demand: number; singalong_strength: number; audience_modifier: number; }
+
+const reactionLabels: Record<AudienceReactionType, string> = { cheer: "Cheer", clap: "Clap", sing_along: "Sing along", hands_up: "Hands up", dance: "Dance", phone_wave: "Phone wave", chant: "Chant", encore_request: "Encore!", support_performer: "Support", highlight: "Highlight" };
+
+export function LiveGigAudiencePanel({ gigId, liveSessionId, currentSegmentId, isAudienceView = false }: LiveGigAudiencePanelProps) {
+  const [attendance, setAttendance] = useState<AttendanceRow | null>(null);
+  const [aggregate, setAggregate] = useState<AggregateRow | null>(null);
+  const [friendCount, setFriendCount] = useState(0);
+  const [cooldownUntil, setCooldownUntil] = useState<Date | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isCheckingIn, setIsCheckingIn] = useState(false);
+
+  const loadAudienceState = useCallback(async () => {
+    const attendanceQuery = (supabase.from("gig_audience_attendance" as never) as any).select("id, attendance_type, status, participation_score, watch_duration_seconds, reward_status, last_presence_at").eq("gig_id", gigId).maybeSingle();
+    const { data: attendanceData } = await attendanceQuery;
+    setAttendance(attendanceData ?? null);
+
+    if (liveSessionId) {
+      const { data: aggregateData } = await (supabase.from("gig_audience_segment_aggregates" as never) as any)
+        .select("participation_level, participation_score, reaction_counts, unique_participants, encore_demand, singalong_strength, audience_modifier")
+        .eq("live_session_id", liveSessionId)
+        .order("updated_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      setAggregate(aggregateData ?? null);
+
+      const { count } = await (supabase.from("gig_audience_attendance" as never) as any)
+        .select("id", { count: "exact", head: true })
+        .eq("live_session_id", liveSessionId)
+        .in("status", ["checked_in", "watching", "completed"]);
+      setFriendCount(count ?? 0);
+    }
+  }, [gigId, liveSessionId]);
+
+  useEffect(() => { loadAudienceState(); }, [loadAudienceState]);
+
+  useEffect(() => {
+    if (!liveSessionId) return;
+    const channel = supabase
+      .channel(`gig-audience-${liveSessionId}`)
+      .on("postgres_changes", { event: "*", schema: "public", table: "gig_audience_segment_aggregates", filter: `live_session_id=eq.${liveSessionId}` }, () => loadAudienceState())
+      .on("postgres_changes", { event: "*", schema: "public", table: "gig_audience_attendance", filter: `live_session_id=eq.${liveSessionId}` }, () => loadAudienceState())
+      .subscribe();
+    return () => { supabase.removeChannel(channel); };
+  }, [liveSessionId, loadAudienceState]);
+
+  const derivedAggregate = useMemo(() => aggregate ?? aggregateAudienceResponse([], friendCount), [aggregate, friendCount]);
+  const cooldownSeconds = cooldownUntil ? Math.max(0, Math.ceil((cooldownUntil.getTime() - Date.now()) / 1000)) : 0;
+
+  const checkIn = async (attendanceType: "ticket_holder" | "remote_viewer") => {
+    setIsCheckingIn(true); setMessage(null);
+    const { data, error } = await (supabase.rpc("check_in_gig_audience" as never, { p_gig_id: gigId, p_ticket_id: null, p_attendance_type: attendanceType } as never) as any);
+    if (error) setMessage(error.message); else { setAttendance(data); setMessage(attendanceType === "remote_viewer" ? "Viewing live presentation without attendance rewards." : "Checked in for the gig."); await loadAudienceState(); }
+    setIsCheckingIn(false);
+  };
+
+  const react = async (reactionType: AudienceReactionType) => {
+    if (!attendance) return;
+    const limit = checkAudienceReactionRateLimit({ lastReactionAt: cooldownUntil && cooldownUntil > new Date() ? new Date(Date.now() - 1000).toISOString() : null });
+    if (!limit.allowed) { setMessage(limit.reason ?? "Reaction cooldown active."); return; }
+    const idempotency = `${attendance.id}:${currentSegmentId ?? "current"}:${reactionType}:${Math.floor(Date.now() / 4000)}`;
+    const { error } = await (supabase.rpc("record_gig_audience_reaction" as never, { p_attendance_id: attendance.id, p_reaction_type: reactionType, p_segment_id: currentSegmentId ?? null, p_idempotency_key: idempotency } as never) as any);
+    if (error) setMessage(error.message); else { setCooldownUntil(new Date(Date.now() + 4000)); setMessage(`${reactionLabels[reactionType]} counted in the crowd response.`); await loadAudienceState(); }
+  };
+
+  return (
+    <Card className={isAudienceView ? "border-primary/40 bg-primary/5" : ""}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><Radio className="h-5 w-5" /> Audience participation</CardTitle>
+        <CardDescription>Server-authoritative social viewing with capped, aggregate-only influence.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <div><p className="text-2xl font-bold capitalize">{derivedAggregate.participation_level}</p><p className="text-xs text-muted-foreground">Participation</p></div>
+          <div><p className="text-2xl font-bold">{derivedAggregate.unique_participants}</p><p className="text-xs text-muted-foreground">Active fans</p></div>
+          <div><p className="text-2xl font-bold">{derivedAggregate.encore_demand}%</p><p className="text-xs text-muted-foreground">Encore demand</p></div>
+          <div><p className="text-2xl font-bold">+{Number(derivedAggregate.audience_modifier || 0).toFixed(1)}</p><p className="text-xs text-muted-foreground">Capped atmosphere</p></div>
+        </div>
+        <Progress value={derivedAggregate.participation_score} className="h-2" />
+
+        {attendance ? (
+          <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3">
+            <Badge variant="secondary">{attendance.attendance_type.replace("_", " ")}</Badge>
+            <Badge>{attendance.status}</Badge>
+            <span className="text-sm text-muted-foreground">Your participation score: {attendance.participation_score}/100</span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button disabled={isCheckingIn} onClick={() => checkIn("ticket_holder")}><Users className="mr-2 h-4 w-4" /> Check in</Button>
+            <Button disabled={isCheckingIn} variant="outline" onClick={() => checkIn("remote_viewer")}><ShieldCheck className="mr-2 h-4 w-4" /> View only</Button>
+          </div>
+        )}
+
+        {attendance && !["remote_viewer", "admin_viewer"].includes(attendance.attendance_type) && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between"><p className="text-sm font-medium">Quick reactions</p>{cooldownSeconds > 0 && <Badge variant="outline">Cooldown {cooldownSeconds}s</Badge>}</div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+              {AUDIENCE_REACTION_TYPES.map((type) => <Button key={type} size="sm" variant={type === "encore_request" ? "default" : "outline"} disabled={cooldownSeconds > 0} onClick={() => react(type)}>{reactionLabels[type]}</Button>)}
+            </div>
+          </div>
+        )}
+
+        <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+          <Sparkles className="mr-2 inline h-4 w-4" /> Friend presence is aggregate-only here; privacy, blocking and private gig visibility are enforced by server policies.
+        </div>
+        {message && <Alert><AlertDescription>{message}</AlertDescription></Alert>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/gig/RealtimeGigViewer.tsx
+++ b/src/components/gig/RealtimeGigViewer.tsx
@@ -3,12 +3,13 @@ import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
-import { Music, Star, Users, Clock, TrendingUp, Zap } from "lucide-react";
+import { Music, Star, Clock, TrendingUp, Zap } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { formatDistanceToNowStrict, differenceInSeconds } from "date-fns";
 import type { Database } from "@/lib/supabase-types";
 import { CrowdEnergyVisualizer } from "./CrowdEnergyVisualizer";
 import { PerformanceNarrative, generateNarrativeEvent } from "./PerformanceNarrative";
+import { LiveGigAudiencePanel } from "./LiveGigAudiencePanel";
 
 type Gig = Database['public']['Tables']['gigs']['Row'];
 type SongPerformance = Database['public']['Tables']['gig_song_performances']['Row'];
@@ -372,6 +373,9 @@ export const RealtimeGigViewer = ({ gigId, onComplete }: RealtimeGigViewerProps)
         }
         attendance={gig.attendance || gig.estimated_attendance || 0}
       />
+
+      {/* Audience Participation */}
+      <LiveGigAudiencePanel gigId={gig.id} isAudienceView />
 
       {/* Performance Narrative */}
       <PerformanceNarrative events={narrativeEvents} />

--- a/src/utils/__tests__/gigAudience.test.ts
+++ b/src/utils/__tests__/gigAudience.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateAudienceResponse, calculateAudienceParticipationScore, calculateAudienceReward, checkAudienceReactionRateLimit, evaluateAudienceEligibility, validateAudienceReactionTiming } from '../gigAudience';
+
+describe('gigAudience eligibility and check-in rules', () => {
+  it('allows valid same-city ticket holders to attend and view', () => {
+    const result = evaluateAudienceEligibility({ hasTicket: true, playerCityId: 'city-a', venueCityId: 'city-a', gigStatus: 'in_progress' });
+    expect(result.canAttend).toBe(true); expect(result.canView).toBe(true); expect(result.attendanceType).toBe('ticket_holder');
+  });
+  it('rejects wrong-city physical attendance', () => {
+    const result = evaluateAudienceEligibility({ hasTicket: true, playerCityId: 'city-b', venueCityId: 'city-a', gigStatus: 'in_progress' });
+    expect(result.canAttend).toBe(false); expect(result.reasons).toContain('Player is not in the gig city.');
+  });
+  it('allows remote viewing without capacity consumption when public viewing is enabled', () => {
+    const result = evaluateAudienceEligibility({ publicViewingEnabled: true, gigStatus: 'in_progress' });
+    expect(result.canAttend).toBe(false); expect(result.canView).toBe(true); expect(result.attendanceType).toBe('remote_viewer');
+  });
+  it('rejects cancelled gigs', () => {
+    const result = evaluateAudienceEligibility({ hasTicket: true, gigStatus: 'cancelled' });
+    expect(result.canAttend).toBe(false); expect(result.canView).toBe(false);
+  });
+});
+
+describe('gigAudience reactions', () => {
+  const session = { status: 'live' as const };
+  it('accepts a singalong during an active song', () => {
+    expect(validateAudienceReactionTiming('sing_along', { segmentType: 'song', status: 'active' }, session).allowed).toBe(true);
+  });
+  it('rejects future or invalid timing', () => {
+    expect(validateAudienceReactionTiming('encore_request', { segmentType: 'song', status: 'pending' }, session).allowed).toBe(false);
+    expect(validateAudienceReactionTiming('encore_request', { segmentType: 'song', status: 'active' }, session).allowed).toBe(false);
+  });
+  it('rate limits duplicate and rapid reactions', () => {
+    expect(checkAudienceReactionRateLimit({ duplicateIdempotencyKey: true }).allowed).toBe(false);
+    expect(checkAudienceReactionRateLimit({ lastReactionAt: '2026-07-12T00:00:00Z', now: '2026-07-12T00:00:02Z' }).retryAfterSeconds).toBe(2);
+  });
+  it('enforces song, gig and encore caps', () => {
+    expect(checkAudienceReactionRateLimit({ songReactionCount: 6 }).reason).toMatch(/Song/);
+    expect(checkAudienceReactionRateLimit({ gigReactionCount: 40 }).reason).toMatch(/Gig/);
+    expect(checkAudienceReactionRateLimit({ encoreRequestCount: 1 }).reason).toMatch(/Encore/);
+  });
+  it('aggregates by unique attendees so one spammer cannot overpower the crowd', () => {
+    const oneSpammer = Array.from({ length: 20 }, (_, i) => ({ playerId: 'p1', attendanceId: 'a1', reactionType: i % 2 ? 'cheer' as const : 'clap' as const, createdAt: new Date() }));
+    const varied = ['p1', 'p2', 'p3', 'p4'].map((playerId, i) => ({ playerId, attendanceId: `a${i}`, reactionType: 'cheer' as const, createdAt: new Date() }));
+    expect(aggregateAudienceResponse(varied, 8).audienceModifier).toBeGreaterThan(aggregateAudienceResponse(oneSpammer, 8).audienceModifier);
+    expect(aggregateAudienceResponse(oneSpammer, 8).audienceModifier).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('gigAudience rewards and score', () => {
+  it('calculates bounded participation score with invalid attempt penalties', () => {
+    const score = calculateAudienceParticipationScore({ watchedSongs: 8, totalSongs: 10, validReactionCount: 6, reactionVariety: 4, stayedToEnd: true, encoreParticipated: true, invalidAttempts: 2, removed: false, watchDurationSeconds: 1800 });
+    expect(score).toBeGreaterThan(50); expect(score).toBeLessThanOrEqual(100);
+  });
+  it('does not reward remote viewers or removed attendees', () => {
+    expect(calculateAudienceReward(90, 'completed', 'remote_viewer').fanXp).toBe(0);
+    expect(calculateAudienceReward(90, 'removed', 'ticket_holder').fanXp).toBe(0);
+  });
+  it('reduces rewards for leaving early', () => {
+    expect(calculateAudienceReward(80, 'left_early', 'ticket_holder').fanXp).toBeLessThan(calculateAudienceReward(80, 'completed', 'ticket_holder').fanXp);
+  });
+});

--- a/src/utils/gigAudience.ts
+++ b/src/utils/gigAudience.ts
@@ -1,0 +1,98 @@
+import type { GigLiveSegment, LiveGigSessionState, LiveSegmentType } from './gigLive';
+
+export type AudienceAttendanceType = 'ticket_holder' | 'invited_guest' | 'vip_guest' | 'band_friend' | 'venue_staff' | 'crew' | 'support_act' | 'festival_attendee' | 'remote_viewer' | 'admin_viewer';
+export type AudienceAttendanceStatus = 'eligible' | 'checked_in' | 'watching' | 'left_early' | 'completed' | 'no_show' | 'removed' | 'cancelled';
+export type AudienceReactionType = 'cheer' | 'clap' | 'sing_along' | 'hands_up' | 'dance' | 'phone_wave' | 'chant' | 'encore_request' | 'support_performer' | 'highlight';
+export type ParticipationLevel = 'quiet' | 'engaged' | 'lively' | 'electric';
+
+export interface AudienceEligibilityInput { hasTicket?: boolean; hasInvitation?: boolean; isVipGuest?: boolean; isBandFriend?: boolean; isVenueStaff?: boolean; isCrew?: boolean; isSupportAct?: boolean; isFestivalAttendee?: boolean; publicViewingEnabled?: boolean; isAdminViewer?: boolean; gigVisibility?: 'public' | 'friends' | 'private' | string | null; playerCityId?: string | null; venueCityId?: string | null; hasScheduleConflict?: boolean; gigStatus?: string | null; isBanned?: boolean; isBandMember?: boolean; }
+export interface AudienceEligibilityResult { canAttend: boolean; canView: boolean; attendanceType: AudienceAttendanceType | null; reasons: string[]; limitations: string[]; }
+export interface AudienceReaction { playerId: string; attendanceId: string; reactionType: AudienceReactionType; segmentId?: string | null; createdAt: string | Date; idempotencyKey?: string | null; }
+export interface AudienceAggregate { activeAttendees: number; totalReactions: number; reactionCounts: Record<AudienceReactionType, number>; uniqueParticipants: number; participationLevel: ParticipationLevel; dominantReaction: AudienceReactionType | null; encoreDemand: number; singalongStrength: number; participationScore: number; audienceModifier: number; crowdEnergyDelta: number; atmosphereDelta: number; supportRecoveryDelta: number; }
+export interface ReactionLimitState { lastReactionAt?: string | Date | null; songReactionCount?: number; gigReactionCount?: number; encoreRequestCount?: number; duplicateIdempotencyKey?: boolean; now?: string | Date; }
+export interface ReactionLimitResult { allowed: boolean; retryAfterSeconds: number; reason?: string; }
+export interface ParticipationScoreInput { watchedSongs: number; totalSongs: number; validReactionCount: number; reactionVariety: number; stayedToEnd: boolean; encoreParticipated: boolean; invalidAttempts: number; removed: boolean; watchDurationSeconds: number; }
+
+export const AUDIENCE_REACTION_TYPES: AudienceReactionType[] = ['cheer', 'clap', 'sing_along', 'hands_up', 'dance', 'phone_wave', 'chant', 'encore_request', 'support_performer', 'highlight'];
+export const AUDIENCE_RATE_LIMITS = { minSecondsBetweenReactions: 4, maxReactionsPerSong: 6, maxReactionsPerGig: 40, maxEncoreRequestsPerGig: 1 } as const;
+export const AUDIENCE_INFLUENCE_CAPS = { perSegmentModifier: 4, gigModifier: 8, crowdEnergyDelta: 3, atmosphereDelta: 3, supportRecoveryDelta: 2 } as const;
+
+const clamp = (n: number, min = 0, max = 100) => Math.max(min, Math.min(max, n));
+const signedClamp = (n: number, max: number) => Math.max(-max, Math.min(max, n));
+
+export function evaluateAudienceEligibility(input: AudienceEligibilityInput): AudienceEligibilityResult {
+  const reasons: string[] = []; const limitations: string[] = [];
+  const terminal = ['cancelled', 'completed', 'failed'].includes(input.gigStatus ?? '');
+  if (terminal) reasons.push('Gig is not open for live attendance.');
+  if (input.isBanned) reasons.push('Player is restricted from this venue or gig.');
+  if (input.hasScheduleConflict) reasons.push('Player has a conflicting scheduled activity.');
+  if (input.venueCityId && input.playerCityId && input.venueCityId !== input.playerCityId) reasons.push('Player is not in the gig city.');
+  if (!input.venueCityId) limitations.push('Venue-level validation is unavailable; city-level validation is the strongest supported location check.');
+
+  let attendanceType: AudienceAttendanceType | null = null;
+  if (input.hasTicket) attendanceType = 'ticket_holder'; else if (input.isVipGuest) attendanceType = 'vip_guest'; else if (input.hasInvitation) attendanceType = 'invited_guest'; else if (input.isCrew) attendanceType = 'crew'; else if (input.isSupportAct) attendanceType = 'support_act'; else if (input.isVenueStaff) attendanceType = 'venue_staff'; else if (input.isFestivalAttendee) attendanceType = 'festival_attendee'; else if (input.isBandFriend && input.gigVisibility !== 'private') attendanceType = 'band_friend';
+  const canAttend = reasons.length === 0 && attendanceType !== null;
+  const canView = !terminal && (canAttend || input.publicViewingEnabled || input.isAdminViewer || input.isBandMember || input.gigVisibility === 'public' || (input.isBandFriend && input.gigVisibility === 'friends'));
+  if (!canAttend && !canView) reasons.push('No valid ticket, invitation, relationship, staff, festival, public, or admin viewing permission was found.');
+  return { canAttend, canView, attendanceType: canAttend ? attendanceType : input.isAdminViewer ? 'admin_viewer' : input.publicViewingEnabled ? 'remote_viewer' : null, reasons, limitations };
+}
+
+export function validateAudienceReactionTiming(reactionType: AudienceReactionType, segment: Pick<GigLiveSegment, 'segmentType' | 'status'> | null, session: Pick<LiveGigSessionState, 'status'>): { allowed: boolean; reason?: string } {
+  if (session.status !== 'live' && session.status !== 'paused_for_decision') return { allowed: false, reason: 'Gig is not live.' };
+  if (!segment || !['active', 'resolved'].includes(segment.status)) return { allowed: false, reason: 'No current authoritative segment is available.' };
+  const type = segment.segmentType as LiveSegmentType;
+  const windows: Record<AudienceReactionType, LiveSegmentType[]> = {
+    cheer: ['intro', 'song', 'encore_song', 'crowd_interaction', 'outro'], clap: ['song', 'encore_song', 'transition', 'outro'], sing_along: ['song', 'encore_song'], hands_up: ['song', 'encore_song', 'crowd_interaction'], dance: ['song', 'encore_song'], phone_wave: ['song', 'encore_song', 'encore_break'], chant: ['crowd_interaction', 'encore_break', 'outro'], encore_request: ['encore_break', 'outro'], support_performer: ['incident', 'transition', 'song', 'encore_song'], highlight: ['song', 'encore_song', 'crowd_interaction']
+  };
+  return windows[reactionType].includes(type) ? { allowed: true } : { allowed: false, reason: `${reactionType} is not valid during ${type}.` };
+}
+
+export function checkAudienceReactionRateLimit(state: ReactionLimitState): ReactionLimitResult {
+  if (state.duplicateIdempotencyKey) return { allowed: false, retryAfterSeconds: 0, reason: 'Duplicate reaction ignored.' };
+  const now = state.now ? new Date(state.now) : new Date();
+  if (state.lastReactionAt) {
+    const elapsed = (now.getTime() - new Date(state.lastReactionAt).getTime()) / 1000;
+    if (elapsed < AUDIENCE_RATE_LIMITS.minSecondsBetweenReactions) return { allowed: false, retryAfterSeconds: Math.ceil(AUDIENCE_RATE_LIMITS.minSecondsBetweenReactions - elapsed), reason: 'Reaction cooldown active.' };
+  }
+  if ((state.songReactionCount ?? 0) >= AUDIENCE_RATE_LIMITS.maxReactionsPerSong) return { allowed: false, retryAfterSeconds: 0, reason: 'Song reaction limit reached.' };
+  if ((state.gigReactionCount ?? 0) >= AUDIENCE_RATE_LIMITS.maxReactionsPerGig) return { allowed: false, retryAfterSeconds: 0, reason: 'Gig reaction limit reached.' };
+  if ((state.encoreRequestCount ?? 0) >= AUDIENCE_RATE_LIMITS.maxEncoreRequestsPerGig) return { allowed: false, retryAfterSeconds: 0, reason: 'Encore request already counted.' };
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+export function aggregateAudienceResponse(reactions: AudienceReaction[], activeAttendees: number): AudienceAggregate {
+  const counts = Object.fromEntries(AUDIENCE_REACTION_TYPES.map(t => [t, 0])) as Record<AudienceReactionType, number>;
+  const unique = new Set<string>();
+  reactions.forEach(r => { counts[r.reactionType] += 1; unique.add(r.playerId); });
+  const total = reactions.length;
+  const dominantReaction = AUDIENCE_REACTION_TYPES.reduce<AudienceReactionType | null>((best, t) => !best || counts[t] > counts[best] ? t : best, null);
+  const uniqueRatio = activeAttendees > 0 ? unique.size / activeAttendees : 0;
+  const diversity = AUDIENCE_REACTION_TYPES.filter(t => counts[t] > 0).length / AUDIENCE_REACTION_TYPES.length;
+  const encoreDemand = clamp(activeAttendees ? (counts.encore_request / Math.max(3, activeAttendees)) * 100 : 0);
+  const singalongStrength = clamp(activeAttendees ? (counts.sing_along / Math.max(2, activeAttendees)) * 100 : 0);
+  const participationScore = Math.round(clamp(uniqueRatio * 55 + diversity * 25 + Math.min(total, activeAttendees * 3) * 2));
+  const participationLevel: ParticipationLevel = participationScore >= 80 ? 'electric' : participationScore >= 55 ? 'lively' : participationScore >= 25 ? 'engaged' : 'quiet';
+  const positiveParticipantRatio = activeAttendees > 0 ? Math.min(1, unique.size / activeAttendees) : 0;
+  const rawModifier = uniqueRatio * 3.0 + diversity * 1.0 + positiveParticipantRatio * 1.4;
+  const audienceModifier = signedClamp(rawModifier, AUDIENCE_INFLUENCE_CAPS.perSegmentModifier);
+  return { activeAttendees, totalReactions: total, reactionCounts: counts, uniqueParticipants: unique.size, participationLevel, dominantReaction: total ? dominantReaction : null, encoreDemand: Math.round(encoreDemand), singalongStrength: Math.round(singalongStrength), participationScore, audienceModifier: Number(audienceModifier.toFixed(2)), crowdEnergyDelta: Math.round(signedClamp(audienceModifier * 0.7, AUDIENCE_INFLUENCE_CAPS.crowdEnergyDelta)), atmosphereDelta: Math.round(signedClamp(audienceModifier * 0.6, AUDIENCE_INFLUENCE_CAPS.atmosphereDelta)), supportRecoveryDelta: counts.support_performer > 0 ? Math.round(Math.min(AUDIENCE_INFLUENCE_CAPS.supportRecoveryDelta, unique.size / 3)) : 0 };
+}
+
+export function calculateAudienceParticipationScore(input: ParticipationScoreInput): number {
+  if (input.removed) return 0;
+  const watchRatio = input.totalSongs > 0 ? clamp(input.watchedSongs / input.totalSongs, 0, 1) : 0;
+  const durationPoints = Math.min(25, Math.floor(input.watchDurationSeconds / 300) * 3);
+  const reactionPoints = Math.min(28, input.validReactionCount * 3);
+  const varietyPoints = Math.min(16, input.reactionVariety * 2);
+  const completionPoints = input.stayedToEnd ? 18 : 0;
+  const encorePoints = input.encoreParticipated ? 6 : 0;
+  const invalidPenalty = Math.min(30, input.invalidAttempts * 4);
+  return Math.round(clamp(watchRatio * 30 + durationPoints + reactionPoints + varietyPoints + completionPoints + encorePoints - invalidPenalty));
+}
+
+export function calculateAudienceReward(score: number, status: AudienceAttendanceStatus, attendanceType: AudienceAttendanceType) {
+  if (attendanceType === 'remote_viewer' || attendanceType === 'admin_viewer' || status === 'removed' || status === 'cancelled') return { fanXp: 0, socialXp: 0, venueFamiliarity: 0, relationshipProgress: 0 };
+  const multiplier = status === 'completed' ? 1 : status === 'left_early' ? 0.55 : 0.25;
+  const bounded = clamp(score, 0, 100) / 100;
+  return { fanXp: Math.round((8 + bounded * 22) * multiplier), socialXp: Math.round((2 + bounded * 8) * multiplier), venueFamiliarity: Math.round((1 + bounded * 5) * multiplier), relationshipProgress: Math.round((1 + bounded * 4) * multiplier) };
+}

--- a/supabase/migrations/20260712120000_gig_audience_participation.sql
+++ b/supabase/migrations/20260712120000_gig_audience_participation.sql
@@ -1,0 +1,227 @@
+-- Phase 8: Live Audience Participation and Social Viewing.
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_attendance (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  live_session_id uuid REFERENCES public.gig_live_sessions(id) ON DELETE SET NULL,
+  player_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  attendance_type text NOT NULL CHECK (attendance_type IN ('ticket_holder','invited_guest','vip_guest','band_friend','venue_staff','crew','support_act','festival_attendee','remote_viewer','admin_viewer')),
+  ticket_id uuid,
+  invitation_id uuid,
+  status text NOT NULL DEFAULT 'eligible' CHECK (status IN ('eligible','checked_in','watching','left_early','completed','no_show','removed','cancelled')),
+  checked_in_at timestamptz,
+  left_at timestamptz,
+  last_presence_at timestamptz,
+  watch_duration_seconds integer NOT NULL DEFAULT 0 CHECK (watch_duration_seconds >= 0),
+  participation_score integer NOT NULL DEFAULT 0 CHECK (participation_score BETWEEN 0 AND 100),
+  reward_status text NOT NULL DEFAULT 'pending' CHECK (reward_status IN ('pending','not_eligible','processed','blocked')),
+  rewarded_at timestamptz,
+  privacy_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  moderation_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(gig_id, player_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_reactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  live_session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  attendance_id uuid NOT NULL REFERENCES public.gig_audience_attendance(id) ON DELETE CASCADE,
+  player_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  segment_id uuid REFERENCES public.gig_live_segments(id) ON DELETE SET NULL,
+  reaction_type text NOT NULL CHECK (reaction_type IN ('cheer','clap','sing_along','hands_up','dance','phone_wave','chant','encore_request','support_performer','highlight')),
+  reaction_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_segment_aggregates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  live_session_id uuid NOT NULL REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  segment_id uuid REFERENCES public.gig_live_segments(id) ON DELETE CASCADE,
+  reaction_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+  unique_participants integer NOT NULL DEFAULT 0 CHECK (unique_participants >= 0),
+  participation_score integer NOT NULL DEFAULT 0 CHECK (participation_score BETWEEN 0 AND 100),
+  participation_level text NOT NULL DEFAULT 'quiet' CHECK (participation_level IN ('quiet','engaged','lively','electric')),
+  encore_demand integer NOT NULL DEFAULT 0 CHECK (encore_demand BETWEEN 0 AND 100),
+  singalong_strength integer NOT NULL DEFAULT 0 CHECK (singalong_strength BETWEEN 0 AND 100),
+  audience_modifier numeric NOT NULL DEFAULT 0 CHECK (audience_modifier BETWEEN -4 AND 4),
+  finalised_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(live_session_id, segment_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_polls (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  live_session_id uuid REFERENCES public.gig_live_sessions(id) ON DELETE CASCADE,
+  poll_type text NOT NULL CHECK (poll_type IN ('encore_song','standout_member','venue_atmosphere','show_highlight','favourite_song')),
+  question text NOT NULL,
+  options jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status text NOT NULL DEFAULT 'open' CHECK (status IN ('draft','open','closed','expired','cancelled')),
+  opens_at timestamptz NOT NULL DEFAULT now(),
+  closes_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_poll_votes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id uuid NOT NULL REFERENCES public.gig_audience_polls(id) ON DELETE CASCADE,
+  attendance_id uuid NOT NULL REFERENCES public.gig_audience_attendance(id) ON DELETE CASCADE,
+  player_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  option_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(poll_id, attendance_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_ratings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  attendance_id uuid NOT NULL REFERENCES public.gig_audience_attendance(id) ON DELETE CASCADE,
+  player_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  overall_rating integer NOT NULL CHECK (overall_rating BETWEEN 1 AND 5),
+  sound_rating integer CHECK (sound_rating BETWEEN 1 AND 5),
+  production_rating integer CHECK (production_rating BETWEEN 1 AND 5),
+  venue_rating integer CHECK (venue_rating BETWEEN 1 AND 5),
+  value_rating integer CHECK (value_rating BETWEEN 1 AND 5),
+  favourite_song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  standout_member_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(attendance_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.gig_audience_reward_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gig_id uuid NOT NULL REFERENCES public.gigs(id) ON DELETE CASCADE,
+  attendance_id uuid NOT NULL REFERENCES public.gig_audience_attendance(id) ON DELETE CASCADE,
+  player_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reward_type text NOT NULL DEFAULT 'fan_attendance',
+  reward_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text NOT NULL,
+  processed_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_audience_attendance_player ON public.gig_audience_attendance(player_id, checked_in_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gig_audience_attendance_session ON public.gig_audience_attendance(live_session_id, status);
+CREATE INDEX IF NOT EXISTS idx_gig_audience_reactions_segment ON public.gig_audience_reactions(live_session_id, segment_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gig_audience_reactions_player ON public.gig_audience_reactions(player_id, gig_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gig_audience_polls_session ON public.gig_audience_polls(live_session_id, status, closes_at);
+CREATE INDEX IF NOT EXISTS idx_gig_audience_ratings_gig ON public.gig_audience_ratings(gig_id, created_at DESC);
+
+ALTER TABLE public.gig_audience_attendance ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_reactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_segment_aggregates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_polls ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_poll_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_ratings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gig_audience_reward_records ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY audience_attendance_select_own_or_band ON public.gig_audience_attendance FOR SELECT USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = player_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_attendance_insert_own_denied ON public.gig_audience_attendance FOR INSERT WITH CHECK (false);
+CREATE POLICY audience_attendance_update_own_denied ON public.gig_audience_attendance FOR UPDATE USING (false);
+CREATE POLICY audience_attendance_delete_denied ON public.gig_audience_attendance FOR DELETE USING (false);
+CREATE POLICY audience_reactions_select_eligible ON public.gig_audience_reactions FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_audience_attendance a JOIN public.profiles p ON p.id = a.player_id WHERE a.gig_id = gig_audience_reactions.gig_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_reactions_insert_denied ON public.gig_audience_reactions FOR INSERT WITH CHECK (false);
+CREATE POLICY audience_reactions_update_denied ON public.gig_audience_reactions FOR UPDATE USING (false);
+CREATE POLICY audience_reactions_delete_denied ON public.gig_audience_reactions FOR DELETE USING (false);
+CREATE POLICY audience_aggregates_select_eligible ON public.gig_audience_segment_aggregates FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_audience_attendance a JOIN public.profiles p ON p.id = a.player_id WHERE a.gig_id = gig_audience_segment_aggregates.gig_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_aggregates_write_denied ON public.gig_audience_segment_aggregates FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY audience_polls_select_eligible ON public.gig_audience_polls FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_audience_attendance a JOIN public.profiles p ON p.id = a.player_id WHERE a.gig_id = gig_audience_polls.gig_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_polls_write_denied ON public.gig_audience_polls FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY audience_poll_votes_select_own_or_band ON public.gig_audience_poll_votes FOR SELECT USING (EXISTS (SELECT 1 FROM public.gig_audience_attendance a JOIN public.profiles p ON p.id = a.player_id WHERE a.id = attendance_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gig_audience_polls poll JOIN public.gigs g ON g.id = poll.gig_id WHERE poll.id = poll_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_poll_votes_write_denied ON public.gig_audience_poll_votes FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY audience_ratings_select_own_or_band ON public.gig_audience_ratings FOR SELECT USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = player_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_ratings_write_denied ON public.gig_audience_ratings FOR ALL USING (false) WITH CHECK (false);
+CREATE POLICY audience_rewards_select_own_or_band ON public.gig_audience_reward_records FOR SELECT USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = player_id AND p.user_id = auth.uid()) OR EXISTS (SELECT 1 FROM public.gigs g WHERE g.id = gig_id AND public.is_band_leader_or_manager(g.band_id, auth.uid())));
+CREATE POLICY audience_rewards_write_denied ON public.gig_audience_reward_records FOR ALL USING (false) WITH CHECK (false);
+
+CREATE OR REPLACE FUNCTION public.current_profile_id() RETURNS uuid LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$ SELECT id FROM public.profiles WHERE user_id = auth.uid() ORDER BY created_at LIMIT 1 $$;
+
+CREATE OR REPLACE FUNCTION public.check_in_gig_audience(p_gig_id uuid, p_ticket_id uuid DEFAULT NULL, p_attendance_type text DEFAULT 'ticket_holder') RETURNS public.gig_audience_attendance LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_profile uuid; v_gig record; v_session uuid; v_count integer; v_row public.gig_audience_attendance;
+BEGIN
+  v_profile := public.current_profile_id(); IF v_profile IS NULL THEN RAISE EXCEPTION 'Profile required'; END IF;
+  SELECT g.*, v.capacity, v.city_id AS venue_city_id INTO v_gig FROM public.gigs g LEFT JOIN public.venues v ON v.id = g.venue_id WHERE g.id = p_gig_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Gig not found'; END IF;
+  IF v_gig.status IN ('cancelled','completed','failed') THEN RAISE EXCEPTION 'Gig is not open for check-in'; END IF;
+  IF p_attendance_type NOT IN ('ticket_holder','invited_guest','vip_guest','band_friend','venue_staff','crew','support_act','festival_attendee','remote_viewer','admin_viewer') THEN RAISE EXCEPTION 'Invalid attendance type'; END IF;
+  IF p_attendance_type NOT IN ('remote_viewer','admin_viewer') AND v_gig.venue_city_id IS NOT NULL AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = v_profile AND p.current_city_id IS DISTINCT FROM v_gig.venue_city_id) THEN RAISE EXCEPTION 'Player is not in the gig city'; END IF;
+  SELECT id INTO v_session FROM public.gig_live_sessions WHERE gig_id = p_gig_id ORDER BY created_at DESC LIMIT 1;
+  SELECT count(*) INTO v_count FROM public.gig_audience_attendance WHERE gig_id = p_gig_id AND status IN ('checked_in','watching','completed') AND attendance_type NOT IN ('remote_viewer','admin_viewer');
+  IF p_attendance_type NOT IN ('remote_viewer','admin_viewer') AND v_gig.capacity IS NOT NULL AND v_count >= LEAST(COALESCE(v_gig.tickets_sold, v_gig.capacity), v_gig.capacity) THEN RAISE EXCEPTION 'Venue capacity reached'; END IF;
+  INSERT INTO public.gig_audience_attendance(gig_id, live_session_id, player_id, attendance_type, ticket_id, status, checked_in_at, last_presence_at, reward_status)
+  VALUES (p_gig_id, v_session, v_profile, p_attendance_type, p_ticket_id, CASE WHEN p_attendance_type IN ('remote_viewer','admin_viewer') THEN 'watching' ELSE 'checked_in' END, now(), now(), CASE WHEN p_attendance_type IN ('remote_viewer','admin_viewer') THEN 'not_eligible' ELSE 'pending' END)
+  ON CONFLICT (gig_id, player_id) DO UPDATE SET last_presence_at = now(), live_session_id = COALESCE(EXCLUDED.live_session_id, gig_audience_attendance.live_session_id), status = CASE WHEN gig_audience_attendance.status IN ('left_early','eligible') THEN EXCLUDED.status ELSE gig_audience_attendance.status END, updated_at = now()
+  RETURNING * INTO v_row;
+  RETURN v_row;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.record_gig_audience_reaction(p_attendance_id uuid, p_reaction_type text, p_segment_id uuid DEFAULT NULL, p_idempotency_key text DEFAULT NULL) RETURNS public.gig_audience_segment_aggregates LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_att public.gig_audience_attendance; v_session public.gig_live_sessions; v_segment public.gig_live_segments; v_recent integer; v_count integer; v_agg public.gig_audience_segment_aggregates;
+BEGIN
+  SELECT * INTO v_att FROM public.gig_audience_attendance WHERE id = p_attendance_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Attendance not found'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = v_att.player_id AND p.user_id = auth.uid()) THEN RAISE EXCEPTION 'Not your attendance'; END IF;
+  IF v_att.status IN ('removed','cancelled','no_show') OR v_att.attendance_type IN ('remote_viewer','admin_viewer') THEN RAISE EXCEPTION 'Attendance cannot react'; END IF;
+  IF p_reaction_type NOT IN ('cheer','clap','sing_along','hands_up','dance','phone_wave','chant','encore_request','support_performer','highlight') THEN RAISE EXCEPTION 'Invalid reaction'; END IF;
+  SELECT * INTO v_session FROM public.gig_live_sessions WHERE id = v_att.live_session_id;
+  IF v_session.status NOT IN ('live','paused_for_decision') THEN RAISE EXCEPTION 'Gig is not live'; END IF;
+  SELECT * INTO v_segment FROM public.gig_live_segments WHERE id = COALESCE(p_segment_id, (SELECT id FROM public.gig_live_segments WHERE session_id = v_session.id AND segment_index = v_session.current_segment_index LIMIT 1));
+  IF NOT FOUND OR v_segment.status NOT IN ('active','resolved') THEN RAISE EXCEPTION 'No active reaction window'; END IF;
+  SELECT count(*) INTO v_recent FROM public.gig_audience_reactions WHERE attendance_id = p_attendance_id AND created_at > now() - interval '4 seconds'; IF v_recent > 0 THEN RAISE EXCEPTION 'Reaction cooldown active'; END IF;
+  SELECT count(*) INTO v_count FROM public.gig_audience_reactions WHERE attendance_id = p_attendance_id AND segment_id = v_segment.id; IF v_count >= 6 THEN RAISE EXCEPTION 'Song reaction limit reached'; END IF;
+  SELECT count(*) INTO v_count FROM public.gig_audience_reactions WHERE attendance_id = p_attendance_id AND gig_id = v_att.gig_id; IF v_count >= 40 THEN RAISE EXCEPTION 'Gig reaction limit reached'; END IF;
+  IF p_reaction_type = 'encore_request' AND EXISTS (SELECT 1 FROM public.gig_audience_reactions WHERE attendance_id = p_attendance_id AND reaction_type = 'encore_request') THEN RAISE EXCEPTION 'Encore request already counted'; END IF;
+  INSERT INTO public.gig_audience_reactions(gig_id, live_session_id, attendance_id, player_id, segment_id, reaction_type, reaction_context, idempotency_key) VALUES (v_att.gig_id, v_session.id, v_att.id, v_att.player_id, v_segment.id, p_reaction_type, jsonb_build_object('segment_type', v_segment.segment_type), p_idempotency_key) ON CONFLICT (idempotency_key) DO NOTHING;
+  INSERT INTO public.gig_audience_segment_aggregates(gig_id, live_session_id, segment_id, reaction_counts, unique_participants, participation_score, participation_level, encore_demand, singalong_strength, audience_modifier)
+  SELECT v_att.gig_id, v_session.id, v_segment.id, jsonb_object_agg(reaction_type, reaction_count), count(DISTINCT player_id), LEAST(100, count(*)::integer * 3), CASE WHEN count(*) >= 30 THEN 'electric' WHEN count(*) >= 15 THEN 'lively' WHEN count(*) >= 5 THEN 'engaged' ELSE 'quiet' END, LEAST(100, count(*) FILTER (WHERE reaction_type='encore_request')::integer * 20), LEAST(100, count(*) FILTER (WHERE reaction_type='sing_along')::integer * 15), LEAST(4, count(DISTINCT player_id)::numeric * 0.75)
+  FROM (SELECT reaction_type, player_id, count(*) over (partition by reaction_type) reaction_count FROM public.gig_audience_reactions WHERE live_session_id = v_session.id AND segment_id = v_segment.id) r GROUP BY true
+  ON CONFLICT (live_session_id, segment_id) DO UPDATE SET reaction_counts = EXCLUDED.reaction_counts, unique_participants = EXCLUDED.unique_participants, participation_score = EXCLUDED.participation_score, participation_level = EXCLUDED.participation_level, encore_demand = EXCLUDED.encore_demand, singalong_strength = EXCLUDED.singalong_strength, audience_modifier = EXCLUDED.audience_modifier, updated_at = now()
+  RETURNING * INTO v_agg;
+  UPDATE public.gig_audience_attendance SET participation_score = LEAST(100, participation_score + 2), last_presence_at = now(), updated_at = now() WHERE id = v_att.id;
+  RETURN v_agg;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.submit_gig_audience_poll_vote(p_poll_id uuid, p_option_key text) RETURNS public.gig_audience_poll_votes LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_profile uuid := public.current_profile_id(); v_poll public.gig_audience_polls; v_att public.gig_audience_attendance; v_vote public.gig_audience_poll_votes;
+BEGIN
+  SELECT * INTO v_poll FROM public.gig_audience_polls WHERE id = p_poll_id; IF NOT FOUND OR v_poll.status <> 'open' OR now() NOT BETWEEN v_poll.opens_at AND v_poll.closes_at THEN RAISE EXCEPTION 'Poll is closed'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM jsonb_array_elements(v_poll.options) opt WHERE opt->>'key' = p_option_key) THEN RAISE EXCEPTION 'Invalid poll option'; END IF;
+  SELECT * INTO v_att FROM public.gig_audience_attendance WHERE gig_id = v_poll.gig_id AND player_id = v_profile AND status IN ('checked_in','watching','completed') AND attendance_type NOT IN ('remote_viewer','admin_viewer'); IF NOT FOUND THEN RAISE EXCEPTION 'Valid attendance required'; END IF;
+  INSERT INTO public.gig_audience_poll_votes(poll_id, attendance_id, player_id, option_key) VALUES (p_poll_id, v_att.id, v_profile, p_option_key) ON CONFLICT (poll_id, attendance_id) DO UPDATE SET option_key = EXCLUDED.option_key RETURNING * INTO v_vote; RETURN v_vote;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.submit_gig_audience_rating(p_attendance_id uuid, p_overall integer, p_sound integer DEFAULT NULL, p_production integer DEFAULT NULL, p_venue integer DEFAULT NULL, p_value integer DEFAULT NULL, p_favourite_song_id uuid DEFAULT NULL, p_standout_member_id uuid DEFAULT NULL) RETURNS public.gig_audience_ratings LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_att public.gig_audience_attendance; v_rating public.gig_audience_ratings;
+BEGIN
+  SELECT * INTO v_att FROM public.gig_audience_attendance WHERE id = p_attendance_id AND player_id = public.current_profile_id(); IF NOT FOUND OR v_att.status <> 'completed' THEN RAISE EXCEPTION 'Completed attendance required'; END IF;
+  IF v_att.attendance_type IN ('remote_viewer','admin_viewer') THEN RAISE EXCEPTION 'Remote viewers cannot rate attendance'; END IF;
+  INSERT INTO public.gig_audience_ratings(gig_id, attendance_id, player_id, overall_rating, sound_rating, production_rating, venue_rating, value_rating, favourite_song_id, standout_member_id) VALUES (v_att.gig_id, v_att.id, v_att.player_id, p_overall, p_sound, p_production, p_venue, p_value, p_favourite_song_id, p_standout_member_id) ON CONFLICT (attendance_id) DO UPDATE SET overall_rating = EXCLUDED.overall_rating, sound_rating = EXCLUDED.sound_rating, production_rating = EXCLUDED.production_rating, venue_rating = EXCLUDED.venue_rating, value_rating = EXCLUDED.value_rating, favourite_song_id = EXCLUDED.favourite_song_id, standout_member_id = EXCLUDED.standout_member_id, updated_at = now() RETURNING * INTO v_rating; RETURN v_rating;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.process_gig_audience_rewards(p_gig_id uuid) RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_count integer;
+BEGIN
+  INSERT INTO public.gig_audience_reward_records(gig_id, attendance_id, player_id, reward_type, reward_snapshot, idempotency_key)
+  SELECT gig_id, id, player_id, 'fan_attendance', jsonb_build_object('fan_xp', LEAST(30, 8 + participation_score / 4), 'social_xp', LEAST(10, 2 + participation_score / 12), 'participation_score', participation_score), gig_id::text || ':audience:' || id::text
+  FROM public.gig_audience_attendance WHERE gig_id = p_gig_id AND status = 'completed' AND attendance_type NOT IN ('remote_viewer','admin_viewer') AND reward_status = 'pending'
+  ON CONFLICT (idempotency_key) DO NOTHING;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  UPDATE public.gig_audience_attendance SET reward_status = 'processed', rewarded_at = now(), updated_at = now() WHERE gig_id = p_gig_id AND status = 'completed' AND reward_status = 'pending' AND attendance_type NOT IN ('remote_viewer','admin_viewer');
+  RETURN v_count;
+END; $$;
+
+REVOKE ALL ON FUNCTION public.check_in_gig_audience(uuid,uuid,text) FROM PUBLIC, anon; GRANT EXECUTE ON FUNCTION public.check_in_gig_audience(uuid,uuid,text) TO authenticated;
+REVOKE ALL ON FUNCTION public.record_gig_audience_reaction(uuid,text,uuid,text) FROM PUBLIC, anon; GRANT EXECUTE ON FUNCTION public.record_gig_audience_reaction(uuid,text,uuid,text) TO authenticated;
+REVOKE ALL ON FUNCTION public.submit_gig_audience_poll_vote(uuid,text) FROM PUBLIC, anon; GRANT EXECUTE ON FUNCTION public.submit_gig_audience_poll_vote(uuid,text) TO authenticated;
+REVOKE ALL ON FUNCTION public.submit_gig_audience_rating(uuid,integer,integer,integer,integer,integer,uuid,uuid) FROM PUBLIC, anon; GRANT EXECUTE ON FUNCTION public.submit_gig_audience_rating(uuid,integer,integer,integer,integer,integer,uuid,uuid) TO authenticated;
+REVOKE ALL ON FUNCTION public.process_gig_audience_rewards(uuid) FROM PUBLIC, anon, authenticated; GRANT EXECUTE ON FUNCTION public.process_gig_audience_rewards(uuid) TO service_role;
+
+COMMIT;

--- a/supabase/tests/gig_audience_participation_harness.sql
+++ b/supabase/tests/gig_audience_participation_harness.sql
@@ -1,0 +1,28 @@
+-- Harness assertions for live gig audience participation and social viewing.
+BEGIN;
+SELECT plan(23);
+SELECT has_table('public', 'gig_audience_attendance', 'audience attendance table exists');
+SELECT has_table('public', 'gig_audience_reactions', 'audience reactions table exists');
+SELECT has_table('public', 'gig_audience_segment_aggregates', 'audience aggregate table exists');
+SELECT has_table('public', 'gig_audience_polls', 'audience polls table exists');
+SELECT has_table('public', 'gig_audience_poll_votes', 'audience poll votes table exists');
+SELECT has_table('public', 'gig_audience_ratings', 'audience ratings table exists');
+SELECT has_table('public', 'gig_audience_reward_records', 'audience reward records table exists');
+SELECT col_is_unique('public', 'gig_audience_attendance', ARRAY['gig_id', 'player_id'], 'one attendance record per player per gig');
+SELECT col_is_unique('public', 'gig_audience_poll_votes', ARRAY['poll_id', 'attendance_id'], 'one poll vote per attendance');
+SELECT col_is_unique('public', 'gig_audience_ratings', ARRAY['attendance_id'], 'one rating per attendance');
+SELECT col_is_unique('public', 'gig_audience_reward_records', ARRAY['idempotency_key'], 'reward processing is idempotent');
+SELECT has_index('public', 'gig_audience_reactions', 'idx_gig_audience_reactions_segment', 'reaction segment index exists');
+SELECT has_index('public', 'gig_audience_attendance', 'idx_gig_audience_attendance_player', 'attendance player index exists');
+SELECT has_function('public', 'check_in_gig_audience', ARRAY['uuid','uuid','text'], 'server-side audience check-in exists');
+SELECT has_function('public', 'record_gig_audience_reaction', ARRAY['uuid','text','uuid','text'], 'server-side reaction recorder exists');
+SELECT has_function('public', 'submit_gig_audience_poll_vote', ARRAY['uuid','text'], 'server-side poll vote function exists');
+SELECT has_function('public', 'submit_gig_audience_rating', ARRAY['uuid','integer','integer','integer','integer','integer','uuid','uuid'], 'server-side rating function exists');
+SELECT has_function('public', 'process_gig_audience_rewards', ARRAY['uuid'], 'idempotent reward processor exists');
+SELECT policies_are('public', 'gig_audience_attendance', ARRAY['audience_attendance_select_own_or_band', 'audience_attendance_insert_own_denied', 'audience_attendance_update_own_denied', 'audience_attendance_delete_denied']);
+SELECT policies_are('public', 'gig_audience_reactions', ARRAY['audience_reactions_select_eligible', 'audience_reactions_insert_denied', 'audience_reactions_update_denied', 'audience_reactions_delete_denied']);
+SELECT policies_are('public', 'gig_audience_polls', ARRAY['audience_polls_select_eligible', 'audience_polls_write_denied']);
+SELECT policies_are('public', 'gig_audience_poll_votes', ARRAY['audience_poll_votes_select_own_or_band', 'audience_poll_votes_write_denied']);
+SELECT policies_are('public', 'gig_audience_ratings', ARRAY['audience_ratings_select_own_or_band', 'audience_ratings_write_denied']);
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Implement Phase 8: let eligible players attend or view live gigs, participate with constrained reactions, and receive modest fan progression while preserving the server-driven live simulation as authoritative. 
- Provide a privacy-safe, rate-limited, aggregate audience layer that avoids duplicate ticketing/chat systems and prevents abuse or game-result manipulation.

### Description

- Added a database migration `20260712120000_gig_audience_participation.sql` that creates `gig_audience_attendance`, `gig_audience_reactions`, `gig_audience_segment_aggregates`, `gig_audience_polls`, `gig_audience_poll_votes`, `gig_audience_ratings`, and `gig_audience_reward_records`, plus indexes, RLS policies and SECURITY DEFINER RPCs (`check_in_gig_audience`, `record_gig_audience_reaction`, `submit_gig_audience_poll_vote`, `submit_gig_audience_rating`, `process_gig_audience_rewards`).
- Added audience domain utilities in `src/utils/gigAudience.ts` implementing eligibility checks, reaction timing validation, server-friendly rate limit logic, aggregation and bounded influence math, participation scoring and reward calculation.
- Added a mobile-friendly audience UI `LiveGigAudiencePanel` and integrated it into the existing `RealtimeGigViewer` so attendees can check in (or view-only), send quick reactions (cooldown/idempotency aware), and see aggregate participation state without receiving private band/crew data.
- Added unit tests `src/utils/__tests__/gigAudience.test.ts`, a pgTAP-style DB harness `supabase/tests/gig_audience_participation_harness.sql`, and documentation `docs/live-gig-audience-participation.md` describing design decisions, limitations and extension points.

### Testing

- Type checking: `npx tsc --noEmit --skipLibCheck` succeeded.
- Unit tests: `vitest` tests were added but could not be executed in this environment because dependency installation and `vitest` resolution failed (npm registry returned 403); test file is present at `src/utils/__tests__/gigAudience.test.ts`.
- Lint/build: `eslint` and `vite build` attempts were blocked by missing local dependencies (registry access errors), so lint and production build were not completed here.
- Database harness: schema/assertion harness added (`supabase/tests/gig_audience_participation_harness.sql`) but not executed because no test Postgres/Supabase environment was available in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53343ae4288325bff9741ab8a990e3)