### PR TITLE
Add wellness professional roles, services, bookings, contracts and DB schema

### DIFF
--- a/docs/wellness-professionals.md
+++ b/docs/wellness-professionals.md
@@ -1,0 +1,166 @@
+# Wellness Professionals, Support Staff and Care Plans
+
+## Previous Wellness expansion context
+
+The Wellness foundation already centralised character vitals, activity balance, ailments, travel recovery and server-owned activity completion. Food, hydration, accommodation and travel recovery added bounded preparation and recovery hooks for gigs, studio work and touring. This PR adds the next layer: qualified professionals who can sell services, work as company staff and create advisory care plans without replacing the existing schedule, finance, employment or wellness systems.
+
+## Professional-role architecture
+
+`src/lib/wellnessProfessionals.ts` is the shared server/client configuration source for initial roles, service definitions, balance caps and deterministic validation helpers. API handlers and edge functions should import or mirror this module rather than duplicating role logic in UI code.
+
+Initial roles:
+
+| Role | Focus | Remote | Contracts | Compatible employers |
+| --- | --- | --- | --- | --- |
+| Personal Trainer | Fitness, stage stamina, fatigue management, injury prevention | No | Yes | Gyms, wellness centres, tour companies, management companies, bands |
+| Physiotherapist | Fictional performance-care for strain, rehab plans and return-to-performance readiness | No | Yes | Clinics, wellness centres, tour companies, large venues, bands |
+| Therapist | Game-focused stress, motivation, burnout and band-pressure support | Yes | Yes | Clinics, wellness centres, management companies, hotels, bands |
+| Nutritionist | Meal plans, hydration, tour catering and recovery food | Yes | Yes | Wellness centres, hotels, tour companies, management companies, bands |
+| Vocal Coach | Vocal readiness, warm-ups, strain prevention and singing consistency | Yes | Yes | Recording studios, tour companies, management companies, venues, bands |
+| Massage Therapist | Short-term fatigue and compatible muscular strain recovery | No | No | Wellness centres, hotels, venues, tour companies |
+| Wellness Coach | Early-career generalist routines, sleep, stress and recovery planning | Yes | Yes | Wellness centres, gyms, hotels, management companies, bands |
+
+All role text is fictional and game-focused. The system must not claim to diagnose or substitute for real-world healthcare.
+
+## Qualification matrix
+
+Players do not manually claim qualifications. `deriveQualificationTier` derives a tier from role minimum skills, relevant-skill average, completed services, professional reputation and reliability. NPC providers may receive server-assigned tiers during seeding.
+
+| Tier | Skill average | Completed services | Reputation | Reliability |
+| --- | ---: | ---: | ---: | ---: |
+| Trainee | 15 | 0 | 0 | 50 |
+| Qualified | 35 | 8 | 20 | 70 |
+| Experienced | 55 | 35 | 45 | 78 |
+| Expert | 72 | 100 | 70 | 86 |
+| Elite | 88 | 250 | 90 | 94 |
+
+Restricted services such as therapy, physiotherapy treatment and vocal coaching require at least Qualified. Price bounds are configured per role and validated server-side.
+
+## NPC versus real-player comparison
+
+NPC providers provide baseline coverage in every supported city, predictable prices and standardised quality. They should fill gaps in low-population cities and should not dominate top-end outcomes by default.
+
+Real-player providers can exceed NPC quality only through skill, qualification, reliability, attendance, preparation, reputation and completed legitimate work. The real-player advantage cap is intentionally modest: normally no more than 10-20% better than a comparable standard NPC at the same tier. Low-skilled or unreliable player providers perform similarly to NPC baselines or worse.
+
+## Service and outcome table
+
+| Service | Primary roles | Duration | Effects | Important caps |
+| --- | --- | ---: | --- | --- |
+| Personal Training Session | Trainer, Wellness Coach | 60m | Fitness, stage stamina, stress reduction, small immediate fatigue | Cannot erase physical risk; fatigue can rise |
+| Physiotherapy Assessment | Physiotherapist | 45m | Assessment quality, recovery-plan quality, lower worsening risk | Qualified minimum |
+| Physiotherapy Treatment | Physiotherapist | 60m | Compatible strain and physical recovery | Severe conditions capped per appointment |
+| Therapy Session | Therapist | 60m | Stress, motivation, burnout risk, happiness | Fictional coping support only |
+| Nutrition Consultation | Nutritionist, Wellness Coach | 45m | Meal-plan effectiveness, nutrition, hydration support | Plan adherence gives modest gains |
+| Vocal Coaching Session | Vocal Coach | 45m | Vocal readiness, vocal strain prevention, technique support | Qualified minimum |
+| Massage Session | Massage Therapist | 60m | Fatigue, compatible muscular strain, short-term recovery | Does not replace injury treatment |
+| Wellness Review | Generalists and specialists | 45m | Risk review, recommendations and advisory care plan | Advisory, not direct stat setting |
+
+`calculateServiceOutcome` considers provider kind, role, qualification, skill average, provider wellness, fatigue, reliability, compatibility, duration, location quality, plan adherence, familiarity and bounded randomness. Outcomes are capped and severe conditions cannot be instantly cured.
+
+## Appointment lifecycle
+
+1. Client searches provider listings or NPC availability.
+2. Server validates service, role, qualification, price bounds and progression unlocks.
+3. Scheduler checks both client and provider availability, including travel, gigs, rehearsals, recording, work and existing appointments.
+4. Finance system reserves or charges payment with gross price, fees, provider/company revenue and refund liabilities.
+5. Appointment is booked with provider, client, service, date, duration, location/remote status, cost, cancellation terms and attendance requirements.
+6. Scheduled completion confirms attendance, valid location or remote session and payment state.
+7. Outcomes, professional XP, service history, relationship familiarity and reliability changes are applied once.
+8. Reviews unlock only for attended completed appointments.
+
+Cancellation states are early cancellation, late cancellation, client no-show, provider no-show, completed, partially completed, refunded and disputed. Refund rates are configured and must use existing transaction ledgers.
+
+## Contract model
+
+Support contracts are optional recurring care arrangements. They define provider, client or band, service package, frequency, duration, price, included appointments, cancellation terms, renewal rules, missed-appointment rules and expected support effects. Contract cycles must create appointments once and payments once. Contracts improve consistency and planning but never guarantee perfect outcomes.
+
+Band contracts require band permissions and band finance authority. Benefits apply only to attending members and must avoid duplicate individual and group rewards.
+
+## Company employment and job advertising flow
+
+Compatible businesses can employ NPC or real-player wellness staff where the company type supports the role. Employers should extend existing job listings with role, required qualification, minimum skills, location, weekly hours or appointment capacity, salary or revenue share, duration, responsibilities, required availability, remote eligibility, benefits and deadline.
+
+Real-player employees improve service availability, business quality, customer outcomes, reputation, capacity, tour support and staff/band support only when skilled, scheduled, active, paid, available and performing relevant work. NPC staff provide reliable baseline capacity with lower top-end contribution.
+
+## Weekly company cost and revenue impact
+
+Wellness staff must flow through the existing weekly finance model:
+
+- Weekly salary and commissions are staff costs.
+- Completed appointments create appointment revenue.
+- Facility, equipment and training costs remain company operating costs where supported.
+- Missed capacity and inactive staff reduce utilisation.
+- Quality and reputation contribution comes from real completed work, not merely occupying a staff slot.
+
+Financial updates must be auditable and idempotent. No client or provider may submit arbitrary balance changes.
+
+## Professional XP and reputation rules
+
+Professional XP depends on service duration, difficulty, outcome quality, eligible payment, attendance and feedback. Refunded appointments grant no XP. Daily and weekly caps prevent grinding. Repeated low-value sessions between the same pair use diminishing returns after the configured threshold.
+
+Professional reputation is separate from fame where possible. It considers completed appointments, reliability, ratings, outcome consistency, qualification, contract completion, cancellations, disputes and verified experience. Suggested states are New, Developing, Trusted, Respected, Leading and Elite.
+
+## Reviews
+
+Reviews require one completed, attended appointment. Cancelled, refunded-only or no-show appointments cannot be reviewed. Duplicate reviews are rejected through a unique appointment constraint. Aggregates should be weighted so simple manipulation has limited impact, and review moderation flags should be visible to admin tools.
+
+## Anti-abuse protections
+
+Required controls:
+
+- Same-character self-booking prohibition.
+- Related-party and circular-payment fraud flags.
+- Diminishing XP for repeated provider/client pairs.
+- Daily and weekly XP caps.
+- Minimum service duration and eligible payment checks.
+- No XP from refunded services.
+- Attendance verification before completion, XP and reviews.
+- Server-computed outcomes only.
+- Price bounds and qualification validation.
+- One review per completed appointment.
+- Bounded familiarity bonuses.
+- Audit logs for booking failures, conflicts, no-shows, refunds, XP, fraud flags and moderation flags.
+
+Legitimate long-term client relationships should remain possible; diminishing returns are preferred over total prohibition when risk is moderate.
+
+## Database and migration plan
+
+A production migration should extend existing jobs, company staff, finance, schedule and wellness structures where possible. The recommended table set is:
+
+- `wellness_provider_profiles` for role, qualification snapshot, XP, reliability and reputation.
+- `wellness_provider_listings` for services, prices, cities, remote eligibility and pause state.
+- `wellness_appointments` for scheduler-linked one-off sessions and lifecycle state.
+- `wellness_support_contracts` for recurring client, band or tour support.
+- `wellness_care_plans` and `wellness_plan_adherence` for advisory recommendations and lightweight adherence.
+- `wellness_professional_reviews` for one review per completed appointment.
+- `wellness_professional_audit_events` for fraud, disputes, no-shows and idempotency evidence.
+- Add wellness role metadata to existing `jobs` and `company_employees` rather than creating a separate employment framework.
+
+Migrations must be non-destructive. Existing staff, jobs and wellness activities remain valid. NPC provider defaults should seed safely and missing provider data should degrade to NPC baseline availability.
+
+## Gig, tour and care-plan integration
+
+Gig preparation can surface active care plans, upcoming appointments, provider recommendations, warm-up plans and recovery appointments. Suggested actions should book normal services such as vocal coaching, massage, physiotherapy, nutrition review, trainer warm-up or therapist support through normal scheduling and payment rules.
+
+Tour support can include travelling physiotherapists, trainers, vocal coaches, nutrition consultants, wellness coaches and on-call local providers. Capacity must consider tour length, number of performers, travel, accommodation, transport and provider schedule. One professional cannot serve unlimited simultaneous tours.
+
+Care plans are advisory and may recommend rest, exercises, meals, hydration, strain limits, pre-gig routines and tour recovery. Plans must not directly set wellness values. Adherence modestly improves plan effectiveness.
+
+## API and security notes
+
+All writes require authentication. Only qualified players may advertise restricted services. Players cannot book themselves. Clients cannot submit outcomes. Providers cannot mark arbitrary services successful. Completion uses scheduler evidence. Band and company actions require existing permissions. Private wellness information remains private. Admin actions require RBAC.
+
+## Balance caps and production limits
+
+- Real-player advantage cap: 18% in shared balance.
+- Familiarity cap: 6%.
+- Severe condition max recovery per appointment: 12 points.
+- Daily professional XP cap: 90.
+- Weekly professional XP cap: 320.
+- Repeated-pair XP diminishing starts after three completed sessions per week.
+- One appointment never removes a severe condition.
+- Long-term plans improve consistency rather than granting large instant bonuses.
+
+## Future expansion hooks
+
+Future PRs can add medical clinics, advanced certifications, group classes, player-owned wellness companies, insurance, sponsorships, branded fitness programmes, advanced tour medical support, emergency treatment and long-term coaching careers. Emergency medicine, surgery, prescriptions, severe mental-health crisis simulation, addiction treatment, unlicensed medical claims and unlimited passive staff bonuses remain out of scope.

--- a/src/components/wellness/ProfessionalSupportPanel.tsx
+++ b/src/components/wellness/ProfessionalSupportPanel.tsx
@@ -1,0 +1,130 @@
+import { CalendarClock, HeartHandshake, ShieldCheck, Star, UserRoundCheck } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { WELLNESS_PROFESSIONAL_ROLES, WELLNESS_SERVICES, calculateProfessionalReputation, calculateServiceOutcome, deriveQualificationTier, type WellnessProfessionalRole } from "@/lib/wellnessProfessionals";
+import type { WellnessCoreValues } from "@/lib/wellnessSystem";
+
+interface ProfessionalSupportPanelProps {
+  vitals: WellnessCoreValues;
+  fame?: number;
+}
+
+const recommendedRoles = (vitals: WellnessCoreValues): WellnessProfessionalRole[] => {
+  const roles: WellnessProfessionalRole[] = [];
+  if (vitals.fatigue > 65 || vitals.fitness < 45) roles.push("personal_trainer", "massage_therapist");
+  if (vitals.physical_health < 55) roles.push("physiotherapist");
+  if (vitals.stress > 60 || vitals.burnout_risk > 55) roles.push("therapist");
+  if (vitals.nutrition < 60) roles.push("nutritionist");
+  if (roles.length === 0) roles.push("wellness_coach", "vocal_coach");
+  return Array.from(new Set(roles)).slice(0, 4);
+};
+
+const professionalExamples = [
+  {
+    id: "npc-wellness-coach",
+    name: "City Wellness Desk",
+    role: "wellness_coach" as const,
+    kind: "NPC baseline",
+    service: "wellness_review" as const,
+    skills: { coaching: 38, communication: 42, empathy: 36, organisation: 40 },
+    completed: 0,
+    reputation: 24,
+    reliability: 88,
+    relation: "Drop-in",
+    next: "Baseline availability",
+  },
+  {
+    id: "player-vocal-coach",
+    name: "Qualified player provider",
+    role: "vocal_coach" as const,
+    kind: "Real-player ceiling",
+    service: "vocal_coaching_session" as const,
+    skills: { vocal_technique: 76, coaching: 68, communication: 72, reliability: 83 },
+    completed: 54,
+    reputation: 58,
+    reliability: 91,
+    relation: "Freelance / employed",
+    next: "Uses schedule conflicts",
+  },
+];
+
+export function ProfessionalSupportPanel({ vitals, fame = 0 }: ProfessionalSupportPanelProps) {
+  const roles = recommendedRoles(vitals);
+  const unlockedContracts = fame >= 1000;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <HeartHandshake className="h-4 w-4 text-primary" /> Professional Support
+          <Badge variant="outline">Server rules</Badge>
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Qualified NPC and real-player professionals use the normal scheduler, finance ledger, staff jobs and wellness outcome caps. This is fictional game support, not real-world healthcare.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <section aria-labelledby="support-team-heading">
+          <h2 id="support-team-heading" className="mb-2 text-sm font-semibold">Current support team patterns</h2>
+          <div className="grid gap-3 md:grid-cols-2">
+            {professionalExamples.map((provider) => {
+              const qualification = deriveQualificationTier({ role: provider.role, skills: provider.skills, completedServices: provider.completed, reputation: provider.reputation, reliability: provider.reliability }) ?? "trainee";
+              const rep = calculateProfessionalReputation({ completedAppointments: provider.completed, reliability: provider.reliability, averageRating: 4.4, outcomeConsistency: 78 });
+              const outcome = calculateServiceOutcome({ providerKind: provider.kind.startsWith("Real") ? "player" : "npc", role: provider.role, service: provider.service, qualification, relevantSkillAverage: Object.values(provider.skills).reduce((a, b) => a + b, 0) / Object.values(provider.skills).length, providerWellness: vitals, providerReliability: provider.reliability, conditionCompatible: true, carePlanAdherence: 40, familiarityCount: provider.kind.startsWith("Real") ? 4 : 0 });
+              return (
+                <article key={provider.id} className="rounded-lg border p-3">
+                  <div className="flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium">{provider.name}</p>
+                      <p className="text-xs text-muted-foreground">{WELLNESS_PROFESSIONAL_ROLES[provider.role].label} · {provider.relation}</p>
+                    </div>
+                    <Badge variant="secondary" className="capitalize">{qualification}</Badge>
+                  </div>
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                    <div><dt className="text-muted-foreground">Reliability</dt><dd className="font-medium">{provider.reliability}%</dd></div>
+                    <div><dt className="text-muted-foreground">Reputation</dt><dd className="font-medium">{rep.state} ({rep.score})</dd></div>
+                    <div><dt className="text-muted-foreground">Next appointment</dt><dd className="font-medium">{provider.next}</dd></div>
+                    <div><dt className="text-muted-foreground">Expected quality</dt><dd className="font-medium">{Math.round(outcome.quality * 100)}%</dd></div>
+                  </dl>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section aria-labelledby="appointments-heading" className="grid gap-3 lg:grid-cols-3">
+          <div className="rounded-lg border p-3">
+            <h2 id="appointments-heading" className="flex items-center gap-2 text-sm font-semibold"><CalendarClock className="h-4 w-4" /> Appointment lifecycle</h2>
+            <p className="mt-1 text-xs text-muted-foreground">Booked sessions require client and provider availability, payment validation, attendance evidence and idempotent completion before benefits, XP or reviews unlock.</p>
+          </div>
+          <div className="rounded-lg border p-3">
+            <h2 className="flex items-center gap-2 text-sm font-semibold"><ShieldCheck className="h-4 w-4" /> Contracts & care plans</h2>
+            <p className="mt-1 text-xs text-muted-foreground">{unlockedContracts ? "Ongoing weekly, monthly, band and tour support can create scheduled work without guaranteeing perfect outcomes." : "Ongoing contracts unlock at Professional Artist tier; basic one-off support stays available now."}</p>
+          </div>
+          <div className="rounded-lg border p-3">
+            <h2 className="flex items-center gap-2 text-sm font-semibold"><Star className="h-4 w-4" /> Abuse controls</h2>
+            <p className="mt-1 text-xs text-muted-foreground">Self-booking, fake reviews, refunded XP, circular payments and repeated low-value pair farming are rejected or diminished server-side.</p>
+          </div>
+        </section>
+
+        <section aria-labelledby="recommendations-heading">
+          <h2 id="recommendations-heading" className="mb-2 flex items-center gap-2 text-sm font-semibold"><UserRoundCheck className="h-4 w-4" /> Recommended professionals</h2>
+          <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+            {roles.map((role) => {
+              const def = WELLNESS_PROFESSIONAL_ROLES[role];
+              const service = WELLNESS_SERVICES[def.supportedServices[0]];
+              return (
+                <div key={role} className="rounded-lg border bg-muted/20 p-3">
+                  <div className="flex items-center justify-between gap-2"><p className="text-sm font-medium">{def.label}</p><Badge variant="outline">${Math.round(service.baseFeeCents / 100)}</Badge></div>
+                  <p className="mt-1 text-xs text-muted-foreground">{def.summary}</p>
+                  <p className="mt-2 text-xs"><span className="font-medium">Service:</span> {service.label} · {service.durationMinutes}m · {service.remoteEligible ? "remote or local" : "local only"}</p>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/wellnessProfessionals.test.ts
+++ b/src/lib/wellnessProfessionals.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { calculateProfessionalReputation, calculateProfessionalXp, calculateServiceOutcome, canListService, deriveQualificationTier, validateAppointmentRequest } from "./wellnessProfessionals";
+
+describe("wellness professional qualification and listing", () => {
+  it("derives qualification tiers from role skills, work history, reputation and reliability", () => {
+    expect(deriveQualificationTier({ role: "physiotherapist", skills: { physiotherapy: 82, medical_care: 75, empathy: 70, reliability: 90 }, completedServices: 120, reputation: 75, reliability: 90 })).toBe("expert");
+    expect(deriveQualificationTier({ role: "physiotherapist", skills: { physiotherapy: 20, medical_care: 75, empathy: 70, reliability: 90 }, completedServices: 120, reputation: 75, reliability: 90 })).toBeNull();
+  });
+
+  it("prevents unqualified or mispriced restricted service listings", () => {
+    expect(canListService({ role: "therapist", service: "therapy_session", qualification: "trainee", priceCents: 9000 })).toEqual({ ok: false, reason: "qualification_required" });
+    expect(canListService({ role: "therapist", service: "therapy_session", qualification: "qualified", priceCents: 100000 })).toEqual({ ok: false, reason: "price_out_of_bounds" });
+    expect(canListService({ role: "therapist", service: "therapy_session", qualification: "qualified", priceCents: 9000 })).toEqual({ ok: true });
+  });
+});
+
+describe("wellness professional booking and outcomes", () => {
+  it("rejects self booking, schedule conflicts and invalid remote/location combinations", () => {
+    expect(validateAppointmentRequest({ clientId: "p1", providerId: "p1", providerKind: "player", service: "massage_session", role: "massage_therapist", qualification: "trainee", priceCents: 6500, clientAvailable: true, providerAvailable: true, remote: false, locationTags: ["hotel"] })).toEqual({ ok: false, reason: "self_booking" });
+    expect(validateAppointmentRequest({ clientId: "p1", providerId: "p2", providerKind: "player", service: "massage_session", role: "massage_therapist", qualification: "trainee", priceCents: 6500, clientAvailable: true, providerAvailable: false, remote: false, locationTags: ["hotel"] })).toEqual({ ok: false, reason: "schedule_conflict" });
+    expect(validateAppointmentRequest({ clientId: "p1", providerId: "p2", providerKind: "player", service: "massage_session", role: "massage_therapist", qualification: "trainee", priceCents: 6500, clientAvailable: true, providerAvailable: true, remote: true })).toEqual({ ok: false, reason: "remote_not_allowed" });
+  });
+
+  it("caps skilled real-player advantage and severe condition recovery", () => {
+    const player = calculateServiceOutcome({ providerKind: "player", role: "physiotherapist", service: "physiotherapy_treatment", qualification: "experienced", relevantSkillAverage: 88, providerWellness: { fatigue: 20, burnout_risk: 5 }, providerReliability: 100, clientConditionSeverity: 90, conditionCompatible: true, locationQuality: 100, familiarityCount: 20, randomFactor: 1.06 });
+    const npc = calculateServiceOutcome({ providerKind: "npc", role: "physiotherapist", service: "physiotherapy_treatment", qualification: "experienced", relevantSkillAverage: 88, providerWellness: { fatigue: 20, burnout_risk: 5 }, providerReliability: 100, clientConditionSeverity: 90, conditionCompatible: true, locationQuality: 100, familiarityCount: 20, randomFactor: 1.06 });
+    expect(player.quality).toBeLessThanOrEqual(1.18);
+    expect(player.quality).toBeGreaterThanOrEqual(npc.quality);
+    expect(Math.abs(player.effects.strain as number)).toBeLessThanOrEqual(12);
+  });
+
+  it("reduces quality for incompatible care and poor provider wellness", () => {
+    const good = calculateServiceOutcome({ providerKind: "player", role: "therapist", service: "therapy_session", qualification: "expert", relevantSkillAverage: 80, providerWellness: { fatigue: 25, burnout_risk: 20 }, providerReliability: 92, conditionCompatible: true });
+    const poor = calculateServiceOutcome({ providerKind: "player", role: "therapist", service: "therapy_session", qualification: "expert", relevantSkillAverage: 80, providerWellness: { fatigue: 95, burnout_risk: 95 }, providerReliability: 92, conditionCompatible: false });
+    expect(poor.quality).toBeLessThan(good.quality);
+    expect(Math.abs(poor.effects.stress as number)).toBeLessThan(Math.abs(good.effects.stress as number));
+  });
+});
+
+describe("wellness professional progression, reputation and abuse controls", () => {
+  it("applies repeated-pair diminishing returns, caps and refunded-service exclusion", () => {
+    expect(calculateProfessionalXp({ durationMinutes: 60, outcomeQuality: 1, eligiblePaymentCents: 8000, refunded: true }).xp).toBe(0);
+    const normal = calculateProfessionalXp({ durationMinutes: 60, outcomeQuality: 1, eligiblePaymentCents: 8000, pairCompletedThisWeek: 0 });
+    const repeated = calculateProfessionalXp({ durationMinutes: 60, outcomeQuality: 1, eligiblePaymentCents: 8000, pairCompletedThisWeek: 6 });
+    expect(repeated.xp).toBeLessThan(normal.xp);
+    expect(calculateProfessionalXp({ durationMinutes: 240, outcomeQuality: 1.2, eligiblePaymentCents: 50000, dailyAwarded: 88 }).xp).toBeLessThanOrEqual(2);
+  });
+
+  it("weights reliability, reviews, outcomes and disputes into professional reputation", () => {
+    const respected = calculateProfessionalReputation({ completedAppointments: 130, reliability: 96, averageRating: 4.8, outcomeConsistency: 90, cancellations: 1, disputes: 0 });
+    const risky = calculateProfessionalReputation({ completedAppointments: 130, reliability: 55, averageRating: 2.5, outcomeConsistency: 40, cancellations: 10, disputes: 3 });
+    expect(respected.score).toBeGreaterThan(risky.score);
+    expect(respected.state).not.toBe("New");
+  });
+});

--- a/src/lib/wellnessProfessionals.ts
+++ b/src/lib/wellnessProfessionals.ts
@@ -1,0 +1,191 @@
+import type { WellnessCoreValues, WellnessTierKey } from "./wellnessSystem";
+import { clampWellness } from "./wellnessSystem";
+
+export type WellnessProfessionalRole =
+  | "personal_trainer"
+  | "physiotherapist"
+  | "therapist"
+  | "nutritionist"
+  | "vocal_coach"
+  | "massage_therapist"
+  | "wellness_coach";
+export type ProviderKind = "npc" | "player";
+export type QualificationTier = "trainee" | "qualified" | "experienced" | "expert" | "elite";
+export type WellnessServiceSlug =
+  | "personal_training_session"
+  | "physiotherapy_assessment"
+  | "physiotherapy_treatment"
+  | "therapy_session"
+  | "nutrition_consultation"
+  | "vocal_coaching_session"
+  | "massage_session"
+  | "wellness_review";
+export type AppointmentStatus = "requested" | "booked" | "cancelled_early" | "cancelled_late" | "client_no_show" | "provider_no_show" | "completed" | "refunded" | "disputed";
+
+export interface ProfessionalRoleDefinition {
+  role: WellnessProfessionalRole;
+  label: string;
+  summary: string;
+  relevantSkills: string[];
+  minimumSkills: Record<string, number>;
+  supportedServices: WellnessServiceSlug[];
+  supportedConditions: string[];
+  preventativeEffects: Partial<Record<keyof WellnessCoreValues | "vocal_readiness" | "stage_stamina", number>>;
+  recoveryEffects: Partial<Record<keyof WellnessCoreValues | "strain" | "vocal_strain", number>>;
+  appointmentDurations: number[];
+  baseFeeCents: number;
+  priceBoundsCents: { min: number; max: number };
+  contractAvailable: boolean;
+  progressionUnlock: WellnessTierKey;
+  locationRequirements: string[];
+  remoteEligible: boolean;
+  maxBonusCap: number;
+  compatibleCompanyTypes: string[];
+}
+
+export interface WellnessServiceDefinition {
+  slug: WellnessServiceSlug;
+  label: string;
+  roles: WellnessProfessionalRole[];
+  durationMinutes: number;
+  baseFeeCents: number;
+  minEligibleFeeCents: number;
+  compatibleConditions: string[];
+  outcomeStats: Partial<Record<keyof WellnessCoreValues | "strain" | "vocal_readiness" | "vocal_strain" | "stage_stamina", number>>;
+  immediateFatigueDelta?: number;
+  requiresAttendance: boolean;
+  remoteEligible: boolean;
+  minimumQualification: QualificationTier;
+}
+
+export const QUALIFICATION_THRESHOLDS: Record<QualificationTier, { skillAverage: number; completedServices: number; reputation: number; reliability: number }> = {
+  trainee: { skillAverage: 15, completedServices: 0, reputation: 0, reliability: 50 },
+  qualified: { skillAverage: 35, completedServices: 8, reputation: 20, reliability: 70 },
+  experienced: { skillAverage: 55, completedServices: 35, reputation: 45, reliability: 78 },
+  expert: { skillAverage: 72, completedServices: 100, reputation: 70, reliability: 86 },
+  elite: { skillAverage: 88, completedServices: 250, reputation: 90, reliability: 94 },
+};
+
+export const WELLNESS_PROFESSIONAL_BALANCE = {
+  npcQuality: { trainee: 0.72, qualified: 0.82, experienced: 0.9, expert: 0.96, elite: 1.0 },
+  playerAdvantageCap: 0.18,
+  familiarityCap: 0.06,
+  severeConditionMaxRecovery: 12,
+  dailyXpCap: 90,
+  weeklyXpCap: 320,
+  repeatedPairDiminishingAfter: 3,
+  cancellation: { earlyRefundRate: 0.9, lateRefundRate: 0.5, noShowRefundRate: 0 },
+  reputationThresholds: [
+    { label: "New", min: 0 },
+    { label: "Developing", min: 20 },
+    { label: "Trusted", min: 45 },
+    { label: "Respected", min: 65 },
+    { label: "Leading", min: 82 },
+    { label: "Elite", min: 94 },
+  ],
+} as const;
+
+export const WELLNESS_PROFESSIONAL_ROLES: Record<WellnessProfessionalRole, ProfessionalRoleDefinition> = {
+  personal_trainer: { role: "personal_trainer", label: "Personal Trainer", summary: "Fitness, stage stamina, fatigue management and physical-strain prevention.", relevantSkills: ["fitness", "coaching", "organisation", "reliability"], minimumSkills: { fitness: 30, coaching: 20 }, supportedServices: ["personal_training_session", "wellness_review"], supportedConditions: ["fatigue", "physical_strain", "tour_conditioning"], preventativeEffects: { fitness: 8, stage_stamina: 6, fatigue: -3 }, recoveryEffects: { fatigue: -2, physical_health: 3 }, appointmentDurations: [45, 60, 90], baseFeeCents: 8000, priceBoundsCents: { min: 4000, max: 22000 }, contractAvailable: true, progressionUnlock: "new_artist", locationRequirements: ["gym", "park", "venue"], remoteEligible: false, maxBonusCap: 0.16, compatibleCompanyTypes: ["gym", "wellness_center", "tour_company", "management_company", "band_organisation"] },
+  physiotherapist: { role: "physiotherapist", label: "Physiotherapist", summary: "Fictional performance-care for muscular strain, rehab planning and return-to-performance readiness.", relevantSkills: ["physiotherapy", "medical_care", "empathy", "reliability"], minimumSkills: { physiotherapy: 40, medical_care: 25 }, supportedServices: ["physiotherapy_assessment", "physiotherapy_treatment", "wellness_review"], supportedConditions: ["muscle_strain", "sprained_wrist", "back_pain", "shoulder_strain"], preventativeEffects: { physical_health: 5, fatigue: -2 }, recoveryEffects: { strain: -10, physical_health: 6 }, appointmentDurations: [45, 60], baseFeeCents: 12000, priceBoundsCents: { min: 7000, max: 30000 }, contractAvailable: true, progressionUnlock: "professional_artist", locationRequirements: ["clinic", "wellness_center", "venue"], remoteEligible: false, maxBonusCap: 0.18, compatibleCompanyTypes: ["clinic", "wellness_center", "tour_company", "large_venue", "band_organisation"] },
+  therapist: { role: "therapist", label: "Therapist", summary: "Game-focused support for stress, motivation, confidence, burnout risk and band pressure.", relevantSkills: ["psychology", "empathy", "communication", "reliability"], minimumSkills: { psychology: 40, empathy: 25 }, supportedServices: ["therapy_session", "wellness_review"], supportedConditions: ["stress", "burnout_warning", "tour_pressure", "band_conflict"], preventativeEffects: { stress: -6, burnout_risk: -5, motivation: 4 }, recoveryEffects: { happiness: 5, stress: -8, motivation: 4 }, appointmentDurations: [45, 60], baseFeeCents: 11000, priceBoundsCents: { min: 6000, max: 28000 }, contractAvailable: true, progressionUnlock: "professional_artist", locationRequirements: ["clinic", "wellness_center", "remote"], remoteEligible: true, maxBonusCap: 0.16, compatibleCompanyTypes: ["clinic", "wellness_center", "management_company", "hotel", "band_organisation"] },
+  nutritionist: { role: "nutritionist", label: "Nutritionist", summary: "Meal plans, hydration targets, tour catering and recovery food preparation.", relevantSkills: ["nutrition", "coaching", "organisation", "communication"], minimumSkills: { nutrition: 35, coaching: 15 }, supportedServices: ["nutrition_consultation", "wellness_review"], supportedConditions: ["poor_nutrition", "dehydration", "tour_catering"], preventativeEffects: { nutrition: 9, energy: 3 }, recoveryEffects: { nutrition: 8, energy: 3, fatigue: -2 }, appointmentDurations: [30, 45, 60], baseFeeCents: 7000, priceBoundsCents: { min: 3500, max: 18000 }, contractAvailable: true, progressionUnlock: "active_musician", locationRequirements: ["wellness_center", "restaurant", "remote"], remoteEligible: true, maxBonusCap: 0.14, compatibleCompanyTypes: ["wellness_center", "hotel", "tour_company", "management_company", "band_organisation"] },
+  vocal_coach: { role: "vocal_coach", label: "Vocal Coach", summary: "Vocal readiness, warm-up plans, vocal strain prevention and singing consistency.", relevantSkills: ["vocal_technique", "coaching", "communication", "reliability"], minimumSkills: { vocal_technique: 40, coaching: 20 }, supportedServices: ["vocal_coaching_session", "wellness_review"], supportedConditions: ["vocal_strain", "sore_throat", "pre_gig_warmup"], preventativeEffects: { vocal_readiness: 9, stress: -2 }, recoveryEffects: { vocal_strain: -8, motivation: 3 }, appointmentDurations: [30, 45, 60], baseFeeCents: 9000, priceBoundsCents: { min: 5000, max: 24000 }, contractAvailable: true, progressionUnlock: "active_musician", locationRequirements: ["studio", "venue", "remote"], remoteEligible: true, maxBonusCap: 0.17, compatibleCompanyTypes: ["recording_studio", "tour_company", "management_company", "large_venue", "band_organisation"] },
+  massage_therapist: { role: "massage_therapist", label: "Massage Therapist", summary: "Short-term fatigue and compatible muscular-strain recovery after heavy performance load.", relevantSkills: ["medical_care", "empathy", "reliability"], minimumSkills: { medical_care: 25, empathy: 20 }, supportedServices: ["massage_session"], supportedConditions: ["fatigue", "muscle_strain", "back_pain"], preventativeEffects: { fatigue: -4, stress: -3 }, recoveryEffects: { fatigue: -10, strain: -5 }, appointmentDurations: [45, 60, 90], baseFeeCents: 6500, priceBoundsCents: { min: 3500, max: 16000 }, contractAvailable: false, progressionUnlock: "new_artist", locationRequirements: ["wellness_center", "hotel", "venue"], remoteEligible: false, maxBonusCap: 0.12, compatibleCompanyTypes: ["wellness_center", "hotel", "large_venue", "tour_company"] },
+  wellness_coach: { role: "wellness_coach", label: "Wellness Coach", summary: "Early-career generalist for basic routines, sleep, stress, nutrition and recovery planning.", relevantSkills: ["coaching", "communication", "empathy", "organisation"], minimumSkills: { coaching: 20, communication: 15 }, supportedServices: ["wellness_review", "nutrition_consultation", "personal_training_session"], supportedConditions: ["basic_routine", "sleep", "stress", "poor_nutrition"], preventativeEffects: { sleep_quality: 4, stress: -4, nutrition: 4 }, recoveryEffects: { fatigue: -3, motivation: 3 }, appointmentDurations: [30, 45, 60], baseFeeCents: 4500, priceBoundsCents: { min: 2000, max: 12000 }, contractAvailable: true, progressionUnlock: "new_artist", locationRequirements: ["wellness_center", "home", "remote"], remoteEligible: true, maxBonusCap: 0.1, compatibleCompanyTypes: ["wellness_center", "gym", "hotel", "management_company", "band_organisation"] },
+};
+
+export const WELLNESS_SERVICES: Record<WellnessServiceSlug, WellnessServiceDefinition> = {
+  personal_training_session: { slug: "personal_training_session", label: "Personal Training Session", roles: ["personal_trainer", "wellness_coach"], durationMinutes: 60, baseFeeCents: 8000, minEligibleFeeCents: 3000, compatibleConditions: ["fatigue", "tour_conditioning", "physical_strain"], outcomeStats: { fitness: 6, stage_stamina: 6, stress: -3 }, immediateFatigueDelta: 4, requiresAttendance: true, remoteEligible: false, minimumQualification: "trainee" },
+  physiotherapy_assessment: { slug: "physiotherapy_assessment", label: "Physiotherapy Assessment", roles: ["physiotherapist"], durationMinutes: 45, baseFeeCents: 10000, minEligibleFeeCents: 6000, compatibleConditions: ["muscle_strain", "sprained_wrist", "back_pain", "shoulder_strain"], outcomeStats: { physical_health: 3, strain: -4 }, requiresAttendance: true, remoteEligible: false, minimumQualification: "qualified" },
+  physiotherapy_treatment: { slug: "physiotherapy_treatment", label: "Physiotherapy Treatment", roles: ["physiotherapist"], durationMinutes: 60, baseFeeCents: 14000, minEligibleFeeCents: 8000, compatibleConditions: ["muscle_strain", "sprained_wrist", "back_pain", "shoulder_strain"], outcomeStats: { physical_health: 6, strain: -10 }, requiresAttendance: true, remoteEligible: false, minimumQualification: "qualified" },
+  therapy_session: { slug: "therapy_session", label: "Therapy Session", roles: ["therapist"], durationMinutes: 60, baseFeeCents: 11000, minEligibleFeeCents: 6000, compatibleConditions: ["stress", "burnout_warning", "tour_pressure", "band_conflict"], outcomeStats: { stress: -10, motivation: 5, burnout_risk: -6, happiness: 4 }, requiresAttendance: true, remoteEligible: true, minimumQualification: "qualified" },
+  nutrition_consultation: { slug: "nutrition_consultation", label: "Nutrition Consultation", roles: ["nutritionist", "wellness_coach"], durationMinutes: 45, baseFeeCents: 7000, minEligibleFeeCents: 3500, compatibleConditions: ["poor_nutrition", "dehydration", "tour_catering"], outcomeStats: { nutrition: 10, energy: 3, fatigue: -2 }, requiresAttendance: true, remoteEligible: true, minimumQualification: "trainee" },
+  vocal_coaching_session: { slug: "vocal_coaching_session", label: "Vocal Coaching Session", roles: ["vocal_coach"], durationMinutes: 45, baseFeeCents: 9000, minEligibleFeeCents: 5000, compatibleConditions: ["vocal_strain", "sore_throat", "pre_gig_warmup"], outcomeStats: { vocal_readiness: 10, vocal_strain: -6, motivation: 3 }, requiresAttendance: true, remoteEligible: true, minimumQualification: "qualified" },
+  massage_session: { slug: "massage_session", label: "Massage Session", roles: ["massage_therapist"], durationMinutes: 60, baseFeeCents: 6500, minEligibleFeeCents: 3500, compatibleConditions: ["fatigue", "muscle_strain", "back_pain"], outcomeStats: { fatigue: -14, strain: -5, stress: -4 }, requiresAttendance: true, remoteEligible: false, minimumQualification: "trainee" },
+  wellness_review: { slug: "wellness_review", label: "Wellness Review", roles: ["wellness_coach", "personal_trainer", "therapist", "nutritionist", "physiotherapist", "vocal_coach"], durationMinutes: 45, baseFeeCents: 4500, minEligibleFeeCents: 2000, compatibleConditions: ["basic_routine", "sleep", "stress", "poor_nutrition", "tour_pressure"], outcomeStats: { sleep_quality: 3, stress: -3, nutrition: 3, motivation: 3 }, requiresAttendance: true, remoteEligible: true, minimumQualification: "trainee" },
+};
+
+const tierRank: QualificationTier[] = ["trainee", "qualified", "experienced", "expert", "elite"];
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export function deriveQualificationTier(input: { role: WellnessProfessionalRole; skills: Record<string, number>; completedServices?: number; reputation?: number; reliability?: number; serverAssignedTier?: QualificationTier }): QualificationTier | null {
+  if (input.serverAssignedTier) return input.serverAssignedTier;
+  const role = WELLNESS_PROFESSIONAL_ROLES[input.role];
+  if (Object.entries(role.minimumSkills).some(([skill, min]) => (input.skills[skill] ?? 0) < min)) return null;
+  const average = role.relevantSkills.reduce((sum, skill) => sum + (input.skills[skill] ?? 0), 0) / role.relevantSkills.length;
+  let best: QualificationTier = "trainee";
+  for (const tier of tierRank) {
+    const threshold = QUALIFICATION_THRESHOLDS[tier];
+    if (average >= threshold.skillAverage && (input.completedServices ?? 0) >= threshold.completedServices && (input.reputation ?? 0) >= threshold.reputation && (input.reliability ?? 100) >= threshold.reliability) best = tier;
+  }
+  return best;
+}
+
+export function canListService(input: { role: WellnessProfessionalRole; service: WellnessServiceSlug; qualification: QualificationTier | null; priceCents: number }) {
+  const role = WELLNESS_PROFESSIONAL_ROLES[input.role];
+  const service = WELLNESS_SERVICES[input.service];
+  if (!role.supportedServices.includes(input.service) || !service.roles.includes(input.role)) return { ok: false as const, reason: "unsupported_service" };
+  if (!input.qualification || tierRank.indexOf(input.qualification) < tierRank.indexOf(service.minimumQualification)) return { ok: false as const, reason: "qualification_required" };
+  if (input.priceCents < role.priceBoundsCents.min || input.priceCents > role.priceBoundsCents.max) return { ok: false as const, reason: "price_out_of_bounds" };
+  return { ok: true as const };
+}
+
+export function calculateServiceOutcome(input: { providerKind: ProviderKind; role: WellnessProfessionalRole; service: WellnessServiceSlug; qualification: QualificationTier; relevantSkillAverage: number; providerWellness: Partial<WellnessCoreValues>; providerReliability: number; clientConditionSeverity?: number; conditionCompatible?: boolean; durationMinutes?: number; locationQuality?: number; carePlanAdherence?: number; familiarityCount?: number; randomFactor?: number }) {
+  const role = WELLNESS_PROFESSIONAL_ROLES[input.role];
+  const service = WELLNESS_SERVICES[input.service];
+  const tierIndex = tierRank.indexOf(input.qualification);
+  const skill = clamp(input.relevantSkillAverage, 0, 100) / 100;
+  const reliability = clamp(input.providerReliability, 0, 100) / 100;
+  const providerFatiguePenalty = clamp(((input.providerWellness.fatigue ?? 35) - 65) / 100, 0, 0.12);
+  const providerBurnoutPenalty = clamp(((input.providerWellness.burnout_risk ?? 25) - 70) / 100, 0, 0.1);
+  const tierMultiplier = 0.78 + tierIndex * 0.08;
+  const skillMultiplier = 0.75 + skill * 0.35;
+  const reliabilityMultiplier = 0.85 + reliability * 0.2;
+  const locationMultiplier = 0.9 + clamp(input.locationQuality ?? 70, 0, 100) / 500;
+  const durationMultiplier = clamp((input.durationMinutes ?? service.durationMinutes) / service.durationMinutes, 0.75, 1.2);
+  const compatibilityMultiplier = input.conditionCompatible === false ? 0.45 : 1;
+  const planMultiplier = 1 + clamp(input.carePlanAdherence ?? 0, 0, 100) / 1000;
+  const familiarityMultiplier = 1 + Math.min(WELLNESS_PROFESSIONAL_BALANCE.familiarityCap, (input.familiarityCount ?? 0) * 0.01);
+  const playerMultiplier = input.providerKind === "player" ? 1 + Math.min(WELLNESS_PROFESSIONAL_BALANCE.playerAdvantageCap, Math.max(0, (skill - 0.55) * 0.3 + (reliability - 0.75) * 0.12)) : WELLNESS_PROFESSIONAL_BALANCE.npcQuality[input.qualification];
+  const randomMultiplier = clamp(input.randomFactor ?? 1, 0.94, 1.06);
+  const quality = clamp(tierMultiplier * skillMultiplier * reliabilityMultiplier * locationMultiplier * durationMultiplier * compatibilityMultiplier * planMultiplier * familiarityMultiplier * playerMultiplier * (1 - providerFatiguePenalty - providerBurnoutPenalty) * randomMultiplier, 0.25, 1 + role.maxBonusCap);
+  const severity = clamp(input.clientConditionSeverity ?? 35, 0, 100);
+  const maxRecovery = severity >= 70 ? WELLNESS_PROFESSIONAL_BALANCE.severeConditionMaxRecovery : 22;
+  const effects = Object.fromEntries(Object.entries(service.outcomeStats).map(([key, value]) => [key, Math.round(clamp(Math.abs(value) * quality, 0, key.includes("strain") || value < 0 ? maxRecovery : 18) * Math.sign(value))]));
+  return { quality: Number(quality.toFixed(3)), effects, cappedBySevereCondition: severity >= 70 };
+}
+
+export function validateAppointmentRequest(input: { clientId: string; providerId?: string | null; providerKind: ProviderKind; service: WellnessServiceSlug; role: WellnessProfessionalRole; qualification: QualificationTier | null; priceCents: number; clientAvailable: boolean; providerAvailable: boolean; remote: boolean; locationTags?: string[] }) {
+  if (input.providerKind === "player" && input.providerId && input.clientId === input.providerId) return { ok: false as const, reason: "self_booking" };
+  const listing = canListService({ role: input.role, service: input.service, qualification: input.qualification, priceCents: input.priceCents });
+  if (!listing.ok) return listing;
+  const role = WELLNESS_PROFESSIONAL_ROLES[input.role];
+  const service = WELLNESS_SERVICES[input.service];
+  if (input.remote && (!role.remoteEligible || !service.remoteEligible)) return { ok: false as const, reason: "remote_not_allowed" };
+  if (!input.remote && input.locationTags && !input.locationTags.some((tag) => role.locationRequirements.includes(tag))) return { ok: false as const, reason: "invalid_location" };
+  if (!input.clientAvailable || !input.providerAvailable) return { ok: false as const, reason: "schedule_conflict" };
+  return { ok: true as const };
+}
+
+export function calculateProfessionalXp(input: { durationMinutes: number; serviceDifficulty?: number; outcomeQuality: number; eligiblePaymentCents: number; refunded?: boolean; pairCompletedThisWeek?: number; dailyAwarded?: number; weeklyAwarded?: number }) {
+  if (input.refunded || input.eligiblePaymentCents <= 0) return { xp: 0, diminished: false, capped: false };
+  const base = (input.durationMinutes / 30) * 8 * clamp(input.serviceDifficulty ?? 1, 0.5, 2) * clamp(input.outcomeQuality, 0.25, 1.2);
+  const repeats = input.pairCompletedThisWeek ?? 0;
+  const diminishing = repeats >= WELLNESS_PROFESSIONAL_BALANCE.repeatedPairDiminishingAfter ? 1 / (1 + (repeats - WELLNESS_PROFESSIONAL_BALANCE.repeatedPairDiminishingAfter + 1) * 0.5) : 1;
+  const remainingDaily = Math.max(0, WELLNESS_PROFESSIONAL_BALANCE.dailyXpCap - (input.dailyAwarded ?? 0));
+  const remainingWeekly = Math.max(0, WELLNESS_PROFESSIONAL_BALANCE.weeklyXpCap - (input.weeklyAwarded ?? 0));
+  const xp = Math.floor(Math.min(base * diminishing, remainingDaily, remainingWeekly));
+  return { xp, diminished: diminishing < 1, capped: xp < Math.floor(base * diminishing) };
+}
+
+export function calculateProfessionalReputation(input: { completedAppointments: number; reliability: number; averageRating?: number; outcomeConsistency?: number; cancellations?: number; disputes?: number }) {
+  const experience = Math.min(30, Math.log10(1 + input.completedAppointments) * 16);
+  const reliability = clamp(input.reliability, 0, 100) * 0.3;
+  const rating = clamp(input.averageRating ?? 3.5, 1, 5) * 8;
+  const consistency = clamp(input.outcomeConsistency ?? 70, 0, 100) * 0.15;
+  const penalties = (input.cancellations ?? 0) * 1.5 + (input.disputes ?? 0) * 4;
+  const score = clamp(Math.round(experience + reliability + rating + consistency - penalties), 0, 100);
+  const state = [...WELLNESS_PROFESSIONAL_BALANCE.reputationThresholds].reverse().find((threshold) => score >= threshold.min)?.label ?? "New";
+  return { score, state };
+}

--- a/src/pages/wellness/index.tsx
+++ b/src/pages/wellness/index.tsx
@@ -21,6 +21,7 @@ import WellnessVitalsPanel from "@/components/wellness/WellnessVitalsPanel";
 import ActivityCard from "@/components/wellness/ActivityCard";
 import AilmentsPanel from "@/components/wellness/AilmentsPanel";
 import NutritionHydrationPanel from "@/components/wellness/NutritionHydrationPanel";
+import { ProfessionalSupportPanel } from "@/components/wellness/ProfessionalSupportPanel";
 
 import { useGameData } from "@/hooks/useGameData";
 import { useWellnessState } from "@/hooks/useWellnessState";
@@ -170,6 +171,8 @@ const WellnessPage = () => {
       <WellnessVitalsPanel vitals={vitals} fame={profile?.fame ?? 0} />
 
       <NutritionHydrationPanel vitals={vitals} />
+
+      <ProfessionalSupportPanel vitals={vitals} fame={profile?.fame ?? 0} />
 
       {blocks.length > 0 && (
         <Card className="border-amber-500/40 bg-amber-500/5">

--- a/supabase/migrations/20260712120000_wellness_professionals.sql
+++ b/supabase/migrations/20260712120000_wellness_professionals.sql
@@ -1,0 +1,145 @@
+-- Wellness professionals schema extension. Non-destructive and designed to reuse
+-- existing profiles, jobs, company_employees, schedule_events and finance ledgers.
+
+create table if not exists public.wellness_provider_profiles (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid references public.profiles(id) on delete cascade,
+  provider_kind text not null check (provider_kind in ('npc', 'player')),
+  role text not null,
+  qualification_tier text not null default 'trainee' check (qualification_tier in ('trainee', 'qualified', 'experienced', 'expert', 'elite')),
+  professional_xp integer not null default 0 check (professional_xp >= 0),
+  completed_appointments integer not null default 0 check (completed_appointments >= 0),
+  reliability numeric not null default 85 check (reliability >= 0 and reliability <= 100),
+  reputation_score numeric not null default 0 check (reputation_score >= 0 and reputation_score <= 100),
+  active boolean not null default true,
+  server_assigned boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint wellness_provider_player_or_npc check ((provider_kind = 'player' and profile_id is not null) or provider_kind = 'npc')
+);
+
+create unique index if not exists wellness_provider_profiles_player_role_idx
+  on public.wellness_provider_profiles(profile_id, role)
+  where profile_id is not null;
+
+create table if not exists public.wellness_provider_listings (
+  id uuid primary key default gen_random_uuid(),
+  provider_profile_id uuid not null references public.wellness_provider_profiles(id) on delete cascade,
+  service_slug text not null,
+  price_cents integer not null check (price_cents >= 0),
+  city_id uuid references public.cities(id) on delete set null,
+  remote_available boolean not null default false,
+  weekly_capacity_minutes integer not null default 240 check (weekly_capacity_minutes >= 0 and weekly_capacity_minutes <= 2400),
+  paused boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique(provider_profile_id, service_slug, city_id, remote_available)
+);
+
+create table if not exists public.wellness_appointments (
+  id uuid primary key default gen_random_uuid(),
+  provider_profile_id uuid not null references public.wellness_provider_profiles(id) on delete restrict,
+  client_profile_id uuid not null references public.profiles(id) on delete cascade,
+  service_slug text not null,
+  role text not null,
+  schedule_event_id uuid references public.schedule_events(id) on delete set null,
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  location_city_id uuid references public.cities(id) on delete set null,
+  remote boolean not null default false,
+  price_cents integer not null check (price_cents >= 0),
+  status text not null default 'booked' check (status in ('requested', 'booked', 'cancelled_early', 'cancelled_late', 'client_no_show', 'provider_no_show', 'completed', 'partially_completed', 'refunded', 'disputed')),
+  client_attended boolean,
+  provider_attended boolean,
+  payment_transaction_id uuid,
+  refund_transaction_id uuid,
+  outcome_applied_at timestamptz,
+  xp_awarded_at timestamptz,
+  cancellation_deadline timestamptz,
+  related_party_flag boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint wellness_appointments_valid_time check (ends_at > starts_at)
+);
+
+create index if not exists wellness_appointments_provider_time_idx on public.wellness_appointments(provider_profile_id, starts_at, ends_at) where status in ('requested', 'booked');
+create index if not exists wellness_appointments_client_time_idx on public.wellness_appointments(client_profile_id, starts_at, ends_at) where status in ('requested', 'booked');
+create unique index if not exists wellness_appointments_outcome_once_idx on public.wellness_appointments(id) where outcome_applied_at is not null;
+
+create table if not exists public.wellness_support_contracts (
+  id uuid primary key default gen_random_uuid(),
+  provider_profile_id uuid not null references public.wellness_provider_profiles(id) on delete restrict,
+  client_profile_id uuid references public.profiles(id) on delete cascade,
+  band_id uuid references public.bands(id) on delete cascade,
+  company_id uuid references public.companies(id) on delete set null,
+  service_package text not null,
+  frequency text not null check (frequency in ('weekly', 'biweekly', 'monthly', 'tour', 'retainer')),
+  starts_on date not null,
+  ends_on date,
+  price_cents integer not null check (price_cents >= 0),
+  included_appointments integer not null default 1 check (included_appointments >= 0),
+  auto_renew boolean not null default false,
+  status text not null default 'active' check (status in ('draft', 'active', 'cancelled', 'completed', 'disputed')),
+  last_cycle_processed_on date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint wellness_support_contracts_client_or_band check (client_profile_id is not null or band_id is not null)
+);
+
+create table if not exists public.wellness_care_plans (
+  id uuid primary key default gen_random_uuid(),
+  provider_profile_id uuid not null references public.wellness_provider_profiles(id) on delete restrict,
+  client_profile_id uuid not null references public.profiles(id) on delete cascade,
+  contract_id uuid references public.wellness_support_contracts(id) on delete set null,
+  name text not null,
+  starts_on date not null,
+  ends_on date,
+  review_on date,
+  recommendations jsonb not null default '{}'::jsonb,
+  expected_benefits jsonb not null default '{}'::jsonb,
+  adherence_score numeric not null default 0 check (adherence_score >= 0 and adherence_score <= 100),
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.wellness_professional_reviews (
+  id uuid primary key default gen_random_uuid(),
+  appointment_id uuid not null references public.wellness_appointments(id) on delete cascade,
+  provider_profile_id uuid not null references public.wellness_provider_profiles(id) on delete cascade,
+  client_profile_id uuid not null references public.profiles(id) on delete cascade,
+  rating integer not null check (rating between 1 and 5),
+  comment text,
+  punctual boolean,
+  helpful boolean,
+  moderation_status text not null default 'visible' check (moderation_status in ('visible', 'flagged', 'hidden')),
+  created_at timestamptz not null default now(),
+  unique(appointment_id),
+  unique(appointment_id, client_profile_id)
+);
+
+create table if not exists public.wellness_professional_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  appointment_id uuid references public.wellness_appointments(id) on delete set null,
+  provider_profile_id uuid references public.wellness_provider_profiles(id) on delete set null,
+  client_profile_id uuid references public.profiles(id) on delete set null,
+  event_type text not null,
+  severity text not null default 'info' check (severity in ('info', 'warning', 'fraud_risk', 'admin')),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.jobs add column if not exists wellness_role text;
+alter table public.jobs add column if not exists wellness_required_qualification text check (wellness_required_qualification is null or wellness_required_qualification in ('trainee', 'qualified', 'experienced', 'expert', 'elite'));
+alter table public.jobs add column if not exists wellness_required_skills jsonb not null default '{}'::jsonb;
+alter table public.jobs add column if not exists remote_eligible boolean not null default false;
+alter table public.company_employees add column if not exists wellness_role text;
+alter table public.company_employees add column if not exists wellness_provider_profile_id uuid references public.wellness_provider_profiles(id) on delete set null;
+
+alter table public.wellness_provider_profiles enable row level security;
+alter table public.wellness_provider_listings enable row level security;
+alter table public.wellness_appointments enable row level security;
+alter table public.wellness_support_contracts enable row level security;
+alter table public.wellness_care_plans enable row level security;
+alter table public.wellness_professional_reviews enable row level security;
+alter table public.wellness_professional_audit_events enable row level security;


### PR DESCRIPTION
### Motivation
- Extend the existing Wellness layer so players and NPCs can offer hireable professional services that integrate with scheduling, company staff, jobs, finance, reputation and wellness outcomes. 
- Provide a server-authoritative, anti-abuse foundation for one-off appointments, recurring contracts, care plans, XP and reputation while reusing existing systems rather than adding separate employment/payment frameworks.

### Description
- Added a shared professional-role and service engine in `src/lib/wellnessProfessionals.ts` that defines roles, services, qualification thresholds, outcome calculations, appointment validation, XP, reputation and anti-abuse caps. 
- Added a Wellness UI panel `src/components/wellness/ProfessionalSupportPanel.tsx` and integrated it into the Wellness page to surface recommended professionals, expected quality, appointment lifecycle rules and contract info. 
- Introduced a non-destructive Supabase migration `supabase/migrations/20260712120000_wellness_professionals.sql` that adds provider profiles, listings, appointments, support contracts, care plans, reviews and audit events and extends `jobs`/`company_employees` with wellness metadata. 
- Added documentation `docs/wellness-professionals.md` and unit tests `src/lib/wellnessProfessionals.test.ts` covering qualification derivation, listing validation, booking validation, capped outcomes, XP diminishing/caps and reputation weighting.

### Testing
- Ran unit tests with the local test runner `node local-packages/vitest/bin.js run src/lib/wellnessProfessionals.test.ts` and all tests passed. 
- Ran type checking with `npm run typecheck` (calls `tsc --noEmit`) which succeeded. 
- Attempted a full build with `npm run build` but the environment lacked the `vite` binary and `npm install` was blocked by registry access policy, so a production build and UI screenshots could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539ec337f48325bbf273094838839e)