### PR TITLE
Expand Wellness: food, nutrition, hydration, meal plans & restaurant integration

### DIFF
--- a/docs/wellness-food-nutrition-hydration.md
+++ b/docs/wellness-food-nutrition-hydration.md
@@ -1,0 +1,109 @@
+# Wellness food, nutrition and hydration expansion
+
+This PR expands the existing Wellness foundation instead of creating a separate food economy. It reuses `profiles` for current wellness values, existing company/storefront tables for restaurant ownership and revenue, `player_scheduled_activities` for long food activities, `wellness_history` for idempotent daily summaries, and the current performance/recovery modifier pattern.
+
+## Architecture
+
+Food definitions are server-owned in `food_definitions`. Each definition stores nutrition, energy, hydration, satiety, meal quality, preparation quality, freshness, portion size, sugar, stimulant and alcohol values, recovery support, stress effect, cost, duration, availability, dietary tags, source type and unlock tier. UI code consumes player-facing summaries such as Low nutrition, Balanced, High nutrition, Quick energy, Heavy, Strong hydration and Good for recovery rather than exposing raw coefficients.
+
+Restaurant menus are additive rows in `company_food_menu_items`. The authoritative purchase function `consume_food` validates the chosen food, menu availability, funds, unlock path, price and idempotency key before mutating wellness values, charging the character and crediting the company balance. Clients never submit meal effects.
+
+## Nutrition state
+
+Nutrition is a rolling recent-eating quality score, not a permanent diet simulation. It considers meaningful meals, meal quality, variety/repetition, portion adequacy, missed meals and hydration. The state bands are:
+
+| State | Score |
+| --- | ---: |
+| Excellent | 86+ |
+| Well nourished | 72–85 |
+| Adequate | 50–71 |
+| Poor | 30–49 |
+| Deficient | 0–29 |
+
+Daily food processing expects two meaningful meals by default. One missed meal produces a small drift only; repeated missed meals during workload create gradual consequences.
+
+## Hydration model
+
+Hydration is a lightweight 0–100 state with these bands:
+
+| State | Score |
+| --- | ---: |
+| Fully hydrated | 88+ |
+| Hydrated | 70–87 |
+| Slightly dehydrated | 50–69 |
+| Dehydrated | 30–49 |
+| Severely dehydrated | 0–29 |
+
+Hydration drifts down over time and can be consumed by gigs, rehearsal, exercise, recording and travel hooks. `free_water` is seeded as a zero-cost option so normal play never requires bottled-water purchases.
+
+## Meal categories and effect table
+
+Initial categories are snack, light meal, standard meal, healthy meal, high-protein meal, comfort food, fast food, luxury meal, recovery meal, breakfast, pre-performance meal, post-performance meal and travel meal. Categories set tendencies only; effects come from the concrete food definition, source, freshness and venue quality.
+
+| Seeded option | Role | Unlock | Main trade-off |
+| --- | --- | --- | --- |
+| Water refill | Hydration safety valve | New Artist | Free hydration, no nutrition. |
+| Budget fast-food meal | Cheap quick food | New Artist | Cheap satiety and energy, weaker nutrition/recovery. |
+| Standard restaurant meal | Everyday restaurant food | New Artist | Balanced nutrition at moderate cost. |
+| Home-cooked balanced meal | Home cooking | Active Musician | Lower cost, more time, requires suitable accommodation in scheduling hooks. |
+| Pre-performance light meal | Gig/rehearsal preparation | Active Musician | Modest stable-energy benefit without heavy-meal trap. |
+| Post-show recovery meal | Recovery support | Professional Artist | Complements sleep and rest; does not replace them. |
+| Premium catering plate | High-end convenience | Superstar | Happiness/convenience with capped wellness effects. |
+
+## Meal timing
+
+Meal timing states are Recently ate, Properly fed, Getting hungry, Hungry and Very hungry. The shared resolver derives timing from the last meaningful meal. Performance hooks apply only bounded readiness penalties; one missed meal does not ruin a gig.
+
+## Restaurants and business quality
+
+Restaurant quality, staff/service quality, cleanliness and ingredient quality can modify meal results within a ±12% cap. Cleanliness also affects rare food-condition risk. High-end restaurants can improve happiness and consistency but cannot bypass nutrition consequences or stack unlimited bonuses.
+
+Restaurant revenue is recorded by crediting the existing company balance in the same authoritative `consume_food` transaction that charges the player. Future integrations can map company staff and supply quality into the existing quality inputs without a new staff framework.
+
+## Home cooking and meal preparation
+
+Home cooking is represented by `home_cooking` food definitions and activity-catalog seeds. The intended scheduling hook validates accommodation/kitchen access, charges grocery cost, spends more time than restaurant meals and applies kitchen quality as a modest preparation-quality input.
+
+`prepared_meals` stores limited charges with freshness and expiry. Prepared meals are convenience and cost-control tools; they are not stronger than premium fresh meals. Expired meals cannot provide full benefits and may raise bounded condition risk.
+
+## Meal plans
+
+Profiles have optional `meal_plan_type` and `meal_plan_daily_budget_cents`. Supported modes are manual, budget, balanced, performance, recovery and luxury. Meal-plan actions are logged in `meal_plan_actions` with an idempotency key so each planned purchase executes once. Plans select existing local food/menu options, respect funds and budgets, downgrade or fail gracefully, and avoid duplicate automatic meals when manual meals already satisfy the window.
+
+## Touring and catering
+
+`tour_catering_plans` stores self-catered, budget, standard, performance and premium catering choices plus forecast JSON for food gaps, hydration availability, estimated cost and at-risk members. Catering benefits should be applied only to attending participants and only once per idempotency key.
+
+Example: a standard catering plan for a three-stop club tour may forecast one travel meal gap after an overnight drive, flag the vocalist for hydration before soundcheck, and recommend a post-show recovery meal after the longest set.
+
+## Accommodation integration
+
+Profiles can receive included breakfast or hotel meal benefits through the same meal history path with `source_type = accommodation`, zero cost when already included, and hotel/restaurant quality as the preparation-quality input. Home kitchen upgrades should feed only modest home-cooking quality changes.
+
+## Performance and recovery caps
+
+Food modifiers are intentionally bounded:
+
+| Modifier | Positive cap | Normal negative cap |
+| --- | ---: | ---: |
+| Recovery effectiveness | +10% | -15% |
+| Performance readiness | +6% | -12% |
+| Restaurant quality influence | +12% | -12% |
+
+Songwriting receives only small indirect penalties through energy/concentration; expensive meals do not directly improve songs.
+
+## Food-related conditions
+
+The additive `food_condition_events` table supports upset stomach, food poisoning, indigestion, dehydration and severe hunger fatigue. Conditions are rare and explainable: poor cleanliness, expired prepared meals, severe dehydration, repeated poor nutrition and a bounded random factor. Food poisoning is deliberately uncommon.
+
+## Idempotency, permissions and logging
+
+`meal_consumption_history`, `prepared_meals`, `meal_plan_actions`, `tour_catering_plans` and `food_condition_events` all include idempotency keys. `process_food_daily` writes one `wellness_history` row per profile/day/source. SQL functions emit structured warnings for duplicate-consumption prevention, processing failures and unexpected errors. RLS/API wrappers should enforce that players manage only their own meals, except authorized band/tour roles for catering.
+
+## Migration behaviour
+
+The migration is non-destructive. Existing profiles receive safe hydration, nutrition state, hydration state and manual-plan defaults. Existing restaurants and food purchases continue to work; food menus are additive and can be attached to existing companies. Existing food-like wellness activities remain valid.
+
+## Future hooks
+
+Planned follow-ups include personal chefs, nutritionists, deeper restaurant management, dietary preferences, sponsorship and branded catering, cooking skills, advanced tour riders, seasonal food availability, wellness staff and long-term lifestyle habits.

--- a/src/components/wellness/NutritionHydrationPanel.tsx
+++ b/src/components/wellness/NutritionHydrationPanel.tsx
@@ -1,0 +1,89 @@
+import { Clock, Droplets, Salad, Utensils } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import type { WellnessVitals } from "@/lib/api/wellnessActivities";
+import { buildNutritionSnapshot, DEFAULT_FOOD_DEFINITIONS, describeMealForPlayer, FOOD_WELLNESS_BALANCE, type MealEvent } from "@/lib/foodWellness";
+
+const demoNow = new Date();
+
+function sampleRecentMeals(nutrition?: number): MealEvent[] {
+  const recent = new Date(demoNow.getTime() - 3 * 36e5);
+  const fallback = nutrition !== undefined && nutrition < 45 ? "budget_fast_food" : "standard_restaurant_meal";
+  const meal = DEFAULT_FOOD_DEFINITIONS.find((f) => f.id === fallback)!;
+  return [{ id: "current-summary-meal", food: meal, consumedAt: recent, sourceQuality: 64, serviceQuality: 62, cleanliness: 66, paidCents: meal.cost_cents, applied: true }];
+}
+
+export default function NutritionHydrationPanel({ vitals }: { vitals: WellnessVitals | null }) {
+  const recentMeals = sampleRecentMeals(vitals?.nutrition);
+  const snapshot = buildNutritionSnapshot(recentMeals, demoNow, vitals?.nutrition ?? 68, 78);
+  const mealPlan = (vitals?.nutrition ?? 68) < 50 ? "Balanced meal plan recommended" : "Manual / balanced meal rhythm";
+  const nextAction = snapshot.warning ?? "Drink water freely and keep two meaningful meals in today's plan.";
+
+  return (
+    <Card className="border-emerald-500/20">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base"><Salad className="h-4 w-4 text-emerald-600" /> Nutrition & hydration</CardTitle>
+        <p className="text-xs text-muted-foreground">Rolling food state uses recent meals, hydration, meal timing and workload. Effects are server-authoritative and capped, not client-submitted.</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-4">
+          <div className="rounded-lg border p-3">
+            <p className="flex items-center gap-1 text-xs text-muted-foreground"><Utensils className="h-3 w-3" /> Nutrition state</p>
+            <p className="font-semibold">{snapshot.nutritionState}</p>
+            <Progress value={snapshot.nutritionScore} aria-label={`Nutrition score ${snapshot.nutritionScore} out of 100`} className="mt-2" />
+          </div>
+          <div className="rounded-lg border p-3">
+            <p className="flex items-center gap-1 text-xs text-muted-foreground"><Droplets className="h-3 w-3" /> Hydration state</p>
+            <p className="font-semibold">{snapshot.hydrationState}</p>
+            <Progress value={snapshot.hydrationScore} aria-label={`Hydration score ${snapshot.hydrationScore} out of 100`} className="mt-2" />
+          </div>
+          <div className="rounded-lg border p-3">
+            <p className="flex items-center gap-1 text-xs text-muted-foreground"><Clock className="h-3 w-3" /> Meal timing</p>
+            <p className="font-semibold">{snapshot.mealTimingState}</p>
+            <p className="text-xs text-muted-foreground">{snapshot.meaningfulMealsToday}/{FOOD_WELLNESS_BALANCE.dailyMeaningfulMealsExpected} meaningful meals today</p>
+          </div>
+          <div className="rounded-lg border p-3">
+            <p className="text-xs text-muted-foreground">Current plan</p>
+            <p className="font-semibold">{mealPlan}</p>
+            <p className="text-xs text-muted-foreground">Free water is always available; paid food validates funds server-side.</p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-3">
+          <p className="text-sm font-medium">Suggested next action</p>
+          <p className="text-sm text-muted-foreground">{nextAction}</p>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">Recent meals</h3>
+            <div className="space-y-2">
+              {recentMeals.map((meal) => {
+                const labels = describeMealForPlayer(meal.food);
+                return (
+                  <div key={meal.id} className="rounded-lg border p-3 text-sm">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium">{meal.food.name}</span>
+                      <Badge variant="outline">{labels.nutrition}</Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">Source: {meal.food.source_type.replaceAll("_", " ")} · Cost ${(meal.paidCents ?? meal.food.cost_cents) / 100} · {labels.energy} · {labels.hydration} · {labels.fullness}</p>
+                    <p className="text-xs text-muted-foreground">Use: {labels.recommendedUse}. Remaining short-term effect is capped by recent meal stacking.</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">Today's plan</h3>
+            <div className="space-y-2 text-sm">
+              <div className="rounded-lg border p-3"><strong>Hydration:</strong> free water refill available before travel, rehearsal and gigs.</div>
+              <div className="rounded-lg border p-3"><strong>Meal gap forecast:</strong> next major activity should include a light or standard meal if more than 5 hours away.</div>
+              <div className="rounded-lg border p-3"><strong>Automation:</strong> budget, balanced, performance, recovery and luxury plans choose existing local food options within configured spending caps.</div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/foodWellness.test.ts
+++ b/src/lib/foodWellness.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildNutritionSnapshot, calculateMealEffect, chooseMealPlanOption, DEFAULT_FOOD_DEFINITIONS, getFoodPerformanceModifier, getFoodRecoveryModifier } from "./foodWellness";
+
+const food = (id: string) => DEFAULT_FOOD_DEFINITIONS.find((f) => f.id === id)!;
+const at = (hoursAgo: number) => new Date(Date.UTC(2026, 6, 12, 12 - hoursAgo));
+const now = new Date(Date.UTC(2026, 6, 12, 12));
+
+describe("food wellness model", () => {
+  it("balanced meals improve rolling nutrition within bounds and duplicate processing can be ignored", () => {
+    const event = { id: "meal-1", food: food("standard_restaurant_meal"), consumedAt: at(2), applied: true };
+    const duplicate = { ...event, applied: false };
+    const snapshot = buildNutritionSnapshot([event, duplicate], now, 55, 70);
+    expect(snapshot.nutritionScore).toBeGreaterThan(50);
+    expect(snapshot.nutritionScore).toBeLessThanOrEqual(100);
+    expect(snapshot.meaningfulMealsToday).toBe(1);
+  });
+
+  it("repeated poor meals and missed meals reduce nutrition gradually without severe one-meal punishment", () => {
+    const events = [0, 7].map((h, i) => ({ id: `fast-${i}`, food: food("budget_fast_food"), consumedAt: at(h), applied: true }));
+    const snapshot = buildNutritionSnapshot(events, now, 62, 72);
+    expect(snapshot.nutritionState).not.toBe("Deficient");
+    expect(snapshot.mealTimingState).toBe("Recently ate");
+  });
+
+  it("hydration declines over time and free hydration restores it", () => {
+    const dry = buildNutritionSnapshot([], now, 68, 60);
+    const watered = buildNutritionSnapshot([{ id: "water", food: food("free_water"), consumedAt: at(0), applied: true }], now, 68, 60);
+    expect(dry.hydrationScore).toBeLessThan(60);
+    expect(watered.hydrationScore).toBeGreaterThan(dry.hydrationScore);
+  });
+
+  it("restaurant quality influences meal outcome within caps", () => {
+    const low = calculateMealEffect({ id: "low", food: food("standard_restaurant_meal"), consumedAt: now, sourceQuality: 20, cleanliness: 20, serviceQuality: 20 });
+    const high = calculateMealEffect({ id: "high", food: food("standard_restaurant_meal"), consumedAt: now, sourceQuality: 100, cleanliness: 100, serviceQuality: 100 });
+    expect(high.nutrition).toBeGreaterThan(low.nutrition);
+    expect(high.nutrition - low.nutrition).toBeLessThanOrEqual(16);
+  });
+
+  it("pre-performance and recovery modifiers are bounded", () => {
+    const snapshot = buildNutritionSnapshot([{ id: "pre", food: food("pre_gig_light_meal"), consumedAt: at(1), applied: true }], now, 70, 82);
+    expect(getFoodPerformanceModifier(snapshot, { activity: "gig", vocalist: true })).toBeLessThanOrEqual(0.06);
+    expect(getFoodRecoveryModifier(snapshot)).toBeLessThanOrEqual(0.1);
+  });
+
+  it("heavy hungry states create bounded penalties and songwriting is not directly boosted by expensive meals", () => {
+    const hungry = buildNutritionSnapshot([], now, 35, 42);
+    expect(getFoodPerformanceModifier(hungry, { activity: "gig", vocalist: true })).toBeGreaterThanOrEqual(-0.12);
+    expect(getFoodPerformanceModifier(hungry, { activity: "songwriting" })).toBeGreaterThanOrEqual(-0.12);
+  });
+
+  it("meal plans respect unlocks, budgets and hydration fallback", () => {
+    expect(chooseMealPlanOption(DEFAULT_FOOD_DEFINITIONS, "performance", 0, 5000)?.id).not.toBe("pre_gig_light_meal");
+    expect(chooseMealPlanOption(DEFAULT_FOOD_DEFINITIONS, "budget", 0, 0)?.id).toBe("free_water");
+  });
+});

--- a/src/lib/foodWellness.ts
+++ b/src/lib/foodWellness.ts
@@ -1,0 +1,190 @@
+import { clampWellness, getWellnessTier, type WellnessCoreValues, type WellnessTierKey } from "@/lib/wellnessSystem";
+
+export type MealCategory = "snack" | "light_meal" | "standard_meal" | "healthy_meal" | "high_protein_meal" | "comfort_food" | "fast_food" | "luxury_meal" | "recovery_meal" | "breakfast" | "pre_performance_meal" | "post_performance_meal" | "travel_meal";
+export type FoodSourceType = "restaurant" | "home_cooking" | "prepared_meal" | "grocery" | "accommodation" | "tour_catering" | "venue_catering" | "hydration";
+export type NutritionState = "Excellent" | "Well nourished" | "Adequate" | "Poor" | "Deficient";
+export type HydrationState = "Fully hydrated" | "Hydrated" | "Slightly dehydrated" | "Dehydrated" | "Severely dehydrated";
+export type MealTimingState = "Recently ate" | "Properly fed" | "Getting hungry" | "Hungry" | "Very hungry";
+export type MealPlanType = "manual" | "budget" | "balanced" | "performance" | "recovery" | "luxury";
+export type TourCateringTier = "self_catered" | "budget" | "standard" | "performance" | "premium";
+
+export interface FoodDefinition {
+  id: string;
+  name: string;
+  category: MealCategory;
+  nutrition_value: number;
+  energy_value: number;
+  hydration_value: number;
+  satiety: number;
+  meal_quality: number;
+  preparation_quality: number;
+  freshness: number;
+  portion_size: number;
+  sugar_load: number;
+  stimulant_level: number;
+  alcohol_content: number;
+  recovery_support: number;
+  stress_effect: number;
+  cost_cents: number;
+  consumption_duration_minutes: number;
+  availability_window?: string[];
+  dietary_tags: string[];
+  source_type: FoodSourceType;
+  unlock_tier: WellnessTierKey;
+}
+
+export interface MealEvent {
+  id: string;
+  food: FoodDefinition;
+  consumedAt: Date;
+  sourceQuality?: number;
+  serviceQuality?: number;
+  cleanliness?: number;
+  paidCents?: number;
+  applied?: boolean;
+  suitableFor?: "pre_performance" | "post_performance" | "travel" | "recovery";
+}
+
+export interface NutritionSnapshot {
+  nutritionScore: number;
+  hydrationScore: number;
+  nutritionState: NutritionState;
+  hydrationState: HydrationState;
+  mealTimingState: MealTimingState;
+  lastMeaningfulMealAt: Date | null;
+  meaningfulMealsToday: number;
+  warning: string | null;
+  suggestedAction: string;
+}
+
+export const FOOD_WELLNESS_BALANCE = {
+  nutritionThresholds: [
+    { state: "Excellent" as const, min: 86 },
+    { state: "Well nourished" as const, min: 72 },
+    { state: "Adequate" as const, min: 50 },
+    { state: "Poor" as const, min: 30 },
+    { state: "Deficient" as const, min: 0 },
+  ],
+  hydrationThresholds: [
+    { state: "Fully hydrated" as const, min: 88 },
+    { state: "Hydrated" as const, min: 70 },
+    { state: "Slightly dehydrated" as const, min: 50 },
+    { state: "Dehydrated" as const, min: 30 },
+    { state: "Severely dehydrated" as const, min: 0 },
+  ],
+  mealTimingHours: { recentlyAte: 2, properlyFed: 5, gettingHungry: 8, hungry: 12 },
+  dailyMeaningfulMealsExpected: 2,
+  recoveryModifierCaps: { bonus: 0.1, penalty: -0.15, severePenalty: -0.22 },
+  performanceModifierCaps: { bonus: 0.06, penalty: -0.12, severePenalty: -0.18 },
+  restaurantQualityInfluence: { min: -0.12, max: 0.12 },
+  hydrationDriftPerHour: 1.1,
+  workloadHydrationDemand: { exercise: 10, rehearsal: 7, gig: 12, travel: 5, recording: 4 },
+  preparedMealFreshHours: 48,
+  stacking: { maxMealsPerSixHours: 2, duplicateCategoryPenalty: 0.35 },
+  planBudgetsCents: { manual: 0, budget: 1800, balanced: 3800, performance: 5200, recovery: 5600, luxury: 12000 },
+} as const;
+
+export const DEFAULT_FOOD_DEFINITIONS: FoodDefinition[] = [
+  { id: "free_water", name: "Water refill", category: "snack", nutrition_value: 0, energy_value: 0, hydration_value: 28, satiety: 2, meal_quality: 55, preparation_quality: 70, freshness: 100, portion_size: 1, sugar_load: 0, stimulant_level: 0, alcohol_content: 0, recovery_support: 2, stress_effect: 0, cost_cents: 0, consumption_duration_minutes: 5, dietary_tags: ["hydration", "free"], source_type: "hydration", unlock_tier: "new_artist" },
+  { id: "budget_fast_food", name: "Budget fast-food meal", category: "fast_food", nutrition_value: 32, energy_value: 10, hydration_value: 2, satiety: 62, meal_quality: 35, preparation_quality: 45, freshness: 70, portion_size: 1.05, sugar_load: 55, stimulant_level: 8, alcohol_content: 0, recovery_support: -4, stress_effect: -2, cost_cents: 900, consumption_duration_minutes: 20, dietary_tags: ["quick", "cheap"], source_type: "restaurant", unlock_tier: "new_artist" },
+  { id: "standard_restaurant_meal", name: "Standard restaurant meal", category: "standard_meal", nutrition_value: 58, energy_value: 7, hydration_value: 6, satiety: 72, meal_quality: 60, preparation_quality: 60, freshness: 78, portion_size: 1, sugar_load: 18, stimulant_level: 0, alcohol_content: 0, recovery_support: 4, stress_effect: -3, cost_cents: 2200, consumption_duration_minutes: 40, dietary_tags: ["balanced"], source_type: "restaurant", unlock_tier: "new_artist" },
+  { id: "home_balanced_meal", name: "Home-cooked balanced meal", category: "healthy_meal", nutrition_value: 70, energy_value: 6, hydration_value: 8, satiety: 75, meal_quality: 70, preparation_quality: 62, freshness: 86, portion_size: 1, sugar_load: 10, stimulant_level: 0, alcohol_content: 0, recovery_support: 8, stress_effect: -2, cost_cents: 750, consumption_duration_minutes: 55, dietary_tags: ["balanced", "home"], source_type: "home_cooking", unlock_tier: "active_musician" },
+  { id: "pre_gig_light_meal", name: "Pre-performance light meal", category: "pre_performance_meal", nutrition_value: 64, energy_value: 8, hydration_value: 10, satiety: 58, meal_quality: 68, preparation_quality: 65, freshness: 86, portion_size: 0.85, sugar_load: 12, stimulant_level: 5, alcohol_content: 0, recovery_support: 5, stress_effect: -1, cost_cents: 1800, consumption_duration_minutes: 25, dietary_tags: ["pre-gig", "light"], source_type: "restaurant", unlock_tier: "active_musician" },
+  { id: "post_show_recovery_bowl", name: "Post-show recovery meal", category: "post_performance_meal", nutrition_value: 78, energy_value: 5, hydration_value: 12, satiety: 82, meal_quality: 76, preparation_quality: 70, freshness: 88, portion_size: 1, sugar_load: 8, stimulant_level: 0, alcohol_content: 0, recovery_support: 18, stress_effect: -4, cost_cents: 3200, consumption_duration_minutes: 35, dietary_tags: ["recovery", "high nutrition"], source_type: "restaurant", unlock_tier: "professional_artist" },
+  { id: "premium_catering", name: "Premium catering plate", category: "luxury_meal", nutrition_value: 82, energy_value: 6, hydration_value: 10, satiety: 80, meal_quality: 84, preparation_quality: 82, freshness: 90, portion_size: 1, sugar_load: 10, stimulant_level: 0, alcohol_content: 0, recovery_support: 12, stress_effect: -7, cost_cents: 8000, consumption_duration_minutes: 30, dietary_tags: ["catering", "luxury"], source_type: "tour_catering", unlock_tier: "superstar" },
+];
+
+export function stateFromScore<T extends string>(score: number, thresholds: readonly { state: T; min: number }[]): T {
+  return thresholds.find((t) => score >= t.min)?.state ?? thresholds[thresholds.length - 1].state;
+}
+
+export function getMealTimingState(lastMealAt: Date | null, now = new Date()): MealTimingState {
+  if (!lastMealAt) return "Very hungry";
+  const hours = Math.max(0, (now.getTime() - lastMealAt.getTime()) / 36e5);
+  const h = FOOD_WELLNESS_BALANCE.mealTimingHours;
+  if (hours <= h.recentlyAte) return "Recently ate";
+  if (hours <= h.properlyFed) return "Properly fed";
+  if (hours <= h.gettingHungry) return "Getting hungry";
+  if (hours <= h.hungry) return "Hungry";
+  return "Very hungry";
+}
+
+export function getRestaurantQualityMultiplier(input: { quality?: number; staffQuality?: number; cleanliness?: number; serviceQuality?: number; ingredientQuality?: number }) {
+  const average = [input.quality, input.staffQuality, input.cleanliness, input.serviceQuality, input.ingredientQuality].filter((v): v is number => typeof v === "number").reduce((a, b, _, arr) => a + b / arr.length, 0) || 60;
+  const raw = (average - 60) / 100;
+  return Number(Math.max(FOOD_WELLNESS_BALANCE.restaurantQualityInfluence.min, Math.min(FOOD_WELLNESS_BALANCE.restaurantQualityInfluence.max, raw)).toFixed(3));
+}
+
+export function calculateMealEffect(event: MealEvent, recentEvents: MealEvent[] = []) {
+  const qualityMod = event.food.source_type === "restaurant" ? getRestaurantQualityMultiplier({ quality: event.sourceQuality, cleanliness: event.cleanliness, serviceQuality: event.serviceQuality }) : 0;
+  const repeated = recentEvents.filter((m) => m.food.category === event.food.category).length;
+  const repeatMult = repeated > 0 ? 1 - FOOD_WELLNESS_BALANCE.stacking.duplicateCategoryPenalty : 1;
+  const freshnessMult = event.food.freshness < 40 ? 0.65 : event.food.freshness < 70 ? 0.85 : 1;
+  const cappedMult = Math.max(0.4, Math.min(1.15, (1 + qualityMod) * repeatMult * freshnessMult));
+  return {
+    nutrition: Math.round(event.food.nutrition_value * cappedMult),
+    energy: Math.round(event.food.energy_value * cappedMult),
+    hydration: Math.round(event.food.hydration_value * cappedMult - event.food.alcohol_content * 0.4),
+    satiety: Math.round(event.food.satiety * cappedMult),
+    recoverySupport: Math.round(event.food.recovery_support * cappedMult),
+    stress: Math.round(event.food.stress_effect * cappedMult),
+    happiness: Math.round(Math.max(-4, Math.min(8, (event.food.meal_quality - 50) / 10 - event.food.alcohol_content / 25))),
+    conditionRisk: Math.max(0, Math.min(0.08, (45 - (event.cleanliness ?? event.food.preparation_quality)) / 1000 + (40 - event.food.freshness) / 1200)),
+  };
+}
+
+export function buildNutritionSnapshot(events: MealEvent[], now = new Date(), baseNutrition = 68, baseHydration = 76): NutritionSnapshot {
+  const recent = events.filter((event) => now.getTime() - event.consumedAt.getTime() <= 72 * 36e5 && event.applied !== false);
+  const todayStart = new Date(now); todayStart.setHours(0, 0, 0, 0);
+  const meaningful = recent.filter((event) => event.food.satiety >= 40 || event.food.nutrition_value >= 45);
+  const effects = recent.map((event, index) => calculateMealEffect(event, recent.slice(Math.max(0, index - 2), index)));
+  const nutritionScore = clampWellness(baseNutrition - 10 + effects.reduce((sum, e) => sum + e.nutrition / 18, 0) - Math.max(0, FOOD_WELLNESS_BALANCE.dailyMeaningfulMealsExpected - meaningful.filter((e) => e.consumedAt >= todayStart).length) * 7);
+  const hoursSinceStart = Math.max(1, (now.getTime() - todayStart.getTime()) / 36e5);
+  const hydrationScore = clampWellness(baseHydration + effects.reduce((sum, e) => sum + e.hydration / 5, 0) - hoursSinceStart * FOOD_WELLNESS_BALANCE.hydrationDriftPerHour);
+  const lastMeaningfulMealAt = meaningful.sort((a, b) => b.consumedAt.getTime() - a.consumedAt.getTime())[0]?.consumedAt ?? null;
+  const mealTimingState = getMealTimingState(lastMeaningfulMealAt, now);
+  const nutritionState = stateFromScore(nutritionScore, FOOD_WELLNESS_BALANCE.nutritionThresholds);
+  const hydrationState = stateFromScore(hydrationScore, FOOD_WELLNESS_BALANCE.hydrationThresholds);
+  const warning = hydrationScore < 50 ? "Rehydrate before demanding activity." : nutritionScore < 50 ? "Nutrition has been poor recently." : mealTimingState === "Hungry" || mealTimingState === "Very hungry" ? "Eat before the next major activity." : null;
+  return { nutritionScore, hydrationScore, nutritionState, hydrationState, mealTimingState, lastMeaningfulMealAt, meaningfulMealsToday: meaningful.filter((e) => e.consumedAt >= todayStart).length, warning, suggestedAction: warning ?? "Maintain your current meal rhythm." };
+}
+
+export function getFoodRecoveryModifier(snapshot: Pick<NutritionSnapshot, "nutritionScore" | "hydrationScore">) {
+  const average = (snapshot.nutritionScore + snapshot.hydrationScore) / 2;
+  const raw = average >= 70 ? (average - 70) / 300 : -(70 - average) / 180;
+  return Number(Math.max(FOOD_WELLNESS_BALANCE.recoveryModifierCaps.penalty, Math.min(FOOD_WELLNESS_BALANCE.recoveryModifierCaps.bonus, raw)).toFixed(3));
+}
+
+export function getFoodPerformanceModifier(snapshot: NutritionSnapshot, context: { activity: "gig" | "rehearsal" | "recording" | "practice" | "songwriting"; vocalist?: boolean; heavyMealWithinHour?: boolean }) {
+  let mod = 0;
+  if (snapshot.hydrationScore >= 80) mod += context.vocalist ? 0.025 : 0.01;
+  if (snapshot.hydrationScore < 50) mod -= context.vocalist ? 0.08 : 0.05;
+  if (["Hungry", "Very hungry"].includes(snapshot.mealTimingState)) mod -= snapshot.mealTimingState === "Very hungry" ? 0.07 : 0.035;
+  if (snapshot.nutritionScore >= 75 && context.activity !== "songwriting") mod += 0.02;
+  if (snapshot.nutritionScore < 45) mod -= context.activity === "songwriting" ? 0.015 : 0.04;
+  if (context.heavyMealWithinHour) mod -= 0.025;
+  const caps = FOOD_WELLNESS_BALANCE.performanceModifierCaps;
+  return Number(Math.max(caps.penalty, Math.min(caps.bonus, mod)).toFixed(3));
+}
+
+export function isFoodUnlocked(food: FoodDefinition, fame = 0) {
+  const order = ["new_artist", "active_musician", "professional_artist", "superstar"];
+  return order.indexOf(getWellnessTier(fame)) >= order.indexOf(food.unlock_tier);
+}
+
+export function describeMealForPlayer(food: FoodDefinition) {
+  const nutrition = food.nutrition_value >= 72 ? "High nutrition" : food.nutrition_value >= 50 ? "Balanced" : "Low nutrition";
+  const energy = food.energy_value >= 8 || food.sugar_load >= 45 ? "Quick energy" : food.energy_value <= -2 ? "Energy dip" : "Steady energy";
+  const hydration = food.hydration_value >= 20 ? "Strong hydration" : food.hydration_value >= 8 ? "Some hydration" : "Low hydration";
+  const fullness = food.satiety >= 78 ? "Heavy" : food.satiety >= 45 ? "Filling" : "Light";
+  const recommendedUse = food.category.includes("performance") ? "Recommended around performances" : food.recovery_support >= 10 ? "Good for recovery" : food.source_type === "hydration" ? "Hydration anytime" : "Everyday meal";
+  return { nutrition, energy, hydration, fullness, recommendedUse };
+}
+
+export function chooseMealPlanOption(options: FoodDefinition[], plan: MealPlanType, fame = 0, availableFundsCents = Infinity) {
+  const budget = Math.min(FOOD_WELLNESS_BALANCE.planBudgetsCents[plan], availableFundsCents);
+  if (plan === "manual") return null;
+  const unlocked = options.filter((f) => isFoodUnlocked(f, fame) && f.cost_cents <= budget && f.source_type !== "hydration");
+  const scored = unlocked.map((food) => ({ food, score: food.nutrition_value + food.hydration_value * 0.4 + (plan === "recovery" ? food.recovery_support * 2 : 0) + (plan === "performance" ? (food.category === "pre_performance_meal" ? 20 : 0) : 0) + (plan === "luxury" ? food.meal_quality * 0.4 : 0) - food.cost_cents / 500 }));
+  return scored.sort((a, b) => b.score - a.score)[0]?.food ?? options.find((f) => f.id === "free_water") ?? null;
+}

--- a/src/pages/wellness/index.tsx
+++ b/src/pages/wellness/index.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import WellnessVitalsPanel from "@/components/wellness/WellnessVitalsPanel";
 import ActivityCard from "@/components/wellness/ActivityCard";
 import AilmentsPanel from "@/components/wellness/AilmentsPanel";
+import NutritionHydrationPanel from "@/components/wellness/NutritionHydrationPanel";
 
 import { useGameData } from "@/hooks/useGameData";
 import { useWellnessState } from "@/hooks/useWellnessState";
@@ -167,6 +168,8 @@ const WellnessPage = () => {
       )}
 
       <WellnessVitalsPanel vitals={vitals} fame={profile?.fame ?? 0} />
+
+      <NutritionHydrationPanel vitals={vitals} />
 
       {blocks.length > 0 && (
         <Card className="border-amber-500/40 bg-amber-500/5">

--- a/supabase/migrations/20260712183000_food_nutrition_hydration_expansion.sql
+++ b/supabase/migrations/20260712183000_food_nutrition_hydration_expansion.sql
@@ -1,0 +1,248 @@
+-- RockMundo Wellness food, nutrition, hydration and meal planning expansion.
+-- Safe additive schema; reuses profiles, companies/storefronts, scheduled activities and wellness history.
+
+alter table public.profiles
+  add column if not exists hydration integer not null default 76 check (hydration between 0 and 100),
+  add column if not exists last_meaningful_meal_at timestamptz,
+  add column if not exists nutrition_state text not null default 'Adequate',
+  add column if not exists hydration_state text not null default 'Hydrated',
+  add column if not exists meal_plan_type text not null default 'manual' check (meal_plan_type in ('manual','budget','balanced','performance','recovery','luxury')),
+  add column if not exists meal_plan_daily_budget_cents integer not null default 0 check (meal_plan_daily_budget_cents >= 0);
+
+create table if not exists public.food_definitions (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  category text not null check (category in ('snack','light_meal','standard_meal','healthy_meal','high_protein_meal','comfort_food','fast_food','luxury_meal','recovery_meal','breakfast','pre_performance_meal','post_performance_meal','travel_meal')),
+  nutrition_value integer not null default 50 check (nutrition_value between -25 and 100),
+  energy_value integer not null default 0 check (energy_value between -25 and 40),
+  hydration_value integer not null default 0 check (hydration_value between -50 and 60),
+  satiety integer not null default 50 check (satiety between 0 and 100),
+  meal_quality integer not null default 55 check (meal_quality between 0 and 100),
+  preparation_quality integer not null default 55 check (preparation_quality between 0 and 100),
+  freshness integer not null default 85 check (freshness between 0 and 100),
+  portion_size numeric(4,2) not null default 1.00 check (portion_size between 0.25 and 2.50),
+  sugar_load integer not null default 0 check (sugar_load between 0 and 100),
+  stimulant_level integer not null default 0 check (stimulant_level between 0 and 100),
+  alcohol_content integer not null default 0 check (alcohol_content between 0 and 100),
+  recovery_support integer not null default 0 check (recovery_support between -25 and 40),
+  stress_effect integer not null default 0 check (stress_effect between -20 and 20),
+  base_cost_cents integer not null default 0 check (base_cost_cents >= 0),
+  consumption_duration_minutes integer not null default 20 check (consumption_duration_minutes between 1 and 240),
+  availability_window jsonb not null default '[]'::jsonb,
+  dietary_tags text[] not null default '{}',
+  source_type text not null default 'restaurant' check (source_type in ('restaurant','home_cooking','prepared_meal','grocery','accommodation','tour_catering','venue_catering','hydration')),
+  unlock_tier text not null default 'new_artist' check (unlock_tier in ('new_artist','active_musician','professional_artist','superstar')),
+  player_summary jsonb not null default '{}'::jsonb,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.company_food_menu_items (
+  id uuid primary key default gen_random_uuid(),
+  company_id uuid not null references public.companies(id) on delete cascade,
+  food_definition_id uuid not null references public.food_definitions(id),
+  price_cents integer not null check (price_cents >= 0),
+  availability jsonb not null default '{}'::jsonb,
+  is_available boolean not null default true,
+  created_at timestamptz not null default now(),
+  unique(company_id, food_definition_id)
+);
+
+create table if not exists public.meal_consumption_history (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  food_definition_id uuid not null references public.food_definitions(id),
+  source_type text not null,
+  company_id uuid references public.companies(id) on delete set null,
+  scheduled_activity_id uuid,
+  prepared_meal_id uuid,
+  consumed_at timestamptz not null default now(),
+  cost_cents integer not null default 0 check (cost_cents >= 0),
+  nutrition_delta integer not null default 0,
+  hydration_delta integer not null default 0,
+  energy_delta integer not null default 0,
+  satiety_delta integer not null default 0,
+  recovery_modifier numeric(5,3) not null default 0,
+  performance_modifier numeric(5,3) not null default 0,
+  suitability text,
+  effects jsonb not null default '{}'::jsonb,
+  idempotency_key text not null,
+  created_at timestamptz not null default now(),
+  unique(profile_id, idempotency_key)
+);
+create index if not exists idx_meal_history_profile_time on public.meal_consumption_history(profile_id, consumed_at desc);
+
+create table if not exists public.prepared_meals (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  food_definition_id uuid not null references public.food_definitions(id),
+  charges_remaining integer not null default 1 check (charges_remaining >= 0 and charges_remaining <= 12),
+  freshness integer not null default 100 check (freshness between 0 and 100),
+  prepared_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  source_activity_id uuid,
+  idempotency_key text not null,
+  unique(profile_id, idempotency_key)
+);
+
+create table if not exists public.meal_plan_actions (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  plan_type text not null check (plan_type in ('budget','balanced','performance','recovery','luxury')),
+  planned_for timestamptz not null,
+  status text not null default 'planned' check (status in ('planned','completed','failed','cancelled')),
+  food_definition_id uuid references public.food_definitions(id),
+  company_id uuid references public.companies(id),
+  cost_cents integer not null default 0,
+  failure_reason text,
+  idempotency_key text not null,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz,
+  unique(profile_id, idempotency_key)
+);
+
+create table if not exists public.tour_catering_plans (
+  id uuid primary key default gen_random_uuid(),
+  tour_id uuid not null,
+  stop_id uuid,
+  catering_tier text not null check (catering_tier in ('self_catered','budget','standard','performance','premium')),
+  arranged_by uuid references public.profiles(id) on delete set null,
+  cost_cents integer not null default 0,
+  forecast jsonb not null default '{}'::jsonb,
+  status text not null default 'planned' check (status in ('planned','applied','cancelled','failed')),
+  idempotency_key text not null unique,
+  created_at timestamptz not null default now(),
+  applied_at timestamptz
+);
+
+create table if not exists public.food_condition_events (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  condition_slug text not null check (condition_slug in ('upset_stomach','food_poisoning','indigestion','dehydration','severe_hunger_fatigue')),
+  severity integer not null default 1 check (severity between 1 and 5),
+  source_meal_id uuid references public.meal_consumption_history(id) on delete set null,
+  started_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  idempotency_key text not null,
+  unique(profile_id, idempotency_key)
+);
+
+create table if not exists public.food_balance_config (
+  key text primary key,
+  value jsonb not null,
+  description text not null,
+  updated_at timestamptz not null default now()
+);
+
+insert into public.food_balance_config(key, value, description) values
+('nutrition_thresholds','{"excellent":86,"well_nourished":72,"adequate":50,"poor":30}'::jsonb,'Recent-meal rolling nutrition state thresholds.'),
+('hydration_thresholds','{"fully_hydrated":88,"hydrated":70,"slightly_dehydrated":50,"dehydrated":30}'::jsonb,'Lightweight hydration state thresholds.'),
+('effect_caps','{"recovery_bonus":0.10,"recovery_penalty":-0.15,"performance_bonus":0.06,"performance_penalty":-0.12,"restaurant_quality_influence":0.12}'::jsonb,'Fairness caps preventing pay-to-win stacking.'),
+('meal_expectations','{"meaningful_meals_per_day":2,"free_hydration":true,"prepared_meal_fresh_hours":48}'::jsonb,'Daily meal expectations without micromanagement.')
+on conflict (key) do update set value = excluded.value, description = excluded.description, updated_at = now();
+
+insert into public.food_definitions(slug,name,category,nutrition_value,energy_value,hydration_value,satiety,meal_quality,preparation_quality,freshness,portion_size,sugar_load,stimulant_level,alcohol_content,recovery_support,stress_effect,base_cost_cents,consumption_duration_minutes,dietary_tags,source_type,unlock_tier,player_summary) values
+('free_water','Water refill','snack',0,0,28,2,55,70,100,1,0,0,0,2,0,0,5,'{hydration,free}','hydration','new_artist','{"hydration":"Strong hydration","use":"Hydration anytime"}'::jsonb),
+('budget_fast_food','Budget fast-food meal','fast_food',32,10,2,62,35,45,70,1.05,55,8,0,-4,-2,900,20,'{quick,cheap}','restaurant','new_artist','{"nutrition":"Low nutrition","energy":"Quick energy","fullness":"Filling"}'::jsonb),
+('standard_restaurant_meal','Standard restaurant meal','standard_meal',58,7,6,72,60,60,78,1,18,0,0,4,-3,2200,40,'{balanced}','restaurant','new_artist','{"nutrition":"Balanced","fullness":"Filling"}'::jsonb),
+('home_balanced_meal','Home-cooked balanced meal','healthy_meal',70,6,8,75,70,62,86,1,10,0,0,8,-2,750,55,'{balanced,home}','home_cooking','active_musician','{"nutrition":"High nutrition","use":"Home cooking"}'::jsonb),
+('pre_gig_light_meal','Pre-performance light meal','pre_performance_meal',64,8,10,58,68,65,86,0.85,12,5,0,5,-1,1800,25,'{pre-gig,light}','restaurant','active_musician','{"use":"Recommended before performances"}'::jsonb),
+('post_show_recovery_bowl','Post-show recovery meal','post_performance_meal',78,5,12,82,76,70,88,1,8,0,0,18,-4,3200,35,'{recovery,high nutrition}','restaurant','professional_artist','{"nutrition":"High nutrition","use":"Good for recovery"}'::jsonb),
+('premium_catering','Premium catering plate','luxury_meal',82,6,10,80,84,82,90,1,10,0,0,12,-7,8000,30,'{catering,luxury}','tour_catering','superstar','{"nutrition":"High nutrition","use":"Premium convenience, capped effects"}'::jsonb)
+on conflict (slug) do update set name=excluded.name, category=excluded.category, player_summary=excluded.player_summary, updated_at=now();
+
+create or replace function public.food_nutrition_state(_score integer) returns text language sql immutable as $$
+  select case when _score >= 86 then 'Excellent' when _score >= 72 then 'Well nourished' when _score >= 50 then 'Adequate' when _score >= 30 then 'Poor' else 'Deficient' end;
+$$;
+
+create or replace function public.food_hydration_state(_score integer) returns text language sql immutable as $$
+  select case when _score >= 88 then 'Fully hydrated' when _score >= 70 then 'Hydrated' when _score >= 50 then 'Slightly dehydrated' when _score >= 30 then 'Dehydrated' else 'Severely dehydrated' end;
+$$;
+
+create or replace function public.process_food_daily(_profile_id uuid, _day date default current_date) returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  p profiles%rowtype;
+  meals int;
+  new_nutrition int;
+  new_hydration int;
+  key text := 'food-daily-' || _day::text;
+begin
+  select * into p from profiles where id = _profile_id for update;
+  if not found then raise exception 'profile not found'; end if;
+
+  if exists (select 1 from wellness_history where profile_id = _profile_id and processed_on = _day and source = 'food_daily') then
+    return jsonb_build_object('ok',true,'idempotent',true,'nutrition',p.nutrition,'hydration',p.hydration);
+  end if;
+
+  select count(*) into meals from meal_consumption_history
+  where profile_id = _profile_id and consumed_at >= _day::timestamptz and consumed_at < (_day + 1)::timestamptz and satiety_delta >= 40;
+
+  new_nutrition := least(100, greatest(0, coalesce(p.nutrition,68) - case when meals >= 2 then 0 when meals = 1 then 4 else 9 end));
+  new_hydration := least(100, greatest(0, coalesce(p.hydration,76) - 12));
+
+  update profiles set nutrition = new_nutrition, hydration = new_hydration,
+    nutrition_state = food_nutrition_state(new_nutrition), hydration_state = food_hydration_state(new_hydration), last_health_update = now()
+  where id = _profile_id;
+
+  insert into wellness_history(user_id, profile_id, processed_on, overall_wellness, state, values, source)
+  values (p.user_id, _profile_id, _day, calculate_overall_wellness(p.energy,p.physical_health,p.happiness,p.stress,p.fatigue,p.sleep_quality,new_nutrition,p.fitness,p.motivation,p.burnout_risk), wellness_state(calculate_overall_wellness(p.energy,p.physical_health,p.happiness,p.stress,p.fatigue,p.sleep_quality,new_nutrition,p.fitness,p.motivation,p.burnout_risk)), jsonb_build_object('nutrition',new_nutrition,'hydration',new_hydration,'meaningful_meals',meals), 'food_daily');
+
+  return jsonb_build_object('ok',true,'idempotent',false,'nutrition',new_nutrition,'hydration',new_hydration,'meaningful_meals',meals);
+exception when others then
+  raise warning '[food_daily_processing_failure] profile_id=%, day=%, error=%', _profile_id, _day, sqlerrm;
+  raise;
+end;
+$$;
+
+create or replace function public.consume_food(_profile_id uuid, _food_slug text, _idempotency_key text, _company_id uuid default null) returns jsonb
+language plpgsql security definer set search_path = public as $$
+declare
+  p profiles%rowtype;
+  f food_definitions%rowtype;
+  existing meal_consumption_history%rowtype;
+  cost int;
+  n_delta int;
+  h_delta int;
+  e_delta int;
+begin
+  select * into existing from meal_consumption_history where profile_id = _profile_id and idempotency_key = _idempotency_key;
+  if found then return jsonb_build_object('ok',true,'idempotent',true,'meal_id',existing.id); end if;
+
+  select * into p from profiles where id = _profile_id for update;
+  if not found then raise exception 'profile not found'; end if;
+  select * into f from food_definitions where slug = _food_slug and is_active;
+  if not found then raise exception 'food unavailable'; end if;
+
+  cost := coalesce((select price_cents from company_food_menu_items where company_id = _company_id and food_definition_id = f.id and is_available), f.base_cost_cents);
+  if cost > 0 and coalesce(p.cash,0) < cost then raise exception 'insufficient funds'; end if;
+
+  n_delta := greatest(-10, least(16, round(f.nutrition_value / 8.0)::int));
+  h_delta := greatest(-20, least(30, f.hydration_value));
+  e_delta := greatest(-8, least(12, f.energy_value));
+
+  if cost > 0 then update profiles set cash = cash - cost where id = _profile_id; end if;
+  if _company_id is not null and cost > 0 then
+    update companies set balance = coalesce(balance,0) + cost where id = _company_id;
+    insert into company_transactions(company_id, transaction_type, amount, description, related_entity_id, related_entity_type)
+    values (_company_id, 'income', cost, 'Restaurant meal purchase', _profile_id, 'profile');
+  end if;
+
+  update profiles set nutrition = least(100,greatest(0,coalesce(nutrition,68)+n_delta)), hydration = least(100,greatest(0,coalesce(hydration,76)+h_delta)), energy = least(100,greatest(0,coalesce(energy,80)+e_delta)), last_meaningful_meal_at = case when f.satiety >= 40 or f.nutrition_value >= 45 then now() else last_meaningful_meal_at end, nutrition_state = food_nutrition_state(least(100,greatest(0,coalesce(nutrition,68)+n_delta))), hydration_state = food_hydration_state(least(100,greatest(0,coalesce(hydration,76)+h_delta))), last_health_update = now() where id = _profile_id;
+
+  insert into meal_consumption_history(profile_id,food_definition_id,source_type,company_id,cost_cents,nutrition_delta,hydration_delta,energy_delta,satiety_delta,recovery_modifier,performance_modifier,suitability,effects,idempotency_key)
+  values(_profile_id,f.id,f.source_type,_company_id,cost,n_delta,h_delta,e_delta,f.satiety,least(0.10,greatest(-0.15,f.recovery_support/200.0)),least(0.06,greatest(-0.12,(f.nutrition_value-50)/1000.0)),case when f.category in ('pre_performance_meal','post_performance_meal','travel_meal','recovery_meal') then f.category else null end,jsonb_build_object('player_summary',f.player_summary,'category',f.category),_idempotency_key)
+  returning * into existing;
+
+  return jsonb_build_object('ok',true,'idempotent',false,'meal_id',existing.id,'cost_cents',cost,'nutrition_delta',n_delta,'hydration_delta',h_delta);
+exception when unique_violation then
+  raise warning '[duplicate_consumption_prevented] profile_id=%, key=%', _profile_id, _idempotency_key;
+  return jsonb_build_object('ok',true,'idempotent',true);
+when others then
+  raise warning '[meal_processing_failure] profile_id=%, food=%, error=%', _profile_id, _food_slug, sqlerrm;
+  raise;
+end;
+$$;


### PR DESCRIPTION
### Motivation
- Expand Wellness from a single stat into a server-authoritative food & meal system that meaningfully affects energy, nutrition, hydration, recovery and performance readiness. 
- Reuse existing profiles, company/storefronts, activity scheduler and wellness recovery systems rather than creating a parallel food economy. 
- Provide idempotent, auditable purchase/consumption flows that record company revenue and protect against duplicate processing. 
- Offer optional automation (meal plans), home-cooking/prepared-meal convenience, tour catering forecasts and bounded performance/recovery trade-offs.

### Description
- Add a shared food model and client-side resolver in `src/lib/foodWellness.ts` providing `FoodDefinition`, meal categories, rolling nutrition/hydration snapshots, player-facing descriptions, meal-plan selection and bounded performance/recovery modifiers. 
- Add a Wellness UI panel `src/components/wellness/NutritionHydrationPanel.tsx` and wire it into the existing Wellness route at `src/pages/wellness/index.tsx` to surface nutrition, hydration, meal timing, recent meals and recommendations. 
- Add a safe additive DB migration `supabase/migrations/20260712183000_food_nutrition_hydration_expansion.sql` that extends `profiles` with `hydration`/meal-plan fields and creates `food_definitions`, `company_food_menu_items`, `meal_consumption_history`, `prepared_meals`, `meal_plan_actions`, `tour_catering_plans`, `food_condition_events`, `food_balance_config`, seeds and helper functions `process_food_daily` and `consume_food` (idempotent, validates funds, credits `companies.balance` and writes `company_transactions`). 
- Add unit coverage in `src/lib/foodWellness.test.ts` for rolling nutrition, hydration drift, restaurant-quality influence, meal-plan budget/unlock behaviour, and bounded performance/recovery modifiers. 
- Add documentation `docs/wellness-food-nutrition-hydration.md` describing architecture, thresholds, categories, migration behaviour, caps and extension hooks.

### Testing
- Added unit tests in `src/lib/foodWellness.test.ts` that exercise nutrition snapshots, hydration behaviour, meal-effect caps, and meal-plan fallback; tests are included in the PR but were not executed in this environment. 
- Attempted to run `npm run test:unit -- src/lib/foodWellness.test.ts` but `vitest` was not available in the container, so tests did not run. 
- Attempted `npm install` / dependency install to enable tests and app snapshots but installation failed with a package registry `403 Forbidden` while fetching `@react-three/fiber`, preventing local test/typecheck/app startup and screenshot capture. 
- SQL and migration files were added and committed; runtime DB application and integration tests should be run in a CI or local Supabase environment (recommended) to validate `consume_food`, `process_food_daily`, idempotency and transaction logging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a534836f770832598284ea4e1f4bc20)