### PR TITLE
Standardise hub layouts and navigation route conventions

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -1,0 +1,67 @@
+# Navigation and hub refactor plan
+
+## PR 2 shared hub pattern
+
+RockMundo now uses a small reusable `HubLayout` shell for sections that are ready to migrate without rewriting the global navigation. The shell provides a hub title, optional description and icon, contextual actions, logical breadcrumbs, desktop child navigation, mobile scrollable child navigation, status content, loading, error and empty states, and a consistent content wrapper.
+
+A hub declares static typed navigation items with an id, label, path, optional icon, optional alias match paths, optional badge, and optional mobile visibility. This keeps route metadata close to the migrated section while avoiding a registry, plugin framework or dynamic route generator.
+
+Example using real routes:
+
+```tsx
+<HubLayout
+  title="Character"
+  description="Identity, progression, property, relationships, and legacy."
+  navItems={[{ id: "overview", label: "Overview", path: "/character" }]}
+  breadcrumbs={[{ label: "Character" }]}
+/>
+```
+
+## Routing conventions
+
+- Hub landing routes use Option A: the stable base route renders the overview directly when possible, for example `/character` and `/schedule`.
+- Child routes use predictable paths under the hub base, for example `/character/wellness` and `/character/skills`.
+- Existing legacy top-level pages remain functional during migration. Character child routes introduced in this PR redirect to their existing implementations (`/skills`, `/wellness`, `/inventory`, `/clothing-shop`, `/housing`, `/statistics`, `/legacy`) and preserve query strings.
+- Temporary aliases are explicit route entries and should be removed only after the destination page has been migrated under the hub path.
+- Redirects must use `replace`, avoid redirecting a route to itself, and preserve query parameters where practical.
+
+## Selected-state matching
+
+`HubLayout` normalizes trailing slashes and ignores query strings before matching. A child item is active for its exact path, nested paths below it, and declared legacy aliases. Match boundaries prevent unrelated routes such as `/characters` from matching `/character`.
+
+## Breadcrumbs
+
+Hub breadcrumbs are configured from human-readable metadata instead of raw path splitting. They render a Home link, hub label, and current-page indication. Future entity pages should append entity labels, such as a song, band or company name, supplied by the page.
+
+## Page titles
+
+Browser titles continue to use the existing `PageTitle` logic in `src/App.tsx`. Hub routes should register visible child context in `ROUTE_TITLES`, producing titles such as `Wellness | Character | Rockmundo` while preserving the existing Rockmundo suffix convention.
+
+## Desktop and mobile navigation
+
+Desktop child navigation renders as accessible button links above hub content. Mobile uses a horizontally scrollable button-link row, matching existing compact RockMundo navigation patterns without adding drawers or new animations. Active links use `aria-current="page"`, visible non-colour state, keyboard-focus rings inherited from the design system, and no horizontal page overflow.
+
+## Sections migrated in PR 2
+
+- Character: migrated to the shared hub shell while preserving the existing overview cards and legacy direct page links. `/character` is now the stable overview route; `/hub/character` remains as a legacy alias surface.
+- Schedule: selected as the second low-risk section because it already had a stable landing page, limited child booking links, no admin-only policy changes, and no overlap with the upcoming Music consolidation. `/schedule` remains the overview and `/schedule/calendar` redirects back to `/schedule` for compatibility.
+
+## Pending sections
+
+Music, Band, World, Social, Business, Career, media and deeper Schedule booking pages remain pending. Music consolidation is intentionally deferred to the next PR.
+
+## Deviations and known legacy routes
+
+The current repository did not contain the proposed PR 1 document at `docs/navigation-and-hub-refactor.md`, so this PR establishes it from the observed implementation. Existing route definitions are still centralized in `src/App.tsx` with React Router v6. Global desktop and mobile navigation remains in `HorizontalNavigation`; authenticated application pages are nested under `Layout`; admin pages continue to use the existing admin route policy where already implemented.
+
+Known legacy routes retained: `/hub/character`, `/skills`, `/wellness`, `/inventory`, `/clothing-shop`, `/housing`, `/statistics`, `/legacy`, `/booking/education`, `/booking/performance`, `/booking/work`.
+
+## Migration guidance
+
+1. Choose a low-risk section with an existing landing page.
+2. Add a stable base route that renders the overview directly.
+3. Define static hub nav items once and reuse them for desktop, mobile, breadcrumbs and active matching.
+4. Preserve existing deep links with explicit temporary redirects or aliases.
+5. Register browser title metadata for the hub and child routes.
+6. Keep global navigation unchanged unless a section has fully migrated.
+7. Do not create placeholder tabs; include only existing pages.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -356,6 +356,16 @@ for (const module of FM_MODULES) {
   }
 }
 
+ROUTE_TITLES.set("/character", "Character");
+ROUTE_TITLES.set("/character/skills", "Skills | Character");
+ROUTE_TITLES.set("/character/wellness", "Wellness | Character");
+ROUTE_TITLES.set("/character/inventory", "Inventory | Character");
+ROUTE_TITLES.set("/character/wardrobe", "Wardrobe | Character");
+ROUTE_TITLES.set("/character/lifestyle", "Lifestyle | Character");
+ROUTE_TITLES.set("/character/achievements", "Achievements | Character");
+ROUTE_TITLES.set("/character/history", "History | Character");
+ROUTE_TITLES.set("/schedule", "Schedule");
+
 const getRouteTitle = (pathname: string) => {
   const exactTitle = ROUTE_TITLES.get(pathname);
   if (exactTitle) return exactTitle;
@@ -376,6 +386,11 @@ const PageTitle = () => {
   }, [pathname]);
 
   return null;
+};
+
+const PreserveQueryRedirect = ({ to }: { to: string }) => {
+  const { search } = useLocation();
+  return <Navigate to={`${to}${search}`} replace />;
 };
 
 function App() {
@@ -459,6 +474,7 @@ function App() {
                     <Route path="competitive-charts" element={<CompetitiveCharts />} />
                     <Route path="country-charts" element={<CountryCharts />} />
                     <Route path="schedule" element={<Schedule />} />
+                    <Route path="schedule/calendar" element={<PreserveQueryRedirect to="/schedule" />} />
                     <Route path="booking/education" element={<EducationBooking />} />
                     <Route path="booking/performance" element={<PerformanceBooking />} />
                     <Route path="booking/work" element={<WorkBooking />} />
@@ -586,6 +602,14 @@ function App() {
                     <Route path="casino/slots" element={<CasinoSlots />} />
                     
                     {/* Category hub pages */}
+                    <Route path="character" element={<CharacterHub />} />
+                    <Route path="character/skills/*" element={<PreserveQueryRedirect to="/skills" />} />
+                    <Route path="character/wellness/*" element={<PreserveQueryRedirect to="/wellness" />} />
+                    <Route path="character/inventory/*" element={<PreserveQueryRedirect to="/inventory" />} />
+                    <Route path="character/wardrobe/*" element={<PreserveQueryRedirect to="/clothing-shop" />} />
+                    <Route path="character/lifestyle/*" element={<PreserveQueryRedirect to="/housing" />} />
+                    <Route path="character/achievements/*" element={<PreserveQueryRedirect to="/statistics" />} />
+                    <Route path="character/history/*" element={<PreserveQueryRedirect to="/legacy" />} />
                     <Route path="hub/character" element={<CharacterHub />} />
                     <Route path="hub/music" element={<MusicHubPage />} />
                     <Route path="hub/band-live" element={<BandLiveHub />} />

--- a/src/components/CategoryHub.tsx
+++ b/src/components/CategoryHub.tsx
@@ -25,6 +25,7 @@ interface CategoryHubProps {
   featuredEyebrow?: string;
   featuredHeadline?: string;
   featuredCopy?: string;
+  bare?: boolean;
 }
 
 export const CategoryHub = ({
@@ -36,6 +37,7 @@ export const CategoryHub = ({
   featuredEyebrow,
   featuredHeadline,
   featuredCopy,
+  bare = false,
 }: CategoryHubProps) => {
   const { t } = useTranslation();
   const title = t(titleKey);
@@ -53,8 +55,8 @@ export const CategoryHub = ({
 
   const hasRealStats = stats && stats.length > 0;
 
-  return (
-    <FMPageScaffold title={title} subtitle={description} eyebrow={featuredEyebrow}>
+  const content = (
+    <>
       {allGroups.length === 0 && (
         <PageEmptyState
           title="Nothing is on the setlist yet"
@@ -85,6 +87,14 @@ export const CategoryHub = ({
           <TileGrid tiles={group.tiles} />
         </SectionBand>
       ))}
+    </>
+  );
+
+  if (bare) return content;
+
+  return (
+    <FMPageScaffold title={title} subtitle={description} eyebrow={featuredEyebrow}>
+      {content}
     </FMPageScaffold>
   );
 };

--- a/src/components/hub/HubLayout.test.tsx
+++ b/src/components/hub/HubLayout.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isHubNavItemActive, type HubNavItem } from "./HubLayout";
+
+describe("hub navigation matching", () => {
+  const characterWellness: HubNavItem = {
+    id: "wellness",
+    label: "Wellness",
+    path: "/character/wellness",
+    matchPaths: ["/wellness"],
+  };
+
+  it("matches exact child routes and nested child routes", () => {
+    expect(isHubNavItemActive("/character/wellness", characterWellness)).toBe(true);
+    expect(isHubNavItemActive("/character/wellness/recovery", characterWellness)).toBe(true);
+  });
+
+  it("normalizes query-free paths and trailing slashes", () => {
+    expect(isHubNavItemActive("/character/wellness/", characterWellness)).toBe(true);
+  });
+
+  it("supports legacy alias paths without selecting unrelated items", () => {
+    expect(isHubNavItemActive("/wellness", characterWellness)).toBe(true);
+    expect(isHubNavItemActive("/wellness-plan", characterWellness)).toBe(false);
+    expect(isHubNavItemActive("/character/skills", characterWellness)).toBe(false);
+  });
+
+  it("keeps overview routes exact unless a nested route is under the base", () => {
+    const overview: HubNavItem = { id: "overview", label: "Overview", path: "/character", matchPaths: ["/hub/character"], end: true };
+    expect(isHubNavItemActive("/character", overview)).toBe(true);
+    expect(isHubNavItemActive("/character/skills", overview)).toBe(false);
+    expect(isHubNavItemActive("/characters", overview)).toBe(false);
+  });
+});

--- a/src/components/hub/HubLayout.tsx
+++ b/src/components/hub/HubLayout.tsx
@@ -1,0 +1,110 @@
+import { ReactNode } from "react";
+import { Link, useLocation } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import { Home } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { cn } from "@/lib/utils";
+
+export type HubNavItem = {
+  id: string;
+  label: string;
+  path: string;
+  icon?: LucideIcon;
+  matchPaths?: string[];
+  mobile?: boolean;
+  end?: boolean;
+  badge?: ReactNode;
+};
+
+export type HubBreadcrumb = { label: string; path?: string };
+
+const normalizePath = (path: string) => {
+  const withoutQuery = path.split("?")[0] || "/";
+  return withoutQuery.length > 1 ? withoutQuery.replace(/\/+$/, "") : withoutQuery;
+};
+
+export const isHubNavItemActive = (pathname: string, item: HubNavItem) => {
+  const current = normalizePath(pathname);
+  const candidates = [item.path, ...(item.matchPaths ?? [])].map(normalizePath);
+  return candidates.some((candidate) => current === candidate || (!item.end && current.startsWith(`${candidate}/`)));
+};
+
+export interface HubLayoutProps {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  navLabel?: string;
+  navItems: HubNavItem[];
+  breadcrumbs?: HubBreadcrumb[];
+  actions?: ReactNode;
+  status?: ReactNode;
+  loading?: boolean;
+  error?: { title?: string; description?: string; retry?: () => void } | null;
+  empty?: { title: string; description?: string } | null;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Shared hub shell for progressively migrated sections.
+ * Example: <HubLayout title="Character" navItems={[{ id: "overview", label: "Overview", path: "/character" }]} />.
+ */
+export function HubLayout({
+  title,
+  description,
+  icon,
+  navLabel,
+  navItems,
+  breadcrumbs,
+  actions,
+  status,
+  loading,
+  error,
+  empty,
+  children,
+  className,
+}: HubLayoutProps) {
+  const { pathname } = useLocation();
+  const visibleMobileItems = navItems.filter((item) => item.mobile !== false);
+  const content = loading ? (
+    <PageLoadingState title={`Loading ${title}`} description="Preparing this hub and its latest activity." />
+  ) : error ? (
+    <PageErrorState title={error.title ?? `Unable to load ${title}`} description={error.description ?? "Try again in a moment."} onRetry={error.retry} />
+  ) : empty ? (
+    <PageEmptyState title={empty.title} description={empty.description} />
+  ) : children;
+
+  return (
+    <FMPageScaffold title={title} subtitle={description} icon={icon} headerActions={actions} className={className}>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav aria-label={`${title} breadcrumb`} className="-mt-1 flex items-center gap-1 overflow-x-auto whitespace-nowrap text-xs text-muted-foreground">
+          <Link to="/dashboard" className="inline-flex items-center gap-1 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            <Home className="h-3.5 w-3.5" aria-hidden /> Home
+          </Link>
+          {breadcrumbs.map((crumb, index) => {
+            const isLast = index === breadcrumbs.length - 1;
+            return <span key={`${crumb.label}-${index}`} className="inline-flex items-center gap-1"><span aria-hidden>/</span>{crumb.path && !isLast ? <Link to={crumb.path} className="rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">{crumb.label}</Link> : <span aria-current={isLast ? "page" : undefined} className={cn(isLast && "font-medium text-foreground")}>{crumb.label}</span>}</span>;
+          })}
+        </nav>
+      )}
+      {status && <Card><CardContent className="p-3">{status}</CardContent></Card>}
+      <nav aria-label={navLabel ?? `${title} sections`} className="hidden md:flex flex-wrap gap-2">
+        {navItems.map((item) => <HubNavLink key={item.id} item={item} active={isHubNavItemActive(pathname, item)} />)}
+      </nav>
+      <nav aria-label={`${navLabel ?? title} mobile sections`} className="md:hidden -mx-1 overflow-x-auto pb-1">
+        <div className="flex min-w-max gap-2 px-1">{visibleMobileItems.map((item) => <HubNavLink key={item.id} item={item} active={isHubNavItemActive(pathname, item)} compact />)}</div>
+      </nav>
+      <main className="min-w-0" tabIndex={-1}>{content}</main>
+    </FMPageScaffold>
+  );
+}
+
+function HubNavLink({ item, active, compact }: { item: HubNavItem; active: boolean; compact?: boolean }) {
+  const Icon = item.icon;
+  return <Button asChild variant={active ? "secondary" : "outline"} size={compact ? "sm" : "default"} className={cn("gap-2", active && "border-primary text-primary")} aria-current={active ? "page" : undefined}><Link to={item.path}>{Icon && <Icon className="h-4 w-4" aria-hidden />}<span>{item.label}</span>{item.badge}</Link></Button>;
+}
+
+export default HubLayout;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -5,12 +5,17 @@ import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { DaySchedule } from "@/components/schedule/DaySchedule";
 import { addDays, startOfWeek, format } from "date-fns";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useTranslation } from "@/hooks/useTranslation";
 import { GigLocationWarning } from "@/components/notifications/GigLocationWarning";
-import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { HubLayout, type HubNavItem } from "@/components/hub/HubLayout";
+
+const scheduleHubNavItems: HubNavItem[] = [
+  { id: "overview", label: "Overview", path: "/schedule", icon: Calendar, end: true },
+  { id: "education", label: "Education", path: "/booking/education", icon: CalendarDays },
+  { id: "performance", label: "Performance", path: "/booking/performance", icon: CalendarDays },
+  { id: "work", label: "Work", path: "/booking/work", icon: CalendarDays },
+];
 
 const Schedule = () => {
-  const { t } = useTranslation();
   const { userId } = useActiveProfile();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [viewMode, setViewMode] = useState<'day' | 'week'>('day');
@@ -19,12 +24,12 @@ const Schedule = () => {
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 
   return (
-    <FMPageScaffold
+    <HubLayout
       title="Schedule"
-      subtitle="Read-only view of your booked activities"
-      backTo="/dashboard"
-      backLabel="Back to Dashboard"
+      description="Read-only view of your booked activities and booking entry points."
       icon={Calendar}
+      navItems={scheduleHubNavItems}
+      breadcrumbs={[{ label: "Schedule" }]}
     >
 
       <GigLocationWarning />
@@ -97,7 +102,7 @@ const Schedule = () => {
           ))}
         </Tabs>
       )}
-    </FMPageScaffold>
+    </HubLayout>
   );
 };
 

--- a/src/pages/hubs/CharacterHub.tsx
+++ b/src/pages/hubs/CharacterHub.tsx
@@ -1,12 +1,33 @@
 import { CategoryHub } from "@/components/CategoryHub";
+import { HubLayout, type HubNavItem } from "@/components/hub/HubLayout";
 import {
   User, Users, ShoppingCart, Guitar, HeartPulse, History, BookOpen, GraduationCap, Sparkles,
-  Palette, Skull, Crown, Scissors, Package, Home, Car, Heart,
+  Palette, Skull, Crown, Scissors, Package, Home, Car, Heart, Shirt, Trophy,
 } from "lucide-react";
+
+const characterHubNavItems: HubNavItem[] = [
+  { id: "overview", label: "Overview", path: "/character", matchPaths: ["/hub/character"], icon: User, end: true },
+  { id: "skills", label: "Skills", path: "/character/skills", matchPaths: ["/skills"], icon: Sparkles },
+  { id: "wellness", label: "Wellness", path: "/character/wellness", matchPaths: ["/wellness"], icon: HeartPulse },
+  { id: "inventory", label: "Inventory", path: "/character/inventory", matchPaths: ["/inventory"], icon: Package },
+  { id: "wardrobe", label: "Wardrobe", path: "/character/wardrobe", matchPaths: ["/clothing-shop", "/skin-store", "/avatar-designer"], icon: Shirt },
+  { id: "lifestyle", label: "Lifestyle", path: "/character/lifestyle", matchPaths: ["/housing", "/personal-vehicles"], icon: Home },
+  { id: "achievements", label: "Achievements", path: "/character/achievements", matchPaths: ["/hall-of-immortals", "/statistics"], icon: Trophy },
+  { id: "history", label: "History", path: "/character/history", matchPaths: ["/legacy", "/journal"], icon: History },
+];
 
 export default function CharacterHub() {
   return (
+    <HubLayout
+      title="Character"
+      description="Identity, progression, property, relationships, and legacy."
+      icon={User}
+      navItems={characterHubNavItems}
+      breadcrumbs={[{ label: "Character" }]}
+      actions={<a className="text-sm font-medium text-primary underline-offset-4 hover:underline" href="/my-character/edit">Edit appearance</a>}
+    >
     <CategoryHub
+      bare
       titleKey="nav.character"
       description="Identity, property, relationships, and legacy."
       groups={[
@@ -49,5 +70,6 @@ export default function CharacterHub() {
         },
       ]}
     />
+    </HubLayout>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide a small, reusable hub shell so sections can be migrated incrementally with a consistent header, child navigation, breadcrumbs and page-state handling.
- Stabilise the Character entry so `/character` is a predictable overview landing (avoid unexpected defaults such as Wellness) while preserving existing deep links.
- Establish routing conventions and lightweight alias/redirect patterns to preserve legacy deep links and prepare for future hub migrations (Music, Band, World, Social, Business, Schedule, Career).

### Description

- Added a reusable `HubLayout` component with typed `HubNavItem` metadata, accessible desktop and mobile child navigation, breadcrumbs, contextual actions, status/empty/loading/error handling, and `aria-current` support (`src/components/hub/HubLayout.tsx`).
- Refactored the Character hub to use `HubLayout` and declared a small navigational map for Character child pages while embedding the existing overview via a new `bare` mode on `CategoryHub` (`src/pages/hubs/CharacterHub.tsx`, `src/components/CategoryHub.tsx`).
- Applied the shared layout to `Schedule` as a second low-risk migration, adding limited hub nav items and preserving existing booking entry points (`src/pages/Schedule.tsx`).
- Added explicit, query-preserving compatibility redirects and title registrations via a small `PreserveQueryRedirect` helper and `ROUTE_TITLES` entries so legacy routes remain functional (`src/App.tsx`).
- Added a unit test exercising the selected-state matching logic for hub nav items (`src/components/hub/HubLayout.test.tsx`).
- Documented the chosen hub pattern, route conventions, redirects, breadcrumbs and migration guidance in `docs/navigation-and-hub-refactor.md`.

### Testing

- `npm run typecheck` (`tsc --noEmit`) completed successfully and reported no type errors.
- `npm run lint` could not be executed in this environment because ESLint failed to resolve `@eslint/js` (missing/partial dependencies in the runtime container).
- `npm run test:unit -- src/components/hub/HubLayout.test.tsx` could not run because `vitest` was not available in the execution environment despite the test file being added.
- `npm run build` could not run because build tooling (`vite`) was not present in the environment and `npm install` failed due to a registry `403` on a dependency, preventing full dependency installation and end-to-end CI verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54bcd673b08325af18c9314701e54e)