### PR TITLE
Harden expanded Wellness scheduling foundation

### DIFF
--- a/src/lib/wellnessSystem.test.ts
+++ b/src/lib/wellnessSystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyDailyWellnessDrift, calculateOverallWellness, createDefaultWellnessCore, getPerformanceModifier, getWellnessState, getWellnessTier, getWellnessWarnings, isWellnessActivityUnlocked, isWellnessStatUnlocked } from "./wellnessSystem";
+import { applyDailyWellnessDrift, calculateOverallWellness, createDefaultWellnessCore, getPerformanceModifier, getWellnessState, getWellnessTier, getWellnessWarnings, isWellnessActivityUnlocked, isWellnessStatUnlocked, validateWellnessScheduleWindow } from "./wellnessSystem";
 
 describe("wellness calculations", () => {
   it("derives excellent and critical overall wellness from underlying stats", () => {
@@ -46,5 +46,22 @@ describe("wellness gating", () => {
   it("rejects locked activity access server config can mirror", () => {
     expect(isWellnessActivityUnlocked("exercise", 0)).toBe(false);
     expect(isWellnessActivityUnlocked("exercise", 100)).toBe(true);
+  });
+});
+
+
+describe("wellness scheduling validation", () => {
+  const now = new Date("2026-07-12T12:00:00Z");
+
+  it("rejects past and invalid wellness bookings", () => {
+    expect(validateWellnessScheduleWindow({ startsAt: new Date("2026-07-12T11:59:00Z"), endsAt: new Date("2026-07-12T13:00:00Z"), now })).toEqual({ ok: false, reason: "past" });
+    expect(validateWellnessScheduleWindow({ startsAt: new Date("2026-07-12T13:00:00Z"), endsAt: new Date("2026-07-12T13:00:00Z"), now })).toEqual({ ok: false, reason: "invalid_duration" });
+  });
+
+  it("rejects active overlaps but allows non-blocking statuses and overlap-enabled activities", () => {
+    const existing = [{ startsAt: new Date("2026-07-12T13:00:00Z"), endsAt: new Date("2026-07-12T14:00:00Z"), status: "scheduled" }];
+    expect(validateWellnessScheduleWindow({ startsAt: new Date("2026-07-12T13:30:00Z"), endsAt: new Date("2026-07-12T14:30:00Z"), existing, now })).toEqual({ ok: false, reason: "overlap" });
+    expect(validateWellnessScheduleWindow({ startsAt: new Date("2026-07-12T13:30:00Z"), endsAt: new Date("2026-07-12T14:30:00Z"), existing, canOverlap: true, now })).toEqual({ ok: true });
+    expect(validateWellnessScheduleWindow({ startsAt: new Date("2026-07-12T13:30:00Z"), endsAt: new Date("2026-07-12T14:30:00Z"), existing: [{ ...existing[0], status: "cancelled" }], now })).toEqual({ ok: true });
   });
 });

--- a/src/lib/wellnessSystem.ts
+++ b/src/lib/wellnessSystem.ts
@@ -132,6 +132,27 @@ export function createDefaultWellnessCore(existing?: Partial<{ health: number; e
   return { energy, physical_health, happiness, stress, fatigue: clampWellness(35 + Math.max(0, 50 - energy) / 2), sleep_quality: 72, nutrition: 68, fitness: 55, motivation: happiness, burnout_risk: clampWellness(stress * 0.45 + Math.max(0, 60 - happiness) * 0.35) };
 }
 
+export interface WellnessScheduleWindow {
+  startsAt: Date;
+  endsAt: Date;
+  canOverlap?: boolean;
+  existing?: Array<{ startsAt: Date; endsAt: Date; status?: string }>;
+  now?: Date;
+}
+
+export function validateWellnessScheduleWindow({ startsAt, endsAt, canOverlap = false, existing = [], now = new Date() }: WellnessScheduleWindow): { ok: true } | { ok: false; reason: "past" | "invalid_duration" | "overlap" } {
+  if (startsAt < now) return { ok: false, reason: "past" };
+  if (endsAt <= startsAt) return { ok: false, reason: "invalid_duration" };
+  if (!canOverlap) {
+    const overlaps = existing.some((activity) => {
+      if (activity.status && !["scheduled", "in_progress"].includes(activity.status)) return false;
+      return activity.startsAt < endsAt && activity.endsAt > startsAt;
+    });
+    if (overlaps) return { ok: false, reason: "overlap" };
+  }
+  return { ok: true };
+}
+
 export function applyDailyWellnessDrift(values: WellnessCoreValues, sleptMinutes = 0): WellnessCoreValues {
   const sleptWell = sleptMinutes >= 420;
   return {

--- a/supabase/functions/wellness-perform-activity/index.ts
+++ b/supabase/functions/wellness-perform-activity/index.ts
@@ -107,6 +107,30 @@ Deno.serve(async (req) => {
       return json({ error: gateRow.reason, suggestion_slug: gateRow.suggestion_slug }, 423);
     }
 
+    const scheduledStart = new Date();
+    const scheduledEnd = new Date(scheduledStart.getTime() + entry.duration_minutes * 60_000);
+    if (scheduledEnd <= scheduledStart) {
+      console.warn("[wellness_invalid_booking] invalid_duration", { profile_id, catalog_slug, duration_minutes: entry.duration_minutes });
+      return json({ error: "Invalid activity duration" }, 400);
+    }
+
+    if (entry.duration_minutes >= 60 && entry.can_overlap !== true) {
+      const { data: hasConflict, error: conflictError } = await supabase.rpc("check_scheduling_conflict", {
+        p_user_id: user.id,
+        p_start: scheduledStart.toISOString(),
+        p_end: scheduledEnd.toISOString(),
+        p_exclude_id: null,
+      });
+      if (conflictError) {
+        console.warn("[wellness_invalid_booking] conflict_check_failed", { profile_id, catalog_slug, error: conflictError.message });
+        return json({ error: "Could not validate schedule availability" }, 409);
+      }
+      if (hasConflict) {
+        console.warn("[wellness_invalid_booking] schedule_conflict", { profile_id, catalog_slug });
+        return json({ error: "This overlaps another scheduled activity" }, 409);
+      }
+    }
+
     // Apply stat effects
     const eff = entry.stat_effects ?? {};
     const newHealth = clamp((profile.health ?? 100) + (eff.health ?? eff.physical_health ?? 0));
@@ -188,12 +212,11 @@ Deno.serve(async (req) => {
 
     // Long activities create a schedule block
     if (entry.duration_minutes >= 60) {
-      const end = new Date(Date.now() + entry.duration_minutes * 60_000).toISOString();
       await supabase.from("player_scheduled_activities").insert({
         user_id: user.id, profile_id,
         activity_type: `wellness_${entry.category}`,
-        scheduled_start: new Date().toISOString(),
-        scheduled_end: end,
+        scheduled_start: scheduledStart.toISOString(),
+        scheduled_end: scheduledEnd.toISOString(),
         duration_minutes: entry.duration_minutes,
         status: "in_progress",
         title: entry.name,


### PR DESCRIPTION
### Motivation
- Strengthen the Wellness activity booking flow so long recovery/medical activities follow the same schedule conflict rules as gigs, rehearsals and travel. 
- Prevent stat/cash mutations from being applied before schedule availability is validated to avoid inconsistent state and scheduling races. 
- Provide a small, testable scheduling validation utility so future Wellness booking work can reuse a single source of truth for overlap/past/time validation.

### Description
- Added a shared schedule-window validator `validateWellnessScheduleWindow` and `WellnessScheduleWindow` types to `src/lib/wellnessSystem.ts` that reject past starts, zero/negative durations and active overlaps while allowing overlap-enabled activities and non-blocking statuses. 
- Hardened the server edge function `supabase/functions/wellness-perform-activity/index.ts` to compute a single stable `scheduledStart`/`scheduledEnd`, call the existing `check_scheduling_conflict` RPC for long non-overlapping activities, reject conflicts before applying stat/cash mutations, and reuse the validated window when creating `player_scheduled_activities`. 
- Added unit tests in `src/lib/wellnessSystem.test.ts` covering scheduling validation cases (past bookings, invalid durations, overlapping active commitments, overlap-enabled allowances, and cancelled/non-blocking statuses). 
- Kept existing wellness balance, activity catalog and performance formulas unchanged and reused the current gating/unlock checks already enforced by the server-side catalog check. 

### Testing
- Added unit tests for scheduling validation in `src/lib/wellnessSystem.test.ts` (new tests committed). 
- Attempted to run `npm run test:unit` for the modified spec but test execution failed in this environment because `vitest` was not available (`vitest: not found`). 
- Attempted `npm install` / typecheck but dependency install was blocked by registry access errors (npm registry 403), so full test/typecheck and local app screenshots could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5341fc2d9c8325975f84d8757e65cc)