### PR TITLE
Add player progression history, outcome analytics and comparison tools

### DIFF
--- a/docs/progression/PLAYER_ANALYTICS_AUDIT.md
+++ b/docs/progression/PLAYER_ANALYTICS_AUDIT.md
@@ -1,0 +1,103 @@
+# Player analytics audit
+
+## Scope reviewed
+
+Repository search covered player statistics, analytics, progression history, skill XP, attribute points, outcome breakdowns, performance history, trends, comparisons, charts, snapshots, leaderboards and profile stats across `src`, `docs` and `supabase`.
+
+## Current player statistics pages
+
+- The dashboard Skills & Attributes surface is the current player-facing progression surface. It focuses on current state and spending actions rather than historical analytics.
+- Existing profile and social pages display public identity, fame, level and privacy-related profile sections, but not a full private progression history.
+- Existing finance and campaign analytics components are business/marketing oriented and should not become the foundation for player progression analytics.
+
+## Current charts
+
+- Charts exist for finance, FM, festivals, city/population and campaign analytics, but there is no canonical reusable player-progression chart model with table alternatives.
+- Some live/festival components render moment-to-moment trend indicators from local arrays. These are presentation helpers, not authoritative historical trends.
+
+## Current progression history
+
+- XP wallets and daily XP grants exist for progression accounting.
+- Skill spending is stored in `skill_progress`; attribute state is stored in `player_attributes`; wallet state is stored in `player_xp_wallet`.
+- There is no complete player-facing timeline that distinguishes normal skill XP, mastery XP, maintenance/sharpness recovery and attribute spending.
+- `profile_daily_snapshots` currently supports daily fame/fans/cash inbox deltas, not progression readiness snapshots.
+
+## Current data sources
+
+Authoritative or semi-authoritative sources found:
+
+| Area | Source | Notes | Authoritative for analytics? |
+| --- | --- | --- | --- |
+| XP earnings | `profile_daily_xp_grants`, `player_xp_wallet` | Server functions cap daily grants and update wallet balances. | Yes for earned wallet deltas; incomplete as skill-specific history. |
+| Skill state | `skill_progress` | Updated by progression function. | Yes for current skill state; history is limited. |
+| Attribute state | `player_attributes` | Updated by progression function. | Yes for current attributes; needs spend history/snapshots. |
+| Songwriting outcome | songwriting outcome docs and completion components | New model requires stored breakdowns; legacy records may be incomplete. | Yes only when persisted breakdown/version exists. |
+| Recording outcome | `recording_sessions.outcome_breakdown`, quality/version fields | Completion function persists structured breakdowns. | Yes for completed masters. |
+| Gig outcome | gig outcome calculator and outcome documentation | Technical, stage and audience response are separate concepts. | Yes when completion persisted fields exist. |
+| Band contribution | band contribution helpers/docs | Aggregate contribution model exists but should remain privacy-safe. | Partially; needs analytics projection. |
+| Achievements | achievement feature/tests | Earned badges/titles are historical milestones. | Yes for earned milestones. |
+
+## Current aggregation logic
+
+- Progression handlers aggregate daily XP grants server-side for daily activity processing.
+- Recording and gig outcome calculators compute breakdowns at completion time, then persisted rows become the only safe historical analytics source.
+- Several UI components perform local summary calculations over already-loaded rows. These are acceptable for small lists but should not be extended to raw lifetime analytics.
+
+## Retention periods
+
+- No explicit progression analytics retention policy was found.
+- Proposed policy: retain raw authoritative outcome rows according to each subsystem; retain daily progression snapshots for career-length trend views; cap raw event reads to bounded ranges and pagination.
+
+## Privacy behaviour
+
+- Many Supabase-facing systems rely on profile ownership, band membership or RLS conventions.
+- Current analytics-specific privacy is missing because analytics tables and exports did not exist.
+- Direct named-player comparison is not supported and should remain out of scope.
+
+## Performance issues and risks
+
+- No central service currently prevents unbounded raw lifetime history queries.
+- Existing chart components are not tied to a bounded analytics query contract.
+- Without snapshots, career trends would require joining current state, XP grants, outcomes, bands, teaching and achievements repeatedly.
+
+## Misleading or unclear statistics
+
+- Current state can look like lifetime progress, because the UI lacks explicit separation between current values, historical deltas and outcome results.
+- Gig quality can be misunderstood if technical performance, stage performance and audience response are merged.
+- Recording quality can be misleading if source-song quality is not separated from recording execution.
+- A single overall player rating would be misleading and is intentionally avoided.
+
+## Missing indexes
+
+- A progression snapshot table needs `(profile_id, snapshot_date desc)`.
+- Export audit and telemetry need `(profile_id, started_at/created_at desc)`.
+- Any future raw-event history table should have `(profile_id, occurred_at desc, category)` or narrower equivalent indexes.
+
+## Duplicate data
+
+- Wallet lifetime/balance fields overlap older `xp_balance`/`lifetime_xp` compatibility fields.
+- Some components duplicate small trend or summary calculations locally rather than using a shared analytics model.
+
+## Unavailable historical breakdowns
+
+- Legacy songwriting projects, recordings and gigs may have final scores without the newer breakdown or calculation-version fields.
+- Mastery, maintenance and sharpness history is not available as a single normalized player analytics feed.
+- Teaching/mentoring outcomes are available in feature-specific records but not normalized for private student-safe analytics.
+
+## Legacy-data limitations
+
+- Completed legacy outcomes must remain visible, but analytics should label incomplete breakdowns instead of recalculating them with newer formulas.
+- Scores spanning formula versions need warnings and optional filtering.
+- Historical values must not be rewritten.
+
+## Known bugs / follow-up risks
+
+- Analytics exports need rate limiting beyond basic audit rows before broad release.
+- Admin diagnostics need a richer read-only view once aggregation jobs are scheduled.
+- Generated Supabase types must be regenerated after applying the migration.
+
+## Follow-up analytics and personalisation work
+
+- Add background snapshot generation from authoritative daily and completion events.
+- Add privacy-approved peer benchmark materialized aggregates with minimum cohort enforcement.
+- Add full UI dashboard and drill-down pages once server APIs are wired to live data.

--- a/docs/progression/PLAYER_ANALYTICS_DESIGN.md
+++ b/docs/progression/PLAYER_ANALYTICS_DESIGN.md
@@ -1,0 +1,131 @@
+# Player analytics design
+
+## Goals
+
+Player analytics should help players understand progress, preparation and outcomes without exposing hidden formulas, random seeds, private member data or unsupported causal claims.
+
+## Concepts
+
+### Current state
+
+The player’s present skills, attributes, role readiness, sharpness, mastery, active goals and nearby milestones. Current state answers: “Where am I now?”
+
+### Progression history
+
+Time-based changes to skills, attributes, mastery ranks, sharpness and role readiness. Progression history answers: “How did I change?” It uses snapshots and bounded event summaries rather than raw unbounded lifetime queries.
+
+### Activity history
+
+The activities that generated progression, such as self-practice, lessons, university, rehearsal, jam sessions, songwriting, recording, gigs, teaching, mentoring, workshops and band plans. Activity efficiency is contextual and should not reduce the game to a single XP-per-hour score.
+
+### Outcome history
+
+Completed songwriting, recording and gig results. Drafts, previews and uncompleted records are excluded. Songwriting, recording and gig histories use persisted breakdowns and calculation versions only; legacy incomplete records are labelled rather than recalculated.
+
+### Contribution history
+
+Privacy-safe summaries of band, teaching, mentoring, professional and achievement contributions. Band views aggregate contribution without exact private member attributes, XP balances or shaming leaderboards.
+
+### Trend
+
+A direction derived from multiple observations over time. Minimum sample rules are:
+
+- 0-1 observations: show result/no data, not a trend.
+- 2 observations: comparison with low confidence.
+- 3-5 observations: early indication.
+- 6+ compatible observations: normal trend.
+
+Trend copy must say “suggests”, “is associated with” or “coincided with” unless an authoritative preview calculation supports a stronger statement.
+
+### Comparison
+
+A safe comparison against the player’s own history, role targets or privacy-approved aggregate cohorts. Self-comparison is default. Comparisons reject incompatible systems and warn when scoring versions differ.
+
+## Supported ranges
+
+Supported ranges are `7d`, `30d`, `90d`, `6m`, `1y` and `career`. UTC game-day boundaries are used consistently. `6m`, `1y` and `career` views should prefer snapshots or pre-aggregated data.
+
+## Snapshot strategy
+
+`player_progression_snapshots` stores one compact daily/event snapshot per profile/date with:
+
+- total unlocked skills;
+- total skill levels;
+- role readiness summary;
+- attribute summary;
+- mastery summary;
+- sharpness summary;
+- balance/calculation version.
+
+Snapshots support trend calculations without rewriting history. They intentionally omit raw hidden inputs and fields that can be derived efficiently.
+
+## Authoritative services
+
+Server-side services/RPCs should expose bounded, authorised analytics:
+
+- `getPlayerProgressionSummary(profileId, range)` / `get_player_progression_summary`;
+- `getPlayerSkillHistory(profileId, skillId, range)`;
+- `getPlayerAttributeHistory(profileId, attributeKey, range)`;
+- `getPlayerOutcomeHistory(profileId, systemKey, range)`;
+- `getPlayerActivityEfficiency(profileId, range)`;
+- `getPlayerRoleTrend(profileId, roleKey, range)` / `get_player_role_trend`;
+- `getPlayerContributionSummary(profileId, range)`.
+
+All services validate profile ownership or feature-specific visibility. Browsers must not load all raw lifetime events and aggregate them client-side.
+
+## Skill and attribute history
+
+Skill history distinguishes normal skill XP, mastery XP and maintenance/recovery events. Attribute history shows value changes, upgrade dates, AP spent, AP source summary, related skills and estimated role-readiness movement only where an authoritative preview supports it.
+
+## Outcome history
+
+- Songwriting: completed projects, score trends, craft/attribute/genre/collaboration/completion/polish breakdowns and legacy-incomplete labels.
+- Recording: completed masters, final master quality, performer execution, production, engineering, studio quality, rehearsal readiness, role coverage and source-song quality separation.
+- Gigs: completed gigs, technical performance, stage performance and audience response as separate trends plus setlist flow, readiness, equipment/crew, venue fit and fan/reputation deltas.
+
+## Role readiness
+
+Role readiness is contextual. Supported roles compare current and historical readiness against beginner, competent, strong, advanced and elite target bands. The system must not create a universal overall character rating.
+
+## Mastery and maintenance
+
+Mastery analytics show eligibility dates, mastery XP source, rank progression, challenges and measurable perk use. Maintenance analytics show sharpness, rust periods, recovery sessions and comeback bonus use. Temporary rust is labelled as recoverable, not permanent loss.
+
+## Teaching and band analytics
+
+Teaching analytics separate teacher and student views and never expose private student progression publicly. Band analytics show aggregate role coverage, rehearsal readiness, gig/recording/songwriting readiness, goal completion and attendance consistency without exact private member values.
+
+## Personal bests and timeline
+
+Personal bests include highest songwriting score, recording quality, technical gig score, audience response, fan gain, role readiness, skill XP week, teaching rating and sharpness recovery. The progression timeline includes meaningful events only and filters out minor XP transactions.
+
+## Recommendations
+
+Recommendations require repeated evidence, accessible actions and dismissal state checks. Confidence is based on sample size, recency, consistency, calculation-version stability and directness of evidence. Labels are Low, Moderate or High confidence.
+
+## Peer benchmark privacy
+
+Peer benchmarks require anonymised aggregates, minimum cohort size, opt-out compliance, no named players, no hidden skills and no small-group inference. Direct named-player stat comparison remains out of scope.
+
+## Charts, tables and accessibility
+
+Charts are used only when they improve comprehension. Every important chart has an accessible text summary and a table/list alternative with date, activity, result, contributors, XP, calculation version and links where useful. Axes must not be misleading.
+
+## Export
+
+Players may export their own safe progression summary as CSV, with JSON reserved for future structured history if existing patterns support it. Exports validate ownership, exclude hidden internal fields, enforce date limits, create audit rows and should be rate limited.
+
+## Telemetry
+
+Telemetry tracks analytics page opens, time range changes, chart views, comparisons, recommendation actions/dismissals, history item opens, export requests, band analytics views and personal-best views. Metadata must avoid private values.
+
+## Data-quality warnings
+
+Player-facing warnings are simple: incomplete legacy data, scoring changed, not enough data, partial analytics unavailable. Admin diagnostics may include snapshot freshness, failed queries, duplicate events, negative XP, unknown versions, spikes, export activity and missing indexes.
+
+## Follow-up analytics and personalisation work
+
+- Build full React dashboard/drill-down pages using the service contract.
+- Add materialized peer benchmark cohorts after privacy review.
+- Add scheduled snapshot jobs and admin freshness monitors.
+- Add richer recommendation routing to accessible in-game actions.

--- a/src/lib/analytics/playerAnalytics.test.ts
+++ b/src/lib/analytics/playerAnalytics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildSafeComparison, createRecommendations, filterMeaningfulTimelineEvents, isPeerBenchmarkAvailable, resolveAnalyticsRange, summarizeTrend } from "./playerAnalytics";
+
+describe("player analytics helpers", () => {
+  it("uses stable UTC boundaries and aggregates long ranges", () => {
+    expect(resolveAnalyticsRange("7d", new Date("2026-07-13T15:30:00Z"))).toEqual({ start: "2026-07-07T00:00:00.000Z", end: "2026-07-14T00:00:00.000Z", useAggregates: false });
+    expect(resolveAnalyticsRange("career", new Date("2026-07-13T15:30:00Z"))).toEqual({ start: null, end: "2026-07-14T00:00:00.000Z", useAggregates: true });
+  });
+
+  it("does not create a trend from one data point", () => {
+    const trend = summarizeTrend([{ id: "one", occurredAt: "2026-07-10T00:00:00Z", value: 71, calculationVersion: "v1" }], "gig");
+    expect(trend.label).toBe("Not enough data");
+    expect(trend.direction).toBe("unknown");
+    expect(trend.delta).toBeNull();
+  });
+
+  it("labels small and larger samples with confidence and version warnings", () => {
+    expect(summarizeTrend([
+      { id: "a", occurredAt: "2026-07-01T00:00:00Z", value: 50, calculationVersion: "v1" },
+      { id: "b", occurredAt: "2026-07-02T00:00:00Z", value: 54, calculationVersion: "v1" },
+    ]).label).toBe("Low confidence");
+    const trend = summarizeTrend(Array.from({ length: 6 }, (_, index) => ({ id: String(index), occurredAt: `2026-07-0${index + 1}T00:00:00Z`, value: 50 + index * 2, calculationVersion: index < 3 ? "v1" : "v2" })), "recording");
+    expect(trend.label).toBe("Strong trend");
+    expect(trend.versionWarning).toBe(true);
+  });
+
+  it("rejects incompatible outcome comparisons and warns on version changes", () => {
+    expect(buildSafeComparison({ systemKey: "gig", calculationVersion: "v1" }, { systemKey: "recording", calculationVersion: "v1" }).compatible).toBe(false);
+    expect(buildSafeComparison({ systemKey: "gig", calculationVersion: "v1" }, { systemKey: "gig", calculationVersion: "v2" }).warning).toContain("Scoring changed");
+  });
+
+  it("keeps timeline events meaningful and ordered", () => {
+    const events = filterMeaningfulTimelineEvents([
+      { id: "xp", occurredAt: "2026-07-01T00:00:00Z", category: "skill", title: "XP", summary: "small", significance: "minor" },
+      { id: "level", occurredAt: "2026-07-03T00:00:00Z", category: "skill", title: "Level", summary: "up", significance: "meaningful" },
+      { id: "gig", occurredAt: "2026-07-02T00:00:00Z", category: "gig", title: "Gig", summary: "best", significance: "milestone" },
+    ]);
+    expect(events.map((event) => event.id)).toEqual(["level", "gig"]);
+  });
+
+  it("requires repeated accessible recommendation evidence and applies privacy-safe cohorts", () => {
+    expect(createRecommendations([{ id: "r", actionKey: "rehearse", evidenceCount: 2, isAccessible: true, isDismissed: false, versionStable: true, consistency: 0.9, recencyDays: 3, explanation: "x" }])).toHaveLength(0);
+    expect(createRecommendations([{ id: "r", actionKey: "rehearse", evidenceCount: 5, isAccessible: true, isDismissed: false, versionStable: true, consistency: 0.9, recencyDays: 3, explanation: "Repeated low readiness before gigs." }])[0].confidence).toBe("High confidence");
+    expect(isPeerBenchmarkAvailable({ cohortSize: 24 })).toBe(false);
+    expect(isPeerBenchmarkAvailable({ cohortSize: 30, containsHiddenSkill: true })).toBe(false);
+    expect(isPeerBenchmarkAvailable({ cohortSize: 30 })).toBe(true);
+  });
+});

--- a/src/lib/analytics/playerAnalytics.ts
+++ b/src/lib/analytics/playerAnalytics.ts
@@ -1,0 +1,150 @@
+export type AnalyticsRangeKey = "7d" | "30d" | "90d" | "6m" | "1y" | "career";
+
+export type TrendConfidence = "not_enough_data" | "low" | "early" | "normal";
+export type TrendDirection = "improving" | "declining" | "stable" | "volatile" | "unknown";
+
+export interface AnalyticsObservation {
+  id: string;
+  occurredAt: string;
+  value: number;
+  calculationVersion?: string | null;
+}
+
+export interface TrendSummary {
+  sampleSize: number;
+  direction: TrendDirection;
+  confidence: TrendConfidence;
+  label: "Not enough data" | "Low confidence" | "Early indication" | "Stable trend" | "Strong trend";
+  delta: number | null;
+  versionWarning: boolean;
+  explanation: string;
+}
+
+export interface SafeComparison<T = unknown> {
+  compatible: boolean;
+  warning?: string;
+  before: T;
+  after: T;
+}
+
+export interface AnalyticsTimelineEvent {
+  id: string;
+  occurredAt: string;
+  category:
+    | "skill"
+    | "attribute"
+    | "mastery"
+    | "maintenance"
+    | "songwriting"
+    | "recording"
+    | "gig"
+    | "teaching"
+    | "band"
+    | "achievement";
+  title: string;
+  summary: string;
+  significance: "minor" | "meaningful" | "milestone";
+  calculationVersion?: string | null;
+}
+
+export interface RecommendationSignal {
+  id: string;
+  actionKey: string;
+  evidenceCount: number;
+  isAccessible: boolean;
+  isDismissed: boolean;
+  versionStable: boolean;
+  consistency: number;
+  recencyDays: number;
+  explanation: string;
+}
+
+export interface AnalyticsRecommendation {
+  actionKey: string;
+  confidence: "Low confidence" | "Moderate confidence" | "High confidence";
+  explanation: string;
+}
+
+export interface PeerBenchmarkRequest {
+  cohortSize: number;
+  minimumCohortSize?: number;
+  optedOut?: boolean;
+  containsHiddenSkill?: boolean;
+}
+
+export const SUPPORTED_ANALYTICS_RANGES: ReadonlyArray<AnalyticsRangeKey> = ["7d", "30d", "90d", "6m", "1y", "career"];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function resolveAnalyticsRange(range: AnalyticsRangeKey, now = new Date()): { start: string | null; end: string; useAggregates: boolean } {
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+  if (range === "career") return { start: null, end: end.toISOString(), useAggregates: true };
+  const days = range === "7d" ? 7 : range === "30d" ? 30 : range === "90d" ? 90 : range === "6m" ? 183 : 365;
+  const start = new Date(end.getTime() - days * DAY_MS);
+  return { start: start.toISOString(), end: end.toISOString(), useAggregates: days > 90 };
+}
+
+export function summarizeTrend(observations: AnalyticsObservation[], metricLabel = "result"): TrendSummary {
+  const ordered = observations
+    .filter((point) => Number.isFinite(point.value) && !Number.isNaN(Date.parse(point.occurredAt)))
+    .sort((a, b) => Date.parse(a.occurredAt) - Date.parse(b.occurredAt));
+  const sampleSize = ordered.length;
+  const versions = new Set(ordered.map((point) => point.calculationVersion ?? "unknown"));
+  const versionWarning = versions.size > 1 || versions.has("unknown");
+
+  if (sampleSize === 0) {
+    return { sampleSize, direction: "unknown", confidence: "not_enough_data", label: "Not enough data", delta: null, versionWarning, explanation: `No ${metricLabel} history is available for this range.` };
+  }
+  if (sampleSize === 1) {
+    return { sampleSize, direction: "unknown", confidence: "not_enough_data", label: "Not enough data", delta: null, versionWarning, explanation: `One ${metricLabel} result is available, so this is a result rather than a trend.` };
+  }
+
+  const first = ordered[0].value;
+  const last = ordered[ordered.length - 1].value;
+  const delta = Number((last - first).toFixed(2));
+  const values = ordered.map((point) => point.value);
+  const averageStep = values.slice(1).reduce((sum, value, index) => sum + Math.abs(value - values[index]), 0) / (sampleSize - 1);
+  const direction: TrendDirection = averageStep > Math.max(8, Math.abs(delta) * 2.5)
+    ? "volatile"
+    : Math.abs(delta) < 2
+      ? "stable"
+      : delta > 0
+        ? "improving"
+        : "declining";
+  const confidence: TrendConfidence = sampleSize === 2 ? "low" : sampleSize <= 5 ? "early" : "normal";
+  const label = sampleSize === 2 ? "Low confidence" : sampleSize <= 5 ? "Early indication" : direction === "stable" ? "Stable trend" : "Strong trend";
+  const caution = versionWarning ? " Scoring changed or is unknown during this period, so interpret the trend cautiously." : "";
+  return { sampleSize, direction, confidence, label, delta, versionWarning, explanation: `${sampleSize} ${metricLabel} observations show ${direction === "unknown" ? "no clear" : `a ${direction}`} pattern (${delta >= 0 ? "+" : ""}${delta}).${caution}` };
+}
+
+export function buildSafeComparison<T extends { calculationVersion?: string | null; systemKey?: string | null }>(before: T, after: T): SafeComparison<T> {
+  if (before.systemKey && after.systemKey && before.systemKey !== after.systemKey) {
+    return { compatible: false, warning: "These outcomes use different systems and should not be compared directly.", before, after };
+  }
+  if ((before.calculationVersion ?? "unknown") !== (after.calculationVersion ?? "unknown")) {
+    return { compatible: true, warning: "Scoring changed during this comparison. Trends should be interpreted cautiously.", before, after };
+  }
+  return { compatible: true, before, after };
+}
+
+export function filterMeaningfulTimelineEvents(events: AnalyticsTimelineEvent[], limit = 50): AnalyticsTimelineEvent[] {
+  return events
+    .filter((event) => event.significance !== "minor")
+    .sort((a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt))
+    .slice(0, Math.max(1, Math.min(limit, 100)));
+}
+
+export function createRecommendations(signals: RecommendationSignal[]): AnalyticsRecommendation[] {
+  return signals
+    .filter((signal) => signal.isAccessible && !signal.isDismissed && signal.evidenceCount >= 3 && signal.consistency >= 0.5)
+    .map((signal) => {
+      const score = signal.evidenceCount + signal.consistency * 4 - (signal.versionStable ? 0 : 2) - (signal.recencyDays > 60 ? 1 : 0);
+      const confidence = score >= 8 ? "High confidence" : score >= 5 ? "Moderate confidence" : "Low confidence";
+      return { actionKey: signal.actionKey, confidence, explanation: signal.explanation };
+    });
+}
+
+export function isPeerBenchmarkAvailable(request: PeerBenchmarkRequest): boolean {
+  const minimum = request.minimumCohortSize ?? 25;
+  return !request.optedOut && !request.containsHiddenSkill && request.cohortSize >= minimum;
+}

--- a/supabase/migrations/20260713090000_player_progression_analytics.sql
+++ b/supabase/migrations/20260713090000_player_progression_analytics.sql
@@ -1,0 +1,185 @@
+-- Player-facing progression analytics foundations.
+-- This migration adds compact, permission-aware storage for snapshots,
+-- recommendation state, export audits and telemetry. It intentionally keeps
+-- hidden formulas, raw random seeds and exact peer data out of player-visible rows.
+
+create table if not exists public.player_progression_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  snapshot_date date not null,
+  total_unlocked_skills integer not null default 0 check (total_unlocked_skills >= 0),
+  total_skill_levels integer not null default 0 check (total_skill_levels >= 0),
+  role_readiness jsonb not null default '{}'::jsonb,
+  attribute_summary jsonb not null default '{}'::jsonb,
+  mastery_summary jsonb not null default '{}'::jsonb,
+  sharpness_summary jsonb not null default '{}'::jsonb,
+  balance_version text not null default 'unknown',
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  unique (profile_id, snapshot_date)
+);
+
+create index if not exists idx_player_progression_snapshots_profile_date
+  on public.player_progression_snapshots (profile_id, snapshot_date desc);
+
+create table if not exists public.player_analytics_recommendation_states (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  recommendation_key text not null,
+  state text not null check (state in ('dismissed', 'snoozed', 'not_relevant', 'acted')),
+  evidence_fingerprint text,
+  snoozed_until timestamptz,
+  created_at timestamptz not null default timezone('utc'::text, now()),
+  updated_at timestamptz not null default timezone('utc'::text, now()),
+  unique (profile_id, recommendation_key)
+);
+
+create index if not exists idx_player_analytics_recommendation_states_profile
+  on public.player_analytics_recommendation_states (profile_id, updated_at desc);
+
+create table if not exists public.player_analytics_exports (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  requested_by uuid not null default auth.uid(),
+  range_key text not null check (range_key in ('7d', '30d', '90d', '6m', '1y', 'career')),
+  export_format text not null check (export_format in ('csv', 'json')),
+  started_at timestamptz not null default timezone('utc'::text, now()),
+  completed_at timestamptz,
+  status text not null default 'requested' check (status in ('requested', 'completed', 'failed', 'rate_limited')),
+  row_count integer not null default 0 check (row_count >= 0)
+);
+
+create index if not exists idx_player_analytics_exports_profile_started
+  on public.player_analytics_exports (profile_id, started_at desc);
+
+create table if not exists public.player_analytics_telemetry (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid references public.profiles(id) on delete set null,
+  viewer_id uuid default auth.uid(),
+  event_key text not null check (event_key in (
+    'analytics_page_opened', 'time_range_changed', 'chart_viewed', 'comparison_used',
+    'recommendation_acted', 'recommendation_dismissed', 'history_item_opened',
+    'export_requested', 'band_analytics_viewed', 'personal_best_viewed'
+  )),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc'::text, now())
+);
+
+create index if not exists idx_player_analytics_telemetry_profile_created
+  on public.player_analytics_telemetry (profile_id, created_at desc);
+
+alter table public.player_progression_snapshots enable row level security;
+alter table public.player_analytics_recommendation_states enable row level security;
+alter table public.player_analytics_exports enable row level security;
+alter table public.player_analytics_telemetry enable row level security;
+
+drop policy if exists "Players can read own progression snapshots" on public.player_progression_snapshots;
+create policy "Players can read own progression snapshots"
+  on public.player_progression_snapshots for select
+  using (exists (select 1 from public.profiles p where p.id = player_progression_snapshots.profile_id and p.user_id = auth.uid()));
+
+drop policy if exists "Players can read own recommendation state" on public.player_analytics_recommendation_states;
+create policy "Players can read own recommendation state"
+  on public.player_analytics_recommendation_states for select
+  using (exists (select 1 from public.profiles p where p.id = player_analytics_recommendation_states.profile_id and p.user_id = auth.uid()));
+
+drop policy if exists "Players can manage own recommendation state" on public.player_analytics_recommendation_states;
+create policy "Players can manage own recommendation state"
+  on public.player_analytics_recommendation_states for all
+  using (exists (select 1 from public.profiles p where p.id = player_analytics_recommendation_states.profile_id and p.user_id = auth.uid()))
+  with check (exists (select 1 from public.profiles p where p.id = player_analytics_recommendation_states.profile_id and p.user_id = auth.uid()));
+
+drop policy if exists "Players can read own export audits" on public.player_analytics_exports;
+create policy "Players can read own export audits"
+  on public.player_analytics_exports for select
+  using (exists (select 1 from public.profiles p where p.id = player_analytics_exports.profile_id and p.user_id = auth.uid()));
+
+drop policy if exists "Players can create own export audits" on public.player_analytics_exports;
+create policy "Players can create own export audits"
+  on public.player_analytics_exports for insert
+  with check (requested_by = auth.uid() and exists (select 1 from public.profiles p where p.id = player_analytics_exports.profile_id and p.user_id = auth.uid()));
+
+drop policy if exists "Players can create own analytics telemetry" on public.player_analytics_telemetry;
+create policy "Players can create own analytics telemetry"
+  on public.player_analytics_telemetry for insert
+  with check ((profile_id is null or exists (select 1 from public.profiles p where p.id = player_analytics_telemetry.profile_id and p.user_id = auth.uid())) and (viewer_id is null or viewer_id = auth.uid()));
+
+create or replace function public.get_player_progression_summary(p_profile_id uuid, p_range text default '30d')
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_start date;
+  v_result jsonb;
+begin
+  if p_range not in ('7d', '30d', '90d', '6m', '1y', 'career') then
+    raise exception 'Unsupported analytics range: %', p_range using errcode = '22023';
+  end if;
+
+  if not exists (select 1 from public.profiles p where p.id = p_profile_id and p.user_id = auth.uid()) then
+    raise exception 'Not authorised to view analytics for this profile' using errcode = '42501';
+  end if;
+
+  v_start := case p_range
+    when '7d' then (timezone('utc'::text, now())::date - 7)
+    when '30d' then (timezone('utc'::text, now())::date - 30)
+    when '90d' then (timezone('utc'::text, now())::date - 90)
+    when '6m' then (timezone('utc'::text, now())::date - 183)
+    when '1y' then (timezone('utc'::text, now())::date - 365)
+    else null
+  end;
+
+  select jsonb_build_object(
+    'profile_id', p_profile_id,
+    'range', p_range,
+    'generated_at', timezone('utc'::text, now()),
+    'snapshots', coalesce(jsonb_agg(to_jsonb(s) order by s.snapshot_date), '[]'::jsonb),
+    'uses_aggregates', p_range in ('6m', '1y', 'career')
+  ) into v_result
+  from public.player_progression_snapshots s
+  where s.profile_id = p_profile_id
+    and (v_start is null or s.snapshot_date >= v_start);
+
+  return coalesce(v_result, jsonb_build_object('profile_id', p_profile_id, 'range', p_range, 'snapshots', '[]'::jsonb));
+end;
+$$;
+
+create or replace function public.get_player_role_trend(p_profile_id uuid, p_role_key text, p_range text default '30d')
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_summary jsonb;
+begin
+  v_summary := public.get_player_progression_summary(p_profile_id, p_range);
+  return jsonb_build_object(
+    'profile_id', p_profile_id,
+    'role_key', p_role_key,
+    'range', p_range,
+    'observations', (
+      select coalesce(jsonb_agg(jsonb_build_object(
+        'snapshot_date', s.snapshot_date,
+        'readiness', s.role_readiness -> p_role_key,
+        'balance_version', s.balance_version
+      ) order by s.snapshot_date), '[]'::jsonb)
+      from public.player_progression_snapshots s
+      where s.profile_id = p_profile_id
+        and s.role_readiness ? p_role_key
+    ),
+    'version_warning', exists (
+      select 1
+      from public.player_progression_snapshots s
+      where s.profile_id = p_profile_id
+      group by s.profile_id
+      having count(distinct s.balance_version) > 1
+    )
+  );
+end;
+$$;
+
+comment on table public.player_progression_snapshots is 'Compact daily/event player progression snapshots for trend analytics. Stores summaries only, not hidden formula inputs or raw private event streams.';
+comment on function public.get_player_progression_summary(uuid, text) is 'Authorised player progression summary over bounded supported ranges; clients must not fetch unbounded raw lifetime events for analytics.';
+comment on function public.get_player_role_trend(uuid, text, text) is 'Authorised role-readiness observations derived from progression snapshots.';


### PR DESCRIPTION
### Motivation
- Provide a focused, player-facing analytics layer so players can review skill/attribute/mastery progress, link activity to progression, inspect songwriting/recording/gig outcomes, review band contributions and get recommendation signals without exposing hidden formulas or private player data. 
- Close gaps where the codebase had stateful wallets and outcome calculators but no compact, authorized snapshot feed, export/telemetry audits, or safe comparison/trend helpers.
- Enforce bounded, server-authoritative analytics (no unbounded raw-event client aggregation) and a privacy-aware approach for peer/band aggregates.

### Description
- Added documentation audit and design: `docs/progression/PLAYER_ANALYTICS_AUDIT.md` and `docs/progression/PLAYER_ANALYTICS_DESIGN.md` describing current surfaces, data sources, snapshot strategy, supported ranges, trend confidence rules, comparisons, recommendation logic, version handling, export and telemetry requirements. 
- Introduced frontend/shared helpers in `src/lib/analytics/playerAnalytics.ts` providing `resolveAnalyticsRange`, `summarizeTrend`, `buildSafeComparison`, `filterMeaningfulTimelineEvents`, `createRecommendations`, and `isPeerBenchmarkAvailable` plus types and supported ranges (`7d`,`30d`,`90d`,`6m`,`1y`,`career`). 
- Added unit coverage in `src/lib/analytics/playerAnalytics.test.ts` validating UTC range boundaries, minimum-sample trend behaviour (0/1/2/3+ points), version warnings, incompatible comparison rejection, timeline filtering and recommendation/cohort privacy rules. 
- Added a Supabase migration `supabase/migrations/20260713090000_player_progression_analytics.sql` that creates compact snapshot storage (`player_progression_snapshots`), recommendation state (`player_analytics_recommendation_states`), export audit rows (`player_analytics_exports`), telemetry (`player_analytics_telemetry`), indexes, Row-Level Security policies, and two authorized RPCs: `get_player_progression_summary` and `get_player_role_trend` (bounded ranges, ownership checks and version-warning flags). 

### Testing
- Unit tests were added at `src/lib/analytics/playerAnalytics.test.ts` covering range logic, trend sample rules, version warnings, safe comparisons, timeline filtering, recommendation evidence gating, and peer cohort availability. 
- Attempted to run `npm run test:unit -- src/lib/analytics/playerAnalytics.test.ts` but the test runner `vitest` was not available in the environment, so the tests were not executed (failure: `vitest: not found`). 
- Attempted dependency install with `npm install` to enable running tests and typechecks but installation failed due to an external registry error (`403 Forbidden` fetching a dependency), so automated tests and type checks could not complete in this environment. 
- The SQL migration and RLS policies are included in the PR and should be applied in a Supabase environment; no migration-run or DB-backed integration tests were executed here and should be run in CI (migration application, RLS verification and export/permission tests are required in staging).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54817f1b648325807379a589f99817)