### PR TITLE
Upgrade Skills and Attributes page with progression planning and role guidance

### DIFF
--- a/docs/progression/SKILLS_PAGE_UX_AUDIT.md
+++ b/docs/progression/SKILLS_PAGE_UX_AUDIT.md
@@ -1,0 +1,80 @@
+# Skills & Attributes Page UX Audit
+
+## Current information hierarchy
+- The page opens with wallet/stipend information, practice restrictions, four summary cards, and then a three-tab interface.
+- Tabs are currently ordered around implementation areas: Practice, Skill Tree, Attributes.
+- The first actionable area is practice scheduling, so strategic progression planning is not visible until the player infers it from individual lists.
+
+## Current tabs
+- Practice Skills: lists practiceable unlocked skills and allows scheduling.
+- Skill Tree: delegates to the existing tree component for unlocks and level context.
+- Attributes: delegates to the attribute panel and cards.
+
+## Duplicated information
+- Wallet values appear in the wallet display and are partially echoed by summary cards.
+- Practice availability appears in a page-level alert and inside the practice tab description.
+- Skill category/status badges are repeated in the practice list and skill tree context.
+
+## Missing explanations
+- No role-based explanation tells players which skills matter for their current job in a band.
+- Locked skills do not consistently explain whether the next action is education, activity, prerequisite levelling, or an inactive/hidden state.
+- Skill effects on songwriting, recording, gigs, rehearsal, production, business, social, and wellness systems are not summarized in one place.
+- Attribute cards show spend mechanics but do not provide enough before/after effect context for role decisions.
+
+## Unclear terminology
+- Players must distinguish Skill XP, Attribute Points, learned skills, and core attributes without a concise explanation.
+- Raw system keys and role slugs can leak into labels when canonical display names are unavailable.
+- Practice copy explains configuration values, but not why a practice choice is strategically useful.
+
+## Mobile issues
+- Existing tab cards consume substantial vertical space and start with Practice rather than overview context.
+- Long prerequisite or blocked-reason strings can wrap awkwardly inside cards.
+- Filter-heavy workflows need a compact layout that remains usable on narrow Android widths.
+
+## Accessibility issues
+- Icon-only actions need explicit accessible names.
+- Progress bars require text equivalents for screen readers.
+- Locked reasons and recommendation explanations should be readable without relying on colour or hover tooltips.
+- Details panels need focus restoration and keyboard dismissal if upgraded to modal/drawer patterns.
+
+## Poor empty states
+- Practice has a helpful education link, but other sections lack specific next actions for no role, no tracked skills, no recommendations, no recent progression, and no filtered results.
+- Loading states avoid zeroes in some areas but not every independent data section has a retry affordance.
+
+## Information players must currently infer
+- Which role a skill supports.
+- Whether a skill is a foundation gap, specialist gap, or optional support skill.
+- Which gameplay systems a skill affects.
+- Which attribute improves learning speed for a skill.
+- Which near-level skills are efficient next spends.
+- Which locked skills are reachable now versus blocked by prerequisites.
+
+## Progression decisions that are difficult to make
+- Choosing a development focus without a band role.
+- Comparing a role-relevant skill against an attribute upgrade.
+- Planning toward common goals such as competent lead guitarist, producer, songwriter, engineer, frontperson, or specialist unlock.
+- Understanding how a training session relates to upcoming gigs, recordings, and songwriting work.
+
+## Current links to education and activities
+- Practice empty state links to `/education` for starter lessons.
+- Unlock routes exist in the catalogue metadata, but they are not consistently presented as player-facing training routes.
+- Activity scheduling restrictions are queried for practice, but no concise upcoming activity context is shown on the overview.
+
+## Current role and band context
+- Canonical role links exist for skill relevance, but the page does not yet use them as an initial progression lens.
+- Band membership and privacy-aware bandmate coverage need to remain backend-authoritative; the page should not expose private skill data.
+
+## Current performance problems
+- Catalogue and availability are already batched/cached through React Query, which is good.
+- Filtering, recommendation scoring, and relationship joins should be memoised to avoid recalculating on every render.
+- The skill tree should not be rendered until its tab is selected.
+
+## Current analytics or telemetry
+- No obvious structured Skills page telemetry is emitted from the current page.
+- Useful events include page opened, focus selected, recommendation viewed/actioned, search/filter usage, detail opens, favourites, practice starts, and planner goal selection.
+
+## Follow-up progression experience work
+- Replace placeholder client-side effect copy with richer server-authoritative batched preview payloads where APIs expose them.
+- Add privacy-aware band coverage once member visibility rules expose summarized role coverage.
+- Expand recent progression history from a bounded ledger if/when the backend ledger is available.
+- Consider a dedicated mobile filter drawer if the catalogue grows beyond the current responsive grid.

--- a/src/components/attributes/AttributeCard.tsx
+++ b/src/components/attributes/AttributeCard.tsx
@@ -71,7 +71,17 @@ export const AttributeCard = ({
           <span className="text-xs text-muted-foreground">{currentValue}</span>
         </div>
 
-        <Progress value={progress} className="h-1.5" />
+        <Progress value={progress} className="h-1.5" aria-label={`${label} attribute value ${currentValue} of ${ATTRIBUTE_MAX_VALUE}`} />
+
+        <div className="rounded-md bg-muted/50 p-2 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">Current effects</p>
+          <p>{affectedSystems.length ? affectedSystems.join(", ") : "General progression"}</p>
+          <p className="mt-1">Upgrade preview: {currentValue} → {Math.min(ATTRIBUTE_MAX_VALUE, currentValue + cost)} for {cost} AP. Estimated contribution only; outcomes are not guaranteed.</p>
+        </div>
+
+        {!canAfford && !isMaxed && (
+          <p className="text-xs text-muted-foreground" role="status">You need more Attribute Points for this upgrade.</p>
+        )}
 
         <Button 
           aria-label={`Train ${label} for ${cost} AP`}

--- a/src/pages/SkillsPage.tsx
+++ b/src/pages/SkillsPage.tsx
@@ -1,10 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SkillTree } from "@/components/SkillTree";
 import { useGameData } from "@/hooks/useGameData";
@@ -12,20 +6,10 @@ import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  TrendingUp,
-  Target,
-  Award,
-  Zap,
-  Calendar,
-  AlertCircle,
-  Dumbbell,
-  GitBranch,
-  Gauge,
-  Sparkles,
-} from "lucide-react";
+import { TrendingUp, Target, Award, Zap, Calendar, AlertCircle, Dumbbell, GitBranch, Gauge, Sparkles, Search, Star, RotateCcw, ListChecks, Users, Activity } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { useSkillPracticeRestrictions } from "@/hooks/useSkillPractice";
 import { SchedulePracticeDialog } from "@/components/skills/SchedulePracticeDialog";
@@ -35,428 +19,107 @@ import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { AttributePanel } from "@/components/attributes/AttributePanel";
 import { useTranslation } from "@/hooks/useTranslation";
 import { usePlayerAttributesQuery } from "@/hooks/usePlayerAttributesQuery";
-import {
-  calculateSkillOverviewStats,
-  getSkillDisplayProgress,
-  SKILL_PRACTICE_CONFIG,
-} from "@/utils/skillProgressDisplay";
-import {
-  useSkillCatalogue,
-  useProfileSkillAvailability,
-  useSkillCatalogueRelationships,
-} from "@/hooks/useSkillCatalogue";
-import {
-  getAttributeLabel,
-  calculateWeightedLearningMultiplier,
-} from "@/utils/skillCatalogue";
+import { calculateSkillOverviewStats, SKILL_PRACTICE_CONFIG } from "@/utils/skillProgressDisplay";
+import { useSkillCatalogue, useProfileSkillAvailability, useSkillCatalogueRelationships } from "@/hooks/useSkillCatalogue";
+import { getAttributeLabel, calculateWeightedLearningMultiplier, SKILL_ROLE_KEYS, SKILL_SYSTEM_KEYS, type SkillRoleKey } from "@/utils/skillCatalogue";
+import { buildRecommendations, buildSkillDashboardRows, filterAndSortSkillRows, summarizeRoleReadiness, type LockFilter, type SkillSortKey } from "@/utils/skillsProgressionDashboard";
 
-const formatReset = (value?: string | null) =>
-  value ? new Date(value).toLocaleString() : "the next daily reset";
+const formatReset = (value?: string | null) => value ? new Date(value).toLocaleString() : "the next daily reset";
+const roleLabel = (role: string) => role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()).replace("Dj", "DJ");
+const systemLabel = (system: string) => ({ live_gig: "Gigs", social_media: "Social" }[system] ?? roleLabel(system));
+const trackEvent = (name: string, payload: Record<string, unknown> = {}) => window.dispatchEvent(new CustomEvent("progression:telemetry", { detail: { name, ...payload } }));
 
 const SkillsPage = () => {
   const { t } = useTranslation();
   const { profileId } = useActiveProfile();
-  const {
-    skillProgress,
-    loading,
-    error,
-    xpWallet,
-    profile,
-    dailyXpGrant,
-    refetch,
-  } = useGameData();
-  const [selectedSkill, setSelectedSkill] = useState<{
-    slug: string;
-    name: string;
-  } | null>(null);
+  const { skillProgress, loading, error, xpWallet, profile, dailyXpGrant, refetch } = useGameData();
+  const [params, setParams] = useSearchParams();
+  const [selectedSkill, setSelectedSkill] = useState<{ slug: string; name: string } | null>(null);
+  const [detailsSlug, setDetailsSlug] = useState(params.get("skill") ?? "");
+  const [compare, setCompare] = useState<string[]>([]);
+  const [favourites, setFavourites] = useState<string[]>(() => JSON.parse(sessionStorage.getItem(`skill-favourites:${profileId ?? "anon"}`) ?? "[]"));
+  const [activeTab, setActiveTab] = useState(params.get("tab") ?? "overview");
+  const [selectedRole, setSelectedRole] = useState<SkillRoleKey | "all">((params.get("role") as SkillRoleKey) || "all");
+  const [search, setSearch] = useState(params.get("q") ?? "");
+  const [category, setCategory] = useState(params.get("category") ?? "all");
+  const [subcategory, setSubcategory] = useState(params.get("subcategory") ?? "all");
+  const [system, setSystem] = useState(params.get("system") ?? "all");
+  const [lock, setLock] = useState<LockFilter>((params.get("state") as LockFilter) || "all");
+  const [sort, setSort] = useState<SkillSortKey>((params.get("sort") as SkillSortKey) || "recommended");
+  const [plannerGoal, setPlannerGoal] = useState<SkillRoleKey | "all">((params.get("goal") as SkillRoleKey) || "lead_guitarist");
+
   const attributesQuery = usePlayerAttributesQuery(profile?.id ?? profileId);
-  const restrictionsQuery = useSkillPracticeRestrictions(
-    profileId ?? undefined,
-  );
+  const restrictionsQuery = useSkillPracticeRestrictions(profileId ?? undefined);
   const restrictions = restrictionsQuery.data;
   const catalogueQuery = useSkillCatalogue();
-  const availabilityQuery = useProfileSkillAvailability(
-    profile?.id ?? profileId,
-  );
+  const availabilityQuery = useProfileSkillAvailability(profile?.id ?? profileId);
   const relationships = useSkillCatalogueRelationships();
-
   const skillXpBalance = xpWallet?.skill_xp_balance ?? xpWallet?.xp_balance;
-  const skillXpLifetime = xpWallet?.skill_xp_lifetime ?? xpWallet?.lifetime_xp;
   const attributePointsBalance = xpWallet?.attribute_points_balance;
   const attributePointsSpent = attributesQuery.data?.attribute_points_spent;
-  const streak = xpWallet?.stipend_claim_streak ?? 0;
-  const lastClaimDate =
-    xpWallet?.last_stipend_claim_date ?? dailyXpGrant?.created_at;
+  const stats = useMemo(() => calculateSkillOverviewStats(skillProgress ?? []), [skillProgress]);
 
-  const stats = useMemo(
-    () => calculateSkillOverviewStats(skillProgress ?? []),
-    [skillProgress],
-  );
-  const xpCardLabel =
-    stats.lifetimeXp === null ? "Current Level XP" : "Lifetime Skill XP";
-  const xpCardValue = stats.lifetimeXp ?? stats.currentLevelXp;
-  const catalogueBySlug = useMemo(
-    () =>
-      new Map((catalogueQuery.data ?? []).map((skill) => [skill.slug, skill])),
-    [catalogueQuery.data],
-  );
-  const availabilityBySlug = useMemo(
-    () =>
-      new Map((availabilityQuery.data ?? []).map((item) => [item.slug, item])),
-    [availabilityQuery.data],
-  );
-  const practiceableSkills = useMemo(
-    () =>
-      (skillProgress ?? []).filter(
-        (skill) => getSkillDisplayProgress(skill).can_practice,
-      ),
-    [skillProgress],
-  );
+  useEffect(() => { trackEvent("skills_page_opened"); }, []);
+  useEffect(() => {
+    const next = new URLSearchParams();
+    if (activeTab !== "overview") next.set("tab", activeTab);
+    if (selectedRole !== "all") next.set("role", selectedRole);
+    if (search) next.set("q", search);
+    if (category !== "all") next.set("category", category);
+    if (subcategory !== "all") next.set("subcategory", subcategory);
+    if (system !== "all") next.set("system", system);
+    if (lock !== "all") next.set("state", lock);
+    if (sort !== "recommended") next.set("sort", sort);
+    if (detailsSlug) next.set("skill", detailsSlug);
+    setParams(next, { replace: true });
+  }, [activeTab, selectedRole, search, category, subcategory, system, lock, sort, detailsSlug, setParams]);
+  useEffect(() => { sessionStorage.setItem(`skill-favourites:${profileId ?? "anon"}`, JSON.stringify(favourites)); }, [favourites, profileId]);
 
-  const refreshProgressionData = async () => {
-    await Promise.all([attributesQuery.refetch(), refetch()]);
-  };
-
-  const retryAll = () => {
-    refetch();
-    attributesQuery.refetch();
-    restrictionsQuery.refetch();
-  };
-
+  const rows = useMemo(() => buildSkillDashboardRows({ catalogue: catalogueQuery.data ?? [], progress: (skillProgress ?? []) as any[], availability: availabilityQuery.data ?? [], ...relationships, favourites, selectedRole }), [catalogueQuery.data, skillProgress, availabilityQuery.data, relationships, favourites, selectedRole]);
+  const filteredRows = useMemo(() => filterAndSortSkillRows(rows, { search, category, subcategory, role: selectedRole, system, lock, sort }), [rows, search, category, subcategory, selectedRole, system, lock, sort]);
+  const readiness = useMemo(() => selectedRole === "all" ? null : summarizeRoleReadiness(selectedRole, rows), [selectedRole, rows]);
+  const recommendations = useMemo(() => buildRecommendations(rows, selectedRole), [rows, selectedRole]);
+  const detail = rows.find((row) => row.catalogue.slug === detailsSlug);
+  const categories = Array.from(new Set(rows.map((r) => r.catalogue.category))).sort();
+  const subcategories = Array.from(new Set(rows.map((r) => r.catalogue.subcategory).filter(Boolean) as string[])).sort();
+  const highest = rows.filter((r) => r.progress.is_unlocked).sort((a, b) => b.progress.current_level - a.progress.current_level).slice(0, 4);
+  const closest = rows.filter((r) => r.progress.is_unlocked && !r.progress.is_max_level).sort((a, b) => b.progress.progress_percent - a.progress.progress_percent).slice(0, 4);
+  const refreshProgressionData = async () => { await Promise.all([attributesQuery.refetch(), refetch(), availabilityQuery.refetch()]); };
+  const resetFilters = () => { setSearch(""); setCategory("all"); setSubcategory("all"); setSystem("all"); setLock("all"); setSort("recommended"); trackEvent("skills_filters_reset"); };
+  const toggleFavourite = (slug: string) => setFavourites((current) => current.includes(slug) ? current.filter((s) => s !== slug) : current.length >= 5 ? current : [...current, slug]);
   const tabs = [
-    {
-      value: "practice",
-      icon: Dumbbell,
-      label: t("skills.tabs.practice", "Practice Skills"),
-      desc: `Book ${SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour sessions (+${SKILL_PRACTICE_CONFIG.baseXpReward} XP)`,
-    },
-    {
-      value: "tree",
-      icon: GitBranch,
-      label: t("skills.tabs.tree", "Skill Tree"),
-      desc: t("skills.tabs.treeDesc", "Unlock and level up abilities"),
-    },
-    {
-      value: "attributes",
-      icon: Gauge,
-      label: t("skills.tabs.attributes", "Attributes"),
-      desc: t("skills.tabs.attributesDesc", "Spend AP on core stats"),
-    },
-  ];
+    ["overview", Sparkles, t("skills.tabs.overview", "Overview"), t("skills.tabs.overviewDesc", "Plan your next progression move")],
+    ["skills", ListChecks, t("skills.tabs.skills", "Skills"), t("skills.tabs.skillsDesc", "Search, filter and inspect skills")],
+    ["tree", GitBranch, t("skills.tabs.tree", "Skill Tree"), t("skills.tabs.treeDesc", "Unlock and level up abilities")],
+    ["attributes", Gauge, t("skills.tabs.attributes", "Attributes"), t("skills.tabs.attributesDesc", "Spend AP on core stats")],
+    ["practice", Dumbbell, t("skills.tabs.practice", "Practice"), `Book ${SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour sessions`],
+  ] as const;
 
-  return (
-    <FMPageScaffold
-      title={t("skills.title", "Skills & Attributes")}
-      subtitle={t(
-        "skills.subtitle",
-        "Master your craft and unlock new abilities",
-      )}
-      icon={Sparkles}
-      backTo="/hub/character"
-    >
-      {(error || attributesQuery.error || restrictionsQuery.error) && (
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription className="flex items-center justify-between gap-3">
-            <span>
-              {t(
-                "skills.errors.loadFailed",
-                "Some progression data failed to load. Values are not being replaced with zero.",
-              )}
-            </span>
-            <Button size="sm" variant="outline" onClick={retryAll}>
-              {t("common.retry", "Retry")}
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
+  const SkillCard = ({ row }: { row: typeof rows[number] }) => {
+    const learningBonus = calculateWeightedLearningMultiplier(row.catalogue.slug, attributesQuery.data as any, row.attributeLinks);
+    return <Card className="overflow-hidden"><CardHeader><div className="flex items-start justify-between gap-2"><div><CardTitle className="text-base">{row.catalogue.name}</CardTitle><CardDescription>{row.catalogue.category}{row.catalogue.subcategory ? ` • ${row.catalogue.subcategory}` : ""}</CardDescription></div><Button variant="ghost" size="sm" aria-label={`${row.isFavourite ? "Untrack" : "Track"} ${row.catalogue.name}`} disabled={!row.progress.is_unlocked && row.availability?.status === "hidden"} onClick={() => { toggleFavourite(row.catalogue.slug); trackEvent("skill_favourited", { skill: row.catalogue.slug }); }}><Star className={cn("h-4 w-4", row.isFavourite && "fill-yellow-400 text-yellow-500")} /></Button></div></CardHeader><CardContent className="space-y-3"><div className="flex flex-wrap gap-2"><Badge>Level {row.progress.current_level}/{row.catalogue.max_level}</Badge><Badge variant="outline">{row.availability?.status?.replace(/_/g, " ") ?? (row.progress.is_unlocked ? "unlocked" : "locked")}</Badge>{row.roleLinks.slice(0,2).map((r) => <Badge key={r.role_key} variant="secondary">{roleLabel(r.role_key)}</Badge>)}</div><Progress value={row.progress.progress_percent} aria-label={`${row.catalogue.name} progress ${Math.round(row.progress.progress_percent)} percent`} /><p className="text-sm text-muted-foreground">{row.progress.xp_into_level}/{row.progress.xp_required_for_next_level ?? "Max"} XP to next level • learning bonus +{learningBonus.boostPercent}%</p><p className="text-sm">Systems: {row.systemLinks.map((s) => systemLabel(s.system_key)).slice(0, 4).join(", ") || "General progression"}</p>{row.availability?.blockedReason && <p className="text-sm text-destructive" role="status">Locked: {row.availability.blockedReason.message}</p>}<div className="flex flex-wrap gap-2"><Button size="sm" variant="outline" onClick={() => { setDetailsSlug(row.catalogue.slug); trackEvent("skill_details_opened", { skill: row.catalogue.slug }); }}>Details</Button><Button size="sm" variant="outline" disabled={!row.progress.can_practice || !restrictions?.canPractice} onClick={() => { setSelectedSkill({ slug: row.catalogue.slug, name: row.catalogue.name }); trackEvent("practice_started_from_recommendation", { skill: row.catalogue.slug }); }}><Calendar className="mr-2 h-4 w-4" />Practice</Button><Button size="sm" variant="ghost" disabled={compare.length >= 3 && !compare.includes(row.catalogue.slug)} onClick={() => setCompare((c) => c.includes(row.catalogue.slug) ? c.filter((s) => s !== row.catalogue.slug) : [...c, row.catalogue.slug])}>Compare</Button></div></CardContent></Card>;
+  };
 
-      {loading || !xpWallet ? (
-        <Card>
-          <CardContent className="pt-6">
-            {loading
-              ? t("skills.loading.wallet", "Loading XP wallet…")
-              : t("skills.empty.wallet", "XP wallet row is missing.")}
-          </CardContent>
-        </Card>
-      ) : (
-        <XpWalletDisplay
-          skillXpBalance={skillXpBalance ?? 0}
-          skillXpLifetime={skillXpLifetime ?? 0}
-          attributePointsBalance={attributePointsBalance ?? 0}
-          attributePointsSpent={attributePointsSpent ?? 0}
-          streak={streak}
-        />
-      )}
+  return <FMPageScaffold title={t("skills.title", "Skills & Attributes")} subtitle={t("skills.subtitle", "Master your craft and unlock new abilities")} icon={Sparkles} backTo="/hub/character">
+    {(error || attributesQuery.error || restrictionsQuery.error || catalogueQuery.error || availabilityQuery.error) && <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription className="flex items-center justify-between gap-3"><span>{t("skills.errors.loadFailed", "Some progression data failed to load. Values are not being replaced with zero.")}</span><Button size="sm" variant="outline" onClick={() => { refetch(); attributesQuery.refetch(); restrictionsQuery.refetch(); catalogueQuery.refetch(); availabilityQuery.refetch(); }}>{t("common.retry", "Retry")}</Button></AlertDescription></Alert>}
+    {loading || !xpWallet ? <Card><CardContent className="pt-6">{loading ? t("skills.loading.wallet", "Loading XP wallet…") : t("skills.empty.wallet", "XP wallet row is missing.")}</CardContent></Card> : <XpWalletDisplay skillXpBalance={skillXpBalance ?? 0} skillXpLifetime={xpWallet?.skill_xp_lifetime ?? xpWallet?.lifetime_xp ?? 0} attributePointsBalance={attributePointsBalance ?? 0} attributePointsSpent={attributePointsSpent ?? 0} streak={xpWallet?.stipend_claim_streak ?? 0} />}
+    <DailyStipendCard lastClaimDate={xpWallet?.last_stipend_claim_date ?? dailyXpGrant?.created_at} streak={xpWallet?.stipend_claim_streak ?? 0} />
+    {restrictionsQuery.isLoading ? <Alert><Target className="h-4 w-4" /><AlertDescription>{t("skills.loading.practice", "Checking practice availability…")}</AlertDescription></Alert> : restrictions && <Alert variant={restrictions.canPractice ? "default" : "destructive"}><Target className="h-4 w-4" /><AlertDescription>{restrictions.canPractice ? `Practice sessions today: ${restrictions.sessionsUsed}/${restrictions.maxDailySessions} — ${restrictions.sessionsRemaining} remaining.` : restrictions.reason} Next reset: {formatReset(restrictions.nextResetAt)}</AlertDescription></Alert>}
 
-      <DailyStipendCard lastClaimDate={lastClaimDate} streak={streak} />
+    <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full"><TabsList className="grid w-full grid-cols-2 gap-2 bg-transparent p-0 h-auto md:grid-cols-5">{tabs.map(([value, Icon, label, desc]) => <TabsTrigger key={value} value={value} aria-label={label} className={cn("flex min-h-20 flex-col items-start gap-1 rounded-lg border bg-card p-3 text-left", "data-[state=active]:border-primary data-[state=active]:bg-primary/10")}><div className="flex items-center gap-2"><Icon className="h-4 w-4 text-primary" /><span className="font-semibold">{label}</span></div><span className="text-xs text-muted-foreground">{desc}</span></TabsTrigger>)}</TabsList>
 
-      {restrictionsQuery.isLoading && (
-        <Alert>
-          <Target className="h-4 w-4" />
-          <AlertDescription>
-            {t("skills.loading.practice", "Checking practice availability…")}
-          </AlertDescription>
-        </Alert>
-      )}
-      {restrictions && !restrictions.canPractice && (
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription>
-            {restrictions.reason} Next reset:{" "}
-            {formatReset(restrictions.nextResetAt)}
-          </AlertDescription>
-        </Alert>
-      )}
-      {restrictions?.canPractice && (
-        <Alert>
-          <Target className="h-4 w-4" />
-          <AlertDescription>
-            Practice sessions today: {restrictions.sessionsUsed}/
-            {restrictions.maxDailySessions} — {restrictions.sessionsRemaining}{" "}
-            remaining. Next reset: {formatReset(restrictions.nextResetAt)}
-          </AlertDescription>
-        </Alert>
-      )}
+      <TabsContent value="overview" className="mt-6 space-y-6"><div className="grid gap-4 md:grid-cols-4">{[{label:"Skill XP", value: skillXpBalance?.toLocaleString() ?? "—", icon:TrendingUp},{label:"Attribute Points", value: attributePointsBalance?.toLocaleString() ?? "—", icon:Zap},{label:"Skills Unlocked", value:stats.unlockedCount, icon:Target},{label:"Average Level", value:stats.averageLevel.toFixed(1), icon:Award}].map(({label,value,icon:Icon}) => <Card key={label}><CardHeader className="flex flex-row items-center justify-between pb-2"><CardTitle className="text-sm font-medium">{label}</CardTitle><Icon className="h-4 w-4 text-muted-foreground" /></CardHeader><CardContent><div className="text-2xl font-bold">{value}</div></CardContent></Card>)}</div><Card><CardHeader><CardTitle>Development focus</CardTitle><CardDescription>Choose a temporary focus for role guidance. This does not create permanent role data.</CardDescription></CardHeader><CardContent><select aria-label="Development focus" className="w-full rounded-md border bg-background p-2 md:w-80" value={selectedRole} onChange={(e) => { setSelectedRole(e.target.value as SkillRoleKey | "all"); trackEvent("role_focus_selected", { role: e.target.value }); }}><option value="all">No role focus</option>{SKILL_ROLE_KEYS.map((r) => <option key={r} value={r}>{roleLabel(r)}</option>)}</select></CardContent></Card>{readiness && <Card><CardHeader><CardTitle>{roleLabel(readiness.role)} readiness: {readiness.band}</CardTitle><CardDescription>{readiness.score}% based on canonical role-to-skill mappings.</CardDescription></CardHeader><CardContent className="grid gap-4 md:grid-cols-3"><div><h3 className="font-semibold">Strengths</h3>{readiness.strengths.length ? readiness.strengths.map((r) => <p key={r.catalogue.slug} className="text-sm">{r.catalogue.name} L{r.progress.current_level}</p>) : <p className="text-sm text-muted-foreground">No role strengths yet. Start with a foundation skill.</p>}</div><div><h3 className="font-semibold">Important gaps</h3>{readiness.gaps.map((r) => <p key={r.catalogue.slug} className="text-sm">{r.catalogue.name}: target +{r.gap} levels</p>)}</div><div><h3 className="font-semibold">Expected impact</h3><p className="text-sm">Supports {readiness.impact.join(", ") || "general progression"}; useful attributes include {readiness.usefulAttributes.map(getAttributeLabel).join(", ") || "core attributes"}.</p></div></CardContent></Card>}<div className="grid gap-4 lg:grid-cols-3"><Card><CardHeader><CardTitle>Recommended next actions</CardTitle></CardHeader><CardContent className="space-y-3">{recommendations.length ? recommendations.map((rec) => <div key={rec.id} className="rounded-md border p-3"><p className="font-medium">{rec.title}</p><p className="text-sm text-muted-foreground">{rec.reason}</p></div>) : <p className="text-sm text-muted-foreground">No recommendations are available. Try selecting a development focus.</p>}</CardContent></Card><Card><CardHeader><CardTitle>Highest skills</CardTitle></CardHeader><CardContent>{highest.length ? highest.map((r) => <p key={r.catalogue.slug} className="text-sm">{r.catalogue.name}: level {r.progress.current_level}</p>) : <p className="text-sm text-muted-foreground">Unlock your first starter skill through education.</p>}</CardContent></Card><Card><CardHeader><CardTitle>Closest level-ups</CardTitle></CardHeader><CardContent>{closest.length ? closest.map((r) => <p key={r.catalogue.slug} className="text-sm">{r.catalogue.name}: {Math.round(r.progress.progress_percent)}%</p>) : <p className="text-sm text-muted-foreground">No near-level skills yet.</p>}</CardContent></Card></div><div className="grid gap-4 lg:grid-cols-3"><Card><CardHeader><CardTitle>Progression planner</CardTitle><CardDescription>Estimates use current balances and normal activity assumptions, not exact dates.</CardDescription></CardHeader><CardContent className="space-y-3"><select aria-label="Progression goal" className="w-full rounded-md border bg-background p-2" value={plannerGoal} onChange={(e) => { setPlannerGoal(e.target.value as SkillRoleKey); trackEvent("progression_goal_selected", { goal: e.target.value }); }}>{SKILL_ROLE_KEYS.map((r) => <option key={r} value={r}>Become a competent {roleLabel(r)}</option>)}</select>{summarizeRoleReadiness(plannerGoal as SkillRoleKey, rows).gaps.slice(0,4).map((r, i) => <p key={r.catalogue.slug} className="text-sm">{i + 1}. Train {r.catalogue.name} toward level {r.progress.current_level + r.gap}. Routes: {r.unlockRoutes.map((u) => u.route_type.replace(/_/g," ")).join(", ") || "practice/education"}.</p>)}</CardContent></Card><Card><CardHeader><CardTitle><Users className="mr-2 inline h-4 w-4" />Band skill gaps</CardTitle></CardHeader><CardContent><p className="text-sm text-muted-foreground">Bandmate coverage is shown only when privacy-safe summaries are available. For now, your best contribution is improving current role gaps and non-duplicated specialist skills.</p></CardContent></Card><Card><CardHeader><CardTitle><Activity className="mr-2 inline h-4 w-4" />Recent progress & goals</CardTitle></CardHeader><CardContent><p className="text-sm">Long-term goals: first competent role, first advanced skill, first specialist unlock, five role-relevant skills at target level.</p><p className="mt-2 text-sm text-muted-foreground">Recent progression history will use the bounded ledger when available.</p></CardContent></Card></div></TabsContent>
 
-      <div className="grid gap-4 md:grid-cols-4">
-        {[
-          {
-            label: xpCardLabel,
-            value: xpCardValue.toLocaleString(),
-            icon: TrendingUp,
-          },
-          {
-            label: "Skills Unlocked",
-            value: stats.unlockedCount,
-            icon: Target,
-          },
-          {
-            label: "Average Level",
-            value: stats.averageLevel.toFixed(1),
-            icon: Award,
-          },
-          {
-            label: "Can Practice",
-            value: stats.practiceableCount,
-            icon: Zap,
-            note: `Meets level ${SKILL_PRACTICE_CONFIG.minimumSkillLevel}+ and server rules`,
-          },
-        ].map(({ label, value, icon: Icon, note }) => (
-          <Card key={label}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">{label}</CardTitle>
-              <Icon className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{value}</div>
-              {note && <p className="text-xs text-muted-foreground">{note}</p>}
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <TabsContent value="skills" className="mt-6 space-y-4"><Card><CardHeader><CardTitle>Skill catalogue</CardTitle><CardDescription>Search, filter, sort, track, compare, and open details without exposing hidden skills.</CardDescription></CardHeader><CardContent className="grid gap-3 md:grid-cols-4"><label className="md:col-span-2"><span className="text-sm font-medium">Search skills</span><div className="relative"><Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" /><input className="w-full rounded-md border bg-background py-2 pl-8 pr-2" value={search} onChange={(e) => { setSearch(e.target.value); trackEvent("skill_searched"); }} placeholder="Search by name, category, or description" /></div></label><label><span className="text-sm font-medium">Category</span><select className="w-full rounded-md border bg-background p-2" value={category} onChange={(e) => { setCategory(e.target.value); trackEvent("skill_filter_used", { filter:"category" }); }}><option value="all">All categories</option>{categories.map((c) => <option key={c} value={c}>{c}</option>)}</select></label><label><span className="text-sm font-medium">Subcategory</span><select className="w-full rounded-md border bg-background p-2" value={subcategory} onChange={(e) => setSubcategory(e.target.value)}><option value="all">All subcategories</option>{subcategories.map((c) => <option key={c} value={c}>{c}</option>)}</select></label><label><span className="text-sm font-medium">System</span><select className="w-full rounded-md border bg-background p-2" value={system} onChange={(e) => setSystem(e.target.value)}><option value="all">All systems</option>{SKILL_SYSTEM_KEYS.map((s) => <option key={s} value={s}>{systemLabel(s)}</option>)}</select></label><label><span className="text-sm font-medium">State</span><select className="w-full rounded-md border bg-background p-2" value={lock} onChange={(e) => setLock(e.target.value as LockFilter)}>{["all","unlocked","locked","trainable","available","favourite","maxed"].map((s) => <option key={s} value={s}>{roleLabel(s)}</option>)}</select></label><label><span className="text-sm font-medium">Sort</span><select className="w-full rounded-md border bg-background p-2" value={sort} onChange={(e) => setSort(e.target.value as SkillSortKey)}>{["recommended","level","closest","recent","alphabetical","role","system","unlock","lowestGap","highestGap"].map((s) => <option key={s} value={s}>{roleLabel(s)}</option>)}</select></label><Button className="self-end" variant="outline" onClick={resetFilters}><RotateCcw className="mr-2 h-4 w-4" />Reset</Button></CardContent></Card>{catalogueQuery.isLoading || loading ? <Card><CardContent className="pt-6">Loading skills without showing misleading zeroes…</CardContent></Card> : filteredRows.length ? <div className="grid gap-4 lg:grid-cols-2">{filteredRows.map((row) => <SkillCard key={row.catalogue.slug} row={row} />)}</div> : <Card><CardContent className="py-8 text-center"><p className="font-medium">No skills match these filters.</p><p className="text-sm text-muted-foreground">Reset filters or choose a broader role/system focus.</p><Button className="mt-3" onClick={resetFilters}>Reset filters</Button></CardContent></Card>}</TabsContent>
 
-      <Tabs defaultValue="practice" className="w-full">
-        <TabsList className="grid w-full grid-cols-3 h-auto gap-2 bg-transparent p-0">
-          {tabs.map(({ value, icon: Icon, label, desc }) => (
-            <TabsTrigger
-              key={value}
-              value={value}
-              aria-label={label}
-              className={cn(
-                "flex flex-col items-start gap-1 h-auto p-4 rounded-lg border border-border bg-card text-left",
-                "data-[state=active]:border-primary data-[state=active]:bg-primary/10 data-[state=active]:shadow-md",
-                "hover:border-primary/60 transition-colors",
-              )}
-            >
-              <div className="flex items-center gap-2 w-full">
-                <Icon className="h-5 w-5 text-primary" />
-                <span className="font-semibold text-base">{label}</span>
-              </div>
-              <span className="text-xs text-muted-foreground font-normal">
-                {desc}
-              </span>
-            </TabsTrigger>
-          ))}
-        </TabsList>
+      <TabsContent value="tree" className="mt-6">{loading ? <Card><CardContent className="pt-6">{t("skills.loading.skills", "Loading skills…")}</CardContent></Card> : <SkillTree />}</TabsContent>
+      <TabsContent value="attributes" className="mt-6">{attributesQuery.isLoading ? <Card><CardContent className="pt-6">{t("skills.loading.attributes", "Loading attributes…")}</CardContent></Card> : attributesQuery.data ? <AttributePanel attributes={attributesQuery.data} xpBalance={attributePointsBalance ?? 0} onXpSpent={refreshProgressionData} /> : <Card><CardContent className="pt-6">{t("skills.empty.attributes", "Attribute row is missing for this profile.")}</CardContent></Card>}</TabsContent>
+      <TabsContent value="practice" className="mt-6"><Card><CardHeader><CardTitle>Practice Skills</CardTitle><CardDescription>Compare valid practice options. Rewards and restrictions come from server-authoritative practice checks.</CardDescription></CardHeader><CardContent>{filteredRows.filter((r) => r.progress.can_practice).length === 0 ? <div className="py-8 text-center text-muted-foreground"><Target className="mx-auto mb-4 h-12 w-12 opacity-50" /><p>No skills available to practice yet.</p><Button asChild size="sm" className="mt-4"><a href="/education" onClick={() => trackEvent("education_route_opened")}>Find starter lessons</a></Button></div> : <div className="space-y-4">{filteredRows.filter((r) => r.progress.can_practice).map((row) => <SkillCard key={row.catalogue.slug} row={row} />)}</div>}</CardContent></Card></TabsContent>
+    </Tabs>
 
-        <TabsContent value="attributes" className="mt-6">
-          {attributesQuery.isLoading ? (
-            <Card>
-              <CardContent className="pt-6">
-                {t("skills.loading.attributes", "Loading attributes…")}
-              </CardContent>
-            </Card>
-          ) : attributesQuery.data ? (
-            <AttributePanel
-              attributes={attributesQuery.data}
-              xpBalance={attributePointsBalance ?? 0}
-              onXpSpent={refreshProgressionData}
-            />
-          ) : (
-            <Card>
-              <CardContent className="pt-6">
-                {t(
-                  "skills.empty.attributes",
-                  "Attribute row is missing for this profile.",
-                )}
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
-
-        <TabsContent value="tree" className="mt-6">
-          {loading ? (
-            <Card>
-              <CardContent className="pt-6">
-                {t("skills.loading.skills", "Loading skills…")}
-              </CardContent>
-            </Card>
-          ) : (
-            <SkillTree />
-          )}
-        </TabsContent>
-
-        <TabsContent value="practice" className="mt-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Practice Skills</CardTitle>
-              <CardDescription>
-                Schedule practice sessions using the shared practice
-                configuration:{" "}
-                {SKILL_PRACTICE_CONFIG.durationOptionsHours.join("/")}-hour
-                duration, {SKILL_PRACTICE_CONFIG.baseXpReward} XP reward,
-                maximum{" "}
-                {restrictions?.maxDailySessions ??
-                  SKILL_PRACTICE_CONFIG.maxDailySessions}{" "}
-                sessions per server day.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {loading ? (
-                <p>{t("skills.loading.skills", "Loading skills…")}</p>
-              ) : practiceableSkills.length === 0 ? (
-                <div className="text-center py-8 text-muted-foreground">
-                  <Target className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                  <p>No skills available to practice yet.</p>
-                  <p className="text-sm mt-2">
-                    Starter skills can be unlocked through education and
-                    supported practice or rehearsal activities.
-                  </p>
-                  <Button asChild size="sm" className="mt-4">
-                    <a href="/education">Find starter lessons</a>
-                  </Button>
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  {practiceableSkills.map((skill) => {
-                    const display = getSkillDisplayProgress(skill);
-                    const canonical = catalogueBySlug.get(skill.skill_slug);
-                    const name =
-                      canonical?.name ??
-                      `${skill.skill_slug.replace(/_/g, " ")} (legacy)`;
-                    const attrLinks = relationships.attributeLinks.filter(
-                      (link) => link.skill_slug === skill.skill_slug,
-                    );
-                    const availability = availabilityBySlug.get(
-                      skill.skill_slug,
-                    );
-                    const learningBonus = calculateWeightedLearningMultiplier(
-                      skill.skill_slug,
-                      attributesQuery.data as any,
-                      attrLinks,
-                    );
-                    const primaryRole = relationships.roleLinks
-                      .find((link) => link.skill_slug === skill.skill_slug)
-                      ?.role_key.replace(/_/g, " ");
-                    return (
-                      <div
-                        key={skill.skill_slug}
-                        className="border rounded-lg p-4"
-                      >
-                        <div className="flex items-center justify-between mb-3">
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2 mb-1">
-                              <h4 className="font-semibold capitalize">
-                                {name}
-                              </h4>
-                              <Badge variant="outline">
-                                Level {display.current_level}
-                              </Badge>
-                              {canonical && (
-                                <Badge variant="secondary">
-                                  {canonical.category}
-                                </Badge>
-                              )}
-                              {availability && (
-                                <Badge variant="outline">
-                                  {availability.status.replace(/_/g, " ")}
-                                </Badge>
-                              )}
-                            </div>
-                            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                              <span>
-                                {display.xp_into_level}/
-                                {display.xp_required_for_next_level ?? "Max"} XP
-                              </span>
-                              {attrLinks.length > 0 && (
-                                <span>
-                                  Attributes:{" "}
-                                  {attrLinks
-                                    .map(
-                                      (link) =>
-                                        `${getAttributeLabel(link.attribute_key)} ${Math.round(link.weight * 100)}%`,
-                                    )
-                                    .join(", ")}{" "}
-                                  (+{learningBonus.boostPercent}%)
-                                </span>
-                              )}
-                              {primaryRole && <span>Role: {primaryRole}</span>}
-                              {availability?.blockedReason && (
-                                <span className="text-destructive">
-                                  {availability.blockedReason.message}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            aria-label={`Schedule practice for ${name}`}
-                            disabled={!restrictions?.canPractice}
-                            onClick={() =>
-                              setSelectedSkill({ slug: skill.skill_slug, name })
-                            }
-                          >
-                            <Calendar className="mr-2 h-4 w-4" />
-                            Schedule Practice
-                          </Button>
-                        </div>
-                        <Progress
-                          value={display.progress_percent}
-                          className="h-2"
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
-
-      {selectedSkill && (
-        <SchedulePracticeDialog
-          open={!!selectedSkill}
-          onOpenChange={(open) => !open && setSelectedSkill(null)}
-          skillSlug={selectedSkill.slug}
-          skillName={selectedSkill.name}
-          practiceConfig={restrictions}
-        />
-      )}
-    </FMPageScaffold>
-  );
+    {detail && <Card className="border-primary"><CardHeader><CardTitle>{detail.catalogue.name} details</CardTitle><CardDescription>{detail.catalogue.description}</CardDescription></CardHeader><CardContent className="grid gap-4 md:grid-cols-2"><div><p>Tier: {detail.catalogue.tier} • Max level {detail.catalogue.max_level}</p><p>XP: {detail.progress.xp_into_level}/{detail.progress.xp_required_for_next_level ?? "Max"}</p><p>Prerequisites: {detail.prerequisites.length ? detail.prerequisites.map((p) => `${p.prerequisite_skill_slug} L${p.required_level}`).join(", ") : "All prerequisites completed or none required."}</p><p>Unlock routes: {detail.unlockRoutes.map((u) => u.route_type.replace(/_/g, " ")).join(", ") || "No public route listed."}</p></div><div><p>Relevant roles: {detail.roleLinks.map((r) => roleLabel(r.role_key)).join(", ") || "Generalist"}</p><p>Attributes: {detail.attributeLinks.map((a) => getAttributeLabel(a.attribute_key)).join(", ") || "None listed"}</p><p>Current effects: {detail.systemLinks.map((s) => `${s.usage_type} ${systemLabel(s.system_key)}`).join("; ") || "No implemented gameplay preview exposed."}</p><Button className="mt-2" variant="outline" onClick={() => setDetailsSlug("")}>Close details</Button></div></CardContent></Card>}
+    {compare.length > 0 && <Card><CardHeader><CardTitle>Comparison ({compare.length}/3)</CardTitle></CardHeader><CardContent className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th className="text-left">Item</th><th>Level</th><th>Role gap</th><th>Systems</th><th>Training</th></tr></thead><tbody>{rows.filter((r) => compare.includes(r.catalogue.slug)).map((r) => <tr key={r.catalogue.slug}><td>{r.catalogue.name}</td><td className="text-center">{r.progress.current_level}</td><td className="text-center">{r.gap}</td><td>{r.systemLinks.map((s) => systemLabel(s.system_key)).slice(0,2).join(", ")}</td><td>{r.progress.can_practice ? "Practiceable" : r.availability?.status?.replace(/_/g," ")}</td></tr>)}</tbody></table></CardContent></Card>}
+    {selectedSkill && <SchedulePracticeDialog open={!!selectedSkill} onOpenChange={(open) => !open && setSelectedSkill(null)} skillSlug={selectedSkill.slug} skillName={selectedSkill.name} practiceConfig={restrictions} />}
+  </FMPageScaffold>;
 };
-
 export default SkillsPage;

--- a/src/utils/__tests__/skillsProgressionDashboard.test.ts
+++ b/src/utils/__tests__/skillsProgressionDashboard.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { CANONICAL_ATTRIBUTE_LINKS, CANONICAL_PREREQUISITES, CANONICAL_ROLE_LINKS, CANONICAL_SKILLS, CANONICAL_SYSTEM_LINKS, CANONICAL_UNLOCK_ROUTES } from "../skillCatalogue";
+import { buildRecommendations, buildSkillDashboardRows, filterAndSortSkillRows, summarizeRoleReadiness } from "../skillsProgressionDashboard";
+
+const rows = () => buildSkillDashboardRows({
+  catalogue: CANONICAL_SKILLS,
+  progress: [
+    { skill_slug: "guitar", current_level: 3, xp_into_level: 90, xp_required_for_next_level: 100, is_unlocked: true },
+    { skill_slug: "vocals", current_level: 1, xp_into_level: 10, xp_required_for_next_level: 100, is_unlocked: true },
+    { skill_slug: "performance", current_level: 0, xp_into_level: 0, xp_required_for_next_level: 100, is_unlocked: false },
+  ],
+  availability: [
+    { slug: "guitar", status: "unlocked" },
+    { slug: "vocals", status: "unlocked" },
+    { slug: "performance", status: "available_to_unlock" },
+    { slug: "hidden_test", status: "hidden" },
+  ],
+  roleLinks: CANONICAL_ROLE_LINKS,
+  systemLinks: CANONICAL_SYSTEM_LINKS,
+  attributeLinks: CANONICAL_ATTRIBUTE_LINKS,
+  prerequisites: CANONICAL_PREREQUISITES,
+  unlockRoutes: CANONICAL_UNLOCK_ROUTES,
+  favourites: ["guitar"],
+  selectedRole: "lead_guitarist",
+});
+
+describe("skills progression dashboard", () => {
+  it("builds role readiness from canonical mappings and exposes gaps", () => {
+    const readiness = summarizeRoleReadiness("lead_guitarist", rows());
+    expect(readiness.role).toBe("lead_guitarist");
+    expect(readiness.band).toMatch(/Beginner|Developing|Competent|Strong|Advanced|Elite/);
+    expect(readiness.gaps.some((gap) => gap.roleLinks.some((link) => link.role_key === "lead_guitarist"))).toBe(true);
+  });
+
+  it("filters text, role, state and favourites together", () => {
+    const filtered = filterAndSortSkillRows(rows(), { search: "guitar", role: "lead_guitarist", lock: "favourite", sort: "alphabetical" });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].catalogue.slug).toBe("guitar");
+  });
+
+  it("prioritises nearly completed relevant skills deterministically", () => {
+    const recs = buildRecommendations(rows(), "lead_guitarist", 3);
+    expect(recs[0].title).toContain("Guitar");
+    expect(recs[0].reason).toContain("Estimated contributions");
+    expect(recs.map((r) => r.id)).toEqual(buildRecommendations(rows(), "lead_guitarist", 3).map((r) => r.id));
+  });
+
+  it("excludes inactive and hidden catalogue rows", () => {
+    const built = rows();
+    expect(built.every((row) => row.catalogue.is_active && !row.catalogue.is_hidden)).toBe(true);
+  });
+});

--- a/src/utils/skillsProgressionDashboard.ts
+++ b/src/utils/skillsProgressionDashboard.ts
@@ -1,0 +1,177 @@
+import type { CanonicalSkill, SkillAttributeLink, SkillAvailability, SkillPrerequisite, SkillRoleKey, SkillRoleLink, SkillSystemLink, SkillUnlockRoute } from "./skillCatalogue";
+import type { SkillDisplayProgress } from "./skillProgressDisplay";
+import { getSkillDisplayProgress } from "./skillProgressDisplay";
+
+export type ReadinessBand = "Beginner" | "Developing" | "Competent" | "Strong" | "Advanced" | "Elite";
+export type SkillSortKey = "recommended" | "level" | "closest" | "recent" | "alphabetical" | "role" | "system" | "unlock" | "lowestGap" | "highestGap";
+export type LockFilter = "all" | "unlocked" | "locked" | "trainable" | "available" | "favourite" | "maxed";
+
+export interface SkillDashboardRow {
+  catalogue: CanonicalSkill;
+  progress: SkillDisplayProgress;
+  availability?: SkillAvailability;
+  roleLinks: SkillRoleLink[];
+  systemLinks: SkillSystemLink[];
+  attributeLinks: SkillAttributeLink[];
+  prerequisites: SkillPrerequisite[];
+  unlockRoutes: SkillUnlockRoute[];
+  isFavourite: boolean;
+  roleScore: number;
+  recommendationScore: number;
+  gap: number;
+}
+
+export interface SkillFilters {
+  search?: string;
+  category?: string;
+  subcategory?: string;
+  role?: SkillRoleKey | "all";
+  system?: string;
+  lock?: LockFilter;
+  sort?: SkillSortKey;
+}
+
+export interface RoleReadinessSummary {
+  role: SkillRoleKey;
+  score: number;
+  band: ReadinessBand;
+  foundationSkills: SkillDashboardRow[];
+  specialistSkills: SkillDashboardRow[];
+  strengths: SkillDashboardRow[];
+  gaps: SkillDashboardRow[];
+  blocked: SkillDashboardRow[];
+  usefulAttributes: string[];
+  impact: string[];
+}
+
+const bandForScore = (score: number): ReadinessBand => {
+  if (score >= 85) return "Elite";
+  if (score >= 70) return "Advanced";
+  if (score >= 55) return "Strong";
+  if (score >= 35) return "Competent";
+  if (score >= 15) return "Developing";
+  return "Beginner";
+};
+
+const stable = (a: SkillDashboardRow, b: SkillDashboardRow) => a.catalogue.display_order - b.catalogue.display_order || a.catalogue.name.localeCompare(b.catalogue.name);
+
+export function buildSkillDashboardRows(args: {
+  catalogue: CanonicalSkill[];
+  progress: Array<Record<string, unknown>>;
+  availability: SkillAvailability[];
+  roleLinks: SkillRoleLink[];
+  systemLinks: SkillSystemLink[];
+  attributeLinks: SkillAttributeLink[];
+  prerequisites: SkillPrerequisite[];
+  unlockRoutes: SkillUnlockRoute[];
+  favourites?: string[];
+  selectedRole?: SkillRoleKey | "all" | null;
+}): SkillDashboardRow[] {
+  const progressBySlug = new Map(args.progress.map((p) => [String(p.skill_slug ?? p.slug), getSkillDisplayProgress(p)]));
+  const availabilityBySlug = new Map(args.availability.map((a) => [a.slug, a]));
+  const favourites = new Set(args.favourites ?? []);
+  return args.catalogue
+    .filter((skill) => skill.is_active && !skill.is_hidden)
+    .map((skill) => {
+      const progress = progressBySlug.get(skill.slug) ?? getSkillDisplayProgress({ current_level: 0, xp_into_level: 0, xp_required_for_next_level: 100, is_unlocked: false });
+      const roleLinks = args.roleLinks.filter((l) => l.skill_slug === skill.slug);
+      const selectedRoleLink = args.selectedRole && args.selectedRole !== "all" ? roleLinks.find((l) => l.role_key === args.selectedRole) : undefined;
+      const roleScore = selectedRoleLink ? selectedRoleLink.weight * (selectedRoleLink.relevance === "primary" ? 3 : selectedRoleLink.relevance === "secondary" ? 2 : 1) : Math.max(0, ...roleLinks.map((l) => l.weight));
+      const target = selectedRoleLink?.minimum_recommended_level ?? (skill.is_foundational ? 3 : 1);
+      const gap = Math.max(0, target - progress.current_level);
+      const availability = availabilityBySlug.get(skill.slug);
+      const closeBonus = progress.xp_required_for_next_level ? progress.progress_percent / 20 : 0;
+      const unlockBonus = availability?.status === "available_to_unlock" ? 8 : 0;
+      const recommendationScore = roleScore * 10 + gap * 4 + closeBonus + unlockBonus + (progress.can_practice ? 3 : 0);
+      return {
+        catalogue: skill,
+        progress,
+        availability,
+        roleLinks,
+        systemLinks: args.systemLinks.filter((l) => l.skill_slug === skill.slug),
+        attributeLinks: args.attributeLinks.filter((l) => l.skill_slug === skill.slug),
+        prerequisites: args.prerequisites.filter((p) => p.skill_slug === skill.slug && p.prerequisite_type !== "hidden_unlock"),
+        unlockRoutes: args.unlockRoutes.filter((r) => r.skill_slug === skill.slug && r.is_active && r.route_type !== "hidden_discovery"),
+        isFavourite: favourites.has(skill.slug),
+        roleScore,
+        recommendationScore,
+        gap,
+      };
+    })
+    .sort(stable);
+}
+
+export function filterAndSortSkillRows(rows: SkillDashboardRow[], filters: SkillFilters): SkillDashboardRow[] {
+  const q = (filters.search ?? "").trim().toLowerCase();
+  const filtered = rows.filter((row) => {
+    if (q && ![row.catalogue.name, row.catalogue.description, row.catalogue.category, row.catalogue.subcategory ?? ""].join(" ").toLowerCase().includes(q)) return false;
+    if (filters.category && filters.category !== "all" && row.catalogue.category !== filters.category) return false;
+    if (filters.subcategory && filters.subcategory !== "all" && row.catalogue.subcategory !== filters.subcategory) return false;
+    if (filters.role && filters.role !== "all" && !row.roleLinks.some((l) => l.role_key === filters.role)) return false;
+    if (filters.system && filters.system !== "all" && !row.systemLinks.some((l) => l.system_key === filters.system)) return false;
+    switch (filters.lock) {
+      case "unlocked": return row.progress.is_unlocked;
+      case "locked": return !row.progress.is_unlocked;
+      case "trainable": return row.progress.can_practice;
+      case "available": return row.availability?.status === "available_to_unlock";
+      case "favourite": return row.isFavourite;
+      case "maxed": return row.progress.is_max_level;
+      default: return true;
+    }
+  });
+  const sorted = [...filtered];
+  const sort = filters.sort ?? "recommended";
+  sorted.sort((a, b) => {
+    const tie = stable(a, b);
+    if (sort === "level") return b.progress.current_level - a.progress.current_level || tie;
+    if (sort === "closest") return b.progress.progress_percent - a.progress.progress_percent || tie;
+    if (sort === "alphabetical") return a.catalogue.name.localeCompare(b.catalogue.name) || tie;
+    if (sort === "role") return b.roleScore - a.roleScore || tie;
+    if (sort === "system") return b.systemLinks.length - a.systemLinks.length || tie;
+    if (sort === "unlock") return (b.availability?.status === "available_to_unlock" ? 1 : 0) - (a.availability?.status === "available_to_unlock" ? 1 : 0) || tie;
+    if (sort === "lowestGap") return a.gap - b.gap || tie;
+    if (sort === "highestGap") return b.gap - a.gap || tie;
+    return b.recommendationScore - a.recommendationScore || tie;
+  });
+  return sorted;
+}
+
+export function summarizeRoleReadiness(role: SkillRoleKey, rows: SkillDashboardRow[]): RoleReadinessSummary {
+  const relevant = rows.filter((r) => r.roleLinks.some((l) => l.role_key === role));
+  const weighted = relevant.reduce((acc, row) => {
+    const link = row.roleLinks.find((l) => l.role_key === role)!;
+    const target = Math.max(1, link.minimum_recommended_level);
+    return acc + Math.min(1, row.progress.current_level / target) * link.weight;
+  }, 0);
+  const total = relevant.reduce((acc, row) => acc + (row.roleLinks.find((l) => l.role_key === role)?.weight ?? 0), 0) || 1;
+  const score = Math.round((weighted / total) * 100);
+  const sorted = relevant.sort((a, b) => b.roleScore - a.roleScore || stable(a, b));
+  return {
+    role,
+    score,
+    band: bandForScore(score),
+    foundationSkills: sorted.filter((r) => r.catalogue.is_foundational).slice(0, 5),
+    specialistSkills: sorted.filter((r) => !r.catalogue.is_foundational).slice(0, 5),
+    strengths: sorted.filter((r) => r.gap === 0 && r.progress.is_unlocked).slice(0, 4),
+    gaps: sorted.filter((r) => r.gap > 0).sort((a, b) => b.gap - a.gap || stable(a, b)).slice(0, 5),
+    blocked: sorted.filter((r) => r.availability?.status === "prerequisites_missing").slice(0, 4),
+    usefulAttributes: Array.from(new Set(sorted.flatMap((r) => r.attributeLinks.map((l) => l.attribute_key)))).slice(0, 6),
+    impact: Array.from(new Set(sorted.flatMap((r) => r.systemLinks.map((l) => l.system_key.replace(/_/g, " "))))).slice(0, 5),
+  };
+}
+
+export function buildRecommendations(rows: SkillDashboardRow[], role?: SkillRoleKey | "all" | null, limit = 5): Array<{ id: string; title: string; reason: string; skillSlug?: string }> {
+  return rows
+    .filter((r) => r.catalogue.is_active && !r.catalogue.is_hidden && r.availability?.status !== "hidden" && r.availability?.status !== "inactive")
+    .filter((r) => !role || role === "all" || r.roleLinks.some((l) => l.role_key === role) || r.progress.progress_percent >= 70)
+    .sort((a, b) => b.recommendationScore - a.recommendationScore || stable(a, b))
+    .slice(0, limit)
+    .map((r) => ({
+      id: `skill:${r.catalogue.slug}`,
+      skillSlug: r.catalogue.slug,
+      title: r.progress.is_unlocked ? `Improve ${r.catalogue.name} to level ${r.progress.next_level ?? r.progress.current_level}` : `Unlock ${r.catalogue.name}`,
+      reason: r.progress.is_unlocked
+        ? `${r.catalogue.name} supports ${r.systemLinks.map((l) => l.system_key.replace(/_/g, " ")).slice(0, 2).join(" and ") || "your progression"}${r.gap > 0 ? " and is a current role gap" : ""}. Estimated contributions are previews, not guaranteed outcome changes.`
+        : `${r.catalogue.name} is a foundation or role-relevant skill with accessible routes: ${r.unlockRoutes.map((u) => u.route_type.replace(/_/g, " ")).join(", ") || "education or activity progression"}.`,
+    }));
+}


### PR DESCRIPTION
### Motivation
- Turn the Skills & Attributes area from a raw list into a management-style progression dashboard so players can see what they're good at, what to train next, and how that affects songwriting/recording/gigs without external guides.
- Use the canonical skill catalogue, role mappings and existing practice / preview integrations to provide role-focused recommendations and planner views while avoiding any economy rebalance.
- Fix UX and accessibility gaps (mobile layout, empty/loading/error states, screen-reader labels) and add lightweight telemetry to measure feature usage. 

### Description
- Replaced the Skills page UI with an Overview-first scaffold and added tabs: Overview, Skills, Skill Tree, Attributes and Practice in `src/pages/SkillsPage.tsx`, including role focus selection, readiness summary, recommended next actions, progression planner, comparison mode, search/filters/sorts and URL/state persistence. 
- Added a progression utility `src/utils/skillsProgressionDashboard.ts` that joins canonical catalogue, availability and progress rows into memoised dashboard rows, implements deterministic filtering/sorting, role-readiness banding, gap scoring and recommendation generation. 
- Added a focused unit test `src/utils/__tests__/skillsProgressionDashboard.test.ts` that asserts readiness summaries, combined filters/favourites, recommendation stability and hidden/inactive exclusion. 
- Improved attribute presentation in `src/components/attributes/AttributeCard.tsx` by adding accessible progress labels, current affected systems, upgrade preview copy and insufficient-AP messaging, and wired attribute spend refresh hooks into the page refresh flow. 
- Added a UX audit `docs/progression/SKILLS_PAGE_UX_AUDIT.md` documenting current hierarchy, missing explanations, mobile/accessibility issues and follow-up work; retained existing React Query hooks and caching to avoid extra requests and kept skill-tree rendering scoped to its tab. 
- Telemetry: page emits structured `progression:telemetry` events for key actions (page open, role focus, searches, filters/reset, details, favourites, practice starts, planner goal selection) and favourites are session-scoped with optimistic UI. 

### Testing
- Type checks: `npm run typecheck` completed successfully (no TypeScript errors). 
- Unit tests: new test file `src/utils/__tests__/skillsProgressionDashboard.test.ts` was added, but `npm run test:unit` could not be executed in this environment because local test runner dependencies are not installed (`vitest: not found`).
- Lint/build: `npm run lint` and `npm run build` were not runnable here due to missing local dev dependencies (`@eslint/js`, `vite`), so CI should run lint, unit, integration and accessibility checks as part of the merge validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53fcf59b5483259b7ad6fe2e2b8781)