### PR TITLE
Standardise hub layouts and navigation route conventions

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -133,3 +133,115 @@ PR 1 uses existing semantic page states, visible `h1`, labelled navigation links
 - No broad Music/Band/World/Social/Business/Career migration.
 - No removal of existing deep links.
 - No redesign of the global navigation visual system.
+
+## PR 2 update — shared hub layout and conventions
+
+PR 2 establishes a reusable hub-page pattern without starting the Music consolidation or moving every legacy page. The implementation deliberately keeps the existing React Router v6 `BrowserRouter`/`Routes` table in `src/App.tsx` and the existing FM shell navigation in `src/config/fmNavigation.ts` so future migrations can remain incremental.
+
+### Shared hub pattern
+
+The shared pattern is `HubLayout` in `src/components/hub/HubLayout.tsx`, with concise developer notes in `src/components/hub/README.md`. A hub supplies static typed navigation items from `src/config/hubNavigation.ts` and the layout renders:
+
+- a logical hub breadcrumb trail,
+- the existing `PageHeader` visual treatment,
+- optional contextual actions,
+- optional summary/status content,
+- horizontal child navigation for desktop and mobile,
+- a content region that preserves child loading, empty and error states.
+
+The layout intentionally does not generate routes. Route declarations remain explicit in `App.tsx` to match the current architecture and avoid circular imports between route definitions, global navigation and page components.
+
+### Route conventions selected
+
+RockMundo will use **Option A** for hub overviews: the stable base route renders the overview directly.
+
+Examples:
+
+- `/character` renders the Character overview.
+- `/schedule` renders the Schedule overview.
+- Future hubs should prefer `/music`, `/band`, `/world`, `/business`, `/social` and `/career` as render routes once each section is migrated.
+
+`/section/overview` routes may exist only as compatibility aliases that redirect to the base overview. They should not become the canonical route.
+
+### Child-route convention
+
+Future child pages should use predictable hub-owned paths such as `/character/wellness` or `/music/songwriting` when a section is migrated. PR 2 does not move the existing flat pages into all final paths. Instead, it keeps current deep links working and adds a small number of explicit Character aliases:
+
+- `/character/overview` redirects to `/character`.
+- `/character/wellness` redirects to `/wellness`.
+- `/character/skills` redirects to `/skills`.
+- `/character/inventory` redirects to `/inventory`.
+- `/character/wardrobe` redirects to `/clothing-shop`.
+- `/schedule/overview` redirects to `/schedule`.
+
+These redirects preserve query strings where practical and use `replace` so the browser back button does not bounce between alias and canonical route.
+
+### Selected-route matching rules
+
+Hub navigation items match:
+
+1. their exact canonical path,
+2. nested routes below that path,
+3. explicit legacy or alias `matchPaths`,
+4. paths regardless of query string,
+5. paths with trailing slashes normalised.
+
+Only the first matching hub item is treated as current. This prevents unrelated tabs from being highlighted while still allowing aliases such as `/character/wellness` to select Wellness.
+
+### Breadcrumb convention
+
+Hub breadcrumbs are metadata-driven, not raw URL-segment driven. The shared layout renders `Home > Hub label > Child label` using the active hub navigation item. Existing global breadcrumbs remain mounted in `Layout` for non-migrated pages and can be replaced gradually as hubs adopt `HubLayout`.
+
+### Page-title convention
+
+The browser title now uses hub context for migrated hubs:
+
+- overview: `Character | Rockmundo`, `Schedule | Rockmundo`,
+- child context: `Wellness | Character | Rockmundo`, `Education | Schedule | Rockmundo`.
+
+Non-migrated pages continue to use route titles derived from FM navigation metadata, with module context added where it is safe to infer.
+
+### Mobile navigation pattern
+
+The shared hub child navigation uses the existing compact button styling and `fm-scrollbar-thin` horizontal overflow pattern already used by FM sub-tabs. This keeps active pages visible, avoids a new drawer/select interaction model, and works with touch, mouse and keyboard focus states.
+
+### Accessibility expectations
+
+Migrated hubs must keep:
+
+- a labelled hub section and logical heading hierarchy,
+- `aria-current="page"` on the active child link,
+- labelled breadcrumb navigation,
+- accessible labels for contextual actions,
+- visible focus states from the existing button/link styles,
+- non-colour selected-state indicators through button variant and text/icon state,
+- no new animation unless it respects reduced-motion preferences.
+
+### Sections migrated in PR 2
+
+1. **Character** — selected because PR 1 made `/character` the canonical overview and the section already had clear existing child pages. Character now uses `HubLayout` and static hub metadata while preserving existing `/wellness`, `/skills`, `/inventory`, `/clothing-shop`, `/legacy` and related links.
+2. **Schedule** — selected as the second low-risk vertical slice because `/schedule` already existed as a stable landing page, it has a small set of existing booking child routes, and it does not overlap with the upcoming Music consolidation. The Schedule page now uses `HubLayout` with child links to existing booking flows only.
+
+### Sections still pending
+
+Music, Band, World, Social, Business, Career, Media and the broader Home/dashboard surfaces remain on their existing hub or flat-page patterns. Music consolidation is explicitly deferred to PR 3.
+
+### Deviations from the original plan
+
+The original plan anticipated route metadata replacing segment-derived breadcrumbs more broadly. PR 2 limits metadata-driven breadcrumbs to pages rendered by `HubLayout` so the shared pattern can be reviewed independently without rewriting the global breadcrumb component or sidebar.
+
+### Known legacy routes that remain
+
+The flat Character routes (`/wellness`, `/skills`, `/inventory`, `/clothing-shop`, `/housing`, `/gear`, `/legacy`, `/hall-of-immortals`) remain canonical for now. The existing `/hub/character` tile hub remains available as a legacy route. Schedule booking routes remain under `/booking/*` until a later Schedule/Home slice decides whether to move them under `/schedule/*`.
+
+### Migration guidance for future PRs
+
+For each future hub migration:
+
+1. Add static hub navigation items to `src/config/hubNavigation.ts` using only real existing pages.
+2. Render the section overview at the stable base route.
+3. Wrap the overview or shared section shell in `HubLayout`.
+4. Add explicit aliases only for renamed routes, preserving query strings and avoiding redirect loops.
+5. Update page-title metadata if new canonical child paths are introduced.
+6. Keep existing deep links until analytics and release notes confirm they can be removed.
+7. Add tests for base landing, child selected state, breadcrumbs, redirects and query preservation.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,9 @@ import { TutorialProvider } from "./contexts/TutorialContext";
 import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
-import { FM_MODULES } from "./config/fmNavigation";
+import { FM_MODULES, findModuleForPath } from "./config/fmNavigation";
+import { characterHubNavigation, scheduleHubNavigation } from "./config/hubNavigation";
+import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
 
@@ -24,6 +26,11 @@ const RedirectTo = ({ to }: { to: string }) => {
     window.location.replace(to);
   }, [to]);
   return null;
+};
+
+const PreserveQueryRedirect = ({ to }: { to: string }) => {
+  const { search } = useLocation();
+  return <Navigate to={`${to}${search}`} replace />;
 };
 import WorldPulsePage from "./pages/WorldPulse";
 import BandManager from "./pages/BandManager";
@@ -357,12 +364,27 @@ for (const module of FM_MODULES) {
   }
 }
 
+const HUB_TITLE_CONFIGS = [
+  { title: "Character", overviewPath: "/character", items: characterHubNavigation },
+  { title: "Schedule", overviewPath: "/schedule", items: scheduleHubNavigation },
+];
+
 const getRouteTitle = (pathname: string) => {
+  for (const hub of HUB_TITLE_CONFIGS) {
+    const activeItem = hub.items.find((item) => isHubNavigationItemActive(pathname, item));
+    if (activeItem) {
+      return activeItem.path === hub.overviewPath ? hub.title : `${activeItem.label} | ${hub.title}`;
+    }
+  }
+
   const exactTitle = ROUTE_TITLES.get(pathname);
   if (exactTitle) return exactTitle;
 
   for (const [route, title] of ROUTE_TITLES) {
-    if (matchPath({ path: route, end: true }, pathname)) return title;
+    if (matchPath({ path: route, end: true }, pathname)) {
+      const mod = findModuleForPath(pathname);
+      return mod.id !== "overview" && title !== mod.label ? `${title} | ${mod.label}` : title;
+    }
   }
 
   return "Rockmundo";
@@ -420,7 +442,11 @@ function App() {
 
                     <Route path="todays-news" element={<TodaysNewsPage />} />
                     <Route path="character" element={<CharacterOverview />} />
-                    <Route path="character/overview" element={<Navigate to="/character" replace />} />
+                    <Route path="character/overview" element={<PreserveQueryRedirect to="/character" />} />
+                    <Route path="character/wellness" element={<PreserveQueryRedirect to="/wellness" />} />
+                    <Route path="character/skills" element={<PreserveQueryRedirect to="/skills" />} />
+                    <Route path="character/inventory" element={<PreserveQueryRedirect to="/inventory" />} />
+                    <Route path="character/wardrobe" element={<PreserveQueryRedirect to="/clothing-shop" />} />
                     <Route path="wellness" element={<WellnessPage />} />
                     <Route path="underworld" element={<UnderworldNew />} />
                     <Route path="dikcok" element={<DikCok />} />
@@ -462,6 +488,7 @@ function App() {
                     <Route path="competitive-charts" element={<CompetitiveCharts />} />
                     <Route path="country-charts" element={<CountryCharts />} />
                     <Route path="schedule" element={<Schedule />} />
+                    <Route path="schedule/overview" element={<PreserveQueryRedirect to="/schedule" />} />
                     <Route path="booking/education" element={<EducationBooking />} />
                     <Route path="booking/performance" element={<PerformanceBooking />} />
                     <Route path="booking/work" element={<WorkBooking />} />

--- a/src/components/hub/HubLayout.test.tsx
+++ b/src/components/hub/HubLayout.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { Calendar, Heart, Users } from "lucide-react";
+
+import { HubLayout, isHubNavigationItemActive, type HubNavigationItem } from "./HubLayout";
+
+const characterItems: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/character", icon: Users, matchPaths: ["/character/overview", "/hub/character"] },
+  { id: "wellness", label: "Wellness", path: "/wellness", icon: Heart, matchPaths: ["/character/wellness"] },
+];
+
+const renderHub = (route: string, items = characterItems) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <HubLayout title="Character" description="Character hub" icon={Users} overviewPath="/character" navigation={items}>
+        <p>Hub content</p>
+      </HubLayout>
+    </MemoryRouter>,
+  );
+
+describe("HubLayout", () => {
+  it("marks the exact overview route as current", () => {
+    renderHub("/character?tab=summary");
+
+    expect(screen.getByRole("link", { name: "Overview" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Wellness" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("matches nested and legacy child routes", () => {
+    expect(isHubNavigationItemActive("/wellness/recovery", characterItems[1])).toBe(true);
+    expect(isHubNavigationItemActive("/character/wellness", characterItems[1])).toBe(true);
+    expect(isHubNavigationItemActive("/character", characterItems[1])).toBe(false);
+  });
+
+  it("renders logical breadcrumbs from hub metadata", () => {
+    renderHub("/wellness");
+
+    expect(screen.getByRole("navigation", { name: "Hub breadcrumb" })).toHaveTextContent("Character");
+    expect(screen.getByRole("navigation", { name: "Hub breadcrumb" })).toHaveTextContent("Wellness");
+  });
+
+  it("renders mobile-visible horizontal child navigation", () => {
+    renderHub("/schedule", [
+      { id: "overview", label: "Overview", path: "/schedule", icon: Calendar },
+      { id: "education", label: "Education", path: "/booking/education", icon: Calendar },
+    ]);
+
+    expect(screen.getByRole("navigation", { name: "Character pages" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Education" })).toBeVisible();
+  });
+});

--- a/src/components/hub/HubLayout.tsx
+++ b/src/components/hub/HubLayout.tsx
@@ -1,0 +1,177 @@
+import { ReactNode } from "react";
+import { Link, matchPath, useLocation } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+import { ChevronRight, Home } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { cn } from "@/lib/utils";
+
+export type HubNavigationItem = {
+  id: string;
+  label: string;
+  path: string;
+  icon?: LucideIcon;
+  description?: string;
+  matchPaths?: string[];
+  mobileVisible?: boolean;
+  badge?: ReactNode;
+};
+
+export type HubBreadcrumbItem = {
+  label: string;
+  path?: string;
+};
+
+export type HubAction = {
+  label: string;
+  path: string;
+  icon?: LucideIcon;
+  variant?: "default" | "outline" | "secondary" | "ghost";
+  ariaLabel?: string;
+};
+
+export type HubLayoutState =
+  | { type: "loading"; title?: string; description?: string }
+  | { type: "error"; title?: string; description?: string; onRetry?: () => void }
+  | { type: "empty"; title?: string; description?: string; action?: ReactNode };
+
+export type HubLayoutProps = {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  overviewPath: string;
+  navigation: HubNavigationItem[];
+  children: ReactNode;
+  actions?: HubAction[];
+  breadcrumbs?: HubBreadcrumbItem[];
+  status?: ReactNode;
+  state?: HubLayoutState;
+  className?: string;
+  contentClassName?: string;
+  navigationLabel?: string;
+};
+
+const normalisePath = (path: string) => {
+  const [withoutQuery] = path.split("?");
+  return withoutQuery.length > 1 ? withoutQuery.replace(/\/+$/, "") : withoutQuery;
+};
+
+export const isHubNavigationItemActive = (pathname: string, item: HubNavigationItem) => {
+  const current = normalisePath(pathname);
+  const paths = [item.path, ...(item.matchPaths ?? [])].map(normalisePath);
+
+  return paths.some((path) => {
+    if (current === path) return true;
+    if (matchPath({ path: `${path}/*`, end: false }, current)) return true;
+    return false;
+  });
+};
+
+const HubBreadcrumbs = ({ items }: { items: HubBreadcrumbItem[] }) => {
+  if (!items.length) return null;
+
+  return (
+    <nav aria-label="Hub breadcrumb" className="flex min-w-0 items-center gap-1 overflow-x-auto text-xs text-muted-foreground">
+      <Link to="/dashboard" aria-label="Home" className="inline-flex items-center gap-1 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+        <Home className="h-3.5 w-3.5" aria-hidden />
+      </Link>
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        const content = <span className="truncate max-w-[12rem]">{item.label}</span>;
+        return (
+          <span key={`${item.label}-${index}`} className="inline-flex min-w-0 items-center gap-1">
+            <ChevronRight className="h-3 w-3 shrink-0 opacity-50" aria-hidden />
+            {item.path && !isLast ? (
+              <Link to={item.path} className="inline-flex min-w-0 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+                {content}
+              </Link>
+            ) : (
+              <span aria-current={isLast ? "page" : undefined} className={cn("inline-flex min-w-0", isLast && "font-medium text-foreground")}>
+                {content}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+};
+
+export function HubLayout({
+  title,
+  description,
+  icon,
+  overviewPath,
+  navigation,
+  children,
+  actions = [],
+  breadcrumbs,
+  status,
+  state,
+  className,
+  contentClassName,
+  navigationLabel,
+}: HubLayoutProps) {
+  const { pathname } = useLocation();
+  const activeItem = navigation.find((item) => isHubNavigationItemActive(pathname, item)) ?? navigation.find((item) => item.path === overviewPath);
+  const logicalBreadcrumbs = breadcrumbs ?? [
+    { label: title, path: overviewPath },
+    ...(activeItem && activeItem.path !== overviewPath ? [{ label: activeItem.label }] : []),
+  ];
+
+  const headerActions = actions.length ? (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      {actions.map((action) => {
+        const Icon = action.icon;
+        return (
+          <Button key={action.path} asChild size="sm" variant={action.variant ?? "outline"} aria-label={action.ariaLabel ?? action.label}>
+            <Link to={action.path}>
+              {Icon && <Icon className="mr-1.5 h-4 w-4" aria-hidden />}
+              {action.label}
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
+  ) : undefined;
+
+  const stateContent = state?.type === "loading" ? (
+    <PageLoadingState title={state.title ?? `Loading ${title}`} description={state.description} />
+  ) : state?.type === "error" ? (
+    <PageErrorState title={state.title ?? `${title} could not be loaded`} description={state.description} onRetry={state.onRetry} />
+  ) : state?.type === "empty" ? (
+    <PageEmptyState title={state.title ?? `No ${title} content`} description={state.description} action={state.action} />
+  ) : null;
+
+  return (
+    <section className={cn("mx-auto flex w-full max-w-[1600px] flex-col gap-4", className)} aria-labelledby="hub-title">
+      <HubBreadcrumbs items={logicalBreadcrumbs} />
+      <PageHeader title={title} subtitle={description} icon={icon} actions={headerActions} />
+      {status ? <div aria-label={`${title} summary`}>{status}</div> : null}
+      <nav aria-label={navigationLabel ?? `${title} pages`} className="rounded-xl border bg-card/70 p-1 shadow-sm">
+        <div className="flex gap-1 overflow-x-auto fm-scrollbar-thin" role="list">
+          {navigation.map((item) => {
+            const Icon = item.icon;
+            const active = isHubNavigationItemActive(pathname, item);
+            return (
+              <Button key={item.id} asChild variant={active ? "secondary" : "ghost"} size="sm" className={cn("h-10 shrink-0 justify-start gap-2", item.mobileVisible === false && "hidden md:inline-flex")} aria-current={active ? "page" : undefined}>
+                <Link to={item.path} aria-label={item.description ? `${item.label}: ${item.description}` : item.label}>
+                  {Icon && <Icon className="h-4 w-4" aria-hidden />}
+                  <span>{item.label}</span>
+                  {item.badge}
+                </Link>
+              </Button>
+            );
+          })}
+        </div>
+      </nav>
+      <main className={cn("min-w-0 space-y-4", contentClassName)} aria-busy={state?.type === "loading" ? true : undefined}>
+        {stateContent ?? children}
+      </main>
+    </section>
+  );
+}
+
+export default HubLayout;

--- a/src/components/hub/README.md
+++ b/src/components/hub/README.md
@@ -1,0 +1,16 @@
+# HubLayout
+
+`HubLayout` is the shared shell for incremental section migrations. Keep routes static in the app route table; pass the section's existing links as typed `HubNavigationItem` objects so tabs, selected state and breadcrumbs come from one source.
+
+```tsx
+<HubLayout
+  title="Character"
+  description="Manage identity, progression, wellness and possessions."
+  icon={Users}
+  overviewPath="/character"
+  navigation={characterHubNavigation}
+  actions={[{ label: "Edit character", path: "/my-character" }]}
+>
+  <CharacterOverviewContent />
+</HubLayout>
+```

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -1,0 +1,21 @@
+import { Backpack, BookOpen, Calendar, GraduationCap, Heart, Package, Palette, Sparkles, Trophy, Users, Zap } from "lucide-react";
+import type { HubNavigationItem } from "@/components/hub/HubLayout";
+
+export const characterHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/character", icon: Users, matchPaths: ["/character/overview", "/hub/character"] },
+  { id: "skills", label: "Skills", path: "/skills", icon: Sparkles },
+  { id: "wellness", label: "Wellness", path: "/wellness", icon: Heart },
+  { id: "inventory", label: "Inventory", path: "/inventory", icon: Backpack },
+  { id: "wardrobe", label: "Wardrobe", path: "/clothing-shop", icon: Palette, matchPaths: ["/skin-store", "/tattoo-parlour", "/avatar-designer", "/my-character"] },
+  { id: "lifestyle", label: "Lifestyle", path: "/housing", icon: Package, matchPaths: ["/personal-vehicles", "/gear", "/gear-shop"] },
+  { id: "achievements", label: "Achievements", path: "/hall-of-immortals", icon: Trophy },
+  { id: "history", label: "History", path: "/legacy", icon: BookOpen, matchPaths: ["/family/timeline", "/family/child/:childId"] },
+];
+
+export const scheduleHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/schedule", icon: Calendar },
+  { id: "education", label: "Education", path: "/booking/education", icon: GraduationCap },
+  { id: "performance", label: "Performance", path: "/booking/performance", icon: Zap },
+  { id: "work", label: "Work", path: "/booking/work", icon: Package },
+  { id: "songwriting", label: "Songwriting", path: "/booking/songwriting", icon: Sparkles },
+];

--- a/src/pages/CharacterOverview.tsx
+++ b/src/pages/CharacterOverview.tsx
@@ -1,11 +1,12 @@
 import { Link } from "react-router-dom";
-import { Activity, Backpack, Heart, Palette, Sparkles, Trophy, User, Wallet, Zap } from "lucide-react";
+import { HubLayout } from "@/components/hub/HubLayout";
+import { characterHubNavigation } from "@/config/hubNavigation";
+import { Activity, Backpack, Heart, Palette, Sparkles, Trophy, User, Users, Wallet, Zap } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
 import { useAuth } from "@/hooks/use-auth-context";
 import { useGameData } from "@/hooks/useGameData";
 
@@ -35,31 +36,66 @@ export default function CharacterOverview() {
   const { user, loading: authLoading } = useAuth();
   const { profile, skillProgress, activityStatus, activities, xpWallet, loading, error, refetch } = useGameData();
 
+  const hubProps = {
+    title: "Character",
+    description: "Manage your artist identity, progression, wellness and possessions.",
+    icon: Users,
+    overviewPath: "/character",
+    navigation: characterHubNavigation,
+    actions: [{ label: "Edit character", path: "/my-character", variant: "outline" as const }],
+  };
+
   if (authLoading || loading) {
-    return <PageLoadingState title="Loading Character Overview" description="Fetching your active character snapshot..." />;
+    return (
+      <HubLayout
+        {...hubProps}
+        state={{ type: "loading", title: "Loading Character Overview", description: "Fetching your active character snapshot..." }}
+      >
+        <span />
+      </HubLayout>
+    );
   }
 
   if (!user) {
     return (
-      <PageEmptyState
-        title="Sign in to view your character"
-        description="Character overview is available after you log in and choose an active character."
-        action={<Button asChild><Link to="/auth">Sign in</Link></Button>}
-      />
+      <HubLayout
+        {...hubProps}
+        state={{
+          type: "empty",
+          title: "Sign in to view your character",
+          description: "Character overview is available after you log in and choose an active character.",
+          action: <Button asChild><Link to="/auth">Sign in</Link></Button>,
+        }}
+      >
+        <span />
+      </HubLayout>
     );
   }
 
   if (error) {
-    return <PageErrorState title="Character overview could not be loaded" description={error} onRetry={() => void refetch()} />;
+    return (
+      <HubLayout
+        {...hubProps}
+        state={{ type: "error", title: "Character overview could not be loaded", description: error, onRetry: () => void refetch() }}
+      >
+        <span />
+      </HubLayout>
+    );
   }
 
   if (!profile) {
     return (
-      <PageEmptyState
-        title="No active character found"
-        description="Create or switch to a character before using Character tools."
-        action={<Button asChild><Link to="/characters">Manage characters</Link></Button>}
-      />
+      <HubLayout
+        {...hubProps}
+        state={{
+          type: "empty",
+          title: "No active character found",
+          description: "Create or switch to a character before using Character tools.",
+          action: <Button asChild><Link to="/characters">Manage characters</Link></Button>,
+        }}
+      >
+        <span />
+      </HubLayout>
     );
   }
 
@@ -70,6 +106,7 @@ export default function CharacterOverview() {
   const recentEvents = (activities ?? []).slice(0, 3);
 
   return (
+    <HubLayout {...hubProps}>
     <div className="space-y-6">
       <section className="rounded-xl border bg-card/80 p-5 shadow-sm">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -80,7 +117,7 @@ export default function CharacterOverview() {
             </Avatar>
             <div>
               <Badge variant="outline" className="mb-2">Character</Badge>
-              <h1 className="text-3xl font-bold tracking-tight">{displayName}</h1>
+              <h2 className="text-3xl font-bold tracking-tight">{displayName}</h2>
               <p className="text-sm text-muted-foreground">Overview of your artist status, progression and next actions.</p>
             </div>
           </div>
@@ -158,5 +195,6 @@ export default function CharacterOverview() {
         </Card>
       </div>
     </div>
+    </HubLayout>
   );
 }

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -7,7 +7,8 @@ import { addDays, startOfWeek, format } from "date-fns";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTranslation } from "@/hooks/useTranslation";
 import { GigLocationWarning } from "@/components/notifications/GigLocationWarning";
-import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { HubLayout } from "@/components/hub/HubLayout";
+import { scheduleHubNavigation } from "@/config/hubNavigation";
 
 const Schedule = () => {
   const { t } = useTranslation();
@@ -19,12 +20,13 @@ const Schedule = () => {
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 
   return (
-    <FMPageScaffold
+    <HubLayout
       title="Schedule"
-      subtitle="Read-only view of your booked activities"
-      backTo="/dashboard"
-      backLabel="Back to Dashboard"
+      description="Review your booked activities and jump to existing booking flows."
       icon={Calendar}
+      overviewPath="/schedule"
+      navigation={scheduleHubNavigation}
+      actions={[{ label: "Book activity", path: "/booking/education", variant: "outline" }]}
     >
 
       <GigLocationWarning />
@@ -97,7 +99,7 @@ const Schedule = () => {
           ))}
         </Tabs>
       )}
-    </FMPageScaffold>
+    </HubLayout>
   );
 };
 


### PR DESCRIPTION
### Motivation

- Create a single shared hub-page pattern to make future hub migrations predictable and incremental. 
- Prevent the Character module from restoring arbitrary last-child pages (e.g. Wellness) and ensure `/character` is a stable overview landing. 
- Prove the pattern on a small, low-risk vertical slice (Character + Schedule) while preserving existing deep links and the FM shell.

### Description

- Adds a reusable `HubLayout` component that provides hub header, logical breadcrumbs, contextual actions, horizontal child navigation (desktop + mobile), and loading/error/empty states at `src/components/hub/HubLayout.tsx` with developer notes in `src/components/hub/README.md`.
- Introduces typed hub navigation metadata for Character and Schedule at `src/config/hubNavigation.ts` and uses it for selected-state matching and breadcrumbs.
- Refactors `src/pages/CharacterOverview.tsx` and `src/pages/Schedule.tsx` to render inside `HubLayout` and preserves existing overview content, loading/empty/error handling and mobile behaviour.
- Adds query-preserving compatibility redirects and light title logic updates in `src/App.tsx` (adds `PreserveQueryRedirect`, hub-aware title composition and explicit `/character/*` and `/schedule/overview` aliases) and adds a small unit test suite for `HubLayout` at `src/components/hub/HubLayout.test.tsx` covering overview active state, nested/legacy matching and breadcrumb/nav rendering.

### Testing

- `npm run typecheck` (`tsc --noEmit`) completed successfully and verified the new TypeScript types and imports.
- Unit tests for the new `HubLayout` were added (`src/components/hub/HubLayout.test.tsx`) but could not be executed in this environment because `vitest` and other dev dependencies were not available in `node_modules`.
- `npm install` / dependency installation failed in this environment due to registry access errors (403 on a dependency), which prevented running `npm run lint`, `npm run test:unit` and `npm run build` here.
- Manual validation notes: the change preserves existing routes and deep-links for Character/Schedule and only adds explicit compatibility redirects; browser title composition was adjusted to include hub context for migrated pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54beeeddb0832586ecd812602647f5)