### PR TITLE
Create canonical skills and attributes catalogue with explicit relationships

### DIFF
--- a/docs/progression/SKILLS_CATALOGUE_AUDIT.md
+++ b/docs/progression/SKILLS_CATALOGUE_AUDIT.md
@@ -1,0 +1,117 @@
+# Skills Catalogue Audit
+
+## Executive summary
+
+RockMundo previously split skill metadata across database tables (`skill_definitions`, `skills`, `skill_relationships`, `skill_progress`, `player_skills`), frontend category arrays, education seed migrations, and regex learning-bonus rules. This made it possible for a skill to appear in one system but have no attribute mapping, role relationship, unlock route, or player-facing description.
+
+This PR introduces a canonical catalogue adapter and matching database schema so active skills can be validated and queried with explicit metadata.
+
+## Machine-readable summary
+
+```json
+{
+  "canonical_table": "skill_definitions",
+  "new_relationship_tables": ["skill_attribute_links", "skill_prerequisites", "skill_unlock_routes", "skill_system_links", "skill_role_links"],
+  "active_foundational_slugs": ["guitar", "vocals", "drums", "bass", "songwriting"],
+  "active_specialist_slugs": ["performance", "composition", "technical"],
+  "legacy_fallback_patterns": ["instruments_*", "genres_*", "stage_*", "songwriting_*", "theory_*", "dj_*", "health_*", "business_*", "modeling_*", "fashion_*", "clothing_*"],
+  "critical_risks": ["duplicate skill_definitions creation migrations", "legacy player_skills column model", "skill_progress slug model", "education content references skill slugs directly"]
+}
+```
+
+## Catalogue tables found
+
+- `skill_definitions`: the closest existing catalogue. It stores slug, display name, description, tier caps and default unlock level.
+- `skills`: a later simple catalogue referenced by some book tables.
+- `skill_relationships`: earlier dependency/synergy table that lacked typed prerequisite semantics.
+- `skill_progress` / `profile_skill_progress`: profile-specific progression rows.
+- `player_skills`: legacy wide table and later normalized rows used by older migrations and functions.
+- `skill_books` and `university_courses`: education content with direct `skill_slug` references.
+
+## Active skill slugs audited for this PR
+
+The confidently mapped active gameplay skills are:
+
+- `guitar`
+- `vocals`
+- `drums`
+- `bass`
+- `performance`
+- `songwriting`
+- `composition`
+- `technical`
+
+Extended seeded catalogues also contain genre, stage, instrument, fashion/modeling/clothing, production and education slugs. Those are not deleted. They remain follow-up mapping candidates if production data confirms they are active learnable skills.
+
+## Duplicate or near-duplicate skills
+
+- `songwriting` and `composition` overlap but represent different tiers: broad songwriting vs. advanced arrangement.
+- `performance` and `stage_*` slugs overlap in live show systems.
+- `technical`, `mixing`, `record_production`, and DAW-related slugs overlap in production systems.
+- `guitar` and extended `instruments_*_guitar` style slugs may coexist.
+
+## Inconsistent naming patterns
+
+- Base skills use plain slugs (`guitar`, `vocals`).
+- Extended skills often use namespaced tier slugs (`genres_basic_rock`, `instruments_basic_*`).
+- Some systems still infer categories from substrings such as `stage`, `genre`, `songwriting`, or `instrument`.
+
+## Code references missing from the confident canonical set
+
+Regex fallback diagnostics now records legacy slugs such as `genres_basic_rock` when they are used without explicit relationship rows. These should be added to the canonical seed after product review rather than silently mapped by slug shape.
+
+## Catalogue skills not used by any system
+
+The extended genre/fashion/modeling/clothing skill seeds appear partially used by education content but are not consistently consumed by live gig, recording or skill tree systems. They are marked for follow-up rather than removal.
+
+## Zero-level seeded skills
+
+Legacy migrations seed new players with zero values in `player_skills` or `skill_progress` to preserve rows before a player has trained them. This PR preserves those rows and uses explicit availability status instead of treating every zero row as fully unlocked.
+
+## Current categories and subcategories
+
+Canonical categories introduced here:
+
+- Instruments / Strings
+- Instruments / Percussion
+- Performance / Vocals
+- Stage / Showmanship
+- Songwriting / Composition
+- Songwriting / Arrangement
+- Production / Studio
+
+## Current prerequisite relationships
+
+- `composition` requires `songwriting` level 20.
+- `technical` recommends `performance` level 15.
+
+Older `skill_relationships` rows are left in place for compatibility but are superseded by `skill_prerequisites` for availability rules.
+
+## Current attribute mappings
+
+Explicit learning-speed mappings are weighted. Examples:
+
+- `guitar`: Musical Ability 70%, Musicality 30%.
+- `drums`: Rhythm Sense 70%, Musicality 30%.
+- `vocals`: Vocal Talent 70%, Musicality 30%.
+- `performance`: Stage Presence 60%, Crowd Engagement 40%.
+- `technical`: Technical Mastery 70%, Creative Insight 30%.
+
+## Known education or activity unlock routes
+
+Current represented routes are starter profile unlocks for foundational skills and university-course unlocks for specialist skills. Book, lesson, rehearsal, performance and admin route types are supported by schema for existing/planned systems but are not used to introduce new gameplay in this PR.
+
+## Suspected obsolete or risky skills
+
+- Duplicate early migrations dropped/recreated `skill_definitions`.
+- Some migrations reference `skills(skill_id)` while other code references `skill_definitions(slug)`.
+- Legacy wide `player_skills` columns and normalized `skill_progress` rows coexist.
+- Several database functions still use `LIKE` checks against skill IDs or slugs.
+
+## Follow-up catalogue and balancing work
+
+- Product-review every extended genre, instrument, fashion, modeling, clothing and stage slug.
+- Decide whether plain base slugs or namespaced tier slugs are canonical for instruments and genres.
+- Migrate SQL outcome functions away from `LIKE` skill checks.
+- Add admin editing only after catalogue validation is stable.
+- Use role/system links in future gig, recording and songwriting formulas without changing XP balance in this PR.

--- a/src/components/SkillTree.tsx
+++ b/src/components/SkillTree.tsx
@@ -1,21 +1,51 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Button } from '@/components/ui/button';
-import { toast } from 'sonner';
-import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/lib/supabase-types';
-import { useGameData } from '@/hooks/useGameData';
-import { Star, Music, Users, Mic, Lock, ChevronDown, ChevronUp, LayoutGrid, List, Filter, GraduationCap } from 'lucide-react';
-import { HierarchicalSkillNode } from './skills/HierarchicalSkillNode';
-import { CompactSkillRow } from './skills/CompactSkillRow';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-import { Badge } from '@/components/ui/badge';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { type EducationSource, getSourceFromActivityType } from './skills/EducationSourceBadge';
+import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/lib/supabase-types";
+import { useGameData } from "@/hooks/useGameData";
+import {
+  Star,
+  Music,
+  Users,
+  Mic,
+  Lock,
+  ChevronDown,
+  ChevronUp,
+  LayoutGrid,
+  List,
+  Filter,
+  GraduationCap,
+} from "lucide-react";
+import { HierarchicalSkillNode } from "./skills/HierarchicalSkillNode";
+import { CompactSkillRow } from "./skills/CompactSkillRow";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  type EducationSource,
+  getSourceFromActivityType,
+} from "./skills/EducationSourceBadge";
+import {
+  useSkillCatalogue,
+  useProfileSkillAvailability,
+} from "@/hooks/useSkillCatalogue";
+import {
+  getSkillAttributeLinks,
+  getSkillPrerequisites,
+  getSkillRoleLinks,
+  getSkillSystemLinks,
+  getAttributeLabel,
+} from "@/utils/skillCatalogue";
 
-type SkillDefinition = Database['public']['Tables']['skill_definitions']['Row'];
-type SkillProgress = Database['public']['Tables']['skill_progress']['Row'];
+type SkillDefinition = Database["public"]["Tables"]["skill_definitions"]["Row"];
+type SkillProgress = Database["public"]["Tables"]["skill_progress"]["Row"];
 
 interface SkillCategory {
   key: string;
@@ -29,92 +59,199 @@ interface SkillTreeProps {
   onXpSpent?: () => void;
 }
 
-type ViewMode = 'card' | 'list';
-type FilterMode = 'all' | 'learned' | 'education' | 'unlearned';
+type ViewMode = "card" | "list";
+type FilterMode = "all" | "learned" | "education" | "unlearned";
 
 const SKILL_CATEGORIES: SkillCategory[] = [
   {
-    key: 'songwriting',
-    name: 'Songwriting & Production',
+    key: "songwriting",
+    name: "Songwriting & Production",
     icon: <Music className="h-5 w-5" />,
-    patterns: ['songwriting', 'composing', 'lyrics', 'production', 'daw', 'beatmaking', 'sampling', 'sound_design', 'mixing', 'vocal', 'ai_music', 'live_looping']
+    patterns: [
+      "songwriting",
+      "composing",
+      "lyrics",
+      "production",
+      "daw",
+      "beatmaking",
+      "sampling",
+      "sound_design",
+      "mixing",
+      "vocal",
+      "ai_music",
+      "live_looping",
+    ],
   },
   {
-    key: 'genres',
-    name: 'Genres',
+    key: "genres",
+    name: "Genres",
     icon: <Star className="h-5 w-5" />,
-    patterns: ['genres_', 'rock', 'pop', 'hip_hop', 'jazz', 'blues', 'edm', 'trap', 'country', 'reggae', 'metal', 'classical', 'latin', 'rnb', 'punk', 'flamenco', 'african', 'drill', 'lofi', 'kpop', 'afrobeats', 'synthwave', 'indie', 'hyperpop', 'metalcore', 'alt_rnb', 'funk', 'soul', 'gospel', 'folk', 'ska', 'grunge', 'ambient', 'house', 'techno', 'trance', 'dubstep']
+    patterns: [
+      "genres_",
+      "rock",
+      "pop",
+      "hip_hop",
+      "jazz",
+      "blues",
+      "edm",
+      "trap",
+      "country",
+      "reggae",
+      "metal",
+      "classical",
+      "latin",
+      "rnb",
+      "punk",
+      "flamenco",
+      "african",
+      "drill",
+      "lofi",
+      "kpop",
+      "afrobeats",
+      "synthwave",
+      "indie",
+      "hyperpop",
+      "metalcore",
+      "alt_rnb",
+      "funk",
+      "soul",
+      "gospel",
+      "folk",
+      "ska",
+      "grunge",
+      "ambient",
+      "house",
+      "techno",
+      "trance",
+      "dubstep",
+    ],
   },
   {
-    key: 'instruments',
-    name: 'Instruments & Performance',
+    key: "instruments",
+    name: "Instruments & Performance",
     icon: <Mic className="h-5 w-5" />,
-    patterns: ['instruments_', 'singing', 'rapping', 'brass', 'keyboard', 'percussions', 'strings', 'woodwind', 'electronic_instruments', 'modern_bass', 'synths', 'percussion_drums', 'dj', 'midi', 'piano', 'drums', 'guitar', 'bass', 'vocals', 'violin', 'cello', 'saxophone', 'trumpet', 'harmonica']
+    patterns: [
+      "instruments_",
+      "singing",
+      "rapping",
+      "brass",
+      "keyboard",
+      "percussions",
+      "strings",
+      "woodwind",
+      "electronic_instruments",
+      "modern_bass",
+      "synths",
+      "percussion_drums",
+      "dj",
+      "midi",
+      "piano",
+      "drums",
+      "guitar",
+      "bass",
+      "vocals",
+      "violin",
+      "cello",
+      "saxophone",
+      "trumpet",
+      "harmonica",
+    ],
   },
   {
-    key: 'stage',
-    name: 'Stage & Showmanship',
+    key: "stage",
+    name: "Stage & Showmanship",
     icon: <Users className="h-5 w-5" />,
-    patterns: ['showmanship', 'stage', 'visual', 'social_media', 'streaming', 'crowd', 'performance']
-  }
+    patterns: [
+      "showmanship",
+      "stage",
+      "visual",
+      "social_media",
+      "streaming",
+      "crowd",
+      "performance",
+    ],
+  },
 ];
 
-const getSkillTier = (slug: string): 'basic' | 'professional' | 'mastery' => {
-  if (slug.includes('_basic_') || slug.startsWith('basic_')) return 'basic';
-  if (slug.includes('_professional_') || slug.startsWith('professional_') || slug.includes('professional')) return 'professional';
-  if (slug.includes('_mastery') || slug.includes('mastery_')) return 'mastery';
+const getSkillTier = (slug: string): "basic" | "professional" | "mastery" => {
+  if (slug.includes("_basic_") || slug.startsWith("basic_")) return "basic";
+  if (
+    slug.includes("_professional_") ||
+    slug.startsWith("professional_") ||
+    slug.includes("professional")
+  )
+    return "professional";
+  if (slug.includes("_mastery") || slug.includes("mastery_")) return "mastery";
   // Default simple slugs (vocals, guitar, etc) to basic
-  return 'basic';
+  return "basic";
 };
 
 const matchesCategory = (slug: string, category: SkillCategory): boolean => {
   const lowerSlug = slug.toLowerCase();
-  return category.patterns.some(pattern => lowerSlug.includes(pattern));
+  return category.patterns.some((pattern) => lowerSlug.includes(pattern));
 };
 
-export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }) => {
+export const SkillTree: React.FC<SkillTreeProps> = ({
+  xpBalance = 0,
+  onXpSpent,
+}) => {
   const { profile } = useGameData();
+  const catalogueQuery = useSkillCatalogue();
+  const availabilityQuery = useProfileSkillAvailability(profile?.id);
   const [skills, setSkills] = useState<SkillDefinition[]>([]);
   const [progress, setProgress] = useState<SkillProgress[]>([]);
-  const [educationSources, setEducationSources] = useState<Record<string, EducationSource[]>>({});
+  const [educationSources, setEducationSources] = useState<
+    Record<string, EducationSource[]>
+  >({});
   const [loading, setLoading] = useState(true);
-  const [selectedCategory, setSelectedCategory] = useState<string>('all');
+  const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [refreshKey, setRefreshKey] = useState(0);
   const [showUnlocked, setShowUnlocked] = useState(false);
-  const [viewMode, setViewMode] = useState<ViewMode>('list');
-  const [filterMode, setFilterMode] = useState<FilterMode>('learned');
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [filterMode, setFilterMode] = useState<FilterMode>("learned");
   const [hideMaxed, setHideMaxed] = useState(true);
 
   const fetchData = useCallback(async () => {
     try {
-      const { data: skillsData, error: skillsError } = await supabase
-        .from('skill_definitions')
-        .select('*')
-        .order('display_name');
-
-      if (skillsError) throw skillsError;
-      setSkills(skillsData ?? []);
+      const canonicalSkills = catalogueQuery.data ?? [];
+      setSkills(
+        canonicalSkills.map(
+          (skill) =>
+            ({
+              id: skill.id,
+              slug: skill.slug,
+              display_name: skill.name,
+              description: skill.description,
+              tier_caps: {
+                max_level: skill.max_level,
+                tier: skill.tier,
+              } as any,
+              created_at: null,
+              updated_at: null,
+            }) as SkillDefinition,
+        ),
+      );
 
       if (profile) {
         // Fetch progress
         const { data: progressData, error: progressError } = await supabase
-          .from('skill_progress')
-          .select('*')
-          .eq('profile_id', profile.id);
+          .from("skill_progress")
+          .select("*")
+          .eq("profile_id", profile.id);
 
         if (progressError) throw progressError;
         setProgress(progressData ?? []);
 
         // Fetch education sources from experience_ledger
         const { data: ledgerData } = await supabase
-          .from('experience_ledger')
-          .select('skill_slug, activity_type')
-          .eq('profile_id', profile.id)
-          .not('skill_slug', 'is', null);
+          .from("experience_ledger")
+          .select("skill_slug, activity_type")
+          .eq("profile_id", profile.id)
+          .not("skill_slug", "is", null);
 
         if (ledgerData) {
           const sourcesMap: Record<string, Set<EducationSource>> = {};
-          ledgerData.forEach(entry => {
+          ledgerData.forEach((entry) => {
             if (!entry.skill_slug) return;
             const source = getSourceFromActivityType(entry.activity_type);
             if (source) {
@@ -124,7 +261,7 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
               sourcesMap[entry.skill_slug].add(source);
             }
           });
-          
+
           const formatted: Record<string, EducationSource[]> = {};
           Object.entries(sourcesMap).forEach(([slug, sources]) => {
             formatted[slug] = Array.from(sources);
@@ -133,81 +270,94 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
         }
       }
     } catch (error) {
-      console.error('Error fetching skills:', error);
-      toast.error('Failed to load skills');
+      console.error("Error fetching skills:", error);
+      toast.error("Failed to load skills");
     } finally {
       setLoading(false);
     }
-  }, [profile]);
+  }, [profile, catalogueQuery.data]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData, refreshKey]);
+    if (!catalogueQuery.isLoading) fetchData();
+  }, [fetchData, refreshKey, catalogueQuery.isLoading]);
 
   const handleSkillTrained = () => {
-    setRefreshKey(prev => prev + 1);
+    setRefreshKey((prev) => prev + 1);
     onXpSpent?.();
   };
 
   const getSkillProgress = (skillSlug: string): SkillProgress | null => {
-    return progress.find(p => p.skill_slug === skillSlug) || null;
+    return progress.find((p) => p.skill_slug === skillSlug) || null;
   };
 
   // Get set of learned skill slugs
-  const learnedSlugs = useMemo(() => new Set(progress.map(p => p.skill_slug)), [progress]);
-  
+  const learnedSlugs = useMemo(
+    () => new Set(progress.map((p) => p.skill_slug)),
+    [progress],
+  );
+
   // Education skill slugs
-  const educationSlugs = useMemo(() => new Set(Object.keys(educationSources)), [educationSources]);
+  const educationSlugs = useMemo(
+    () => new Set(Object.keys(educationSources)),
+    [educationSources],
+  );
 
   // Filter and categorize skills
   const filteredSkills = useMemo(() => {
     let filtered = [...skills];
-    
+
     // Also include skills from progress that might not be in definitions
-    const progressSlugs = progress.map(p => p.skill_slug);
-    const missingFromDefs = progressSlugs.filter(slug => !skills.some(s => s.slug === slug));
-    
+    const progressSlugs = progress.map((p) => p.skill_slug);
+    const missingFromDefs = progressSlugs.filter(
+      (slug) => !skills.some((s) => s.slug === slug),
+    );
+
     // Add placeholder definitions for missing skills
-    missingFromDefs.forEach(slug => {
+    missingFromDefs.forEach((slug) => {
       filtered.push({
         id: slug,
         slug,
-        display_name: slug.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
-        description: 'Skill from education or training',
+        display_name: slug
+          .split("_")
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(" "),
+        description: "Skill from education or training",
         tier_caps: null,
         created_at: null,
-        updated_at: null
+        updated_at: null,
       });
     });
 
     // Apply category filter
-    if (selectedCategory !== 'all') {
-      const category = SKILL_CATEGORIES.find(c => c.key === selectedCategory);
+    if (selectedCategory !== "all") {
+      const category = SKILL_CATEGORIES.find((c) => c.key === selectedCategory);
       if (category) {
-        filtered = filtered.filter(skill => matchesCategory(skill.slug, category));
+        filtered = filtered.filter((skill) =>
+          matchesCategory(skill.slug, category),
+        );
       }
     }
 
     // Apply filter mode
     switch (filterMode) {
-      case 'learned':
-        filtered = filtered.filter(skill => learnedSlugs.has(skill.slug));
+      case "learned":
+        filtered = filtered.filter((skill) => learnedSlugs.has(skill.slug));
         break;
-      case 'education':
-        filtered = filtered.filter(skill => educationSlugs.has(skill.slug));
+      case "education":
+        filtered = filtered.filter((skill) => educationSlugs.has(skill.slug));
         break;
-      case 'unlearned':
-        filtered = filtered.filter(skill => !learnedSlugs.has(skill.slug));
+      case "unlearned":
+        filtered = filtered.filter((skill) => !learnedSlugs.has(skill.slug));
         break;
     }
 
     // Hide maxed skills (default on)
     if (hideMaxed) {
-      filtered = filtered.filter(skill => {
-        const sp = progress.find(p => p.skill_slug === skill.slug);
+      filtered = filtered.filter((skill) => {
+        const sp = progress.find((p) => p.skill_slug === skill.slug);
         const lvl = sp?.current_level ?? 0;
         const tier = getSkillTier(skill.slug);
-        const cap = tier === 'basic' ? 10 : tier === 'professional' ? 20 : 30;
+        const cap = tier === "basic" ? 10 : tier === "professional" ? 20 : 30;
         return lvl < cap;
       });
     }
@@ -215,24 +365,41 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
     // Sort by tier then name
     filtered.sort((a, b) => {
       const tierOrder = { basic: 0, professional: 1, mastery: 2 };
-      const tierDiff = tierOrder[getSkillTier(a.slug)] - tierOrder[getSkillTier(b.slug)];
+      const tierDiff =
+        tierOrder[getSkillTier(a.slug)] - tierOrder[getSkillTier(b.slug)];
       if (tierDiff !== 0) return tierDiff;
       return a.display_name.localeCompare(b.display_name);
     });
 
     return filtered;
-  }, [skills, progress, selectedCategory, filterMode, learnedSlugs, educationSlugs, hideMaxed]);
+  }, [
+    skills,
+    progress,
+    selectedCategory,
+    filterMode,
+    learnedSlugs,
+    educationSlugs,
+    hideMaxed,
+  ]);
 
   // Count skills per category
   const categoryCounts = useMemo(() => {
     const counts: Record<string, number> = { all: learnedSlugs.size };
-    SKILL_CATEGORIES.forEach(cat => {
-      counts[cat.key] = [...learnedSlugs].filter(slug => matchesCategory(slug, cat)).length;
+    SKILL_CATEGORIES.forEach((cat) => {
+      counts[cat.key] = [...learnedSlugs].filter((slug) =>
+        matchesCategory(slug, cat),
+      ).length;
     });
     return counts;
   }, [learnedSlugs]);
 
-  if (loading) {
+  const availabilityBySlug = useMemo(
+    () =>
+      new Map((availabilityQuery.data ?? []).map((item) => [item.slug, item])),
+    [availabilityQuery.data],
+  );
+
+  if (loading || catalogueQuery.isLoading) {
     return (
       <div className="flex items-center justify-center p-8">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
@@ -255,9 +422,13 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
               </Badge>
             )}
           </div>
-          
+
           {/* View mode toggle */}
-          <ToggleGroup type="single" value={viewMode} onValueChange={(v) => v && setViewMode(v as ViewMode)}>
+          <ToggleGroup
+            type="single"
+            value={viewMode}
+            onValueChange={(v) => v && setViewMode(v as ViewMode)}
+          >
             <ToggleGroupItem value="list" aria-label="List view" size="sm">
               <List className="h-4 w-4" />
             </ToggleGroupItem>
@@ -266,29 +437,37 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
             </ToggleGroupItem>
           </ToggleGroup>
         </div>
-        
+
         {/* Category tabs */}
         <div className="flex flex-wrap gap-2">
           <Button
-            variant={selectedCategory === 'all' ? 'default' : 'outline'}
+            variant={selectedCategory === "all" ? "default" : "outline"}
             size="sm"
-            onClick={() => setSelectedCategory('all')}
+            onClick={() => setSelectedCategory("all")}
           >
             All
-            <Badge variant="secondary" className="ml-1.5 text-xs">{categoryCounts.all}</Badge>
+            <Badge variant="secondary" className="ml-1.5 text-xs">
+              {categoryCounts.all}
+            </Badge>
           </Button>
           {SKILL_CATEGORIES.map((category) => (
             <Button
               key={category.key}
-              variant={selectedCategory === category.key ? 'default' : 'outline'}
+              variant={
+                selectedCategory === category.key ? "default" : "outline"
+              }
               size="sm"
               onClick={() => setSelectedCategory(category.key)}
               className="flex items-center gap-1.5"
             >
               {category.icon}
               <span className="hidden sm:inline">{category.name}</span>
-              <span className="sm:hidden">{category.key.charAt(0).toUpperCase() + category.key.slice(1)}</span>
-              <Badge variant="secondary" className="ml-1 text-xs">{categoryCounts[category.key] || 0}</Badge>
+              <span className="sm:hidden">
+                {category.key.charAt(0).toUpperCase() + category.key.slice(1)}
+              </span>
+              <Badge variant="secondary" className="ml-1 text-xs">
+                {categoryCounts[category.key] || 0}
+              </Badge>
             </Button>
           ))}
         </div>
@@ -296,22 +475,32 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
         {/* Filter mode */}
         <div className="flex items-center gap-2">
           <Filter className="h-4 w-4 text-muted-foreground" />
-          <ToggleGroup type="single" value={filterMode} onValueChange={(v) => v && setFilterMode(v as FilterMode)}>
-            <ToggleGroupItem value="learned" size="sm">Learned</ToggleGroupItem>
+          <ToggleGroup
+            type="single"
+            value={filterMode}
+            onValueChange={(v) => v && setFilterMode(v as FilterMode)}
+          >
+            <ToggleGroupItem value="learned" size="sm">
+              Learned
+            </ToggleGroupItem>
             <ToggleGroupItem value="education" size="sm">
               <GraduationCap className="h-3 w-3 mr-1" />
               Education
             </ToggleGroupItem>
-            <ToggleGroupItem value="all" size="sm">All</ToggleGroupItem>
-            <ToggleGroupItem value="unlearned" size="sm">Unlearned</ToggleGroupItem>
+            <ToggleGroupItem value="all" size="sm">
+              All
+            </ToggleGroupItem>
+            <ToggleGroupItem value="unlearned" size="sm">
+              Unlearned
+            </ToggleGroupItem>
           </ToggleGroup>
           <Button
-            variant={hideMaxed ? 'default' : 'outline'}
+            variant={hideMaxed ? "default" : "outline"}
             size="sm"
-            onClick={() => setHideMaxed(v => !v)}
+            onClick={() => setHideMaxed((v) => !v)}
             className="text-xs h-8"
           >
-            {hideMaxed ? 'Hide maxed' : 'Show maxed'}
+            {hideMaxed ? "Hide maxed" : "Show maxed"}
           </Button>
         </div>
       </div>
@@ -323,25 +512,69 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
             <p>No skills found matching your filters.</p>
             <p className="text-sm mt-1">Try changing the category or filter.</p>
           </div>
-        ) : viewMode === 'list' ? (
+        ) : viewMode === "list" ? (
           <div className="space-y-1.5">
             {filteredSkills.map((skill) => {
               const skillProgress = getSkillProgress(skill.slug);
               const tier = getSkillTier(skill.slug);
+              const availability = availabilityBySlug.get(skill.slug);
+              const attrSummary = getSkillAttributeLinks(skill.slug)
+                .map(
+                  (link) =>
+                    `${getAttributeLabel(link.attribute_key)} ${Math.round(link.weight * 100)}%`,
+                )
+                .join(", ");
+              const prereqSummary = getSkillPrerequisites(skill.slug)
+                .map(
+                  (req) =>
+                    `${req.prerequisite_skill_slug} Lv ${req.required_level}`,
+                )
+                .join(", ");
+              const systems = getSkillSystemLinks(skill.slug)
+                .map((link) => link.system_key.replace(/_/g, " "))
+                .join(", ");
+              const roles = getSkillRoleLinks(skill.slug)
+                .map((link) => link.role_key.replace(/_/g, " "))
+                .join(", ");
               return (
-                <CompactSkillRow
-                  key={skill.id}
-                  skill={skill}
-                  progress={skillProgress ? {
-                    current_level: skillProgress.current_level || 0,
-                    current_xp: skillProgress.current_xp || 0,
-                    required_xp: skillProgress.required_xp || 100
-                  } : null}
-                  tier={tier}
-                  xpBalance={xpBalance}
-                  educationSources={educationSources[skill.slug] || []}
-                  onTrain={handleSkillTrained}
-                />
+                <div key={skill.id} className="space-y-1">
+                  <CompactSkillRow
+                    key={skill.id}
+                    skill={skill}
+                    progress={
+                      skillProgress
+                        ? {
+                            current_level: skillProgress.current_level || 0,
+                            current_xp: skillProgress.current_xp || 0,
+                            required_xp: skillProgress.required_xp || 100,
+                          }
+                        : null
+                    }
+                    tier={tier}
+                    xpBalance={xpBalance}
+                    educationSources={educationSources[skill.slug] || []}
+                    onTrain={handleSkillTrained}
+                  />
+                  <div className="px-3 pb-2 text-[11px] text-muted-foreground flex flex-wrap gap-x-3 gap-y-1">
+                    <span>
+                      Max {(skill.tier_caps as any)?.max_level ?? 100}
+                    </span>
+                    {availability && (
+                      <span>
+                        Status: {availability.status.replace(/_/g, " ")}
+                      </span>
+                    )}
+                    {availability?.blockedReason && (
+                      <span className="text-destructive">
+                        {availability.blockedReason.message}
+                      </span>
+                    )}
+                    {attrSummary && <span>Attributes: {attrSummary}</span>}
+                    {prereqSummary && <span>Prereqs: {prereqSummary}</span>}
+                    {systems && <span>Systems: {systems}</span>}
+                    {roles && <span>Roles: {roles}</span>}
+                  </div>
+                </div>
               );
             })}
           </div>
@@ -354,11 +587,15 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
                 <HierarchicalSkillNode
                   key={skill.id}
                   skill={skill}
-                  progress={skillProgress ? {
-                    current_level: skillProgress.current_level || 0,
-                    current_xp: skillProgress.current_xp || 0,
-                    required_xp: skillProgress.required_xp || 100
-                  } : null}
+                  progress={
+                    skillProgress
+                      ? {
+                          current_level: skillProgress.current_level || 0,
+                          current_xp: skillProgress.current_xp || 0,
+                          required_xp: skillProgress.required_xp || 100,
+                        }
+                      : null
+                  }
                   tier={tier}
                   xpBalance={xpBalance}
                   onTrain={handleSkillTrained}
@@ -370,51 +607,66 @@ export const SkillTree: React.FC<SkillTreeProps> = ({ xpBalance = 0, onXpSpent }
       </ScrollArea>
 
       {/* Skills Not Started Section */}
-      {filterMode !== 'unlearned' && skills.filter(s => !learnedSlugs.has(s.slug)).length > 0 && (
-        <Card className="border-muted bg-muted/20">
-          <Collapsible open={showUnlocked} onOpenChange={setShowUnlocked}>
-            <CollapsibleTrigger asChild>
-              <CardHeader className="cursor-pointer hover:bg-muted/30 transition-colors py-3">
-                <CardTitle className="flex items-center justify-between text-muted-foreground text-sm">
-                  <div className="flex items-center gap-2">
-                    <Lock className="h-4 w-4" />
-                    <span>Skills Not Started</span>
-                    <Badge variant="secondary" className="ml-1">
-                      {skills.filter(s => !learnedSlugs.has(s.slug)).length}
-                    </Badge>
-                  </div>
-                  {showUnlocked ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                </CardTitle>
-              </CardHeader>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <CardContent className="pt-0">
-                <p className="text-xs text-muted-foreground mb-3">
-                  Learn skills through University, Books, Mentors, or YouTube videos.
-                </p>
-                <div className="grid gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
-                  {skills.filter(s => !learnedSlugs.has(s.slug)).slice(0, 24).map((skill) => (
-                    <div 
-                      key={skill.id} 
-                      className="p-2 rounded border border-muted bg-background/50 opacity-60"
-                    >
-                      <p className="text-xs font-medium truncate">{skill.display_name}</p>
-                      <Badge variant="outline" className="text-xs mt-0.5">
-                        {getSkillTier(skill.slug)}
+      {filterMode !== "unlearned" &&
+        skills.filter((s) => !learnedSlugs.has(s.slug)).length > 0 && (
+          <Card className="border-muted bg-muted/20">
+            <Collapsible open={showUnlocked} onOpenChange={setShowUnlocked}>
+              <CollapsibleTrigger asChild>
+                <CardHeader className="cursor-pointer hover:bg-muted/30 transition-colors py-3">
+                  <CardTitle className="flex items-center justify-between text-muted-foreground text-sm">
+                    <div className="flex items-center gap-2">
+                      <Lock className="h-4 w-4" />
+                      <span>Skills Not Started</span>
+                      <Badge variant="secondary" className="ml-1">
+                        {skills.filter((s) => !learnedSlugs.has(s.slug)).length}
                       </Badge>
                     </div>
-                  ))}
-                  {skills.filter(s => !learnedSlugs.has(s.slug)).length > 24 && (
-                    <div className="p-2 text-xs text-muted-foreground">
-                      +{skills.filter(s => !learnedSlugs.has(s.slug)).length - 24} more
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </CollapsibleContent>
-          </Collapsible>
-        </Card>
-      )}
+                    {showUnlocked ? (
+                      <ChevronUp className="h-4 w-4" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4" />
+                    )}
+                  </CardTitle>
+                </CardHeader>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <CardContent className="pt-0">
+                  <p className="text-xs text-muted-foreground mb-3">
+                    Learn skills through University, Books, Mentors, or YouTube
+                    videos.
+                  </p>
+                  <div className="grid gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
+                    {skills
+                      .filter((s) => !learnedSlugs.has(s.slug))
+                      .slice(0, 24)
+                      .map((skill) => (
+                        <div
+                          key={skill.id}
+                          className="p-2 rounded border border-muted bg-background/50 opacity-60"
+                        >
+                          <p className="text-xs font-medium truncate">
+                            {skill.display_name}
+                          </p>
+                          <Badge variant="outline" className="text-xs mt-0.5">
+                            {getSkillTier(skill.slug)}
+                          </Badge>
+                        </div>
+                      ))}
+                    {skills.filter((s) => !learnedSlugs.has(s.slug)).length >
+                      24 && (
+                      <div className="p-2 text-xs text-muted-foreground">
+                        +
+                        {skills.filter((s) => !learnedSlugs.has(s.slug))
+                          .length - 24}{" "}
+                        more
+                      </div>
+                    )}
+                  </div>
+                </CardContent>
+              </CollapsibleContent>
+            </Collapsible>
+          </Card>
+        )}
     </div>
   );
 };

--- a/src/hooks/useSkillCatalogue.ts
+++ b/src/hooks/useSkillCatalogue.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchCanonicalSkillCatalogue,
+  getAvailableSkillsForProfile,
+  CANONICAL_ATTRIBUTE_LINKS,
+  CANONICAL_PREREQUISITES,
+  CANONICAL_ROLE_LINKS,
+  CANONICAL_SYSTEM_LINKS,
+  CANONICAL_UNLOCK_ROUTES,
+} from "@/utils/skillCatalogue";
+
+export function useSkillCatalogue() {
+  return useQuery({
+    queryKey: ["skill-catalogue", "canonical"],
+    queryFn: fetchCanonicalSkillCatalogue,
+    staleTime: 1000 * 60 * 30,
+  });
+}
+
+export function useProfileSkillAvailability(profileId?: string | null) {
+  return useQuery({
+    queryKey: ["skill-catalogue", "availability", profileId],
+    enabled: !!profileId,
+    queryFn: () => getAvailableSkillsForProfile(profileId!),
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useSkillCatalogueRelationships() {
+  return {
+    attributeLinks: CANONICAL_ATTRIBUTE_LINKS,
+    prerequisites: CANONICAL_PREREQUISITES,
+    roleLinks: CANONICAL_ROLE_LINKS,
+    systemLinks: CANONICAL_SYSTEM_LINKS,
+    unlockRoutes: CANONICAL_UNLOCK_ROUTES,
+  };
+}

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -1,4 +1,10 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SkillTree } from "@/components/SkillTree";
 import { useGameData } from "@/hooks/useGameData";
@@ -6,7 +12,18 @@ import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { TrendingUp, Target, Award, Zap, Calendar, AlertCircle, Dumbbell, GitBranch, Gauge, Sparkles } from "lucide-react";
+import {
+  TrendingUp,
+  Target,
+  Award,
+  Zap,
+  Calendar,
+  AlertCircle,
+  Dumbbell,
+  GitBranch,
+  Gauge,
+  Sparkles,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useState, useMemo } from "react";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
@@ -18,31 +35,81 @@ import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { AttributePanel } from "@/components/attributes/AttributePanel";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePlayerAttributesQuery } from "@/hooks/usePlayerAttributesQuery";
-import { calculateSkillOverviewStats, getSkillDisplayProgress, SKILL_PRACTICE_CONFIG } from "@/utils/skillProgressDisplay";
+import {
+  calculateSkillOverviewStats,
+  getSkillDisplayProgress,
+  SKILL_PRACTICE_CONFIG,
+} from "@/utils/skillProgressDisplay";
+import {
+  useSkillCatalogue,
+  useProfileSkillAvailability,
+  useSkillCatalogueRelationships,
+} from "@/hooks/useSkillCatalogue";
+import {
+  getAttributeLabel,
+  calculateWeightedLearningMultiplier,
+} from "@/utils/skillCatalogue";
 
-const formatReset = (value?: string | null) => value ? new Date(value).toLocaleString() : "the next daily reset";
+const formatReset = (value?: string | null) =>
+  value ? new Date(value).toLocaleString() : "the next daily reset";
 
 const SkillsPage = () => {
   const { t } = useTranslation();
   const { profileId } = useActiveProfile();
-  const { skillProgress, loading, error, xpWallet, profile, dailyXpGrant, refetch } = useGameData();
-  const [selectedSkill, setSelectedSkill] = useState<{ slug: string; name: string } | null>(null);
+  const {
+    skillProgress,
+    loading,
+    error,
+    xpWallet,
+    profile,
+    dailyXpGrant,
+    refetch,
+  } = useGameData();
+  const [selectedSkill, setSelectedSkill] = useState<{
+    slug: string;
+    name: string;
+  } | null>(null);
   const attributesQuery = usePlayerAttributesQuery(profile?.id ?? profileId);
-  const restrictionsQuery = useSkillPracticeRestrictions(profileId ?? undefined);
+  const restrictionsQuery = useSkillPracticeRestrictions(
+    profileId ?? undefined,
+  );
   const restrictions = restrictionsQuery.data;
+  const catalogueQuery = useSkillCatalogue();
+  const availabilityQuery = useProfileSkillAvailability(
+    profile?.id ?? profileId,
+  );
+  const relationships = useSkillCatalogueRelationships();
 
   const skillXpBalance = xpWallet?.skill_xp_balance ?? xpWallet?.xp_balance;
   const skillXpLifetime = xpWallet?.skill_xp_lifetime ?? xpWallet?.lifetime_xp;
   const attributePointsBalance = xpWallet?.attribute_points_balance;
   const attributePointsSpent = attributesQuery.data?.attribute_points_spent;
   const streak = xpWallet?.stipend_claim_streak ?? 0;
-  const lastClaimDate = xpWallet?.last_stipend_claim_date ?? dailyXpGrant?.created_at;
+  const lastClaimDate =
+    xpWallet?.last_stipend_claim_date ?? dailyXpGrant?.created_at;
 
-  const stats = useMemo(() => calculateSkillOverviewStats(skillProgress ?? []), [skillProgress]);
-  const xpCardLabel = stats.lifetimeXp === null ? "Current Level XP" : "Lifetime Skill XP";
+  const stats = useMemo(
+    () => calculateSkillOverviewStats(skillProgress ?? []),
+    [skillProgress],
+  );
+  const xpCardLabel =
+    stats.lifetimeXp === null ? "Current Level XP" : "Lifetime Skill XP";
   const xpCardValue = stats.lifetimeXp ?? stats.currentLevelXp;
+  const catalogueBySlug = useMemo(
+    () =>
+      new Map((catalogueQuery.data ?? []).map((skill) => [skill.slug, skill])),
+    [catalogueQuery.data],
+  );
+  const availabilityBySlug = useMemo(
+    () =>
+      new Map((availabilityQuery.data ?? []).map((item) => [item.slug, item])),
+    [availabilityQuery.data],
+  );
   const practiceableSkills = useMemo(
-    () => (skillProgress ?? []).filter((skill) => getSkillDisplayProgress(skill).can_practice),
+    () =>
+      (skillProgress ?? []).filter(
+        (skill) => getSkillDisplayProgress(skill).can_practice,
+      ),
     [skillProgress],
   );
 
@@ -57,56 +124,337 @@ const SkillsPage = () => {
   };
 
   const tabs = [
-    { value: "practice", icon: Dumbbell, label: t("skills.tabs.practice", "Practice Skills"), desc: `Book ${SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour sessions (+${SKILL_PRACTICE_CONFIG.baseXpReward} XP)` },
-    { value: "tree", icon: GitBranch, label: t("skills.tabs.tree", "Skill Tree"), desc: t("skills.tabs.treeDesc", "Unlock and level up abilities") },
-    { value: "attributes", icon: Gauge, label: t("skills.tabs.attributes", "Attributes"), desc: t("skills.tabs.attributesDesc", "Spend AP on core stats") },
+    {
+      value: "practice",
+      icon: Dumbbell,
+      label: t("skills.tabs.practice", "Practice Skills"),
+      desc: `Book ${SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour sessions (+${SKILL_PRACTICE_CONFIG.baseXpReward} XP)`,
+    },
+    {
+      value: "tree",
+      icon: GitBranch,
+      label: t("skills.tabs.tree", "Skill Tree"),
+      desc: t("skills.tabs.treeDesc", "Unlock and level up abilities"),
+    },
+    {
+      value: "attributes",
+      icon: Gauge,
+      label: t("skills.tabs.attributes", "Attributes"),
+      desc: t("skills.tabs.attributesDesc", "Spend AP on core stats"),
+    },
   ];
 
   return (
-    <FMPageScaffold title={t("skills.title", "Skills & Attributes")} subtitle={t("skills.subtitle", "Master your craft and unlock new abilities")} icon={Sparkles} backTo="/hub/character">
+    <FMPageScaffold
+      title={t("skills.title", "Skills & Attributes")}
+      subtitle={t(
+        "skills.subtitle",
+        "Master your craft and unlock new abilities",
+      )}
+      icon={Sparkles}
+      backTo="/hub/character"
+    >
       {(error || attributesQuery.error || restrictionsQuery.error) && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription className="flex items-center justify-between gap-3">
-            <span>{t("skills.errors.loadFailed", "Some progression data failed to load. Values are not being replaced with zero.")}</span>
-            <Button size="sm" variant="outline" onClick={retryAll}>{t("common.retry", "Retry")}</Button>
+            <span>
+              {t(
+                "skills.errors.loadFailed",
+                "Some progression data failed to load. Values are not being replaced with zero.",
+              )}
+            </span>
+            <Button size="sm" variant="outline" onClick={retryAll}>
+              {t("common.retry", "Retry")}
+            </Button>
           </AlertDescription>
         </Alert>
       )}
 
       {loading || !xpWallet ? (
-        <Card><CardContent className="pt-6">{loading ? t("skills.loading.wallet", "Loading XP wallet…") : t("skills.empty.wallet", "XP wallet row is missing.")}</CardContent></Card>
+        <Card>
+          <CardContent className="pt-6">
+            {loading
+              ? t("skills.loading.wallet", "Loading XP wallet…")
+              : t("skills.empty.wallet", "XP wallet row is missing.")}
+          </CardContent>
+        </Card>
       ) : (
-        <XpWalletDisplay skillXpBalance={skillXpBalance ?? 0} skillXpLifetime={skillXpLifetime ?? 0} attributePointsBalance={attributePointsBalance ?? 0} attributePointsSpent={attributePointsSpent ?? 0} streak={streak} />
+        <XpWalletDisplay
+          skillXpBalance={skillXpBalance ?? 0}
+          skillXpLifetime={skillXpLifetime ?? 0}
+          attributePointsBalance={attributePointsBalance ?? 0}
+          attributePointsSpent={attributePointsSpent ?? 0}
+          streak={streak}
+        />
       )}
 
       <DailyStipendCard lastClaimDate={lastClaimDate} streak={streak} />
 
-      {restrictionsQuery.isLoading && <Alert><Target className="h-4 w-4" /><AlertDescription>{t("skills.loading.practice", "Checking practice availability…")}</AlertDescription></Alert>}
-      {restrictions && !restrictions.canPractice && <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{restrictions.reason} Next reset: {formatReset(restrictions.nextResetAt)}</AlertDescription></Alert>}
-      {restrictions?.canPractice && <Alert><Target className="h-4 w-4" /><AlertDescription>Practice sessions today: {restrictions.sessionsUsed}/{restrictions.maxDailySessions} — {restrictions.sessionsRemaining} remaining. Next reset: {formatReset(restrictions.nextResetAt)}</AlertDescription></Alert>}
+      {restrictionsQuery.isLoading && (
+        <Alert>
+          <Target className="h-4 w-4" />
+          <AlertDescription>
+            {t("skills.loading.practice", "Checking practice availability…")}
+          </AlertDescription>
+        </Alert>
+      )}
+      {restrictions && !restrictions.canPractice && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {restrictions.reason} Next reset:{" "}
+            {formatReset(restrictions.nextResetAt)}
+          </AlertDescription>
+        </Alert>
+      )}
+      {restrictions?.canPractice && (
+        <Alert>
+          <Target className="h-4 w-4" />
+          <AlertDescription>
+            Practice sessions today: {restrictions.sessionsUsed}/
+            {restrictions.maxDailySessions} — {restrictions.sessionsRemaining}{" "}
+            remaining. Next reset: {formatReset(restrictions.nextResetAt)}
+          </AlertDescription>
+        </Alert>
+      )}
 
       <div className="grid gap-4 md:grid-cols-4">
-        {[{label: xpCardLabel, value: xpCardValue.toLocaleString(), icon: TrendingUp}, {label: "Skills Unlocked", value: stats.unlockedCount, icon: Target}, {label: "Average Level", value: stats.averageLevel.toFixed(1), icon: Award}, {label: "Can Practice", value: stats.practiceableCount, icon: Zap, note: `Meets level ${SKILL_PRACTICE_CONFIG.minimumSkillLevel}+ and server rules`}].map(({label,value,icon:Icon,note}) => (
-          <Card key={label}><CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2"><CardTitle className="text-sm font-medium">{label}</CardTitle><Icon className="h-4 w-4 text-muted-foreground" /></CardHeader><CardContent><div className="text-2xl font-bold">{value}</div>{note && <p className="text-xs text-muted-foreground">{note}</p>}</CardContent></Card>
+        {[
+          {
+            label: xpCardLabel,
+            value: xpCardValue.toLocaleString(),
+            icon: TrendingUp,
+          },
+          {
+            label: "Skills Unlocked",
+            value: stats.unlockedCount,
+            icon: Target,
+          },
+          {
+            label: "Average Level",
+            value: stats.averageLevel.toFixed(1),
+            icon: Award,
+          },
+          {
+            label: "Can Practice",
+            value: stats.practiceableCount,
+            icon: Zap,
+            note: `Meets level ${SKILL_PRACTICE_CONFIG.minimumSkillLevel}+ and server rules`,
+          },
+        ].map(({ label, value, icon: Icon, note }) => (
+          <Card key={label}>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">{label}</CardTitle>
+              <Icon className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{value}</div>
+              {note && <p className="text-xs text-muted-foreground">{note}</p>}
+            </CardContent>
+          </Card>
         ))}
       </div>
 
       <Tabs defaultValue="practice" className="w-full">
         <TabsList className="grid w-full grid-cols-3 h-auto gap-2 bg-transparent p-0">
-          {tabs.map(({ value, icon: Icon, label, desc }) => <TabsTrigger key={value} value={value} aria-label={label} className={cn("flex flex-col items-start gap-1 h-auto p-4 rounded-lg border border-border bg-card text-left", "data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:shadow-md", "hover:border-primary/60 transition-colors")}><div className="flex items-center gap-2 w-full"><Icon className="h-5 w-5 text-primary" /><span className="font-semibold text-base">{label}</span></div><span className="text-xs text-muted-foreground font-normal">{desc}</span></TabsTrigger>)}
+          {tabs.map(({ value, icon: Icon, label, desc }) => (
+            <TabsTrigger
+              key={value}
+              value={value}
+              aria-label={label}
+              className={cn(
+                "flex flex-col items-start gap-1 h-auto p-4 rounded-lg border border-border bg-card text-left",
+                "data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:shadow-md",
+                "hover:border-primary/60 transition-colors",
+              )}
+            >
+              <div className="flex items-center gap-2 w-full">
+                <Icon className="h-5 w-5 text-primary" />
+                <span className="font-semibold text-base">{label}</span>
+              </div>
+              <span className="text-xs text-muted-foreground font-normal">
+                {desc}
+              </span>
+            </TabsTrigger>
+          ))}
         </TabsList>
 
         <TabsContent value="attributes" className="mt-6">
-          {attributesQuery.isLoading ? <Card><CardContent className="pt-6">{t("skills.loading.attributes", "Loading attributes…")}</CardContent></Card> : attributesQuery.data ? <AttributePanel attributes={attributesQuery.data} xpBalance={attributePointsBalance ?? 0} onXpSpent={refreshProgressionData} /> : <Card><CardContent className="pt-6">{t("skills.empty.attributes", "Attribute row is missing for this profile.")}</CardContent></Card>}
+          {attributesQuery.isLoading ? (
+            <Card>
+              <CardContent className="pt-6">
+                {t("skills.loading.attributes", "Loading attributes…")}
+              </CardContent>
+            </Card>
+          ) : attributesQuery.data ? (
+            <AttributePanel
+              attributes={attributesQuery.data}
+              xpBalance={attributePointsBalance ?? 0}
+              onXpSpent={refreshProgressionData}
+            />
+          ) : (
+            <Card>
+              <CardContent className="pt-6">
+                {t(
+                  "skills.empty.attributes",
+                  "Attribute row is missing for this profile.",
+                )}
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
 
-        <TabsContent value="tree" className="mt-6">{loading ? <Card><CardContent className="pt-6">{t("skills.loading.skills", "Loading skills…")}</CardContent></Card> : <SkillTree />}</TabsContent>
+        <TabsContent value="tree" className="mt-6">
+          {loading ? (
+            <Card>
+              <CardContent className="pt-6">
+                {t("skills.loading.skills", "Loading skills…")}
+              </CardContent>
+            </Card>
+          ) : (
+            <SkillTree />
+          )}
+        </TabsContent>
 
-        <TabsContent value="practice" className="mt-6"><Card><CardHeader><CardTitle>Practice Skills</CardTitle><CardDescription>Schedule practice sessions using the shared practice configuration: {SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour duration, {SKILL_PRACTICE_CONFIG.baseXpReward} XP reward, maximum {restrictions?.maxDailySessions ?? SKILL_PRACTICE_CONFIG.maxDailySessions} sessions per server day.</CardDescription></CardHeader><CardContent>{loading ? <p>{t("skills.loading.skills", "Loading skills…")}</p> : practiceableSkills.length === 0 ? <div className="text-center py-8 text-muted-foreground"><Target className="h-12 w-12 mx-auto mb-4 opacity-50" /><p>No skills available to practice yet.</p><p className="text-sm mt-2">Starter skills can be unlocked through education and supported practice or rehearsal activities.</p><Button asChild size="sm" className="mt-4"><a href="/education">Find starter lessons</a></Button></div> : <div className="space-y-4">{practiceableSkills.map(skill => { const display = getSkillDisplayProgress(skill); const name = skill.skill_slug.replace(/_/g, " "); return <div key={skill.skill_slug} className="border rounded-lg p-4"><div className="flex items-center justify-between mb-3"><div className="flex-1"><div className="flex items-center gap-2 mb-1"><h4 className="font-semibold capitalize">{name}</h4><Badge variant="outline">Level {display.current_level}</Badge></div><div className="flex items-center gap-2 text-sm text-muted-foreground"><span>{display.xp_into_level}/{display.xp_required_for_next_level ?? "Max"} XP</span></div></div><Button size="sm" variant="outline" aria-label={`Schedule practice for ${name}`} disabled={!restrictions?.canPractice} onClick={() => setSelectedSkill({ slug: skill.skill_slug, name })}><Calendar className="mr-2 h-4 w-4" />Schedule Practice</Button></div><Progress value={display.progress_percent} className="h-2" /></div>; })}</div>}</CardContent></Card></TabsContent>
+        <TabsContent value="practice" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Practice Skills</CardTitle>
+              <CardDescription>
+                Schedule practice sessions using the shared practice
+                configuration:{" "}
+                {SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour
+                duration, {SKILL_PRACTICE_CONFIG.baseXpReward} XP reward,
+                maximum{" "}
+                {restrictions?.maxDailySessions ??
+                  SKILL_PRACTICE_CONFIG.maxDailySessions}{" "}
+                sessions per server day.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <p>{t("skills.loading.skills", "Loading skills…")}</p>
+              ) : practiceableSkills.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <Target className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>No skills available to practice yet.</p>
+                  <p className="text-sm mt-2">
+                    Starter skills can be unlocked through education and
+                    supported practice or rehearsal activities.
+                  </p>
+                  <Button asChild size="sm" className="mt-4">
+                    <a href="/education">Find starter lessons</a>
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {practiceableSkills.map((skill) => {
+                    const display = getSkillDisplayProgress(skill);
+                    const canonical = catalogueBySlug.get(skill.skill_slug);
+                    const name =
+                      canonical?.name ??
+                      `${skill.skill_slug.replace(/_/g, " ")} (legacy)`;
+                    const attrLinks = relationships.attributeLinks.filter(
+                      (link) => link.skill_slug === skill.skill_slug,
+                    );
+                    const availability = availabilityBySlug.get(
+                      skill.skill_slug,
+                    );
+                    const learningBonus = calculateWeightedLearningMultiplier(
+                      skill.skill_slug,
+                      attributesQuery.data as any,
+                      attrLinks,
+                    );
+                    const primaryRole = relationships.roleLinks
+                      .find((link) => link.skill_slug === skill.skill_slug)
+                      ?.role_key.replace(/_/g, " ");
+                    return (
+                      <div
+                        key={skill.skill_slug}
+                        className="border rounded-lg p-4"
+                      >
+                        <div className="flex items-center justify-between mb-3">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                              <h4 className="font-semibold capitalize">
+                                {name}
+                              </h4>
+                              <Badge variant="outline">
+                                Level {display.current_level}
+                              </Badge>
+                              {canonical && (
+                                <Badge variant="secondary">
+                                  {canonical.category}
+                                </Badge>
+                              )}
+                              {availability && (
+                                <Badge variant="outline">
+                                  {availability.status.replace(/_/g, " ")}
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                              <span>
+                                {display.xp_into_level}/
+                                {display.xp_required_for_next_level ?? "Max"} XP
+                              </span>
+                              {attrLinks.length > 0 && (
+                                <span>
+                                  Attributes:{" "}
+                                  {attrLinks
+                                    .map(
+                                      (link) =>
+                                        `${getAttributeLabel(link.attribute_key)} ${Math.round(link.weight * 100)}%`,
+                                    )
+                                    .join(", ")}{" "}
+                                  (+{learningBonus.boostPercent}%)
+                                </span>
+                              )}
+                              {primaryRole && <span>Role: {primaryRole}</span>}
+                              {availability?.blockedReason && (
+                                <span className="text-destructive">
+                                  {availability.blockedReason.message}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            aria-label={`Schedule practice for ${name}`}
+                            disabled={!restrictions?.canPractice}
+                            onClick={() =>
+                              setSelectedSkill({ slug: skill.skill_slug, name })
+                            }
+                          >
+                            <Calendar className="mr-2 h-4 w-4" />
+                            Schedule Practice
+                          </Button>
+                        </div>
+                        <Progress
+                          value={display.progress_percent}
+                          className="h-2"
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
       </Tabs>
 
-      {selectedSkill && <SchedulePracticeDialog open={!!selectedSkill} onOpenChange={(open) => !open && setSelectedSkill(null)} skillSlug={selectedSkill.slug} skillName={selectedSkill.name} practiceConfig={restrictions} />}
+      {selectedSkill && (
+        <SchedulePracticeDialog
+          open={!!selectedSkill}
+          onOpenChange={(open) => !open && setSelectedSkill(null)}
+          skillSlug={selectedSkill.slug}
+          skillName={selectedSkill.name}
+          practiceConfig={restrictions}
+        />
+      )}
     </FMPageScaffold>
   );
 };

--- a/src/utils/__tests__/skillCatalogue.test.ts
+++ b/src/utils/__tests__/skillCatalogue.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  calculateWeightedLearningMultiplier,
+  getAvailabilityForSkill,
+  getSkillAttributeLinks,
+} from "../skillCatalogue";
+import {
+  detectPrerequisiteCycles,
+  validateSkillCatalogue,
+} from "../skillCatalogueValidation";
+import {
+  getSkillLearningMultiplier,
+  skillLearningDiagnostics,
+} from "../skillLearningMultiplier";
+
+describe("canonical skill catalogue", () => {
+  it("passes catalogue integrity validation", () => {
+    expect(validateSkillCatalogue().errors).toEqual([]);
+  });
+  it("uses explicit weighted learning attributes", () => {
+    expect(getSkillAttributeLinks("guitar")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          attribute_key: "musical_ability",
+          weight: 0.7,
+        }),
+      ]),
+    );
+    expect(
+      calculateWeightedLearningMultiplier("guitar", {
+        musical_ability: 1000,
+        musicality: 0,
+      }).boostPercent,
+    ).toBe(35);
+  });
+  it("warns and records diagnostics for legacy regex fallback only", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    skillLearningDiagnostics.fallbackSkillSlugs.clear();
+    expect(
+      getSkillLearningMultiplier("genres_basic_rock", {
+        musical_ability: 1000,
+        creative_insight: 1000,
+      }).boostPercent,
+    ).toBe(50);
+    expect(
+      skillLearningDiagnostics.fallbackSkillSlugs.has("genres_basic_rock"),
+    ).toBe(true);
+    warn.mockRestore();
+  });
+  it("does not assign arbitrary bonuses to unmapped skills", () => {
+    expect(
+      getSkillLearningMultiplier("unknown_legacy_slug", {
+        musical_ability: 1000,
+      }).boostPercent,
+    ).toBe(0);
+  });
+});
+
+describe("skill prerequisites and availability", () => {
+  it("detects missing prerequisite levels", () =>
+    expect(
+      getAvailabilityForSkill({ songwriting: 5 }, "composition"),
+    ).toMatchObject({
+      status: "prerequisites_missing",
+      blockedReason: { code: "PREREQUISITE_LEVEL_TOO_LOW" },
+    }));
+  it("permits valid prerequisite levels", () =>
+    expect(
+      getAvailabilityForSkill({ songwriting: 20 }, "composition").status,
+    ).toBe("available_to_unlock"));
+  it("returns unlocked and maxed states", () => {
+    expect(getAvailabilityForSkill({ guitar: 1 }, "guitar").status).toBe(
+      "unlocked",
+    );
+    expect(getAvailabilityForSkill({ guitar: 100 }, "guitar").status).toBe(
+      "maxed",
+    );
+  });
+  it("detects circular relationships", () =>
+    expect(
+      detectPrerequisiteCycles([
+        {
+          skill_slug: "a",
+          prerequisite_skill_slug: "b",
+          required_level: 1,
+          prerequisite_type: "required",
+        },
+        {
+          skill_slug: "b",
+          prerequisite_skill_slug: "a",
+          required_level: 1,
+          prerequisite_type: "required",
+        },
+      ] as any).length,
+    ).toBeGreaterThan(0));
+});

--- a/src/utils/skillCatalogue.ts
+++ b/src/utils/skillCatalogue.ts
@@ -1,0 +1,526 @@
+import { supabase } from "@/integrations/supabase/client";
+import {
+  ATTRIBUTE_MAX_VALUE,
+  FULL_ATTRIBUTE_KEYS,
+  FULL_ATTRIBUTE_METADATA,
+  type FullAttributeKey,
+} from "./attributeProgression";
+
+export const SKILL_TYPES = [
+  "foundation",
+  "instrument",
+  "vocal",
+  "performance",
+  "songwriting",
+  "theory",
+  "production",
+  "genre",
+  "business",
+  "social",
+  "health",
+  "teaching",
+  "craft",
+  "specialist",
+  "mastery",
+] as const;
+export const SKILL_SYSTEM_KEYS = [
+  "skill_learning",
+  "rehearsal",
+  "songwriting",
+  "recording",
+  "live_gig",
+  "touring",
+  "education",
+  "teaching",
+  "business",
+  "social_media",
+  "interviews",
+  "equipment_crafting",
+  "wellness",
+] as const;
+export const SKILL_ROLE_KEYS = [
+  "lead_vocalist",
+  "backing_vocalist",
+  "lead_guitarist",
+  "rhythm_guitarist",
+  "bassist",
+  "drummer",
+  "keyboard_player",
+  "dj",
+  "producer",
+  "songwriter",
+  "bandleader",
+  "live_frontperson",
+  "sound_engineer",
+] as const;
+export type SkillType = (typeof SKILL_TYPES)[number];
+export type SkillSystemKey = (typeof SKILL_SYSTEM_KEYS)[number];
+export type SkillRoleKey = (typeof SKILL_ROLE_KEYS)[number];
+export type SkillAvailabilityStatus =
+  | "unlocked"
+  | "available_to_unlock"
+  | "prerequisites_missing"
+  | "hidden"
+  | "inactive"
+  | "maxed";
+export type RelationshipType =
+  | "learning_speed"
+  | "effectiveness"
+  | "unlock_requirement"
+  | "consistency"
+  | "fatigue_resistance";
+
+export interface CanonicalSkill {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  subcategory: string | null;
+  tier: "basic" | "professional" | "mastery";
+  skill_type: SkillType;
+  is_active: boolean;
+  is_hidden: boolean;
+  is_practiceable: boolean;
+  is_foundational: boolean;
+  max_level: number;
+  progression_curve_key: string;
+  display_order: number;
+  icon_key: string | null;
+}
+export interface SkillAttributeLink {
+  skill_slug: string;
+  attribute_key: FullAttributeKey;
+  relationship_type: RelationshipType;
+  weight: number;
+  max_bonus: number;
+  is_primary: boolean;
+}
+export interface SkillPrerequisite {
+  skill_slug: string;
+  prerequisite_skill_slug: string;
+  required_level: number;
+  prerequisite_type: "required" | "one_of" | "recommended" | "hidden_unlock";
+}
+export interface SkillUnlockRoute {
+  skill_slug: string;
+  route_type:
+    | "starter"
+    | "lesson"
+    | "university_course"
+    | "activity"
+    | "rehearsal"
+    | "performance"
+    | "book"
+    | "admin"
+    | "hidden_discovery";
+  source_key: string;
+  minimum_source_level: number;
+  unlock_level: number;
+  is_active: boolean;
+}
+export interface SkillSystemLink {
+  skill_slug: string;
+  system_key: SkillSystemKey;
+  usage_type:
+    | "primary"
+    | "secondary"
+    | "prerequisite"
+    | "modifier"
+    | "unlock"
+    | "recommendation";
+  weight: number;
+}
+export interface SkillRoleLink {
+  skill_slug: string;
+  role_key: SkillRoleKey;
+  relevance: "primary" | "secondary" | "supporting";
+  weight: number;
+  minimum_recommended_level: number;
+}
+export interface SkillBlockedReason {
+  code: string;
+  message: string;
+  missingRequirements?: Array<{
+    skillSlug: string;
+    requiredLevel: number;
+    currentLevel: number;
+  }>;
+}
+export interface SkillAvailability {
+  slug: string;
+  status: SkillAvailabilityStatus;
+  blockedReason?: SkillBlockedReason;
+}
+
+export const CANONICAL_SKILLS: CanonicalSkill[] = [
+  {
+    id: "guitar",
+    slug: "guitar",
+    name: "Guitar Mastery",
+    description: "Ability to perform and improvise on guitar across genres.",
+    category: "Instruments",
+    subcategory: "Strings",
+    tier: "basic",
+    skill_type: "instrument",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: true,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 10,
+    icon_key: "guitar",
+  },
+  {
+    id: "vocals",
+    slug: "vocals",
+    name: "Vocal Performance",
+    description: "Pitch, range and delivery for vocal performances.",
+    category: "Performance",
+    subcategory: "Vocals",
+    tier: "basic",
+    skill_type: "vocal",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: true,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 20,
+    icon_key: "mic",
+  },
+  {
+    id: "drums",
+    slug: "drums",
+    name: "Percussion Skills",
+    description: "Timing, groove and creativity behind the kit.",
+    category: "Instruments",
+    subcategory: "Percussion",
+    tier: "basic",
+    skill_type: "instrument",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: true,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 30,
+    icon_key: "drums",
+  },
+  {
+    id: "bass",
+    slug: "bass",
+    name: "Bass Groove",
+    description: "Low-end control and groove crafting for any ensemble.",
+    category: "Instruments",
+    subcategory: "Strings",
+    tier: "basic",
+    skill_type: "instrument",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: true,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 40,
+    icon_key: "bass",
+  },
+  {
+    id: "performance",
+    slug: "performance",
+    name: "Stage Presence",
+    description: "Crowd engagement, stamina and live showmanship.",
+    category: "Stage",
+    subcategory: "Showmanship",
+    tier: "basic",
+    skill_type: "performance",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: false,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 50,
+    icon_key: "stage",
+  },
+  {
+    id: "songwriting",
+    slug: "songwriting",
+    name: "Songwriting",
+    description: "Lyricism, melody crafting and song structure.",
+    category: "Songwriting",
+    subcategory: "Composition",
+    tier: "basic",
+    skill_type: "songwriting",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: true,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 60,
+    icon_key: "pen",
+  },
+  {
+    id: "composition",
+    slug: "composition",
+    name: "Music Composition",
+    description: "Arranging complex pieces and orchestrating multi-part works.",
+    category: "Songwriting",
+    subcategory: "Arrangement",
+    tier: "professional",
+    skill_type: "theory",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: false,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 70,
+    icon_key: "music",
+  },
+  {
+    id: "technical",
+    slug: "technical",
+    name: "Technical Production",
+    description: "Studio technology, mixing and engineering expertise.",
+    category: "Production",
+    subcategory: "Studio",
+    tier: "professional",
+    skill_type: "production",
+    is_active: true,
+    is_hidden: false,
+    is_practiceable: true,
+    is_foundational: false,
+    max_level: 100,
+    progression_curve_key: "standard_skill",
+    display_order: 80,
+    icon_key: "sliders",
+  },
+];
+
+export const CANONICAL_ATTRIBUTE_LINKS: SkillAttributeLink[] = [
+  ["guitar", "musical_ability", 0.7],
+  ["guitar", "musicality", 0.3],
+  ["bass", "musical_ability", 0.6],
+  ["bass", "rhythm_sense", 0.4],
+  ["drums", "rhythm_sense", 0.7],
+  ["drums", "musicality", 0.3],
+  ["vocals", "vocal_talent", 0.7],
+  ["vocals", "musicality", 0.3],
+  ["performance", "stage_presence", 0.6],
+  ["performance", "crowd_engagement", 0.4],
+  ["songwriting", "creative_insight", 0.6],
+  ["songwriting", "musicality", 0.4],
+  ["composition", "musicality", 0.6],
+  ["composition", "mental_focus", 0.4],
+  ["technical", "technical_mastery", 0.7],
+  ["technical", "creative_insight", 0.3],
+].map(([skill_slug, attribute_key, weight], index) => ({
+  skill_slug: skill_slug as string,
+  attribute_key: attribute_key as FullAttributeKey,
+  relationship_type: "learning_speed",
+  weight: weight as number,
+  max_bonus: 0.5,
+  is_primary: index % 2 === 0,
+}));
+export const CANONICAL_PREREQUISITES: SkillPrerequisite[] = [
+  {
+    skill_slug: "composition",
+    prerequisite_skill_slug: "songwriting",
+    required_level: 20,
+    prerequisite_type: "required",
+  },
+  {
+    skill_slug: "technical",
+    prerequisite_skill_slug: "performance",
+    required_level: 15,
+    prerequisite_type: "recommended",
+  },
+];
+export const CANONICAL_UNLOCK_ROUTES: SkillUnlockRoute[] = CANONICAL_SKILLS.map(
+  (s) => ({
+    skill_slug: s.slug,
+    route_type: s.is_foundational ? "starter" : "university_course",
+    source_key: s.is_foundational ? "new_profile" : s.slug,
+    minimum_source_level: 0,
+    unlock_level: s.is_foundational ? 0 : 1,
+    is_active: true,
+  }),
+);
+export const CANONICAL_SYSTEM_LINKS: SkillSystemLink[] = [
+  ["guitar", "recording", "primary"],
+  ["guitar", "live_gig", "primary"],
+  ["bass", "recording", "primary"],
+  ["bass", "live_gig", "primary"],
+  ["drums", "recording", "primary"],
+  ["drums", "live_gig", "primary"],
+  ["vocals", "recording", "primary"],
+  ["vocals", "live_gig", "primary"],
+  ["performance", "live_gig", "primary"],
+  ["songwriting", "songwriting", "primary"],
+  ["composition", "songwriting", "modifier"],
+  ["technical", "recording", "primary"],
+].map(([skill_slug, system_key, usage_type]) => ({
+  skill_slug: skill_slug as string,
+  system_key: system_key as SkillSystemKey,
+  usage_type: usage_type as SkillSystemLink["usage_type"],
+  weight: 1,
+}));
+export const CANONICAL_ROLE_LINKS: SkillRoleLink[] = [
+  ["guitar", "lead_guitarist"],
+  ["guitar", "rhythm_guitarist"],
+  ["bass", "bassist"],
+  ["drums", "drummer"],
+  ["vocals", "lead_vocalist"],
+  ["vocals", "backing_vocalist"],
+  ["performance", "live_frontperson"],
+  ["songwriting", "songwriter"],
+  ["composition", "songwriter"],
+  ["technical", "producer"],
+  ["technical", "sound_engineer"],
+].map(([skill_slug, role_key]) => ({
+  skill_slug: skill_slug as string,
+  role_key: role_key as SkillRoleKey,
+  relevance: "primary",
+  weight: 1,
+  minimum_recommended_level: 10,
+}));
+
+export const getSkillBySlug = (slug: string) =>
+  CANONICAL_SKILLS.find((s) => s.slug === slug);
+export const getSkillsByCategory = (category: string) =>
+  CANONICAL_SKILLS.filter(
+    (s) => s.category.toLowerCase() === category.toLowerCase(),
+  );
+export const getSkillPrerequisites = (slug: string) =>
+  CANONICAL_PREREQUISITES.filter((p) => p.skill_slug === slug);
+export const getSkillAttributeLinks = (
+  slug: string,
+  relationshipType: RelationshipType = "learning_speed",
+) =>
+  CANONICAL_ATTRIBUTE_LINKS.filter(
+    (l) => l.skill_slug === slug && l.relationship_type === relationshipType,
+  );
+export const getSkillUnlockRoutes = (slug: string) =>
+  CANONICAL_UNLOCK_ROUTES.filter((r) => r.skill_slug === slug && r.is_active);
+export const getSkillSystemLinks = (slug: string) =>
+  CANONICAL_SYSTEM_LINKS.filter((l) => l.skill_slug === slug);
+export const getSkillRoleLinks = (slug: string) =>
+  CANONICAL_ROLE_LINKS.filter((l) => l.skill_slug === slug);
+export const getAttributeLabel = (key: FullAttributeKey) =>
+  FULL_ATTRIBUTE_METADATA[key]?.label ?? key;
+
+export function calculateWeightedLearningMultiplier(
+  skillSlug: string,
+  attributes: Record<string, unknown> | null | undefined,
+  links = getSkillAttributeLinks(skillSlug),
+) {
+  if (!attributes || links.length === 0)
+    return { multiplier: 1, boostPercent: 0, attributeNames: [] };
+  const weighted = links.reduce(
+    (sum, link) =>
+      sum +
+      Math.max(
+        0,
+        Math.min(
+          ATTRIBUTE_MAX_VALUE,
+          Number(attributes[link.attribute_key]) || 0,
+        ),
+      ) *
+        link.weight,
+    0,
+  );
+  const maxBonus = links.reduce(
+    (max, link) => Math.max(max, link.max_bonus),
+    0.5,
+  );
+  const bonus = (weighted / ATTRIBUTE_MAX_VALUE) * maxBonus;
+  return {
+    multiplier: Number((1 + bonus).toFixed(3)),
+    boostPercent: Math.round(bonus * 100),
+    attributeNames: links.map((l) => l.attribute_key),
+  };
+}
+
+export function getBlockedReasonForSkill(
+  progress: Record<string, number>,
+  slug: string,
+): SkillBlockedReason | undefined {
+  const missing = getSkillPrerequisites(slug)
+    .filter(
+      (p) =>
+        p.prerequisite_type === "required" &&
+        (progress[p.prerequisite_skill_slug] ?? 0) < p.required_level,
+    )
+    .map((p) => ({
+      skillSlug: p.prerequisite_skill_slug,
+      requiredLevel: p.required_level,
+      currentLevel: progress[p.prerequisite_skill_slug] ?? 0,
+    }));
+  return missing.length
+    ? {
+        code: "PREREQUISITE_LEVEL_TOO_LOW",
+        message: `Requires ${getSkillBySlug(missing[0].skillSlug)?.name ?? missing[0].skillSlug} level ${missing[0].requiredLevel}`,
+        missingRequirements: missing,
+      }
+    : undefined;
+}
+export function getAvailabilityForSkill(
+  progress: Record<string, number>,
+  slug: string,
+): SkillAvailability {
+  const skill = getSkillBySlug(slug);
+  if (!skill)
+    return {
+      slug,
+      status: "inactive",
+      blockedReason: {
+        code: "SKILL_NOT_IN_CATALOGUE",
+        message: "Skill is not in the canonical catalogue.",
+      },
+    };
+  if (!skill.is_active) return { slug, status: "inactive" };
+  if (skill.is_hidden && !progress[slug]) return { slug, status: "hidden" };
+  const level = progress[slug] ?? 0;
+  if (level >= skill.max_level) return { slug, status: "maxed" };
+  if (level > 0 || skill.is_foundational) return { slug, status: "unlocked" };
+  const blockedReason = getBlockedReasonForSkill(progress, slug);
+  return blockedReason
+    ? { slug, status: "prerequisites_missing", blockedReason }
+    : { slug, status: "available_to_unlock" };
+}
+
+export async function fetchCanonicalSkillCatalogue() {
+  const { data, error } = await (supabase as any)
+    .from("skill_catalogue_view")
+    .select("*")
+    .order("display_order");
+  if (error || !data?.length) return CANONICAL_SKILLS;
+  return data.map((row: any) => ({
+    ...getSkillBySlug(row.slug),
+    ...row,
+    name: row.name ?? row.display_name,
+  })) as CanonicalSkill[];
+}
+export async function getUnlockedSkillsForProfile(profileId: string) {
+  const { data } = await supabase
+    .from("skill_progress")
+    .select("skill_slug,current_level")
+    .eq("profile_id", profileId);
+  return (data ?? [])
+    .filter((s: any) => (s.current_level ?? 0) > 0)
+    .map((s: any) => s.skill_slug);
+}
+export async function getAvailableSkillsForProfile(profileId: string) {
+  const { data } = await supabase
+    .from("skill_progress")
+    .select("skill_slug,current_level")
+    .eq("profile_id", profileId);
+  const progress = Object.fromEntries(
+    (data ?? []).map((s: any) => [s.skill_slug, s.current_level ?? 0]),
+  );
+  return CANONICAL_SKILLS.map((s) => getAvailabilityForSkill(progress, s.slug));
+}
+export const KNOWN_ATTRIBUTE_KEYS = FULL_ATTRIBUTE_KEYS;

--- a/src/utils/skillCatalogueValidation.ts
+++ b/src/utils/skillCatalogueValidation.ts
@@ -1,0 +1,134 @@
+import {
+  CANONICAL_ATTRIBUTE_LINKS,
+  CANONICAL_PREREQUISITES,
+  CANONICAL_ROLE_LINKS,
+  CANONICAL_SKILLS,
+  CANONICAL_SYSTEM_LINKS,
+  KNOWN_ATTRIBUTE_KEYS,
+  SKILL_ROLE_KEYS,
+  SKILL_SYSTEM_KEYS,
+  SKILL_TYPES,
+} from "./skillCatalogue";
+
+export interface SkillCatalogueValidationResult {
+  errors: string[];
+  warnings: string[];
+}
+const groupBy = <T, K extends string>(items: T[], key: (item: T) => K) =>
+  items.reduce<Record<K, T[]>>(
+    (acc, item) => {
+      const k = key(item);
+      (acc[k] ??= []).push(item);
+      return acc;
+    },
+    {} as Record<K, T[]>,
+  );
+
+export function detectPrerequisiteCycles(
+  prerequisites = CANONICAL_PREREQUISITES,
+): string[][] {
+  const graph = groupBy(
+    prerequisites.filter((p) => p.prerequisite_type === "required"),
+    (p) => p.prerequisite_skill_slug,
+  );
+  const cycles: string[][] = [];
+  const visit = (node: string, path: string[]) => {
+    if (path.includes(node)) {
+      cycles.push([...path.slice(path.indexOf(node)), node]);
+      return;
+    }
+    for (const edge of graph[node] ?? [])
+      visit(edge.skill_slug, [...path, node]);
+  };
+  CANONICAL_SKILLS.forEach((s) => visit(s.slug, []));
+  return cycles;
+}
+
+export function validateSkillCatalogue(): SkillCatalogueValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const skillsBySlug = groupBy(CANONICAL_SKILLS, (s) => s.slug);
+  Object.entries(skillsBySlug).forEach(([slug, rows]) => {
+    if (rows.length > 1) errors.push(`Duplicate skill slug: ${slug}`);
+  });
+  for (const skill of CANONICAL_SKILLS) {
+    if (!skill.name.trim()) errors.push(`${skill.slug} is missing a name`);
+    if (!skill.category.trim())
+      errors.push(`${skill.slug} is missing a category`);
+    if (!SKILL_TYPES.includes(skill.skill_type as any))
+      errors.push(`${skill.slug} has invalid skill_type ${skill.skill_type}`);
+    if (!skill.progression_curve_key)
+      errors.push(`${skill.slug} is missing a progression curve`);
+    if (skill.max_level <= 0)
+      errors.push(`${skill.slug} has invalid max_level`);
+    if (
+      skill.is_active &&
+      skill.is_practiceable &&
+      !CANONICAL_ATTRIBUTE_LINKS.some(
+        (l) =>
+          l.skill_slug === skill.slug &&
+          l.relationship_type === "learning_speed",
+      )
+    )
+      errors.push(`${skill.slug} has no learning_speed attribute links`);
+  }
+  const weightGroups = groupBy(
+    CANONICAL_ATTRIBUTE_LINKS,
+    (l) => `${l.skill_slug}:${l.relationship_type}`,
+  );
+  Object.entries(weightGroups).forEach(([key, rows]) => {
+    const total = rows.reduce((sum, row) => sum + row.weight, 0);
+    if (Math.abs(total - 1) > 0.001)
+      errors.push(`${key} weights total ${total}, expected 1`);
+  });
+  for (const link of CANONICAL_ATTRIBUTE_LINKS)
+    if (!KNOWN_ATTRIBUTE_KEYS.includes(link.attribute_key))
+      errors.push(
+        `${link.skill_slug} references unknown attribute ${link.attribute_key}`,
+      );
+  for (const link of CANONICAL_SYSTEM_LINKS)
+    if (!SKILL_SYSTEM_KEYS.includes(link.system_key as any))
+      errors.push(
+        `${link.skill_slug} references unknown system ${link.system_key}`,
+      );
+  for (const link of CANONICAL_ROLE_LINKS)
+    if (!SKILL_ROLE_KEYS.includes(link.role_key as any))
+      errors.push(
+        `${link.skill_slug} references unknown role ${link.role_key}`,
+      );
+  for (const prerequisite of CANONICAL_PREREQUISITES) {
+    if (prerequisite.skill_slug === prerequisite.prerequisite_skill_slug)
+      errors.push(`${prerequisite.skill_slug} cannot require itself`);
+    const skill = skillsBySlug[prerequisite.skill_slug]?.[0];
+    const required = skillsBySlug[prerequisite.prerequisite_skill_slug]?.[0];
+    if (!skill || !required)
+      errors.push(
+        `${prerequisite.skill_slug} references missing prerequisite ${prerequisite.prerequisite_skill_slug}`,
+      );
+    if (required && !required.is_active && skill?.is_active)
+      errors.push(
+        `${prerequisite.skill_slug} is blocked by inactive prerequisite ${required.slug}`,
+      );
+    if (required && prerequisite.required_level > required.max_level)
+      errors.push(
+        `${prerequisite.skill_slug} requires impossible level ${prerequisite.required_level} of ${required.slug}`,
+      );
+  }
+  detectPrerequisiteCycles().forEach((cycle) =>
+    errors.push(`Circular prerequisite chain: ${cycle.join(" -> ")}`),
+  );
+  const linkedSlugs = new Set(
+    [
+      ...CANONICAL_ATTRIBUTE_LINKS,
+      ...CANONICAL_PREREQUISITES,
+      ...CANONICAL_ROLE_LINKS,
+      ...CANONICAL_SYSTEM_LINKS,
+    ]
+      .flatMap((l: any) => [l.skill_slug, l.prerequisite_skill_slug])
+      .filter(Boolean),
+  );
+  CANONICAL_SKILLS.filter((s) => !linkedSlugs.has(s.slug)).forEach((s) =>
+    warnings.push(`${s.slug} has no catalogue relationships beyond metadata`),
+  );
+  return { errors, warnings };
+}

--- a/src/utils/skillLearningMultiplier.ts
+++ b/src/utils/skillLearningMultiplier.ts
@@ -1,120 +1,126 @@
 /**
  * Skill Learning Multiplier System
  *
- * Higher attribute values in related areas provide a learning speed bonus
- * when gaining skill XP. Multiplier range: 1.0x → 1.5x.
- *
- * Slugs follow `<prefix>_<tier>_<topic>` (e.g. `instruments_basic_electric_guitar`).
- * We match by topic keywords (regex) so every real slug gets a bonus when the
- * relevant attribute is high.
+ * Runtime learning speed now uses explicit canonical skill_attribute_links.
+ * Regex rules remain only as a development-warning fallback for legacy skills
+ * that are missing canonical relationships.
  */
 
-import { SKILL_ATTRIBUTE_MAP, ATTRIBUTE_MAX_VALUE, type FullAttributeKey } from './attributeProgression';
+import {
+  SKILL_ATTRIBUTE_MAP,
+  ATTRIBUTE_MAX_VALUE,
+  type FullAttributeKey,
+} from "./attributeProgression";
+import {
+  calculateWeightedLearningMultiplier,
+  getSkillAttributeLinks,
+  type SkillAttributeLink,
+} from "./skillCatalogue";
 
 interface MultiplierRule {
   pattern: RegExp;
   attributes: FullAttributeKey[];
 }
+export const skillLearningDiagnostics = {
+  fallbackSkillSlugs: new Set<string>(),
+};
 
 const RULES: MultiplierRule[] = [
-  // Vocals / rap
-  { pattern: /(?:^|_)(vocal|singing|rapping|ad_libs)(?:$|_)/, attributes: ['vocal_talent', 'musicality'] },
-  // Drums & percussion-style instruments
-  { pattern: /(?:_drums|_percussion|tabla|djembe|bongos|cajon|taiko|snare|timpani|beatmaking)(?:$|_)/, attributes: ['rhythm_sense', 'musicality'] },
-  // Stage skills
-  { pattern: /^stage_/, attributes: ['stage_presence', 'crowd_engagement'] },
-  // Audience psychology
-  { pattern: /^audience_/, attributes: ['crowd_engagement', 'charisma'] },
-  // Business
-  { pattern: /^business_/, attributes: ['social_reach', 'charisma'] },
-  // Health
-  { pattern: /^health_/, attributes: ['physical_endurance', 'mental_focus'] },
-  // Songwriting subtopics
-  { pattern: /songwriting_.*_(?:composing|lyrics|record_production|sampling|sound_design|ai_music)/, attributes: ['creative_insight', 'musicality'] },
-  { pattern: /songwriting_.*_(?:mixing|daw|vocal_processing|beatmaking)/, attributes: ['technical_mastery', 'creative_insight'] },
-  // Theory
-  { pattern: /^theory_/, attributes: ['musicality', 'mental_focus'] },
-  // Improvisation
-  { pattern: /^improv_/, attributes: ['creative_insight', 'musicality'] },
-  // DJ
-  { pattern: /^dj_/, attributes: ['rhythm_sense', 'crowd_engagement'] },
-  // Teaching
-  { pattern: /^teaching_/, attributes: ['mental_focus', 'charisma'] },
-  // Genres
-  { pattern: /^genres_/, attributes: ['musical_ability', 'creative_insight'] },
-  // Luthiery
-  { pattern: /^luthiery_/, attributes: ['technical_mastery', 'mental_focus'] },
-  // Modeling / fashion / clothing
-  { pattern: /^modeling_/, attributes: ['charisma', 'stage_presence'] },
-  { pattern: /^fashion_/, attributes: ['creative_insight', 'charisma'] },
-  { pattern: /^clothing_/, attributes: ['creative_insight', 'technical_mastery'] },
-  // Default instruments bucket (must come last among instrument-related)
-  { pattern: /^instruments_/, attributes: ['musical_ability', 'musicality'] },
+  {
+    pattern: /(?:^|_)(vocal|singing|rapping|ad_libs)(?:$|_)/,
+    attributes: ["vocal_talent", "musicality"],
+  },
+  {
+    pattern:
+      /(?:_drums|_percussion|tabla|djembe|bongos|cajon|taiko|snare|timpani|beatmaking)(?:$|_)/,
+    attributes: ["rhythm_sense", "musicality"],
+  },
+  { pattern: /^stage_/, attributes: ["stage_presence", "crowd_engagement"] },
+  { pattern: /^audience_/, attributes: ["crowd_engagement", "charisma"] },
+  { pattern: /^business_/, attributes: ["social_reach", "charisma"] },
+  { pattern: /^health_/, attributes: ["physical_endurance", "mental_focus"] },
+  {
+    pattern:
+      /songwriting_.*_(?:composing|lyrics|record_production|sampling|sound_design|ai_music)/,
+    attributes: ["creative_insight", "musicality"],
+  },
+  {
+    pattern: /songwriting_.*_(?:mixing|daw|vocal_processing|beatmaking)/,
+    attributes: ["technical_mastery", "creative_insight"],
+  },
+  { pattern: /^theory_/, attributes: ["musicality", "mental_focus"] },
+  { pattern: /^improv_/, attributes: ["creative_insight", "musicality"] },
+  { pattern: /^dj_/, attributes: ["rhythm_sense", "crowd_engagement"] },
+  { pattern: /^teaching_/, attributes: ["mental_focus", "charisma"] },
+  { pattern: /^genres_/, attributes: ["musical_ability", "creative_insight"] },
+  { pattern: /^luthiery_/, attributes: ["technical_mastery", "mental_focus"] },
+  { pattern: /^modeling_/, attributes: ["charisma", "stage_presence"] },
+  { pattern: /^fashion_/, attributes: ["creative_insight", "charisma"] },
+  {
+    pattern: /^clothing_/,
+    attributes: ["creative_insight", "technical_mastery"],
+  },
+  { pattern: /^instruments_/, attributes: ["musical_ability", "musicality"] },
 ];
 
-function pickAttributes(skillSlug: string): FullAttributeKey[] {
-  for (const rule of RULES) {
-    if (rule.pattern.test(skillSlug)) return rule.attributes;
-  }
-  return [];
+function warnFallback(skillSlug: string) {
+  skillLearningDiagnostics.fallbackSkillSlugs.add(skillSlug);
+  if (import.meta.env.DEV)
+    console.warn(
+      `[skill-catalogue] Missing explicit learning_speed attribute links for "${skillSlug}"; using legacy fallback.`,
+    );
 }
 
-/**
- * Calculate the skill learning multiplier based on attribute values.
- */
+function legacyFallbackLinks(skillSlug: string): SkillAttributeLink[] {
+  const matched = RULES.find((rule) =>
+    rule.pattern.test(skillSlug),
+  )?.attributes;
+  const attributes =
+    matched ??
+    (SKILL_ATTRIBUTE_MAP[skillSlug]
+      ? [SKILL_ATTRIBUTE_MAP[skillSlug] as FullAttributeKey]
+      : []);
+  if (attributes.length === 0) return [];
+  warnFallback(skillSlug);
+  const weight = 1 / attributes.length;
+  return attributes.map((attribute_key, index) => ({
+    skill_slug: skillSlug,
+    attribute_key,
+    relationship_type: "learning_speed",
+    weight,
+    max_bonus: 0.5,
+    is_primary: index === 0,
+  }));
+}
+
+export function getLearningAttributeLinks(
+  skillSlug: string,
+): SkillAttributeLink[] {
+  const explicit = getSkillAttributeLinks(skillSlug, "learning_speed");
+  return explicit.length > 0 ? explicit : legacyFallbackLinks(skillSlug);
+}
+
 export function getSkillLearningMultiplier(
   skillSlug: string,
   attributes: Record<string, any> | null | undefined,
 ): { multiplier: number; boostPercent: number; attributeNames: string[] } {
-  if (!attributes || !skillSlug) {
+  if (!attributes || !skillSlug)
     return { multiplier: 1.0, boostPercent: 0, attributeNames: [] };
-  }
-
-  const relevantAttrs = pickAttributes(skillSlug);
-
-  if (relevantAttrs.length === 0) {
-    const basicAttr = SKILL_ATTRIBUTE_MAP[skillSlug];
-    if (!basicAttr) {
-      return { multiplier: 1.0, boostPercent: 0, attributeNames: [] };
-    }
-    const value = Math.max(0, Math.min(ATTRIBUTE_MAX_VALUE, Number(attributes[basicAttr]) || 0));
-    const bonus = (value / ATTRIBUTE_MAX_VALUE) * 0.5;
-    return {
-      multiplier: 1 + bonus,
-      boostPercent: Math.round(bonus * 100),
-      attributeNames: [basicAttr],
-    };
-  }
-
-  let totalValue = 0;
-  const attrNames: string[] = [];
-  for (const attrKey of relevantAttrs) {
-    const value = Math.max(0, Math.min(ATTRIBUTE_MAX_VALUE, Number(attributes[attrKey]) || 0));
-    totalValue += value;
-    attrNames.push(attrKey);
-  }
-  const avgValue = totalValue / relevantAttrs.length;
-  const bonus = (avgValue / ATTRIBUTE_MAX_VALUE) * 0.5;
-
-  return {
-    multiplier: parseFloat((1 + bonus).toFixed(3)),
-    boostPercent: Math.round(bonus * 100),
-    attributeNames: attrNames,
-  };
+  return calculateWeightedLearningMultiplier(
+    skillSlug,
+    attributes,
+    getLearningAttributeLinks(skillSlug),
+  );
 }
 
-/**
- * Apply the learning multiplier to an XP amount.
- */
 export function applyLearningMultiplier(
   baseXp: number,
   skillSlug: string,
   attributes: Record<string, any> | null | undefined,
 ): { xp: number; multiplier: number; boostPercent: number } {
-  const { multiplier, boostPercent } = getSkillLearningMultiplier(skillSlug, attributes);
-  return {
-    xp: Math.round(baseXp * multiplier),
-    multiplier,
-    boostPercent,
-  };
+  const { multiplier, boostPercent } = getSkillLearningMultiplier(
+    skillSlug,
+    attributes,
+  );
+  return { xp: Math.round(baseXp * multiplier), multiplier, boostPercent };
 }

--- a/supabase/migrations/20270712120000_create_canonical_skill_catalogue.sql
+++ b/supabase/migrations/20270712120000_create_canonical_skill_catalogue.sql
@@ -1,0 +1,139 @@
+-- Canonical skills and relationships catalogue. Idempotent and progress-preserving.
+
+ALTER TABLE public.skill_definitions
+  ADD COLUMN IF NOT EXISTS category text,
+  ADD COLUMN IF NOT EXISTS subcategory text,
+  ADD COLUMN IF NOT EXISTS tier text NOT NULL DEFAULT 'basic',
+  ADD COLUMN IF NOT EXISTS skill_type text NOT NULL DEFAULT 'foundation',
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS is_hidden boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS is_practiceable boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS is_foundational boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS max_level integer NOT NULL DEFAULT 100,
+  ADD COLUMN IF NOT EXISTS progression_curve_key text NOT NULL DEFAULT 'standard_skill',
+  ADD COLUMN IF NOT EXISTS display_order integer NOT NULL DEFAULT 1000,
+  ADD COLUMN IF NOT EXISTS icon_key text;
+
+ALTER TABLE public.skill_definitions
+  DROP CONSTRAINT IF EXISTS skill_definitions_skill_type_check,
+  ADD CONSTRAINT skill_definitions_skill_type_check CHECK (skill_type IN ('foundation','instrument','vocal','performance','songwriting','theory','production','genre','business','social','health','teaching','craft','specialist','mastery'));
+
+CREATE TABLE IF NOT EXISTS public.skill_attribute_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE CASCADE,
+  attribute_key text NOT NULL,
+  relationship_type text NOT NULL DEFAULT 'learning_speed',
+  weight numeric(6,4) NOT NULL CHECK (weight > 0 AND weight <= 1),
+  max_bonus numeric(6,4) NOT NULL DEFAULT 0.5 CHECK (max_bonus >= 0 AND max_bonus <= 1),
+  is_primary boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (skill_id, attribute_key, relationship_type)
+);
+
+CREATE TABLE IF NOT EXISTS public.skill_prerequisites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE CASCADE,
+  prerequisite_skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE RESTRICT,
+  required_level integer NOT NULL DEFAULT 1 CHECK (required_level >= 0),
+  prerequisite_type text NOT NULL DEFAULT 'required' CHECK (prerequisite_type IN ('required','one_of','recommended','hidden_unlock')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (skill_id <> prerequisite_skill_id),
+  UNIQUE (skill_id, prerequisite_skill_id, prerequisite_type)
+);
+
+CREATE TABLE IF NOT EXISTS public.skill_unlock_routes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE CASCADE,
+  route_type text NOT NULL CHECK (route_type IN ('starter','lesson','university_course','activity','rehearsal','performance','book','mentor','achievement','admin','hidden_discovery')),
+  source_key text NOT NULL,
+  minimum_source_level integer NOT NULL DEFAULT 0,
+  unlock_level integer NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (skill_id, route_type, source_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.skill_system_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE CASCADE,
+  system_key text NOT NULL CHECK (system_key IN ('skill_learning','rehearsal','songwriting','recording','live_gig','touring','education','teaching','business','social_media','interviews','equipment_crafting','wellness')),
+  usage_type text NOT NULL CHECK (usage_type IN ('primary','secondary','prerequisite','modifier','unlock','recommendation')),
+  weight numeric(6,4) NOT NULL DEFAULT 1 CHECK (weight > 0 AND weight <= 1),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (skill_id, system_key, usage_type)
+);
+
+CREATE TABLE IF NOT EXISTS public.skill_role_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  skill_id uuid NOT NULL REFERENCES public.skill_definitions(id) ON DELETE CASCADE,
+  role_key text NOT NULL CHECK (role_key IN ('lead_vocalist','backing_vocalist','lead_guitarist','rhythm_guitarist','bassist','drummer','keyboard_player','dj','producer','songwriter','bandleader','live_frontperson','sound_engineer')),
+  relevance text NOT NULL DEFAULT 'primary' CHECK (relevance IN ('primary','secondary','supporting')),
+  weight numeric(6,4) NOT NULL DEFAULT 1 CHECK (weight > 0 AND weight <= 1),
+  minimum_recommended_level integer NOT NULL DEFAULT 10 CHECK (minimum_recommended_level >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (skill_id, role_key)
+);
+
+WITH seed(slug, display_name, description, category, subcategory, tier, skill_type, is_foundational, display_order, icon_key) AS (VALUES
+  ('guitar','Guitar Mastery','Ability to perform and improvise on guitar across genres.','Instruments','Strings','basic','instrument',true,10,'guitar'),
+  ('vocals','Vocal Performance','Pitch, range and delivery for vocal performances.','Performance','Vocals','basic','vocal',true,20,'mic'),
+  ('drums','Percussion Skills','Timing, groove and creativity behind the kit.','Instruments','Percussion','basic','instrument',true,30,'drums'),
+  ('bass','Bass Groove','Low-end control and groove crafting for any ensemble.','Instruments','Strings','basic','instrument',true,40,'bass'),
+  ('performance','Stage Presence','Crowd engagement, stamina and live showmanship.','Stage','Showmanship','basic','performance',false,50,'stage'),
+  ('songwriting','Songwriting','Lyricism, melody crafting and song structure.','Songwriting','Composition','basic','songwriting',true,60,'pen'),
+  ('composition','Music Composition','Arranging complex pieces and orchestrating multi-part works.','Songwriting','Arrangement','professional','theory',false,70,'music'),
+  ('technical','Technical Production','Studio technology, mixing and engineering expertise.','Production','Studio','professional','production',false,80,'sliders')
+)
+INSERT INTO public.skill_definitions (slug, display_name, description, tier_caps, default_unlock_level, category, subcategory, tier, skill_type, is_foundational, max_level, progression_curve_key, display_order, icon_key)
+SELECT slug, display_name, description, '{"tiers":[{"tier":1,"cap":20},{"tier":2,"cap":40},{"tier":3,"cap":60},{"tier":4,"cap":80},{"tier":5,"cap":100}]}'::jsonb, 0, category, subcategory, tier, skill_type, is_foundational, 100, 'standard_skill', display_order, icon_key FROM seed
+ON CONFLICT (slug) DO UPDATE SET display_name = EXCLUDED.display_name, description = EXCLUDED.description, category = EXCLUDED.category, subcategory = EXCLUDED.subcategory, tier = EXCLUDED.tier, skill_type = EXCLUDED.skill_type, is_foundational = EXCLUDED.is_foundational, max_level = EXCLUDED.max_level, progression_curve_key = EXCLUDED.progression_curve_key, display_order = EXCLUDED.display_order, icon_key = EXCLUDED.icon_key, updated_at = now();
+
+WITH links(skill_slug, attribute_key, weight, is_primary) AS (VALUES
+ ('guitar','musical_ability',0.7,true),('guitar','musicality',0.3,false),('bass','musical_ability',0.6,true),('bass','rhythm_sense',0.4,false),('drums','rhythm_sense',0.7,true),('drums','musicality',0.3,false),('vocals','vocal_talent',0.7,true),('vocals','musicality',0.3,false),('performance','stage_presence',0.6,true),('performance','crowd_engagement',0.4,false),('songwriting','creative_insight',0.6,true),('songwriting','musicality',0.4,false),('composition','musicality',0.6,true),('composition','mental_focus',0.4,false),('technical','technical_mastery',0.7,true),('technical','creative_insight',0.3,false)
+)
+INSERT INTO public.skill_attribute_links (skill_id, attribute_key, relationship_type, weight, max_bonus, is_primary)
+SELECT sd.id, l.attribute_key, 'learning_speed', l.weight, 0.5, l.is_primary FROM links l JOIN public.skill_definitions sd ON sd.slug = l.skill_slug
+ON CONFLICT (skill_id, attribute_key, relationship_type) DO UPDATE SET weight = EXCLUDED.weight, max_bonus = EXCLUDED.max_bonus, is_primary = EXCLUDED.is_primary;
+
+WITH prereqs(skill_slug, req_slug, required_level, prerequisite_type) AS (VALUES ('composition','songwriting',20,'required'),('technical','performance',15,'recommended'))
+INSERT INTO public.skill_prerequisites (skill_id, prerequisite_skill_id, required_level, prerequisite_type)
+SELECT s.id, r.id, p.required_level, p.prerequisite_type FROM prereqs p JOIN public.skill_definitions s ON s.slug=p.skill_slug JOIN public.skill_definitions r ON r.slug=p.req_slug
+ON CONFLICT (skill_id, prerequisite_skill_id, prerequisite_type) DO UPDATE SET required_level = EXCLUDED.required_level;
+
+INSERT INTO public.skill_unlock_routes (skill_id, route_type, source_key, minimum_source_level, unlock_level, is_active)
+SELECT id, CASE WHEN is_foundational THEN 'starter' ELSE 'university_course' END, CASE WHEN is_foundational THEN 'new_profile' ELSE slug END, 0, CASE WHEN is_foundational THEN 0 ELSE 1 END, true FROM public.skill_definitions WHERE slug IN ('guitar','vocals','drums','bass','performance','songwriting','composition','technical')
+ON CONFLICT (skill_id, route_type, source_key) DO NOTHING;
+
+WITH systems(skill_slug, system_key, usage_type) AS (VALUES ('guitar','recording','primary'),('guitar','live_gig','primary'),('bass','recording','primary'),('bass','live_gig','primary'),('drums','recording','primary'),('drums','live_gig','primary'),('vocals','recording','primary'),('vocals','live_gig','primary'),('performance','live_gig','primary'),('songwriting','songwriting','primary'),('composition','songwriting','modifier'),('technical','recording','primary'))
+INSERT INTO public.skill_system_links (skill_id, system_key, usage_type, weight)
+SELECT sd.id, s.system_key, s.usage_type, 1 FROM systems s JOIN public.skill_definitions sd ON sd.slug=s.skill_slug
+ON CONFLICT (skill_id, system_key, usage_type) DO NOTHING;
+
+WITH roles(skill_slug, role_key) AS (VALUES ('guitar','lead_guitarist'),('guitar','rhythm_guitarist'),('bass','bassist'),('drums','drummer'),('vocals','lead_vocalist'),('vocals','backing_vocalist'),('performance','live_frontperson'),('songwriting','songwriter'),('composition','songwriter'),('technical','producer'),('technical','sound_engineer'))
+INSERT INTO public.skill_role_links (skill_id, role_key, relevance, weight, minimum_recommended_level)
+SELECT sd.id, r.role_key, 'primary', 1, 10 FROM roles r JOIN public.skill_definitions sd ON sd.slug=r.skill_slug
+ON CONFLICT (skill_id, role_key) DO NOTHING;
+
+CREATE OR REPLACE VIEW public.skill_catalogue_view AS
+SELECT sd.id, sd.slug, sd.display_name AS name, sd.description, sd.category, sd.subcategory, sd.tier, sd.skill_type, sd.is_active, sd.is_hidden, sd.is_practiceable, sd.is_foundational, sd.max_level, sd.progression_curve_key, sd.display_order, sd.icon_key, sd.created_at, sd.updated_at
+FROM public.skill_definitions sd
+WHERE sd.is_active = true AND sd.is_hidden = false;
+
+ALTER TABLE public.skill_attribute_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.skill_prerequisites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.skill_unlock_routes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.skill_system_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.skill_role_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public can read skill attribute links" ON public.skill_attribute_links;
+CREATE POLICY "Public can read skill attribute links" ON public.skill_attribute_links FOR SELECT USING (true);
+DROP POLICY IF EXISTS "Public can read skill prerequisites" ON public.skill_prerequisites;
+CREATE POLICY "Public can read skill prerequisites" ON public.skill_prerequisites FOR SELECT USING (true);
+DROP POLICY IF EXISTS "Public can read active skill unlock routes" ON public.skill_unlock_routes;
+CREATE POLICY "Public can read active skill unlock routes" ON public.skill_unlock_routes FOR SELECT USING (is_active = true);
+DROP POLICY IF EXISTS "Public can read skill system links" ON public.skill_system_links;
+CREATE POLICY "Public can read skill system links" ON public.skill_system_links FOR SELECT USING (true);
+DROP POLICY IF EXISTS "Public can read skill role links" ON public.skill_role_links;
+CREATE POLICY "Public can read skill role links" ON public.skill_role_links FOR SELECT USING (true);


### PR DESCRIPTION
### Motivation

- The previous skill metadata was fragmented across DB tables, frontend arrays and regex-based slug matching which was fragile and allowed skills to be disconnected from attributes and gameplay systems. 
- The goal is to establish a single authoritative, typed catalogue that answers what a skill is, how it unlocks, what attributes affect it, which systems and roles use it, and whether it is available to a player. 
- Replacing regex-first learning mappings with explicit, weighted `learning_speed` relationships and explicit prerequisites reduces silent breakage and enables validation and safe migrations. 

### Description

- Added an audit document at `docs/progression/SKILLS_CATALOGUE_AUDIT.md` that inventories existing catalogue tables, active slugs, duplicates, inconsistent patterns and follow-up work. 
- Implemented a typed canonical catalogue adapter in `src/utils/skillCatalogue.ts` (models, `CANONICAL_SKILLS`, attribute/prerequisite/unlock/system/role links, availability helpers, weighted learning multiplier, and `fetchCanonicalSkillCatalogue`) plus `src/hooks/useSkillCatalogue.ts` for batched React Query access. 
- Reworked runtime learning logic in `src/utils/skillLearningMultiplier.ts` to prefer explicit `skill_attribute_links` and added a documented regex fallback that emits diagnostics, and added `src/utils/skillCatalogueValidation.ts` plus unit tests in `src/utils/__tests__/skillCatalogue.test.ts` to catch duplicates, missing metadata, invalid weights, prerequisite cycles and related issues. 
- Created an idempotent Supabase migration `supabase/migrations/20270712120000_create_canonical_skill_catalogue.sql` which extends `skill_definitions`, creates relationship tables and `skill_catalogue_view`, seeds canonical skills/links, enables RLS and read policies, and is written to preserve existing player progress through `ON CONFLICT`/`IF NOT EXISTS` patterns. 

### Testing

- Type checking (`npm run typecheck` / `tsc --noEmit`) completed successfully. 
- Repo sanity check (`git diff --check`) completed without issues. 
- Unit tests covering catalogue integrity, weighted learning calculations, fallback diagnostics, prerequisites and cycle detection were added at `src/utils/__tests__/skillCatalogue.test.ts` but could not be executed in this environment because `vitest` was not available. 
- Lint and build steps were not completed in this environment because `npm install` failed due to missing/blocked registry access and local dev dependencies (so `npm run lint` / `npm run build` were not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53ea56f49c8325b3892fbb9217a9f7)