### PR TITLE
Improve navigation architecture and fix Character landing page

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -1,0 +1,135 @@
+# Navigation and hub refactor plan
+
+## Scope of this PR
+
+PR 1 is intentionally narrow: document the current routing/navigation architecture and make Character open a predictable overview page instead of restoring or defaulting to Wellness. Broader hub consolidation is deferred to later PRs.
+
+## Repository evidence audited
+
+- Primary routes are declared in `src/App.tsx` inside the `BrowserRouter`/`Routes` tree.
+- Authenticated game pages are children of `src/components/Layout.tsx`, which wraps content in `FMShell`, `CharacterGate`, global breadcrumbs and game-wide automation hooks.
+- Desktop/module navigation is configured in `src/config/fmNavigation.ts` and rendered by `src/components/fm/ModuleTabs.tsx`, `SubTabs.tsx` and `FMSidebar.tsx`.
+- Breadcrumbs are segment-based in `src/components/ui/Breadcrumbs.tsx`.
+- Admin visibility in the primary module tabs is controlled by `useUserRole()` in `ModuleTabs.tsx`; route components themselves are not consistently wrapped with `AdminRoute` in `App.tsx`.
+- Last-module-path restoration is implemented by `ModuleTabs.tsx` through `getLastModulePath()`/`recordModulePath()` from `src/lib/fmHistory.ts`.
+- The default post-login path currently resolves through `src/pages/Index.tsx`, which navigates authenticated players with a living character to `/dashboard`.
+
+## Current navigation inventory
+
+### Top module tabs
+
+Current FM modules are:
+
+1. Overview (`/dashboard`)
+2. Character (was `/hub/character`; PR 1 changes it to `/character`)
+3. Music (`/hub/music`)
+4. Band & Live (`/hub/band-live`)
+5. Career & Business (`/hub/career-business`)
+6. World (`/hub/world`)
+7. Social (`/social` and `/hub/social` surfaces both exist)
+8. Media & Fun
+9. Admin (`/admin`, visible only for admins in module tabs)
+
+### Character entries before PR 1
+
+Character-owned paths in the module configuration included `/hub/character`, `/characters`, `/my-character`, `/avatar-designer`, `/wellness`, `/skin-store`, `/tattoo-parlour`, `/gear`, `/gear-shop`, `/inventory`, `/clothing-shop`, `/housing`, `/personal-vehicles`, `/family`, `/legacy` and `/hall-of-immortals`.
+
+Before this PR the Character top-level module root was `/hub/character`, a tile hub, while Wellness was a Character subtab and sidebar item. Because primary module clicks restored the last path for inactive modules, a player who last visited `/wellness` could click Character and be returned to Wellness instead of a stable Character landing page.
+
+## Current route inventory by observed route families
+
+The repository currently has many flat authenticated routes rather than nested hub routes. Important route families observed in `src/App.tsx` include:
+
+- Home/overview: `/home`, `/dashboard`, `/inbox`, `/schedule`, `/todays-news`, `/statistics`, `/advisor`, `/journal`.
+- Character: `/character` (added in PR 1), `/hub/character`, `/characters`, `/characters/new`, `/my-character`, `/my-character/edit`, `/avatar-designer`, `/wellness`, `/skills`, `/education`, `/inventory`, `/clothing-shop`, `/skin-store`, `/tattoo-parlour`, `/gear`, `/gear-shop`, `/housing`, `/personal-vehicles`, `/family/timeline`, `/legacy`, `/hall-of-immortals`.
+- Music: `/hub/music`, `/music`, `/music-hub`, `/songwriting`, `/stage-practice`, `/recording-studio`, `/release-manager`, `/release/:id`, `/music-videos`, `/streaming-platforms`, `/streaming/:platformId`, `/song-manager`, `/song-market`, `/song-rankings`, `/music/charts`, `/country-charts`, `/christmas-charts`, `/competitive-charts`.
+- Band/live: `/hub/band-live`, `/band`, `/band/repertoire`, `/bands/:bandId/management`, `/bands/browse`, `/bands/search`, `/bands/finder`, `/band/:bandId`, `/chemistry`, `/setlists`, `/rehearsals`, `/jams`, `/jam-sessions`, `/gigs`, `/gig-booking`, `/gigs/perform/:gigId`, `/performance/gig/:gigId`, `/open-mic`, `/busking`, `/tour-manager`, `/festivals`, `/major-events`, `/events/eurovision`, `/awards`, `/stage-setup`, `/stage-equipment`, `/band-crew`, `/band-riders`, `/band-vehicles`.
+- World: `/hub/world`, `/world`, `/world-map`, `/world-pulse`, `/cities`, `/cities/:cityId`, `/cities/treasury`, `/travel`, `/venues`, `/landmarks`, `/nightclubs`, `/nightclub/:clubId`.
+- Business/career: `/hub/career-business`, `/my-companies`, `/world-companies`, `/companies/directory`, `/company/:companyId`, `/labels`, `/labels/:labelId/manage`, `/finances`, `/jobs`, `/employment`, `/sponsorships`, `/modeling`, `/producer-career`, `/clothing-designer`, `/record-label` redirect.
+- Social: `/social`, `/hub/social`, `/gettit`, `/twaater`, `/twaater/messages`, `/twaater/notifications`, `/relationships` redirect, `/players/search` redirect, `/player/:playerId`.
+- Media/fun: `/hub/media`, `/media/radio`, `/radio/:stationId`, `/media/tv-shows`, `/media/newspapers`, `/media/magazines`, `/media/podcasts`, `/media/films`, `/acting`, `/casino`, `/lottery`, `/premium-store`, `/blind-boxes`.
+- Admin: many `/admin/*` routes declared in `App.tsx`.
+
+## Redirects and index/default routes observed
+
+- `/streaming` redirects to `/streaming-platforms`.
+- `/community/feed` redirects to `/gettit`.
+- `/radio` and `/radio-stations` redirect to `/media/radio`.
+- `/relationships` redirects to `/social?tab=friends`.
+- `/players/search` redirects to `/social?tab=discover`.
+- `/hub` redirects to `/dashboard`.
+- Legacy hub aliases redirect: `/hub/band`, `/hub/live`, `/hub/events`, `/hub/world-social`, `/hub/career`, `/hub/commerce`.
+- `/record-label` redirects to `/labels`.
+- PR 1 adds `/character/overview` redirecting to `/character`.
+
+## Problems found
+
+- Top-level Character restored the last Character route, so Wellness could become the effective Character landing page.
+- Character had a tile hub at `/hub/character` but no canonical `/character` overview route.
+- Many routes are flat and are grouped only by navigation config, so breadcrumbs often reflect URL segments rather than product hierarchy.
+- Music creation routes are split across Music and Band & Live contexts (`/songwriting`, `/stage-practice`, `/rehearsals`, `/recording-studio`, `/release-manager`, `/gigs`).
+- Social has multiple entry points (`/social`, `/hub/social`, `/gettit`, `/twaater`, redirects from relationships/search).
+- World/city/travel/venue routes are partially grouped by module but still live as independent top-level paths.
+- Admin module visibility is gated in navigation, but the route table should be audited in a later PR for consistent `AdminRoute` coverage.
+- Breadcrumb labels are maintained separately from module labels, increasing drift risk.
+
+## Proposed target hierarchy
+
+Target modules should evolve toward: Home, Character, Music, Band, World, Business, Social, Schedule, Career and Admin. The current repository has enough existing surfaces to support this target without inventing placeholder features, but it should be migrated gradually.
+
+## Route migration map
+
+| Existing route(s) | Target owner | PR |
+| --- | --- | --- |
+| `/character`, `/my-character`, `/characters`, `/skills`, `/wellness`, `/inventory`, `/clothing-shop`, `/avatar-designer` | Character | PR 1 starts with overview/default only |
+| `/songwriting`, `/stage-practice`, `/recording-studio`, `/release-manager`, `/song-manager`, `/song-market` | Music | PR 3 |
+| `/band`, `/band/repertoire`, `/chemistry`, `/rehearsals`, `/setlists`, `/gigs`, `/tour-manager`, `/band-crew` | Band | PR 4 |
+| `/world`, `/cities`, `/travel`, `/venues`, `/world-pulse`, `/festivals` where world-facing | World | PR 5 |
+| `/social`, `/gettit`, `/twaater`, `/twaater/messages`, `/relationships` alias | Social | PR 6 |
+| `/my-companies`, `/company/:companyId`, `/labels`, `/finances`, `/jobs`, `/employment` | Business | PR 7 |
+| `/awards`, `/competitive-charts`, `/statistics`, `/legacy`, fame/fans surfaces | Career | PR 7 |
+| `/schedule`, `/booking/*`, current activity surfaces | Schedule | PR 8 |
+| `/dashboard`, `/home`, `/inbox`, `/todays-news`, recommendations/widgets | Home | PR 8 |
+
+## Backwards compatibility requirements
+
+- Preserve existing deep links during migration.
+- Prefer redirects/aliases over removing routes.
+- Preserve query parameters when redirecting search/social/schedule routes in later PRs.
+- Avoid redirect loops by keeping canonical overview routes as render routes, not redirects to child pages.
+- Keep authorization behaviour unchanged in PR 1.
+
+## Mobile and responsive considerations
+
+The current shell is wrapped in `DesktopOnlyGate`, while module navigation itself uses horizontally scrollable tab bars and a collapsible sidebar. PR 1 uses responsive grids and existing cards/buttons so the Character Overview remains usable if mobile access is enabled later. Later PRs should revisit the desktop-only gate and mobile navigation parity as a dedicated slice.
+
+## Accessibility considerations
+
+PR 1 uses existing semantic page states, visible `h1`, labelled navigation links, non-icon-only controls and status cards with text labels. Future PRs should test keyboard focus order across module tabs, subtabs, sidebar collapse controls and hub quick actions.
+
+## Risks
+
+- Some admin routes may be reachable by direct URL if page-level guards are missing; this PR does not change admin protection.
+- Navigation history restoration remains for non-Character modules and may need product review.
+- Breadcrumbs remain segment-derived and may not match future logical hubs until a shared route metadata model exists.
+- Route consolidation could break bookmarked URLs if aliases are removed too early.
+
+## PR sequence
+
+1. **PR 1 — Navigation audit and Character landing fix.** Add this audit, add Character Overview, make `/character` canonical, keep `/hub/character` and `/wellness` working, and add navigation tests.
+2. **PR 2 — Shared hub layout and route conventions.** Standardise hub overview conventions, route metadata, page titles and breadcrumbs.
+3. **PR 3 — Music hub consolidation.** Group songwriting, songs, practice, recording and releases with workflow links.
+4. **PR 4 — Band hub consolidation.** Group band members, chemistry, rehearsals, setlists, gigs, tours, equipment and finances.
+5. **PR 5 — World and Travel consolidation.** Group city, travel, venues, studios, shops, events and festivals.
+6. **PR 6 — Social hub consolidation.** Group friends/messages/Twaater/forums/recruitment where implemented.
+7. **PR 7 — Business and Career consolidation.** Split company/business routes from career/reputation/charts/awards surfaces.
+8. **PR 8 — Schedule and Home improvements.** Make schedule defaults predictable and improve the home dashboard using existing widgets.
+9. **PR 9 — Navigation polish and cleanup.** Responsive behaviour, accessibility, route alias cleanup and stale navigation removal.
+
+## Explicit non-goals for PR 1
+
+- No rewrite of the routing library or shell.
+- No database changes.
+- No broad Music/Band/World/Social/Business/Career migration.
+- No removal of existing deep links.
+- No redesign of the global navigation visual system.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ const PublicRelationsAdmin = lazyWithRetry(() => import("./pages/admin/PublicRel
 const MediaOutletsAdmin = lazyWithRetry(() => import("./pages/admin/MediaOutletsAdmin"));
 const UnderworldAdmin = lazyWithRetry(() => import("./pages/admin/UnderworldAdmin"));
 const WellnessPage = lazyWithRetry(() => import("./pages/Wellness"));
+const CharacterOverview = lazyWithRetry(() => import("./pages/CharacterOverview"));
 const EducationBooking = lazyWithRetry(() => import("./pages/booking/EducationBooking"));
 const PerformanceBooking = lazyWithRetry(() => import("./pages/booking/PerformanceBooking"));
 const WorkBooking = lazyWithRetry(() => import("./pages/booking/WorkBooking"));
@@ -418,6 +419,8 @@ function App() {
 
 
                     <Route path="todays-news" element={<TodaysNewsPage />} />
+                    <Route path="character" element={<CharacterOverview />} />
+                    <Route path="character/overview" element={<Navigate to="/character" replace />} />
                     <Route path="wellness" element={<WellnessPage />} />
                     <Route path="underworld" element={<UnderworldNew />} />
                     <Route path="dikcok" element={<DikCok />} />

--- a/src/components/fm/ModuleTabs.tsx
+++ b/src/components/fm/ModuleTabs.tsx
@@ -19,7 +19,7 @@ export const ModuleTabs = () => {
       navigate(rootPath);
       return;
     }
-    const last = getLastModulePath(modId);
+    const last = modId === "character" ? null : getLastModulePath(modId);
     navigate(last || rootPath);
   };
 

--- a/src/config/__tests__/fmNavigation.character.test.ts
+++ b/src/config/__tests__/fmNavigation.character.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { FM_MODULES, findModuleForPath } from "../fmNavigation";
+
+describe("character navigation defaults", () => {
+  const character = FM_MODULES.find((module) => module.id === "character");
+
+  it("uses Character Overview as the stable module landing route", () => {
+    expect(character?.rootPath).toBe("/character");
+    expect(character?.subTabs[0]).toMatchObject({ label: "Overview", path: "/character" });
+  });
+
+  it("keeps Wellness in the Character module without making it the default", () => {
+    expect(findModuleForPath("/wellness").id).toBe("character");
+    expect(character?.subTabs.some((tab) => tab.path === "/wellness")).toBe(true);
+    expect(character?.rootPath).not.toBe("/wellness");
+  });
+
+  it("recognizes direct Character Overview URLs as Character navigation", () => {
+    expect(findModuleForPath("/character").id).toBe("character");
+    expect(findModuleForPath("/character/overview").id).toBe("character");
+  });
+});

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -68,15 +68,15 @@ export const FM_MODULES: FMModule[] = [
     id: "character",
     label: "Character",
     icon: Users,
-    rootPath: "/hub/character",
+    rootPath: "/character",
     matchPaths: [
-      "/hub/character", "/characters", "/my-character", "/avatar-designer",
+      "/character", "/hub/character", "/characters", "/my-character", "/avatar-designer",
       "/wellness", "/skin-store", "/tattoo-parlour", "/gear", "/gear-shop",
       "/inventory", "/clothing-shop", "/housing", "/personal-vehicles",
       "/family", "/legacy", "/hall-of-immortals",
     ],
     subTabs: [
-      { label: "Hub", path: "/hub/character", icon: Users },
+      { label: "Overview", path: "/character", icon: Users },
       { label: "Wellness", path: "/wellness", icon: Heart },
       { label: "Gear", path: "/gear", icon: Guitar },
       { label: "Housing", path: "/housing", icon: Home },
@@ -86,6 +86,7 @@ export const FM_MODULES: FMModule[] = [
       {
         label: "Identity",
         items: [
+          { label: "Overview", path: "/character", icon: Users },
           { label: "Characters", path: "/characters", icon: Users },
           { label: "Edit Character", path: "/my-character", icon: Users },
           { label: "Avatar Designer", path: "/avatar-designer", icon: Sparkles },

--- a/src/pages/CharacterOverview.tsx
+++ b/src/pages/CharacterOverview.tsx
@@ -1,0 +1,162 @@
+import { Link } from "react-router-dom";
+import { Activity, Backpack, Heart, Palette, Sparkles, Trophy, User, Wallet, Zap } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { useAuth } from "@/hooks/use-auth-context";
+import { useGameData } from "@/hooks/useGameData";
+
+const formatMoney = (value: number | null | undefined) =>
+  new Intl.NumberFormat("en", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value ?? 0);
+
+const StatCard = ({ label, value, icon: Icon }: { label: string; value: string | number; icon: typeof Heart }) => (
+  <Card>
+    <CardContent className="p-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Icon className="h-4 w-4 text-primary" aria-hidden />
+        {label}
+      </div>
+      <p className="mt-2 text-2xl font-semibold text-foreground">{value}</p>
+    </CardContent>
+  </Card>
+);
+
+const quickLinks = [
+  { label: "Skills", path: "/skills", icon: Sparkles, description: "Review progression and unlocks." },
+  { label: "Wellness", path: "/wellness", icon: Heart, description: "Manage health, energy and recovery." },
+  { label: "Inventory", path: "/inventory", icon: Backpack, description: "Check items and owned stock." },
+  { label: "Wardrobe", path: "/clothing-shop", icon: Palette, description: "Shop and maintain your look." },
+];
+
+export default function CharacterOverview() {
+  const { user, loading: authLoading } = useAuth();
+  const { profile, skillProgress, activityStatus, activities, xpWallet, loading, error, refetch } = useGameData();
+
+  if (authLoading || loading) {
+    return <PageLoadingState title="Loading Character Overview" description="Fetching your active character snapshot..." />;
+  }
+
+  if (!user) {
+    return (
+      <PageEmptyState
+        title="Sign in to view your character"
+        description="Character overview is available after you log in and choose an active character."
+        action={<Button asChild><Link to="/auth">Sign in</Link></Button>}
+      />
+    );
+  }
+
+  if (error) {
+    return <PageErrorState title="Character overview could not be loaded" description={error} onRetry={() => void refetch()} />;
+  }
+
+  if (!profile) {
+    return (
+      <PageEmptyState
+        title="No active character found"
+        description="Create or switch to a character before using Character tools."
+        action={<Button asChild><Link to="/characters">Manage characters</Link></Button>}
+      />
+    );
+  }
+
+  const displayName = profile.display_name || profile.username || "Unknown Artist";
+  const topSkills = [...(skillProgress ?? [])]
+    .sort((a, b) => (b.current_level ?? 0) - (a.current_level ?? 0) || (b.current_xp ?? 0) - (a.current_xp ?? 0))
+    .slice(0, 4);
+  const recentEvents = (activities ?? []).slice(0, 3);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-xl border bg-card/80 p-5 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            <Avatar className="h-20 w-20 border-2 border-primary/30">
+              <AvatarImage src={profile.avatar_url || undefined} alt={displayName} />
+              <AvatarFallback><User className="h-9 w-9" aria-hidden /></AvatarFallback>
+            </Avatar>
+            <div>
+              <Badge variant="outline" className="mb-2">Character</Badge>
+              <h1 className="text-3xl font-bold tracking-tight">{displayName}</h1>
+              <p className="text-sm text-muted-foreground">Overview of your artist status, progression and next actions.</p>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline"><Link to="/my-character">Edit character</Link></Button>
+            <Button asChild><Link to="/wellness">Open Wellness</Link></Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5" aria-label="Character status">
+        <StatCard label="Health" value={`${profile.health ?? 100}%`} icon={Heart} />
+        <StatCard label="Energy" value={`${profile.energy ?? 100}%`} icon={Zap} />
+        <StatCard label="Money" value={formatMoney((profile as { money?: number | null }).money)} icon={Wallet} />
+        <StatCard label="Level" value={profile.level ?? 1} icon={Trophy} />
+        <StatCard label="XP" value={xpWallet?.xp_balance ?? 0} icon={Sparkles} />
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
+          <CardHeader><CardTitle className="flex items-center gap-2"><Activity className="h-5 w-5 text-primary" />Current activity</CardTitle></CardHeader>
+          <CardContent>
+            {activityStatus ? (
+              <div className="rounded-lg border bg-muted/40 p-4">
+                <p className="font-medium">{activityStatus.status}</p>
+                {activityStatus.started_at ? <p className="text-sm text-muted-foreground">Started {new Date(activityStatus.started_at).toLocaleString()}</p> : null}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No current activity is running.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>Quick links</CardTitle></CardHeader>
+          <CardContent className="grid gap-2">
+            {quickLinks.map((link) => {
+              const Icon = link.icon;
+              return (
+                <Button key={link.path} asChild variant="ghost" className="h-auto justify-start gap-3 p-3 text-left">
+                  <Link to={link.path}>
+                    <Icon className="h-4 w-4 text-primary" aria-hidden />
+                    <span><span className="block font-medium">{link.label}</span><span className="block text-xs text-muted-foreground">{link.description}</span></span>
+                  </Link>
+                </Button>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader><CardTitle>Skills summary</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {topSkills.length ? topSkills.map((skill) => (
+              <div key={skill.id} className="flex items-center justify-between rounded-lg border p-3">
+                <span className="font-medium">{skill.skill_slug.replace(/[-_]/g, " ")}</span>
+                <Badge variant="secondary">Level {skill.current_level ?? 0}</Badge>
+              </div>
+            )) : <p className="text-sm text-muted-foreground">No skill progress has been recorded yet.</p>}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>Recent events</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {recentEvents.length ? recentEvents.map((event) => (
+              <div key={event.id} className="rounded-lg border p-3">
+                <p className="text-sm font-medium">{event.message}</p>
+                {event.created_at ? <p className="text-xs text-muted-foreground">{new Date(event.created_at).toLocaleString()}</p> : null}
+              </div>
+            )) : <p className="text-sm text-muted-foreground">No recent character events are available.</p>}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Audit and document the current routing/navigation surface and produce a safe, staged migration plan for later hub consolidations.
- Fix an inconsistency where the Character module could land on a narrow child (Wellness) instead of a predictable Character Overview.
- Provide a small, safe first implementation (PR 1) that creates a canonical Character overview without broad refactors.

### Description
- Add `docs/navigation-and-hub-refactor.md` containing the repository-backed audit, route inventory, problems, migration map, risks and the staged PR sequence for the hub refactor.
- Add a real Character Overview page at `src/pages/CharacterOverview.tsx` that uses existing `useGameData`/`useAuth` hooks and handles loading, empty, error and unauthenticated states and shows avatar, key stats, activity, quick links, skills and recent events.
- Register `/character` as the canonical Character route and add `/character/overview` as a compatibility redirect in `src/App.tsx`, while preserving the existing `/hub/character` and `/wellness` routes.
- Update `src/config/fmNavigation.ts` to point the Character module `rootPath` and subtab/sidebar overview items to `/character`, and change `src/components/fm/ModuleTabs.tsx` to avoid restoring the last-visited nested route for the Character module (so clicking Character opens the stable overview).
- Add a focused unit test `src/config/__tests__/fmNavigation.character.test.ts` that asserts the Character module root, subtab and Wellness ownership remain correct.

### Testing
- Added a unit test file for navigation defaults but running `vitest` was blocked in this environment because `vitest` is not installed, so the test could not be executed (blocked/failure).
- Attempted `npm install` to run the project test/tooling but the environment failed installing dependencies due to a `403 Forbidden` for `@react-three/fiber`, preventing further lint/typecheck/build/test runs (install failed).
- Tried `bun test` as a fallback and it errored due to missing installed dependencies (for example `lucide-react`), so automated test execution was not completed (blocked).
- Files changed are limited to navigation/docs/UI surface additions and a single test; no database or backend changes were made and authorisation guards were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54b98a30588325a7ad8ac2191de195)