### PR TITLE
Fix skills and attributes page stability, data accuracy and progression UI

### DIFF
--- a/docs/progression/SKILLS_ATTRIBUTES_MIGRATION_AUDIT.md
+++ b/docs/progression/SKILLS_ATTRIBUTES_MIGRATION_AUDIT.md
@@ -1,0 +1,19 @@
+# Skills & Attributes Migration Audit
+
+## Warning
+Do not rename or rewrite already-applied production migrations without first checking the production Supabase migration history. Renaming historical files can cause Supabase to attempt duplicate or out-of-order changes.
+
+## Suspicious filenames and ordering risks
+
+- `20260923110000_normalize_skills.sql` creates normalized skill definition/progress structures after older skill progress tables. This is future-dated relative to the current 2026 work and may run after dependent feature migrations in fresh environments.
+- `20261025100000_add_extended_skill_definitions.sql` and `20261205100000_create_skill_books_tables.sql` are future-dated and may depend on normalized skill tables being present.
+- `20261030130000_create_xp_tables.sql` and `20270601120000_add_daily_xp_allocation.sql` introduce XP wallet/allocation concepts with future timestamps, which can make local reset order differ from production if production has already applied equivalent changes manually.
+- `20291202090000_beta_rls_hardening.sql` is intentionally far-future dated and should be reviewed before any production reset or migration replay.
+
+## Safety assessment
+
+The suspicious migrations appear additive or hardening-oriented, but the future timestamps create ordering risk for fresh database builds and branch previews. This PR does not rename or rewrite historical migrations.
+
+## Recommended follow-up
+
+Create a dedicated migration-history follow-up to compare production migration records with repository filenames, then add corrective forward-only migrations if any dependency order is unsafe. Avoid editing previously applied files.

--- a/src/components/attributes/AttributeCard.tsx
+++ b/src/components/attributes/AttributeCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, TrendingUp } from "lucide-react";
 import { ATTRIBUTE_MAX_VALUE } from "@/utils/attributeProgression";
+import { clampProgressPercent } from "@/utils/skillProgressDisplay";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { spendAttributeXp } from "@/utils/progression";
 import { toast } from "sonner";
@@ -30,7 +31,7 @@ export const AttributeCard = ({
   const queryClient = useQueryClient();
   const standardCost = 5; // Attributes now cost 5 AP
   const cost = xpBalance > 0 && xpBalance < standardCost ? xpBalance : standardCost;
-  const progress = currentValue / ATTRIBUTE_MAX_VALUE * 100;
+  const progress = clampProgressPercent((currentValue / ATTRIBUTE_MAX_VALUE) * 100);
   const canAfford = xpBalance >= cost;
   const isMaxed = currentValue >= ATTRIBUTE_MAX_VALUE;
 
@@ -42,6 +43,7 @@ export const AttributeCard = ({
     onSuccess: () => {
       toast.success(`${label} trained! +${cost} points`);
       queryClient.invalidateQueries({ queryKey: ["gameData"] });
+      queryClient.invalidateQueries({ queryKey: ["player-attributes"] });
       onXpSpent?.();
     },
     onError: (error: Error) => {
@@ -72,6 +74,7 @@ export const AttributeCard = ({
         <Progress value={progress} className="h-1.5" />
 
         <Button 
+          aria-label={`Train ${label} for ${cost} AP`}
           onClick={() => trainMutation.mutate()} 
           disabled={!canAfford || isMaxed || trainMutation.isPending} 
           className="w-full h-7 text-xs" 

--- a/src/components/attributes/AttributePanel.tsx
+++ b/src/components/attributes/AttributePanel.tsx
@@ -27,7 +27,7 @@ const ATTRIBUTE_CATEGORIES = {
     keys: ["stage_presence", "musicality"] as FullAttributeKey[],
   },
   musical: {
-    title: "Musical Skills",
+    title: "Musical Attributes",
     keys: ["musical_ability", "vocal_talent", "rhythm_sense", "technical_mastery"] as FullAttributeKey[],
   },
 };

--- a/src/components/skills/SchedulePracticeDialog.tsx
+++ b/src/components/skills/SchedulePracticeDialog.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Calendar } from "@/components/ui/calendar";
-import { usePracticeSkill } from "@/hooks/useSkillPractice";
+import { type PracticeRestrictions, usePracticeSkill } from "@/hooks/useSkillPractice";
 import { setHours, setMinutes, setSeconds, setMilliseconds } from "date-fns";
 import { validateFutureBooking } from "@/utils/activityBookingTime";
 import { toast } from "sonner";
@@ -20,6 +20,7 @@ interface SchedulePracticeDialogProps {
   onOpenChange: (open: boolean) => void;
   skillSlug: string;
   skillName: string;
+  practiceConfig?: PracticeRestrictions;
 }
 
 export function SchedulePracticeDialog({
@@ -27,6 +28,7 @@ export function SchedulePracticeDialog({
   onOpenChange,
   skillSlug,
   skillName,
+  practiceConfig,
 }: SchedulePracticeDialogProps) {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [selectedHour, setSelectedHour] = useState<number>(9);
@@ -68,7 +70,7 @@ export function SchedulePracticeDialog({
         <DialogHeader>
           <DialogTitle>Schedule Practice: {skillName}</DialogTitle>
           <DialogDescription>
-            Choose when you'd like to practice this skill. Practice sessions last 1 hour.
+            Choose when you'd like to practice this skill. Practice sessions last {practiceConfig?.durationOptionsHours.join("/") ?? 1} hour(s).
           </DialogDescription>
         </DialogHeader>
 
@@ -105,7 +107,7 @@ export function SchedulePracticeDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSchedule} disabled={practiceSkill.isPending}>
+          <Button aria-label={`Schedule practice for ${skillName}`} onClick={handleSchedule} disabled={practiceSkill.isPending || practiceConfig?.canPractice === false}>
             {practiceSkill.isPending ? "Scheduling..." : "Schedule Practice"}
           </Button>
         </DialogFooter>

--- a/src/hooks/usePlayerAttributesQuery.ts
+++ b/src/hooks/usePlayerAttributesQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/lib/supabase-types";
+
+export const playerAttributesQueryKey = (profileId?: string | null) => ["player-attributes", profileId] as const;
+
+export function usePlayerAttributesQuery(profileId?: string | null) {
+  return useQuery<Tables<"player_attributes"> | null>({
+    queryKey: playerAttributesQueryKey(profileId),
+    enabled: Boolean(profileId),
+    queryFn: async () => {
+      if (!profileId) return null;
+      const { data, error } = await supabase
+        .from("player_attributes")
+        .select("*")
+        .eq("profile_id", profileId)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/hooks/useSkillPractice.ts
+++ b/src/hooks/useSkillPractice.ts
@@ -1,7 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
-import { startOfDay, endOfDay, addHours } from "date-fns";
+import { addHours } from "date-fns";
+import { SKILL_PRACTICE_CONFIG } from "@/utils/skillProgressDisplay";
 import { useCreateScheduledActivity } from "./useScheduledActivities";
 
 interface PracticeSkillData {
@@ -10,31 +11,48 @@ interface PracticeSkillData {
   scheduledStart: Date;
 }
 
-interface PracticeRestrictions {
+export interface PracticeRestrictions {
   canPractice: boolean;
   reason?: string;
   todaysPracticeCount: number;
+  sessionsUsed: number;
+  sessionsRemaining: number;
+  maxDailySessions: number;
+  durationOptionsHours: readonly number[];
+  baseXpReward: number;
+  minimumSkillLevel: number;
+  nextResetAt?: string;
   hasSnookerConflict: boolean;
 }
 
-export function useSkillPracticeRestrictions(userId?: string, currentDate?: Date) {
+export function useSkillPracticeRestrictions(userId?: string) {
   return useQuery({
-    queryKey: ['skill-practice-restrictions', userId, currentDate?.toISOString()],
+    queryKey: ['skill-practice-restrictions', userId],
     queryFn: async (): Promise<PracticeRestrictions> => {
-      if (!userId || !currentDate) {
-        return { canPractice: false, reason: 'Not authenticated', todaysPracticeCount: 0, hasSnookerConflict: false };
+      if (!userId) {
+        return { canPractice: false, reason: 'Not authenticated', todaysPracticeCount: 0, sessionsUsed: 0, sessionsRemaining: 0, maxDailySessions: SKILL_PRACTICE_CONFIG.maxDailySessions, durationOptionsHours: SKILL_PRACTICE_CONFIG.durationOptionsHours, baseXpReward: SKILL_PRACTICE_CONFIG.baseXpReward, minimumSkillLevel: SKILL_PRACTICE_CONFIG.minimumSkillLevel, hasSnookerConflict: false };
       }
 
-      const dayStart = startOfDay(currentDate);
-      const dayEnd = endOfDay(currentDate);
+      let serverNow = new Date();
+      try {
+        const serverTimeResponse = await (supabase as any).rpc("get_server_time");
+        if (serverTimeResponse?.data) serverNow = new Date(String(serverTimeResponse.data));
+      } catch {
+        // Fall back to client formatting only when the server-time RPC is unavailable.
+      }
+      const dayStart = new Date(serverNow);
+      dayStart.setUTCHours(0, 0, 0, 0);
+      const dayEnd = new Date(dayStart);
+      dayEnd.setUTCDate(dayEnd.getUTCDate() + 1);
+      const nextResetAt = dayEnd.toISOString();
 
-      // Get today's scheduled activities
+      // Get today's scheduled activities using server-derived UTC day boundaries.
       const { data: activities, error } = await supabase
         .from('player_scheduled_activities')
         .select('*')
         .eq('user_id', userId)
         .gte('scheduled_start', dayStart.toISOString())
-        .lte('scheduled_start', dayEnd.toISOString())
+        .lt('scheduled_start', dayEnd.toISOString())
         .in('status', ['scheduled', 'in_progress']);
 
       if (error) throw error;
@@ -64,19 +82,26 @@ export function useSkillPracticeRestrictions(userId?: string, currentDate?: Date
       if (hasSnookerConflict) {
         canPractice = false;
         reason = 'Cannot practice while snooker activity is scheduled';
-      } else if (todaysPracticeCount >= 5) {
+      } else if (todaysPracticeCount >= SKILL_PRACTICE_CONFIG.maxDailySessions) {
         canPractice = false;
-        reason = 'Daily practice limit reached (5/5)';
+        reason = `Daily practice limit reached (${todaysPracticeCount}/${SKILL_PRACTICE_CONFIG.maxDailySessions})`;
       }
 
       return {
         canPractice,
         reason,
         todaysPracticeCount,
+        sessionsUsed: todaysPracticeCount,
+        sessionsRemaining: Math.max(0, SKILL_PRACTICE_CONFIG.maxDailySessions - todaysPracticeCount),
+        maxDailySessions: SKILL_PRACTICE_CONFIG.maxDailySessions,
+        durationOptionsHours: SKILL_PRACTICE_CONFIG.durationOptionsHours,
+        baseXpReward: SKILL_PRACTICE_CONFIG.baseXpReward,
+        minimumSkillLevel: SKILL_PRACTICE_CONFIG.minimumSkillLevel,
+        nextResetAt,
         hasSnookerConflict,
       };
     },
-    enabled: !!userId && !!currentDate,
+    enabled: !!userId,
     staleTime: 1000 * 30, // 30 seconds
   });
 }
@@ -108,11 +133,11 @@ export function usePracticeSkill() {
         .eq('skill_slug', skillSlug)
         .maybeSingle();
 
-      if (!skillProgress || skillProgress.current_level < 1) {
+      if (!skillProgress || skillProgress.current_level < SKILL_PRACTICE_CONFIG.minimumSkillLevel) {
         throw new Error('Skill must be at least level 1 to practice');
       }
 
-      const scheduledEnd = addHours(scheduledStart, 1);
+      const scheduledEnd = addHours(scheduledStart, SKILL_PRACTICE_CONFIG.durationOptionsHours[0]);
 
       // Create scheduled activity
       return createActivity.mutateAsync({
@@ -125,7 +150,7 @@ export function usePracticeSkill() {
           isPractice: true,
           skillSlug,
           skillName,
-          xpReward: 5,
+          xpReward: SKILL_PRACTICE_CONFIG.baseXpReward,
         },
       });
     },
@@ -135,7 +160,7 @@ export function usePracticeSkill() {
       queryClient.invalidateQueries({ queryKey: ['skill-practice-restrictions'] });
       
       toast.success('Practice scheduled!', {
-        description: `${variables.skillName} practice booked for 1 hour`,
+        description: `${variables.skillName} practice booked`,
       });
     },
     onError: (error: any) => {
@@ -156,7 +181,7 @@ export function useCompletePracticeSession() {
         body: {
           action: 'spend_skill_xp',
           skill_slug: skillSlug,
-          xp: 5,
+          xp: SKILL_PRACTICE_CONFIG.baseXpReward,
           metadata: {
             activity: 'practice',
             source: 'scheduled_practice',
@@ -185,7 +210,7 @@ export function useCompletePracticeSession() {
       queryClient.invalidateQueries({ queryKey: ['scheduled-activities'] });
       
       toast.success('Practice completed!', {
-        description: 'Gained 5 XP',
+        description: `Gained ${SKILL_PRACTICE_CONFIG.baseXpReward} XP`,
       });
     },
     onError: (error: any) => {

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -6,263 +6,107 @@ import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { TrendingUp, Target, Award, Zap, Calendar, AlertCircle, Dumbbell, GitBranch, Gauge } from "lucide-react";
+import { TrendingUp, Target, Award, Zap, Calendar, AlertCircle, Dumbbell, GitBranch, Gauge, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { useSkillPracticeRestrictions } from "@/hooks/useSkillPractice";
 import { SchedulePracticeDialog } from "@/components/skills/SchedulePracticeDialog";
 import { XpWalletDisplay } from "@/components/attributes/XpWalletDisplay";
 import { DailyStipendCard } from "@/components/attributes/DailyStipendCard";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { Sparkles } from "lucide-react";
 import { AttributePanel } from "@/components/attributes/AttributePanel";
-import { supabase } from "@/integrations/supabase/client";
-import type { Database } from "@/lib/supabase-types";
 import { useTranslation } from "@/hooks/useTranslation";
+import { usePlayerAttributesQuery } from "@/hooks/usePlayerAttributesQuery";
+import { calculateSkillOverviewStats, getSkillDisplayProgress, SKILL_PRACTICE_CONFIG } from "@/utils/skillProgressDisplay";
+
+const formatReset = (value?: string | null) => value ? new Date(value).toLocaleString() : "the next daily reset";
 
 const SkillsPage = () => {
   const { t } = useTranslation();
   const { profileId } = useActiveProfile();
-  const { skillProgress, loading, xpWallet, profile, dailyXpGrant } = useGameData();
+  const { skillProgress, loading, error, xpWallet, profile, dailyXpGrant, refetch } = useGameData();
   const [selectedSkill, setSelectedSkill] = useState<{ slug: string; name: string } | null>(null);
-  const [rawAttributes, setRawAttributes] = useState<Database["public"]["Tables"]["player_attributes"]["Row"] | null>(null);
-  
-  // Get practice restrictions for current date
-  const today = new Date();
-  const { data: restrictions } = useSkillPracticeRestrictions(profileId ?? undefined, today);
+  const attributesQuery = usePlayerAttributesQuery(profile?.id ?? profileId);
+  const restrictionsQuery = useSkillPracticeRestrictions(profileId ?? undefined);
+  const restrictions = restrictionsQuery.data;
 
-  // Fetch full attributes row
-  useEffect(() => {
-    if (profile?.id) {
-      const fetchAttributes = async () => {
-        const { data } = await supabase
-          .from("player_attributes")
-          .select("*")
-          .eq("profile_id", profile.id)
-          .maybeSingle();
-        
-        if (data) {
-          setRawAttributes(data);
-        }
-      };
-      fetchAttributes();
-    }
-  }, [profile?.id]);
-
-  // XP Wallet data - use dual currency columns, fallback to legacy
-  const skillXpBalance = xpWallet?.skill_xp_balance ?? xpWallet?.xp_balance ?? 0;
-  const skillXpLifetime = xpWallet?.skill_xp_lifetime ?? xpWallet?.lifetime_xp ?? 0;
-  const attributePointsBalance = xpWallet?.attribute_points_balance ?? 0;
-  const attributePointsSpent = rawAttributes?.attribute_points_spent ?? 0;
+  const skillXpBalance = xpWallet?.skill_xp_balance ?? xpWallet?.xp_balance;
+  const skillXpLifetime = xpWallet?.skill_xp_lifetime ?? xpWallet?.lifetime_xp;
+  const attributePointsBalance = xpWallet?.attribute_points_balance;
+  const attributePointsSpent = attributesQuery.data?.attribute_points_spent;
   const streak = xpWallet?.stipend_claim_streak ?? 0;
   const lastClaimDate = xpWallet?.last_stipend_claim_date ?? dailyXpGrant?.created_at;
 
-  const totalXP = skillProgress?.reduce((sum, skill) => sum + (skill.current_xp || 0), 0) || 0;
-  const skillCount = skillProgress?.length || 0;
-  const avgLevel = skillProgress?.reduce((sum, skill) => sum + (skill.current_level || 0), 0) / (skillCount || 1);
+  const stats = useMemo(() => calculateSkillOverviewStats(skillProgress ?? []), [skillProgress]);
+  const xpCardLabel = stats.lifetimeXp === null ? "Current Level XP" : "Lifetime Skill XP";
+  const xpCardValue = stats.lifetimeXp ?? stats.currentLevelXp;
+  const practiceableSkills = useMemo(
+    () => (skillProgress ?? []).filter((skill) => getSkillDisplayProgress(skill).can_practice),
+    [skillProgress],
+  );
 
-  // Filter skills that can be practiced (level 1 or higher)
-  const practiceableSkills = useMemo(() => {
-    return skillProgress?.filter(skill => skill.current_level >= 1) || [];
-  }, [skillProgress]);
-
-  const handleOpenPracticeDialog = (skillSlug: string, skillName: string) => {
-    setSelectedSkill({ slug: skillSlug, name: skillName });
+  const refreshProgressionData = async () => {
+    await Promise.all([attributesQuery.refetch(), refetch()]);
   };
 
+  const retryAll = () => {
+    refetch();
+    attributesQuery.refetch();
+    restrictionsQuery.refetch();
+  };
+
+  const tabs = [
+    { value: "practice", icon: Dumbbell, label: t("skills.tabs.practice", "Practice Skills"), desc: `Book ${SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour sessions (+${SKILL_PRACTICE_CONFIG.baseXpReward} XP)` },
+    { value: "tree", icon: GitBranch, label: t("skills.tabs.tree", "Skill Tree"), desc: t("skills.tabs.treeDesc", "Unlock and level up abilities") },
+    { value: "attributes", icon: Gauge, label: t("skills.tabs.attributes", "Attributes"), desc: t("skills.tabs.attributesDesc", "Spend AP on core stats") },
+  ];
 
   return (
-    <FMPageScaffold
-      title="Skills & Attributes"
-      subtitle="Master your craft and unlock new abilities"
-      icon={Sparkles}
-      backTo="/hub/character"
-    >
-
-
-      <XpWalletDisplay
-        skillXpBalance={skillXpBalance}
-        skillXpLifetime={skillXpLifetime}
-        attributePointsBalance={attributePointsBalance}
-        attributePointsSpent={attributePointsSpent}
-        streak={streak}
-      />
-
-      <DailyStipendCard lastClaimDate={lastClaimDate} streak={streak} />
-
-      {/* Practice Restrictions Alert */}
-      {restrictions && !restrictions.canPractice && (
+    <FMPageScaffold title={t("skills.title", "Skills & Attributes")} subtitle={t("skills.subtitle", "Master your craft and unlock new abilities")} icon={Sparkles} backTo="/hub/character">
+      {(error || attributesQuery.error || restrictionsQuery.error) && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription>{restrictions.reason}</AlertDescription>
-        </Alert>
-      )}
-
-      {/* Practice Status */}
-      {restrictions && restrictions.canPractice && (
-        <Alert>
-          <Target className="h-4 w-4" />
-          <AlertDescription>
-            Practice sessions today: {restrictions.todaysPracticeCount}/5
-            {restrictions.todaysPracticeCount < 5 && 
-              ` - You can practice ${5 - restrictions.todaysPracticeCount} more time${5 - restrictions.todaysPracticeCount === 1 ? '' : 's'} today`
-            }
+          <AlertDescription className="flex items-center justify-between gap-3">
+            <span>{t("skills.errors.loadFailed", "Some progression data failed to load. Values are not being replaced with zero.")}</span>
+            <Button size="sm" variant="outline" onClick={retryAll}>{t("common.retry", "Retry")}</Button>
           </AlertDescription>
         </Alert>
       )}
 
-      {/* Overview Stats */}
+      {loading || !xpWallet ? (
+        <Card><CardContent className="pt-6">{loading ? t("skills.loading.wallet", "Loading XP wallet…") : t("skills.empty.wallet", "XP wallet row is missing.")}</CardContent></Card>
+      ) : (
+        <XpWalletDisplay skillXpBalance={skillXpBalance ?? 0} skillXpLifetime={skillXpLifetime ?? 0} attributePointsBalance={attributePointsBalance ?? 0} attributePointsSpent={attributePointsSpent ?? 0} streak={streak} />
+      )}
+
+      <DailyStipendCard lastClaimDate={lastClaimDate} streak={streak} />
+
+      {restrictionsQuery.isLoading && <Alert><Target className="h-4 w-4" /><AlertDescription>{t("skills.loading.practice", "Checking practice availability…")}</AlertDescription></Alert>}
+      {restrictions && !restrictions.canPractice && <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{restrictions.reason} Next reset: {formatReset(restrictions.nextResetAt)}</AlertDescription></Alert>}
+      {restrictions?.canPractice && <Alert><Target className="h-4 w-4" /><AlertDescription>Practice sessions today: {restrictions.sessionsUsed}/{restrictions.maxDailySessions} — {restrictions.sessionsRemaining} remaining. Next reset: {formatReset(restrictions.nextResetAt)}</AlertDescription></Alert>}
+
       <div className="grid gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total XP</CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{totalXP.toLocaleString()}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Skills Unlocked</CardTitle>
-            <Target className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{skillCount}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Average Level</CardTitle>
-            <Award className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{avgLevel.toFixed(1)}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Can Practice</CardTitle>
-            <Zap className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{practiceableSkills.length}</div>
-            <p className="text-xs text-muted-foreground">Level 1+ skills</p>
-          </CardContent>
-        </Card>
+        {[{label: xpCardLabel, value: xpCardValue.toLocaleString(), icon: TrendingUp}, {label: "Skills Unlocked", value: stats.unlockedCount, icon: Target}, {label: "Average Level", value: stats.averageLevel.toFixed(1), icon: Award}, {label: "Can Practice", value: stats.practiceableCount, icon: Zap, note: `Meets level ${SKILL_PRACTICE_CONFIG.minimumSkillLevel}+ and server rules`}].map(({label,value,icon:Icon,note}) => (
+          <Card key={label}><CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2"><CardTitle className="text-sm font-medium">{label}</CardTitle><Icon className="h-4 w-4 text-muted-foreground" /></CardHeader><CardContent><div className="text-2xl font-bold">{value}</div>{note && <p className="text-xs text-muted-foreground">{note}</p>}</CardContent></Card>
+        ))}
       </div>
 
       <Tabs defaultValue="practice" className="w-full">
         <TabsList className="grid w-full grid-cols-3 h-auto gap-2 bg-transparent p-0">
-          {[
-            { value: "practice", icon: Dumbbell, label: "Practice Skills", desc: "Book 1-hour sessions (+5 XP)" },
-            { value: "tree", icon: GitBranch, label: "Skill Tree", desc: "Unlock & level up abilities" },
-            { value: "attributes", icon: Gauge, label: "Attributes", desc: "Spend AP on core stats" },
-          ].map(({ value, icon: Icon, label, desc }) => (
-            <TabsTrigger
-              key={value}
-              value={value}
-              className={cn(
-                "flex flex-col items-start gap-1 h-auto p-4 rounded-lg border border-border bg-card text-left",
-                "data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:shadow-md",
-                "hover:border-primary/60 transition-colors"
-              )}
-            >
-              <div className="flex items-center gap-2 w-full">
-                <Icon className="h-5 w-5 text-primary" />
-                <span className="font-semibold text-base">{label}</span>
-              </div>
-              <span className="text-xs text-muted-foreground font-normal">{desc}</span>
-            </TabsTrigger>
-          ))}
+          {tabs.map(({ value, icon: Icon, label, desc }) => <TabsTrigger key={value} value={value} aria-label={label} className={cn("flex flex-col items-start gap-1 h-auto p-4 rounded-lg border border-border bg-card text-left", "data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:shadow-md", "hover:border-primary/60 transition-colors")}><div className="flex items-center gap-2 w-full"><Icon className="h-5 w-5 text-primary" /><span className="font-semibold text-base">{label}</span></div><span className="text-xs text-muted-foreground font-normal">{desc}</span></TabsTrigger>)}
         </TabsList>
 
         <TabsContent value="attributes" className="mt-6">
-          <AttributePanel attributes={rawAttributes} xpBalance={attributePointsBalance} />
+          {attributesQuery.isLoading ? <Card><CardContent className="pt-6">{t("skills.loading.attributes", "Loading attributes…")}</CardContent></Card> : attributesQuery.data ? <AttributePanel attributes={attributesQuery.data} xpBalance={attributePointsBalance ?? 0} onXpSpent={refreshProgressionData} /> : <Card><CardContent className="pt-6">{t("skills.empty.attributes", "Attribute row is missing for this profile.")}</CardContent></Card>}
         </TabsContent>
 
-        <TabsContent value="tree" className="mt-6">
-          <SkillTree />
-        </TabsContent>
+        <TabsContent value="tree" className="mt-6">{loading ? <Card><CardContent className="pt-6">{t("skills.loading.skills", "Loading skills…")}</CardContent></Card> : <SkillTree />}</TabsContent>
 
-        <TabsContent value="practice" className="mt-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Practice Skills</CardTitle>
-              <CardDescription>
-                Schedule practice sessions to gain XP. Must be level 1+ to practice. 
-                Each session takes 1 hour and grants 5 XP. Maximum 5 sessions per day.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {practiceableSkills.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  <Target className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                  <p>No skills available to practice yet.</p>
-                  <p className="text-sm mt-2">Start with education or a music activity to unlock a level 1 skill.</p>
-                  <Button asChild size="sm" className="mt-4">
-                    <a href="/education">Find starter lessons</a>
-                  </Button>
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  {practiceableSkills.map(skill => {
-                    const requiredXP = Math.floor(100 * Math.pow(1.5, skill.current_level - 1));
-                    const progressPercent = (skill.current_xp / requiredXP) * 100;
-                    const canPracticeThisSkill = restrictions?.canPractice || false;
-
-                    return (
-                      <div key={skill.skill_slug} className="border rounded-lg p-4">
-                        <div className="flex items-center justify-between mb-3">
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2 mb-1">
-                              <h4 className="font-semibold capitalize">
-                                {skill.skill_slug.replace(/_/g, ' ')}
-                              </h4>
-                              <Badge variant="outline">Level {skill.current_level}</Badge>
-                            </div>
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                              <span>{skill.current_xp}/{requiredXP} XP</span>
-                            </div>
-                          </div>
-                          
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={!canPracticeThisSkill}
-                            onClick={() => handleOpenPracticeDialog(
-                              skill.skill_slug, 
-                              skill.skill_slug.replace(/_/g, ' ')
-                            )}
-                          >
-                            <Calendar className="mr-2 h-4 w-4" />
-                            Schedule Practice
-                          </Button>
-                        </div>
-                        <Progress value={progressPercent} className="h-2" />
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
+        <TabsContent value="practice" className="mt-6"><Card><CardHeader><CardTitle>Practice Skills</CardTitle><CardDescription>Schedule practice sessions using the shared practice configuration: {SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour duration, {SKILL_PRACTICE_CONFIG.baseXpReward} XP reward, maximum {restrictions?.maxDailySessions ?? SKILL_PRACTICE_CONFIG.maxDailySessions} sessions per server day.</CardDescription></CardHeader><CardContent>{loading ? <p>{t("skills.loading.skills", "Loading skills…")}</p> : practiceableSkills.length === 0 ? <div className="text-center py-8 text-muted-foreground"><Target className="h-12 w-12 mx-auto mb-4 opacity-50" /><p>No skills available to practice yet.</p><p className="text-sm mt-2">Starter skills can be unlocked through education and supported practice or rehearsal activities.</p><Button asChild size="sm" className="mt-4"><a href="/education">Find starter lessons</a></Button></div> : <div className="space-y-4">{practiceableSkills.map(skill => { const display = getSkillDisplayProgress(skill); const name = skill.skill_slug.replace(/_/g, " "); return <div key={skill.skill_slug} className="border rounded-lg p-4"><div className="flex items-center justify-between mb-3"><div className="flex-1"><div className="flex items-center gap-2 mb-1"><h4 className="font-semibold capitalize">{name}</h4><Badge variant="outline">Level {display.current_level}</Badge></div><div className="flex items-center gap-2 text-sm text-muted-foreground"><span>{display.xp_into_level}/{display.xp_required_for_next_level ?? "Max"} XP</span></div></div><Button size="sm" variant="outline" aria-label={`Schedule practice for ${name}`} disabled={!restrictions?.canPractice} onClick={() => setSelectedSkill({ slug: skill.skill_slug, name })}><Calendar className="mr-2 h-4 w-4" />Schedule Practice</Button></div><Progress value={display.progress_percent} className="h-2" /></div>; })}</div>}</CardContent></Card></TabsContent>
       </Tabs>
 
-      {/* Schedule Practice Dialog */}
-      {selectedSkill && (
-        <SchedulePracticeDialog
-          open={!!selectedSkill}
-          onOpenChange={(open) => !open && setSelectedSkill(null)}
-          skillSlug={selectedSkill.slug}
-          skillName={selectedSkill.name}
-        />
-      )}
+      {selectedSkill && <SchedulePracticeDialog open={!!selectedSkill} onOpenChange={(open) => !open && setSelectedSkill(null)} skillSlug={selectedSkill.slug} skillName={selectedSkill.name} practiceConfig={restrictions} />}
     </FMPageScaffold>
   );
 };

--- a/src/utils/__tests__/skillProgressDisplay.test.ts
+++ b/src/utils/__tests__/skillProgressDisplay.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { calculateSkillOverviewStats, clampProgressPercent, getSkillDisplayProgress, SKILL_PRACTICE_CONFIG } from "../skillProgressDisplay";
+
+describe("skill progress display helpers", () => {
+  it("excludes locked skills from counts and averages", () => {
+    const stats = calculateSkillOverviewStats([
+      { current_level: 0, current_xp: 10, is_unlocked: false, can_practice: false, lifetime_xp: 10 },
+      { current_level: 2, current_xp: 20, is_unlocked: true, can_practice: true, lifetime_xp: 220 },
+    ] as any);
+    expect(stats.unlockedCount).toBe(1);
+    expect(stats.averageLevel).toBe(2);
+    expect(stats.practiceableCount).toBe(1);
+    expect(stats.lifetimeXp).toBe(230);
+  });
+
+  it("returns safe zero with no unlocked skills", () => {
+    const stats = calculateSkillOverviewStats([{ current_level: 0, current_xp: 0 }] as any);
+    expect(stats.unlockedCount).toBe(0);
+    expect(stats.averageLevel).toBe(0);
+  });
+
+  it("clamps malformed progress displays", () => {
+    expect(clampProgressPercent(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(clampProgressPercent(-10)).toBe(0);
+    expect(clampProgressPercent(120)).toBe(100);
+    expect(getSkillDisplayProgress({ current_level: 1, current_xp: 200, xp_required_for_next_level: 100 } as any).progress_percent).toBe(100);
+    expect(getSkillDisplayProgress({ current_level: 1, current_xp: -20, xp_required_for_next_level: 0 } as any).progress_percent).toBe(0);
+  });
+
+  it("uses shared practice config defaults", () => {
+    const display = getSkillDisplayProgress({ current_level: SKILL_PRACTICE_CONFIG.minimumSkillLevel } as any);
+    expect(display.can_practice).toBe(true);
+    expect(SKILL_PRACTICE_CONFIG.maxDailySessions).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/skillProgressDisplay.ts
+++ b/src/utils/skillProgressDisplay.ts
@@ -1,0 +1,72 @@
+import type { SkillProgressRow } from "@/hooks/useGameData";
+
+export const SKILL_PRACTICE_CONFIG = {
+  maxDailySessions: 5,
+  durationOptionsHours: [1],
+  baseXpReward: 5,
+  minimumSkillLevel: 1,
+} as const;
+
+export interface SkillDisplayProgress {
+  current_level: number;
+  xp_into_level: number;
+  xp_required_for_next_level: number | null;
+  progress_percent: number;
+  next_level: number | null;
+  is_max_level: boolean;
+  is_unlocked: boolean;
+  can_practice: boolean;
+  lifetime_xp: number | null;
+}
+
+const finiteNumber = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+export const clampProgressPercent = (value: unknown): number => {
+  const numeric = finiteNumber(value, 0);
+  return Math.max(0, Math.min(100, numeric));
+};
+
+export const getSkillDisplayProgress = (skill: Partial<SkillProgressRow> & Record<string, unknown>): SkillDisplayProgress => {
+  const currentLevel = Math.max(0, Math.floor(finiteNumber(skill.current_level, 0)));
+  const xpIntoLevel = Math.max(0, Math.floor(finiteNumber(skill.xp_into_level ?? skill.current_xp, 0)));
+  const requiredRaw = skill.xp_required_for_next_level ?? skill.required_xp;
+  const required = finiteNumber(requiredRaw, 0);
+  const isMaxLevel = Boolean(skill.is_max_level) || required <= 0;
+  const explicitProgress = skill.progress_percent;
+  const progressPercent = explicitProgress !== undefined
+    ? clampProgressPercent(explicitProgress)
+    : required > 0
+      ? clampProgressPercent((xpIntoLevel / required) * 100)
+      : 0;
+  const isUnlocked = typeof skill.is_unlocked === "boolean" ? skill.is_unlocked : currentLevel > 0;
+  const canPractice = typeof skill.can_practice === "boolean"
+    ? skill.can_practice
+    : isUnlocked && currentLevel >= SKILL_PRACTICE_CONFIG.minimumSkillLevel;
+  const lifetime = finiteNumber(skill.lifetime_xp ?? skill.total_xp, NaN);
+
+  return {
+    current_level: currentLevel,
+    xp_into_level: xpIntoLevel,
+    xp_required_for_next_level: required > 0 ? Math.floor(required) : null,
+    progress_percent: progressPercent,
+    next_level: isMaxLevel ? null : currentLevel + 1,
+    is_max_level: isMaxLevel,
+    is_unlocked: isUnlocked,
+    can_practice: canPractice,
+    lifetime_xp: Number.isFinite(lifetime) ? Math.max(0, Math.floor(lifetime)) : null,
+  };
+};
+
+export const calculateSkillOverviewStats = (skills: Array<Partial<SkillProgressRow> & Record<string, unknown>>) => {
+  const display = skills.map(getSkillDisplayProgress);
+  const unlocked = display.filter((skill) => skill.is_unlocked);
+  const lifetimeXpValues = display.map((skill) => skill.lifetime_xp).filter((value): value is number => value !== null);
+  return {
+    unlockedCount: unlocked.length,
+    averageLevel: unlocked.length ? unlocked.reduce((sum, skill) => sum + skill.current_level, 0) / unlocked.length : 0,
+    practiceableCount: display.filter((skill) => skill.can_practice).length,
+    lifetimeXp: lifetimeXpValues.length === display.length ? lifetimeXpValues.reduce((sum, value) => sum + value, 0) : null,
+    currentLevelXp: display.reduce((sum, skill) => sum + skill.xp_into_level, 0),
+  };
+};


### PR DESCRIPTION
### Motivation
- Fix stale attribute and wallet data so spending an attribute point immediately reflects on the page without a reload.
- Correct misleading overview statistics (Total XP, unlocked counts, average level, practiceable count) so they reflect authoritative progression fields, not ad-hoc frontend sums.
- Remove duplicated progression formulas and hard-coded practice rules from the UI so the server/shared helper is the source of truth for XP, practice limits and reward values.
- Improve loading, error and empty states and first-time player guidance so transient failures or missing rows are visible and recoverable.

### Description
- Introduced a reusable player attributes query hook `usePlayerAttributesQuery` and wired the page to use it instead of a manual fetch, and ensured attribute spend invalidates/refreshes `player-attributes`, XP wallet and progression overview (files: `src/hooks/usePlayerAttributesQuery.ts`, `src/components/attributes/AttributeCard.tsx`, `src/components/attributes/AttributePanel.tsx`, `src/pages/SkillsPage.tsx`).
- Added `src/utils/skillProgressDisplay.ts` to centralize skill display normalization and practice configuration (`SKILL_PRACTICE_CONFIG`), expose UI-safe fields (`xp_into_level`, `xp_required_for_next_level`, `progress_percent`, `is_unlocked`, `can_practice`, `lifetime_xp`), and provide a clamping helper `clampProgressPercent` so progress bars never receive NaN/Infinity or out-of-range values.
- Reworked practice logic to use server-authoritative data where possible: `useSkillPracticeRestrictions` returns `sessionsUsed`, `sessionsRemaining`, `maxDailySessions`, `durationOptionsHours`, `baseXpReward`, `minimumSkillLevel` and `nextResetAt` and the schedule dialog consumes that same payload (files: `src/hooks/useSkillPractice.ts`, `src/components/skills/SchedulePracticeDialog.tsx`).
- Fixed overview card calculations to exclude locked/zero-level rows and show `Lifetime Skill XP` only when lifetime fields are present, otherwise labelled `Current Level XP`; improved loading/error/empty UI and added retry affordances on the page (`src/pages/SkillsPage.tsx`).
- Terminology and accessibility: renamed attribute category label from `"Musical Skills"` to `"Musical Attributes"` and added `aria-label`s for key actions (files: `src/components/attributes/AttributePanel.tsx`, `src/components/attributes/AttributeCard.tsx`).
- Tests and audit: added unit tests for the skill display helpers and progress clamping (`src/utils/__tests__/skillProgressDisplay.test.ts`) and added a migration audit documenting suspicious future-dated progression/XP migrations (`docs/progression/SKILLS_ATTRIBUTES_MIGRATION_AUDIT.md`).

### Testing
- `tsc --noEmit` (typecheck) completed successfully in this environment.
- Unit tests: a new test file `src/utils/__tests__/skillProgressDisplay.test.ts` was added, but running `vitest` could not complete here because test runner binaries were not present in `node_modules` (`vitest: not found`).
- Lint/build: `eslint` and `vite` runs could not complete because local dependencies could not be installed in this environment (npm install encountered registry/policy errors and ESLint failed to resolve `@eslint/js`).
- Result summary: automated type checks passed; unit and lint/build runs were not executed here due to environment dependency installation failures; the new unit tests are included and should be run in CI or a developer environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e7f85a0483258e94bfb7aae24c4a)