### PR TITLE
Add shared band progression goals and coordinated training plans

### DIFF
--- a/docs/progression/BAND_PROGRESSION_AUDIT.md
+++ b/docs/progression/BAND_PROGRESSION_AUDIT.md
@@ -1,0 +1,78 @@
+# Band Progression Audit
+
+## Current band-role handling
+
+Band membership is stored in `band_members` and most UI flows read `role` and `instrument_role` directly. Roster, performance, release, festival, setlist and dashboard components query this table independently, so role display is available but not consistently tied to canonical skill readiness. Previous social implementation docs confirm invite, application and contribution flows use active `band_members` relationships and leader/founder style roles for authorization.
+
+## Current role-gap calculations
+
+The coherent canonical readiness model is character-level: `CANONICAL_ROLE_LINKS` maps skills to roles, and `summarizeRoleReadiness` turns visible skill progress into role readiness. Band-level gaps were not a single server-authoritative workflow before this PR. Existing gig and recording flows infer readiness from their own preparation data, setlists, familiarity and crew/equipment choices rather than a shared band coverage service.
+
+## Current shared progression features
+
+The repository has individual skill progression, teaching/mentoring, rehearsal familiarity, gig preparation, recording preparation, songwriting collaboration and contribution feeds. It did not have durable shared band progression goals, goal requirements, member contribution tasks or coordinated training plans.
+
+## Current rehearsal rewards
+
+Rehearsal components update `band_song_familiarity` and related rehearsal records. Rewards are activity/familiarity oriented. There was no goal-aware reward ledger that checks distinct participants, source-event uniqueness or synergy caps.
+
+## Current cohesion rewards
+
+Band contribution events and relationship/cohesion systems exist, but no shared progression milestone reward model connected role-gap closure, onboarding or training plans to bounded cohesion/reputation outcomes.
+
+## Current member permissions
+
+Existing band workflows use accepted active membership and leader/founder/co-leader/manager style roles for elevated actions. Permission logic is distributed across client components and database RPC/policies from prior social PRs. This creates a risk that new goal features would accidentally rely on client-only checks unless RLS and server-side completion are added.
+
+## Current gig and recording preparation workflows
+
+Gig preparation has dedicated readiness documentation and tables for crew, equipment, costs and readiness previews. Recording flows use song familiarity, session configuration and production-session data. These systems should remain canonical; band goals should reference their preview outputs rather than copy formulas.
+
+## Current band activity feed
+
+`bandContributions` and prior social docs describe immutable contribution events with active-member read access. Existing feeds are appropriate for meaningful progression events, but exact private skill or attribute values should not be logged.
+
+## Current onboarding for new members
+
+Invitations and applications can add members safely, but there is no progression onboarding workflow that suggests a provisional role, starter lesson, setlist familiarity target, first rehearsal and first contribution while preserving autonomy.
+
+## Duplicate or conflicting role logic
+
+Role logic appears in canonical skill mappings, gear performance helpers, rehearsal efficiency helpers, member UI labels and gig/recording preparation screens. The main conflict is label-first role inference versus canonical role-to-skill readiness. Band progression should use canonical mappings and only treat selected role labels as context.
+
+## Known bugs and workflow gaps
+
+- No single band-level gap dashboard exists.
+- No historical completed/abandoned goal snapshots exist.
+- No idempotent band progression reward ledger exists.
+- No structured blocked reason model exists for cancelled source activities, departed members or prerequisites.
+- No clear workflow exists for role handovers.
+
+## Privacy concerns
+
+Band leaders should not see private exact attributes, hidden skills, XP balances, health details or unrelated progression history. Existing readiness UI can expose enough if reused naively. New coverage output must use readiness bands, requirement met/not met and estimated gaps.
+
+## Possible leader-abuse risks
+
+- Assigning tasks in a way that implies control over another player's XP/AP/currency.
+- Scheduling activities without normal acceptance.
+- Turning declined tasks into penalties or public shaming.
+- Accessing private progression through gap analysis.
+
+## Potential reward exploits
+
+- Repeated trivial custom goals.
+- Reusing one lesson/rehearsal event across incompatible rewards.
+- Leaving and rejoining to repeat onboarding rewards.
+- Multi-profile completion where rules prohibit it.
+- Duplicate milestone claims after deletion/recreation.
+
+## Concrete weak-role example
+
+A four-piece band with two guitarists, one vocalist and no bassist/drummer can currently see roles on the roster, rehearse songs and prepare a gig. However, before this PR there was no coherent workflow that says: "bass and drums are missing required general coverage; guitarist two is useful backup guitar coverage; suggested actions are recruit/mentor a bassist, schedule rhythm-section rehearsal, or create a role-handover plan." The band could address the weakness manually through recruitment, rehearsal or lessons, but the system did not coordinate those steps as a measurable shared goal.
+
+## Follow-up band development work
+
+- Move all remaining label-first role calculations onto the shared coverage service.
+- Add richer per-band permission capabilities if leader roles become more granular.
+- Add UI affordances for privacy preferences once profile privacy settings are expanded.

--- a/docs/progression/BAND_PROGRESSION_DESIGN.md
+++ b/docs/progression/BAND_PROGRESSION_DESIGN.md
@@ -1,0 +1,70 @@
+# Band Progression Design
+
+## Concepts
+
+### Band role coverage
+
+Role coverage answers whether important musical and professional roles are adequately covered for a context: general, gig, recording or songwriting. Coverage uses canonical role-to-skill mappings, member status and privacy-safe readiness bands. It reports required roles, optional roles, ready members, secondary coverage, weak/missing coverage, useful backup coverage and unnecessary duplication warnings. It is not a direct performance multiplier.
+
+### Shared progression goal
+
+A shared goal is a high-level target agreed by the band, such as role coverage, gig readiness, recording readiness, songwriting capability, rehearsal readiness, genre development, professional skill, newcomer onboarding, role handover or guided custom work. Draft/proposed goals do not grant rewards. Custom guided goals may organize work but cannot grant automatic progression rewards unless backed by measurable authoritative requirements.
+
+### Individual contribution task
+
+A task is a voluntary member-facing action linked to a goal. Tasks can be suggested, claimed, assigned where permissions allow, declined, unclaimed or completed by authoritative events. They explain group impact but never spend a member's XP/AP/currency, force skill selection, block leaving, or penalize decline.
+
+### Training plan
+
+A training plan is a coordinated set of real activities and individual work supporting a goal. Steps may reference practice, lessons, mentoring, rehearsals, jams, songwriting, recording, gigs, equipment preparation and attendance confirmation. Booking a future activity does not complete a step; completion derives from authoritative completed events.
+
+### Preparation milestone
+
+A milestone is a measurable readiness threshold, such as all required gig roles covered, setlist familiarity reached, accepted attendance confirmed, a rehearsal completed, recording producer/engineer coverage available, or onboarding first activity completed.
+
+### Band reward
+
+A reward is a modest shared benefit for meaningful coordinated completion: cohesion, reputation, cosmetic badge, morale, preparation-friction reduction or a bounded treasury reward where economy rules allow it. Rewards are server-authoritative, idempotent and never replace individual progression with a band XP level.
+
+## Server-authoritative model
+
+`getBandRoleCoverage` returns context-sensitive coverage using `CANONICAL_ROLE_LINKS`. It does not infer coverage only from role labels and does not expose exact private hidden skill data. Goal requirements are calculated by server/RPC/functions from authoritative data such as skill progress, gig previews, recording previews, songwriting projects, rehearsal attendance and teaching/mentoring completions. Clients cannot directly mark requirements complete or submit reward amounts.
+
+## Templates and suggestions
+
+Templates cover first gig, studio recording, songwriter development, new-member onboarding, live frontperson capability and role handover. Suggestions can be generated from missing roles, upcoming gigs/recordings, setlist familiarity, recent weak outcomes, new members, genre mismatch, production gaps, repeated NPC professional spend and skill-gap analysis. Suggestions explain why they matter and require an authorised action to create a goal.
+
+## Complementary-role logic
+
+The composition score is bounded and planning-only. It recognises critical roles, secondary coverage, specialist diversity, songwriting/recording/live coverage, leadership, production skills and substitute resilience. Duplicate coverage is classified as useful backup or potentially unnecessary duplication; creative non-standard lineups receive warnings and recommendations rather than hard restrictions.
+
+## Synergy design
+
+Group synergy is capped at 2-5% and requires an active shared goal, multiple accepted participants, relevant completed activities, distinct complementary roles, unique source events, active membership and anti-farming checks. A goal's existence alone never grants synergy.
+
+## Milestones and history
+
+Completed and abandoned goals retain historical snapshots: participating members, readiness before/after, linked activities, contribution summary, milestone reward and blocked reasons. Completed goals become read-only except admin repair. Deleted or archived goals cannot reclaim rewards.
+
+## Permissions and privacy
+
+Members can view shared goals, claim tasks, update voluntary notes, suggest changes, decline tasks and mute reminders. Leaders may coordinate goals, tasks and plan proposals where authorised, but cannot spend member resources, schedule without consent or view private progression details. RLS protects goals, tasks, plans, rewards and contributions.
+
+## Gig, recording and songwriting links
+
+Gig-linked goals consume existing gig readiness/preview data for lineup, attendance, setlist, familiarity, rehearsal, health warning bands, equipment, crew and stage setup. Recording-linked goals consume recording preview/session data for source song readiness, role coverage, producer/engineer coverage, studio booking, attendance, equipment and funding. Songwriting-linked goals consume project/contributor data, composition/lyric capability and collaboration status.
+
+## Admin diagnostics and telemetry
+
+Admin diagnostics should show active/completed goals, templates, requirements, tasks, source events, rewards, duplicate attempts, suspicious farming, permission overrides, balance version and blocked records. Telemetry tracks suggestion, creation, activation, task claim/decline, plan-step completion, role-gap resolution, milestone, completion/abandonment, synergy reward, onboarding completion and suspicious repeats without private notes or hidden values.
+
+## Legacy compatibility
+
+Bands can still rehearse, gig, record, write songs, manage attendance and schedule normally without goals. Goals coordinate existing systems; they are not mandatory wrappers.
+
+## Follow-up band development work
+
+- Add full dashboard/detail React surfaces for every lifecycle action.
+- Implement edge functions/RPCs that evaluate all requirement types against production tables.
+- Expand admin diagnostics from schema/read model to full support console.
+- Add screenshot-driven mobile polish once the dashboard UI ships.

--- a/src/utils/__tests__/bandProgression.test.ts
+++ b/src/utils/__tests__/bandProgression.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getBandRoleCoverage, validateSynergyReward } from "../bandProgression";
+
+describe("band progression role coverage", () => {
+  const members = [
+    { profileId: "vox", assignedRoles: ["lead_vocalist" as const], skills: [{ slug: "vocals", level: 12 }] },
+    { profileId: "gtr1", assignedRoles: ["lead_guitarist" as const], skills: [{ slug: "guitar", level: 10 }] },
+    { profileId: "gtr2", assignedRoles: ["rhythm_guitarist" as const], skills: [{ slug: "guitar", level: 6 }] },
+    { profileId: "hidden-producer", assignedRoles: ["producer" as const], skills: [{ slug: "technical", level: 20, isPrivate: true }] },
+  ];
+
+  it("detects required, secondary, missing and duplicate coverage from canonical role mappings", () => {
+    const coverage = getBandRoleCoverage({ bandId: "band-1", members });
+    expect(coverage.requiredRoles).toContain("lead_vocalist");
+    expect(coverage.missingCoverage).toEqual(expect.arrayContaining(["bassist", "drummer"]));
+    expect(coverage.roles.find((role) => role.role === "lead_guitarist")?.readyMembers).toContain("gtr1");
+    expect(coverage.roles.find((role) => role.role === "lead_guitarist")?.secondaryCoverage).toContain("gtr2");
+    expect(coverage.duplicateCoverage.find((dup) => dup.role === "lead_guitarist")?.usefulBackup).toBe(true);
+  });
+
+  it("supports context-specific recording and gig coverage without exposing private hidden skills", () => {
+    const recording = getBandRoleCoverage({ bandId: "band-1", members, context: "recording" });
+    const gig = getBandRoleCoverage({ bandId: "band-1", members, context: "gig", upcomingActivities: [{ sourceType: "gig", sourceId: "gig-1", roleKeys: ["live_frontperson"] }] });
+    expect(recording.requiredRoles).toContain("producer");
+    expect(recording.missingCoverage).toContain("producer");
+    expect(gig.requiredRoles).toContain("live_frontperson");
+    expect(gig.upcomingActivityRelevance[0]).toContain("gig:gig-1");
+    expect(recording.privacySafeExplanations.join(" ")).not.toContain("20");
+  });
+
+  it("keeps synergy rewards bounded, multi-participant and idempotent", () => {
+    const valid = validateSynergyReward({ goalStatus: "active", participantProfileIds: ["vox", "gtr1"], relevantCompletedEventIds: ["lesson-1", "rehearsal-1"], distinctRoleKeys: ["lead_vocalist", "lead_guitarist"], bonusPercent: 4 });
+    expect(valid.valid).toBe(true);
+    expect(valid.cappedBonusPercent).toBe(4);
+    expect(valid.idempotencyKey).toBe("band-goal-synergy:lesson-1+rehearsal-1");
+
+    const farming = validateSynergyReward({ goalStatus: "active", participantProfileIds: ["vox", "vox"], relevantCompletedEventIds: ["lesson-1", "lesson-1"], distinctRoleKeys: ["lead_vocalist"], bonusPercent: 50 });
+    expect(farming.valid).toBe(false);
+    expect(farming.cappedBonusPercent).toBe(5);
+  });
+});

--- a/src/utils/bandProgression.ts
+++ b/src/utils/bandProgression.ts
@@ -1,0 +1,73 @@
+import { CANONICAL_ROLE_LINKS, type SkillRoleKey } from "./skillCatalogue";
+
+export type BandCoverageContext = "general" | "gig" | "recording" | "songwriting";
+export type GoalStatus = "draft" | "proposed" | "active" | "blocked" | "completed" | "abandoned" | "archived";
+export type BandGoalType = "role_coverage" | "recording_readiness" | "gig_readiness" | "songwriting_capability" | "rehearsal_readiness" | "genre_development" | "professional_skill" | "newcomer_onboarding" | "role_handover" | "custom_guided";
+export type TaskStatus = "suggested" | "claimed" | "assigned" | "declined" | "completed" | "blocked";
+
+export interface BandMemberSkill { slug: string; level: number; isHidden?: boolean; isPrivate?: boolean }
+export interface BandCoverageMember { profileId: string; displayName?: string; assignedRoles?: SkillRoleKey[]; memberStatus?: "active" | "inactive" | "departed"; skills: BandMemberSkill[] }
+export interface ActivityRelevance { sourceType: "gig" | "recording" | "songwriting" | "rehearsal"; sourceId: string; roleKeys?: SkillRoleKey[]; cancelled?: boolean }
+export interface RoleCoverageEntry { role: SkillRoleKey; required: boolean; assignedMembers: string[]; readyMembers: string[]; secondaryCoverage: string[]; readinessBand: "missing" | "weak" | "covered" | "strong"; explanation: string }
+export interface BandRoleCoverage { bandId: string; context: BandCoverageContext; requiredRoles: SkillRoleKey[]; optionalRoles: SkillRoleKey[]; roles: RoleCoverageEntry[]; missingCoverage: SkillRoleKey[]; weakCoverage: SkillRoleKey[]; duplicateCoverage: Array<{ role: SkillRoleKey; memberIds: string[]; usefulBackup: boolean; explanation: string }>; compositionScore: number; upcomingActivityRelevance: string[]; privacySafeExplanations: string[] }
+
+const CONTEXT_ROLES: Record<BandCoverageContext, { required: SkillRoleKey[]; optional: SkillRoleKey[] }> = {
+  general: { required: ["lead_vocalist", "lead_guitarist", "bassist", "drummer"], optional: ["keyboard_player", "songwriter", "producer", "bandleader", "backing_vocalist"] },
+  gig: { required: ["lead_vocalist", "lead_guitarist", "bassist", "drummer", "live_frontperson"], optional: ["backing_vocalist", "keyboard_player", "sound_engineer", "bandleader"] },
+  recording: { required: ["lead_vocalist", "lead_guitarist", "bassist", "drummer", "producer", "sound_engineer"], optional: ["backing_vocalist", "keyboard_player", "songwriter"] },
+  songwriting: { required: ["songwriter"], optional: ["producer", "lead_vocalist", "lead_guitarist", "keyboard_player"] },
+};
+
+export function calculateMemberRoleReadiness(member: BandCoverageMember, role: SkillRoleKey): number {
+  const links = CANONICAL_ROLE_LINKS.filter((link) => link.role_key === role);
+  if (!links.length || member.memberStatus === "departed" || member.memberStatus === "inactive") return 0;
+  const weighted = links.reduce((sum, link) => {
+    const skill = member.skills.find((s) => s.slug === link.skill_slug && !s.isHidden && !s.isPrivate);
+    return sum + Math.min(1, Math.max(0, skill?.level ?? 0) / Math.max(1, link.minimum_recommended_level)) * link.weight;
+  }, 0);
+  const total = links.reduce((sum, link) => sum + link.weight, 0) || 1;
+  return Math.round((weighted / total) * 100);
+}
+
+export function getBandRoleCoverage(args: { bandId: string; members: BandCoverageMember[]; context?: BandCoverageContext; upcomingActivities?: ActivityRelevance[] }): BandRoleCoverage {
+  const context = args.context ?? "general";
+  const roles = CONTEXT_ROLES[context];
+  const active = args.members.filter((m) => (m.memberStatus ?? "active") === "active");
+  const allRoles = [...roles.required, ...roles.optional];
+  const entries = allRoles.map((role): RoleCoverageEntry => {
+    const scored = active.map((m) => ({ member: m, score: calculateMemberRoleReadiness(m, role), assigned: m.assignedRoles?.includes(role) ?? false })).filter((s) => s.score > 0 || s.assigned);
+    const readyMembers = scored.filter((s) => s.score >= 70).map((s) => s.member.profileId);
+    const secondaryCoverage = scored.filter((s) => s.score >= 35 && s.score < 70).map((s) => s.member.profileId);
+    const assignedMembers = scored.filter((s) => s.assigned).map((s) => s.member.profileId);
+    const best = Math.max(0, ...scored.map((s) => s.score));
+    const readinessBand = best === 0 ? "missing" : best < 50 ? "weak" : best < 85 ? "covered" : "strong";
+    return { role, required: roles.required.includes(role), assignedMembers, readyMembers, secondaryCoverage, readinessBand, explanation: `${role.replace(/_/g, " ")} is ${readinessBand}; shown as readiness bands only, not private exact XP or attributes.` };
+  });
+  const missingCoverage = entries.filter((e) => e.required && e.readinessBand === "missing").map((e) => e.role);
+  const weakCoverage = entries.filter((e) => e.required && e.readinessBand === "weak").map((e) => e.role);
+  const duplicateCoverage = entries.flatMap((e) => {
+    const covered = [...e.readyMembers, ...e.secondaryCoverage];
+    return covered.length > 1 ? [{ role: e.role, memberIds: covered, usefulBackup: e.required || e.role === "backing_vocalist" || context !== "general", explanation: covered.length > 1 && (e.required || context !== "general") ? "Backup coverage improves resilience." : "Consider broader coverage before more duplication." }] : [];
+  });
+  const coveredRequired = entries.filter((e) => e.required && ["covered", "strong"].includes(e.readinessBand)).length;
+  const secondary = entries.filter((e) => e.secondaryCoverage.length > 0).length;
+  const diversity = new Set(entries.flatMap((e) => [...e.readyMembers, ...e.secondaryCoverage].map((id) => `${id}:${e.role}`))).size;
+  const compositionScore = Math.min(100, Math.round((coveredRequired / Math.max(1, roles.required.length)) * 70 + Math.min(15, secondary * 3) + Math.min(15, diversity * 2)));
+  const upcomingActivityRelevance = (args.upcomingActivities ?? []).filter((a) => !a.cancelled).map((a) => `${a.sourceType}:${a.sourceId} needs ${(a.roleKeys ?? roles.required).map((r) => r.replace(/_/g, " ")).join(", ")}`);
+  return { bandId: args.bandId, context, requiredRoles: roles.required, optionalRoles: roles.optional, roles: entries, missingCoverage, weakCoverage, duplicateCoverage, compositionScore, upcomingActivityRelevance, privacySafeExplanations: entries.map((e) => e.explanation) };
+}
+
+export const BAND_GOAL_TEMPLATES: Array<{ type: BandGoalType; title: string; requirementTypes: string[]; taskExamples: string[] }> = [
+  { type: "gig_readiness", title: "Prepare for first gig", requirementTypes: ["gig_preparation", "role_readiness", "song_familiarity", "accepted_attendance", "rehearsal_count", "equipment_readiness"], taskExamples: ["Confirm attendance", "Improve setlist familiarity", "Schedule full-band rehearsal"] },
+  { type: "recording_readiness", title: "Prepare for studio recording", requirementTypes: ["recording_preparation", "role_readiness", "song_familiarity", "accepted_attendance"], taskExamples: ["Assign producer or engineer", "Review recording plan"] },
+  { type: "songwriting_capability", title: "Develop a songwriter", requirementTypes: ["skill_level", "teaching_session", "mentoring_goal"], taskExamples: ["Complete one collaboration", "Train composition or lyrics"] },
+  { type: "newcomer_onboarding", title: "Onboard a new member", requirementTypes: ["role_readiness", "song_familiarity", "rehearsal_count"], taskExamples: ["Choose provisional role", "Attend first rehearsal"] },
+  { type: "role_handover", title: "Plan a role handover", requirementTypes: ["role_readiness", "song_familiarity", "equipment_readiness"], taskExamples: ["Claim replacement coverage", "Rehearse first activity"] },
+];
+
+export function validateSynergyReward(args: { goalStatus: GoalStatus; participantProfileIds: string[]; relevantCompletedEventIds: string[]; distinctRoleKeys: SkillRoleKey[]; bonusPercent: number; departedProfileIds?: string[] }) {
+  const uniqueParticipants = new Set(args.participantProfileIds.filter((id) => !(args.departedProfileIds ?? []).includes(id)));
+  const uniqueEvents = new Set(args.relevantCompletedEventIds);
+  const valid = args.goalStatus === "active" && uniqueParticipants.size >= 2 && uniqueEvents.size >= 2 && new Set(args.distinctRoleKeys).size >= 2 && args.bonusPercent > 0 && args.bonusPercent <= 5;
+  return { valid, cappedBonusPercent: Math.min(5, Math.max(0, args.bonusPercent)), idempotencyKey: `band-goal-synergy:${[...uniqueEvents].sort().join("+")}` };
+}

--- a/supabase/migrations/20260713090000_band_progression_goals.sql
+++ b/supabase/migrations/20260713090000_band_progression_goals.sql
@@ -1,0 +1,181 @@
+create type public.band_progression_goal_status as enum ('draft','proposed','active','blocked','completed','abandoned','archived');
+create type public.band_progression_goal_type as enum ('role_coverage','recording_readiness','gig_readiness','songwriting_capability','rehearsal_readiness','genre_development','professional_skill','newcomer_onboarding','role_handover','custom_guided');
+create type public.band_progression_task_status as enum ('suggested','claimed','assigned','declined','completed','blocked');
+
+create table if not exists public.band_progression_goals (
+  id uuid primary key default gen_random_uuid(),
+  band_id uuid not null references public.bands(id) on delete cascade,
+  title text not null check (char_length(title) between 3 and 120),
+  description text,
+  goal_type public.band_progression_goal_type not null,
+  source_type text,
+  source_id uuid,
+  status public.band_progression_goal_status not null default 'draft',
+  created_by uuid not null references public.profiles(id),
+  target_date date,
+  priority smallint not null default 3 check (priority between 1 and 5),
+  visibility text not null default 'band' check (visibility in ('band','leaders','private_contributors')),
+  balance_version text not null default 'band-progression-v1',
+  blocked_reasons jsonb not null default '[]'::jsonb,
+  completed_snapshot jsonb,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.band_goal_requirements (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.band_progression_goals(id) on delete cascade,
+  requirement_type text not null,
+  target_key text not null,
+  target_value jsonb not null default '{}'::jsonb,
+  comparison text not null default 'gte' check (comparison in ('gte','lte','eq','exists','complete')),
+  member_scope text not null default 'band' check (member_scope in ('band','all_active_members','assigned_member','any_member')),
+  assigned_profile_id uuid references public.profiles(id),
+  is_required boolean not null default true,
+  display_order integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.band_goal_member_tasks (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.band_progression_goals(id) on delete cascade,
+  suggested_profile_id uuid references public.profiles(id),
+  claimed_by uuid references public.profiles(id),
+  assigned_profile_id uuid references public.profiles(id),
+  title text not null,
+  status public.band_progression_task_status not null default 'suggested',
+  progress jsonb not null default '{}'::jsonb,
+  due_date date,
+  priority smallint not null default 3 check (priority between 1 and 5),
+  impact_explanation text not null,
+  declined_reason text,
+  alternative_suggestion text,
+  muted_by uuid[] not null default '{}',
+  source_event_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (claimed_by is null or status in ('claimed','completed','blocked'))
+);
+
+create table if not exists public.band_training_plans (
+  id uuid primary key default gen_random_uuid(),
+  band_id uuid not null references public.bands(id) on delete cascade,
+  goal_id uuid references public.band_progression_goals(id) on delete set null,
+  title text not null,
+  status text not null default 'draft' check (status in ('draft','proposed','active','blocked','completed','abandoned','archived')),
+  starts_at timestamptz,
+  ends_at timestamptz,
+  created_by uuid not null references public.profiles(id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.band_training_plan_steps (
+  id uuid primary key default gen_random_uuid(),
+  training_plan_id uuid not null references public.band_training_plans(id) on delete cascade,
+  step_type text not null check (step_type in ('practice','lesson','mentoring','rehearsal','jam','songwriting','recording','gig','equipment_preparation','attendance_confirmation')),
+  target_profile_id uuid references public.profiles(id),
+  target_skill_id text,
+  source_activity_id uuid,
+  target_value jsonb not null default '{}'::jsonb,
+  status text not null default 'pending' check (status in ('pending','proposed','accepted','completed','cancelled','blocked')),
+  sequence integer not null default 0,
+  optional boolean not null default false,
+  metadata jsonb not null default '{}'::jsonb,
+  completed_source_event_id text,
+  created_at timestamptz not null default now(),
+  unique(training_plan_id, completed_source_event_id)
+);
+
+create table if not exists public.band_progression_rewards (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.band_progression_goals(id) on delete restrict,
+  band_id uuid not null references public.bands(id) on delete cascade,
+  reward_type text not null check (reward_type in ('cohesion','reputation','badge','morale','preparation_friction','treasury')),
+  amount numeric not null default 0 check (amount >= 0),
+  idempotency_key text not null unique,
+  source_event_id text not null,
+  applied_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists public.band_progression_contributions (
+  id uuid primary key default gen_random_uuid(),
+  goal_id uuid not null references public.band_progression_goals(id) on delete cascade,
+  profile_id uuid not null references public.profiles(id),
+  contribution_type text not null,
+  source_event_id text not null,
+  summary text not null,
+  occurred_at timestamptz not null default now(),
+  unique(goal_id, profile_id, source_event_id)
+);
+
+create unique index if not exists idx_band_goal_requirement_unique_target on public.band_goal_requirements(goal_id, requirement_type, target_key, coalesce(assigned_profile_id, '00000000-0000-0000-0000-000000000000'::uuid));
+create index if not exists idx_band_progression_goals_band_status on public.band_progression_goals(band_id, status);
+create index if not exists idx_band_goal_tasks_goal_status on public.band_goal_member_tasks(goal_id, status);
+create index if not exists idx_band_training_plans_band_status on public.band_training_plans(band_id, status);
+
+alter table public.band_progression_goals enable row level security;
+alter table public.band_goal_requirements enable row level security;
+alter table public.band_goal_member_tasks enable row level security;
+alter table public.band_training_plans enable row level security;
+alter table public.band_training_plan_steps enable row level security;
+alter table public.band_progression_rewards enable row level security;
+alter table public.band_progression_contributions enable row level security;
+
+create policy "active band members can view band progression goals" on public.band_progression_goals for select using (public.is_active_band_member(band_id, auth.uid()));
+create policy "active band members can create draft goals" on public.band_progression_goals for insert with check (public.is_active_band_member(band_id, auth.uid()) and created_by in (select id from public.profiles where user_id = auth.uid()) and status in ('draft','proposed'));
+create policy "band leaders can update non-completed goals" on public.band_progression_goals for update using (status not in ('completed','archived') and exists (select 1 from public.band_members bm where bm.band_id = band_progression_goals.band_id and bm.user_id = auth.uid() and bm.member_status = 'active' and lower(coalesce(bm.role,'')) in ('leader','founder','co-leader','manager'))) with check (status not in ('completed','archived'));
+
+create policy "active members can view goal requirements" on public.band_goal_requirements for select using (exists (select 1 from public.band_progression_goals g where g.id = goal_id and public.is_active_band_member(g.band_id, auth.uid())));
+create policy "active members can view goal tasks" on public.band_goal_member_tasks for select using (exists (select 1 from public.band_progression_goals g where g.id = goal_id and public.is_active_band_member(g.band_id, auth.uid())));
+create policy "members can claim or decline own tasks" on public.band_goal_member_tasks for update using (exists (select 1 from public.band_progression_goals g join public.profiles p on p.user_id = auth.uid() where g.id = goal_id and public.is_active_band_member(g.band_id, auth.uid()) and (claimed_by = p.id or suggested_profile_id = p.id or assigned_profile_id = p.id))) with check (status in ('claimed','declined','blocked'));
+create policy "active members can view training plans" on public.band_training_plans for select using (public.is_active_band_member(band_id, auth.uid()));
+create policy "active members can view plan steps" on public.band_training_plan_steps for select using (exists (select 1 from public.band_training_plans p where p.id = training_plan_id and public.is_active_band_member(p.band_id, auth.uid())));
+create policy "active members can view rewards" on public.band_progression_rewards for select using (public.is_active_band_member(band_id, auth.uid()));
+create policy "active members can view contributions" on public.band_progression_contributions for select using (exists (select 1 from public.band_progression_goals g where g.id = goal_id and public.is_active_band_member(g.band_id, auth.uid())));
+
+create table if not exists public.band_progression_telemetry (
+  id uuid primary key default gen_random_uuid(),
+  band_id uuid references public.bands(id) on delete cascade,
+  profile_id uuid references public.profiles(id),
+  event_name text not null check (event_name in ('goal_suggested','goal_created','goal_activated','task_claimed','task_declined','training_plan_step_completed','role_gap_resolved','milestone_reached','goal_completed','goal_abandoned','synergy_reward_applied','onboarding_plan_completed','suspicious_repeat_pattern_detected')),
+  source_type text,
+  source_id uuid,
+  occurred_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb
+);
+
+alter table public.band_progression_telemetry enable row level security;
+create policy "band leaders can view progression telemetry" on public.band_progression_telemetry for select using (
+  band_id is not null and exists (
+    select 1 from public.band_members bm
+    where bm.band_id = band_progression_telemetry.band_id
+      and bm.user_id = auth.uid()
+      and bm.member_status = 'active'
+      and lower(coalesce(bm.role,'')) in ('leader','founder','co-leader','manager')
+  )
+);
+
+create or replace view public.admin_band_progression_diagnostics as
+select
+  g.band_id,
+  g.id as goal_id,
+  g.goal_type,
+  g.status,
+  g.balance_version,
+  g.blocked_reasons,
+  count(distinct r.id) as requirement_count,
+  count(distinct t.id) as task_count,
+  count(distinct p.id) as training_plan_count,
+  count(distinct rw.id) as reward_count,
+  count(distinct c.id) as contribution_count,
+  g.created_at,
+  g.updated_at
+from public.band_progression_goals g
+left join public.band_goal_requirements r on r.goal_id = g.id
+left join public.band_goal_member_tasks t on t.goal_id = g.id
+left join public.band_training_plans p on p.goal_id = g.id
+left join public.band_progression_rewards rw on rw.goal_id = g.id
+left join public.band_progression_contributions c on c.goal_id = g.id
+group by g.band_id, g.id;


### PR DESCRIPTION
### Motivation
- Provide a server-authoritative band-level progression system so bands can identify role gaps, define measurable shared goals, coordinate training plans, and celebrate meaningful group milestones without replacing individual progression.
- Preserve player autonomy and privacy by preventing leaders from spending another member’s XP/AP/currency or exposing private progression values while still enabling coordinated preparation for gigs, recordings and songwriting.
- Reuse canonical skill/role mappings, existing gig/recording preview services and rehearsal/mentoring systems so goals coordinate existing workflows rather than duplicate formulas.
- Introduce anti-exploit, idempotency and RLS protections to avoid trivial farming, duplicate reward claims and improper access.

### Description
- Added auditing and design docs describing current gaps and the approved band-progression model at `docs/progression/BAND_PROGRESSION_AUDIT.md` and `docs/progression/BAND_PROGRESSION_DESIGN.md`.
- Implemented a canonical role-coverage utility `src/utils/bandProgression.ts` exposing `getBandRoleCoverage` plus readiness bands, context-specific coverage (general/gig/recording/songwriting), duplicate/backup detection, composition scoring (planning-only) and `validateSynergyReward` for bounded synergy checks.
- Added Supabase schema and RLS in `supabase/migrations/20260713090000_band_progression_goals.sql` to create `band_progression_goals`, `band_goal_requirements`, `band_goal_member_tasks`, `band_training_plans`, `band_training_plan_steps`, `band_progression_rewards`, `band_progression_contributions`, telemetry and an `admin_band_progression_diagnostics` view with targeted policies enforcing active-member and leader scopes.
- Added unit tests `src/utils/__tests__/bandProgression.test.ts` covering role coverage detection, context-specific coverage, hidden/private skill protection and synergy idempotency/anti-farming; created goal templates and ensured design rules (no band XP replacement, no leader resource spending) are enforced by design and schema.

### Testing
- Unit tests were added at `src/utils/__tests__/bandProgression.test.ts` and are expected to validate canonical coverage logic and synergy checks, but they were not executed end-to-end in this environment because the test runner is unavailable.
- Attempted `npm run test:unit` (which invokes `vitest`) failed because `vitest` was not found in the execution environment, so automated tests did not run here.
- Attempted `npm install` to provision test dependencies failed due to registry/peer-resolution access errors while fetching `@react-three/fiber`, so CI/locally run tests are required to validate the new unit tests and migrations.
- All added automated tests and migration SQL are committed; CI should run `npm install`, `npm run test:unit` and DB migration tests (Supabase harness) to verify RLS, migration and idempotency behavior in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478e7589083258a5fa61079e6fd2e)