### PR TITLE
Consolidate music creation systems into the Music hub

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -245,3 +245,94 @@ For each future hub migration:
 5. Update page-title metadata if new canonical child paths are introduced.
 6. Keep existing deep links until analytics and release notes confirm they can be removed.
 7. Add tests for base landing, child selected state, breadcrumbs, redirects and query preservation.
+
+## PR 3 update — Music hub consolidation
+
+PR 3 makes `/music` the stable Music landing route and uses the shared `HubLayout` pattern from PR 2 for the Music Overview. The top-level Music module now opens the overview instead of restoring `/hub/music`, Songwriting, Recording or another last visited child page.
+
+### Final Music hub hierarchy
+
+The Music hub surfaces existing systems only:
+
+- Overview — `/music`
+- Songs — `/music/songs` aliasing the existing song manager
+- Songwriting — `/music/songwriting` aliasing the existing songwriting page
+- Practice — `/music/practice` aliasing stage practice
+- Rehearsals — `/music/rehearsals` aliasing existing rehearsals
+- Jam Sessions — `/music/jam-sessions` aliasing existing jam-session routes
+- Recording — `/music/recording` aliasing the existing recording studio flow
+- Releases — `/music/releases` aliasing the existing release manager
+- Setlists — `/music/setlists` aliasing existing setlist management
+
+Genres remain available inside the existing song and release flows rather than as a separate hub child because there is no standalone genre page to migrate in this PR. Albums are managed through the release manager, so the hub uses the single player-facing label “Releases” rather than duplicating an Albums tab.
+
+### Route migration table and aliases
+
+| Logical page | Canonical Music route | Existing implementation / preserved legacy route |
+| --- | --- | --- |
+| Music Overview | `/music` | `/hub/music` and `/music-hub` redirect to `/music` with query strings preserved |
+| Songs | `/music/songs` | Redirects to `/song-manager`; public `/song/:songId` remains valid and selects Songs logically |
+| Songwriting | `/music/songwriting` | Redirects to `/songwriting`; `/booking/songwriting` remains a Schedule booking route but is matched as a songwriting-related alias |
+| Practice | `/music/practice` | Redirects to `/stage-practice` |
+| Rehearsals | `/music/rehearsals` | Redirects to `/rehearsals` |
+| Jam Sessions | `/music/jam-sessions` | Redirects to `/jam-sessions`; `/jams` remains valid |
+| Recording | `/music/recording` | Redirects to `/recording-studio` |
+| Releases | `/music/releases` | Redirects to `/release-manager`; `/release/:id` remains valid and selects Releases logically |
+| Setlists | `/music/setlists` | Redirects to `/setlists` |
+
+Aliases use explicit redirects rather than duplicate page implementations, preserving browser history expectations and avoiding multiple mounted copies of data-heavy gameplay screens. Query parameters are preserved by the same redirect helper used by PR 2 aliases.
+
+### Page ownership decisions
+
+Music owns the creation and development journey: songs, songwriting, practice, recording, releases and general music development. Rehearsals, jam sessions and setlists remain shared with Band & Live for now because the existing pages are band-context systems, but Music links to them as contextual workflow steps. This avoids a premature Band hub refactor while making the player journey easier to follow.
+
+Recording-studio discovery and business management remain in the existing world/business surfaces. The Music Recording child routes players to the existing booking and recording flow rather than moving studio ownership.
+
+### Music Overview content
+
+The overview composes existing Supabase data without new backend endpoints:
+
+- recent user songs from the existing `user-songs` query key,
+- recent recording sessions,
+- recent releases,
+- summary counts for songs being written, completed songs, songs needing practice and recording-ready songs.
+
+The overview keeps hub breadcrumbs, hub child navigation, loading state, retryable error state and empty list states visible around the content.
+
+### Quick actions
+
+The Music Overview exposes existing working navigation actions only:
+
+- Write a song → `/music/songwriting`
+- Practice → `/music/practice`
+- Book recording → `/music/recording`
+- Create release → `/music/releases`
+
+Action-level gameplay gating is still enforced by the destination pages. This PR does not invent new permission rules or bypass existing booking/confirmation flows.
+
+### Contextual workflow links
+
+The overview adds safe navigational workflow links for the existing creation path:
+
+Songwriting → Practice → Rehearsals → Jam Sessions → Recording → Releases.
+
+The links only move the player to existing pages; they do not perform mutations or skip required booking dialogs.
+
+### Selected navigation and page titles
+
+Music has been added to the shared hub title configuration so `/music` resolves as `Music | Rockmundo` and Music child or legacy paths resolve with the Music context where route metadata can identify the logical child. Hub child selection ignores query strings and maps legacy aliases such as `/songwriting`, `/recording-studio`, `/release-manager`, `/release/:id` and `/song/:songId` to their logical Music child.
+
+### Gating behaviour
+
+Existing restrictions remain owned by the migrated pages: band membership for rehearsals/setlists/jam sessions, recording eligibility and studio booking requirements in Recording, release permissions in Release Manager, and songwriting/practice skill or activity restrictions in their existing flows. The hub does not hide whole systems solely because one action may be unavailable; destination pages continue to show their established no-band, unavailable, loading, empty and error states.
+
+### Known limitations and deferred defects
+
+- The canonical Music child routes currently redirect to the existing flat implementations instead of rendering every child inside `HubLayout`. This keeps PR 3 low-risk and preserves the existing page-level loading/error states.
+- Albums are not split from Releases because album creation is implemented through the release manager.
+- Genres are not a separate tab because there is no standalone genre management page.
+- Broader songwriting backend defects, if any, are deferred unless they are caused by the route consolidation. The new aliases do not rely on navigation state, so direct `/music/songwriting` refreshes redirect to the existing direct-load-safe `/songwriting` page.
+
+### Follow-up
+
+The next planned navigation PR is Band hub consolidation. That work should decide whether rehearsals, setlists, gigs, band recording participation and performance preparation receive band-owned canonical routes while continuing to share implementations with Music where appropriate.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import { FM_MODULES, findModuleForPath } from "./config/fmNavigation";
-import { characterHubNavigation, scheduleHubNavigation } from "./config/hubNavigation";
+import { characterHubNavigation, musicHubNavigation, scheduleHubNavigation } from "./config/hubNavigation";
 import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
@@ -268,7 +268,6 @@ const FestivalAdmin = lazyWithRetry(() => import("./pages/admin/FestivalAdmin"))
 const Education = lazyWithRetry(() => import("./pages/Education"));
 const RecordingStudio = lazyWithRetry(() => import("./pages/RecordingStudio"));
 const ReleaseManager = lazyWithRetry(() => import("./pages/ReleaseManager"));
-const MusicHub = lazyWithRetry(() => import("./pages/MusicHub"));
 const ReleaseDetail = lazyWithRetry(() => import("./pages/ReleaseDetail"));
 const MediaNetworks = lazyWithRetry(() => import("./pages/MediaNetworks"));
 // const CharityPage = lazyWithRetry(() => import("./pages/community/charity"));
@@ -311,7 +310,7 @@ const CasinoBlackjack = lazyWithRetry(() => import("./pages/casino/Blackjack"));
 const CasinoRoulette = lazyWithRetry(() => import("./pages/casino/Roulette"));
 const CasinoSlots = lazyWithRetry(() => import("./pages/casino/Slots"));
 const CharacterHub = lazyWithRetry(() => import("./pages/hubs/CharacterHub"));
-const MusicHubPage = lazyWithRetry(() => import("./pages/hubs/MusicHubPage"));
+const MusicOverview = lazyWithRetry(() => import("./pages/hubs/MusicOverview"));
 const BandLiveHub = lazyWithRetry(() => import("./pages/hubs/BandLiveHub"));
 const WorldHub = lazyWithRetry(() => import("./pages/hubs/WorldHub"));
 const SocialHubLanding = lazyWithRetry(() => import("./pages/hubs/SocialHub"));
@@ -366,6 +365,7 @@ for (const module of FM_MODULES) {
 
 const HUB_TITLE_CONFIGS = [
   { title: "Character", overviewPath: "/character", items: characterHubNavigation },
+  { title: "Music", overviewPath: "/music", items: musicHubNavigation },
   { title: "Schedule", overviewPath: "/schedule", items: scheduleHubNavigation },
 ];
 
@@ -482,6 +482,15 @@ function App() {
                     <Route path="busking" element={<Busking />} />
                     
                     <Route path="song-manager" element={<SongManager />} />
+                    <Route path="music/overview" element={<PreserveQueryRedirect to="/music" />} />
+                    <Route path="music/songs" element={<PreserveQueryRedirect to="/song-manager" />} />
+                    <Route path="music/songwriting" element={<PreserveQueryRedirect to="/songwriting" />} />
+                    <Route path="music/practice" element={<PreserveQueryRedirect to="/stage-practice" />} />
+                    <Route path="music/rehearsals" element={<PreserveQueryRedirect to="/rehearsals" />} />
+                    <Route path="music/jam-sessions" element={<PreserveQueryRedirect to="/jam-sessions" />} />
+                    <Route path="music/recording" element={<PreserveQueryRedirect to="/recording-studio" />} />
+                    <Route path="music/releases" element={<PreserveQueryRedirect to="/release-manager" />} />
+                    <Route path="music/setlists" element={<PreserveQueryRedirect to="/setlists" />} />
                     <Route path="streaming-platforms" element={<StreamingPlatforms />} />
                     <Route path="streaming/:platformId" element={<StreamingPlatformDetail />} />
                     <Route path="advisor" element={<AdvisorPage />} />
@@ -567,8 +576,8 @@ function App() {
                     <Route path="song-rankings" element={<SongRankings />} />
                     <Route path="recording-studio" element={<RecordingStudio />} />
                     <Route path="release-manager" element={<ReleaseManager />} />
-                    <Route path="music-hub" element={<MusicHub />} />
-                    <Route path="music" element={<MusicHub />} />
+                    <Route path="music-hub" element={<PreserveQueryRedirect to="/music" />} />
+                    <Route path="music" element={<MusicOverview />} />
                     <Route path="music-studio" element={<MusicStudio />} />
                     <Route path="skills" element={<SkillsPage />} />
                     <Route path="prison" element={<Prison />} />
@@ -617,7 +626,7 @@ function App() {
                     
                     {/* Category hub pages */}
                     <Route path="hub/character" element={<CharacterHub />} />
-                    <Route path="hub/music" element={<MusicHubPage />} />
+                    <Route path="hub/music" element={<PreserveQueryRedirect to="/music" />} />
                     <Route path="hub/band-live" element={<BandLiveHub />} />
                     <Route path="hub/career-business" element={<CareerBusinessHub />} />
                     <Route path="social" element={<SocialHubUnified />} />

--- a/src/config/__tests__/fmNavigation.music.test.ts
+++ b/src/config/__tests__/fmNavigation.music.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { musicHubNavigation } from "../hubNavigation";
+import { FM_MODULES, findModuleForPath } from "../fmNavigation";
+import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
+
+describe("music navigation consolidation", () => {
+  const music = FM_MODULES.find((module) => module.id === "music");
+
+  it("uses Music Overview as the stable module landing route", () => {
+    expect(music?.rootPath).toBe("/music");
+    expect(music?.subTabs[0]).toMatchObject({ label: "Overview", path: "/music" });
+  });
+
+  it("recognizes canonical music child routes and legacy aliases", () => {
+    expect(findModuleForPath("/music/songwriting").id).toBe("music");
+    expect(findModuleForPath("/songwriting").id).toBe("music");
+    expect(findModuleForPath("/music/recording").id).toBe("music");
+    expect(findModuleForPath("/release/abc123").id).toBe("music");
+  });
+
+  it("selects logical child items for entity and legacy routes", () => {
+    const releases = musicHubNavigation.find((item) => item.id === "releases")!;
+    const songs = musicHubNavigation.find((item) => item.id === "songs")!;
+
+    expect(isHubNavigationItemActive("/release/abc123?from=notification", releases)).toBe(true);
+    expect(isHubNavigationItemActive("/song/abc123", songs)).toBe(true);
+  });
+});

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -126,7 +126,7 @@ export const FM_MODULES: FMModule[] = [
     id: "music",
     label: "Music",
     icon: Music,
-    rootPath: "/hub/music",
+    rootPath: "/music",
     matchPaths: [
       "/hub/music", "/music", "/music-hub",
       "/songwriting", "/stage-practice", "/recording-studio",
@@ -136,10 +136,10 @@ export const FM_MODULES: FMModule[] = [
       "/competitive-charts", "/song-rankings", "/song-market", "/song-manager",
     ],
     subTabs: [
-      { label: "Hub", path: "/hub/music", icon: Music },
-      { label: "Songwriting", path: "/songwriting", icon: ListMusic },
-      { label: "Studio", path: "/recording-studio", icon: Disc3 },
-      { label: "Releases", path: "/release-manager", icon: Disc3 },
+      { label: "Overview", path: "/music", icon: Music },
+      { label: "Songwriting", path: "/music/songwriting", icon: ListMusic },
+      { label: "Recording", path: "/music/recording", icon: Disc3 },
+      { label: "Releases", path: "/music/releases", icon: Disc3 },
       { label: "Videos", path: "/music-videos", icon: Video },
       { label: "Charts", path: "/music/charts", icon: BarChart3 },
     ],
@@ -147,7 +147,7 @@ export const FM_MODULES: FMModule[] = [
       {
         label: "Create",
         items: [
-          { label: "Songwriting", path: "/songwriting", icon: ListMusic },
+          { label: "Songwriting", path: "/music/songwriting", icon: ListMusic },
           { label: "Stage Practice", path: "/stage-practice", icon: Guitar },
           { label: "Recording Studio", path: "/recording-studio", icon: Disc3 },
           { label: "Song Manager", path: "/song-manager", icon: ListMusic },
@@ -174,9 +174,9 @@ export const FM_MODULES: FMModule[] = [
       },
     ],
     quickActions: [
-      { label: "Write Song", path: "/songwriting", icon: ListMusic, description: "Start a new project" },
-      { label: "Record Track", path: "/recording-studio", icon: Disc3 },
-      { label: "Plan Release", path: "/release-manager", icon: Disc3 },
+      { label: "Write Song", path: "/music/songwriting", icon: ListMusic, description: "Start a new project" },
+      { label: "Record Track", path: "/music/recording", icon: Disc3 },
+      { label: "Plan Release", path: "/music/releases", icon: Disc3 },
       { label: "Create Music Video", path: "/music-videos", icon: Video },
     ],
   },

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -1,4 +1,4 @@
-import { Backpack, BookOpen, Calendar, GraduationCap, Heart, Package, Palette, Sparkles, Trophy, Users, Zap } from "lucide-react";
+import { Backpack, BookOpen, Calendar, Disc3, GraduationCap, Guitar, Heart, ListMusic, Mic2, Music, Package, Palette, Radio, Sparkles, Trophy, Users, Zap } from "lucide-react";
 import type { HubNavigationItem } from "@/components/hub/HubLayout";
 
 export const characterHubNavigation: HubNavigationItem[] = [
@@ -18,4 +18,16 @@ export const scheduleHubNavigation: HubNavigationItem[] = [
   { id: "performance", label: "Performance", path: "/booking/performance", icon: Zap },
   { id: "work", label: "Work", path: "/booking/work", icon: Package },
   { id: "songwriting", label: "Songwriting", path: "/booking/songwriting", icon: Sparkles },
+];
+
+export const musicHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/music", icon: Music, matchPaths: ["/music/overview", "/hub/music", "/music-hub"] },
+  { id: "songs", label: "Songs", path: "/music/songs", icon: ListMusic, matchPaths: ["/song-manager", "/song/:songId"] },
+  { id: "songwriting", label: "Songwriting", path: "/music/songwriting", icon: Sparkles, matchPaths: ["/songwriting", "/booking/songwriting"] },
+  { id: "practice", label: "Practice", path: "/music/practice", icon: Guitar, matchPaths: ["/stage-practice"] },
+  { id: "rehearsals", label: "Rehearsals", path: "/music/rehearsals", icon: Users, matchPaths: ["/rehearsals"] },
+  { id: "jam-sessions", label: "Jam Sessions", path: "/music/jam-sessions", icon: Mic2, matchPaths: ["/jam-sessions", "/jams"] },
+  { id: "recording", label: "Recording", path: "/music/recording", icon: Disc3, matchPaths: ["/recording-studio"] },
+  { id: "releases", label: "Releases", path: "/music/releases", icon: Radio, matchPaths: ["/release-manager", "/release/:id"] },
+  { id: "setlists", label: "Setlists", path: "/music/setlists", icon: ListMusic, matchPaths: ["/setlists"] },
 ];

--- a/src/pages/hubs/MusicOverview.tsx
+++ b/src/pages/hubs/MusicOverview.tsx
@@ -1,0 +1,203 @@
+import { useMemo, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Disc3, Guitar, ListMusic, Mic2, Music, Plus, Radio, Sparkles, Users } from "lucide-react";
+
+import HubLayout from "@/components/hub/HubLayout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { musicHubNavigation } from "@/config/hubNavigation";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { useGameData } from "@/hooks/useGameData";
+import { supabase } from "@/integrations/supabase/client";
+
+const MusicOverview = () => {
+  const { profileId } = useActiveProfile();
+  const { profile } = useGameData();
+  const userId = profile?.user_id ?? profileId;
+
+  const songsQuery = useQuery({
+    queryKey: ["user-songs", userId],
+    enabled: !!userId,
+    queryFn: async () => {
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from("songs")
+        .select("id,title,status,genre,quality_score,practice_level,archived,created_at")
+        .eq("user_id", userId)
+        .order("created_at", { ascending: false })
+        .limit(12);
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const recordingsQuery = useQuery({
+    queryKey: ["recording_sessions", userId, "music-overview"],
+    enabled: !!userId,
+    queryFn: async () => {
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from("recording_sessions")
+        .select("id,status,scheduled_start,scheduled_end,song_id,songs(title)")
+        .eq("user_id", userId)
+        .order("scheduled_start", { ascending: false })
+        .limit(5);
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const releasesQuery = useQuery({
+    queryKey: ["releases", profileId, "music-overview"],
+    enabled: !!profileId,
+    queryFn: async () => {
+      if (!profileId) return [];
+      const { data, error } = await supabase
+        .from("releases")
+        .select("id,title,release_type,release_status,release_date,created_at")
+        .eq("user_id", profileId)
+        .order("created_at", { ascending: false })
+        .limit(5);
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+
+  const stats = useMemo(() => {
+    const songs = songsQuery.data ?? [];
+    return {
+      writing: songs.filter((song) => song.status === "draft" && !song.archived).length,
+      completed: songs.filter((song) => ["completed", "recorded", "released"].includes(song.status ?? "") && !song.archived).length,
+      needsPractice: songs.filter((song) => Number(song.practice_level ?? 0) < 60 && !song.archived).length,
+      recordingReady: songs.filter((song) => Number(song.quality_score ?? 0) >= 50 && !song.archived).length,
+    };
+  }, [songsQuery.data]);
+
+  const actions = [
+    { label: "Write a song", path: "/music/songwriting", icon: Plus },
+    { label: "Practice", path: "/music/practice", icon: Guitar, variant: "secondary" as const },
+    { label: "Book recording", path: "/music/recording", icon: Disc3, variant: "outline" as const },
+    { label: "Create release", path: "/music/releases", icon: Radio, variant: "outline" as const },
+  ];
+
+  const isLoading = songsQuery.isLoading || recordingsQuery.isLoading || releasesQuery.isLoading;
+  const error = songsQuery.error || recordingsQuery.error || releasesQuery.error;
+
+  return (
+    <HubLayout
+      title="Music"
+      description="Move your songs through writing, practice, rehearsal, recording, release and performance."
+      icon={Music}
+      overviewPath="/music"
+      navigation={musicHubNavigation}
+      actions={actions}
+    >
+      {isLoading ? <PageLoadingState title="Loading Music" description="Checking your songs, recordings and releases." /> : null}
+      {error ? (
+        <PageErrorState
+          title="Music could not be loaded"
+          description="Retry to reload your music overview without leaving the hub."
+          onRetry={() => {
+            void songsQuery.refetch();
+            void recordingsQuery.refetch();
+            void releasesQuery.refetch();
+          }}
+        />
+      ) : null}
+      {!isLoading && !error ? (
+        <div className="space-y-4">
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <SummaryCard title="Songs being written" value={stats.writing} icon={Sparkles} to="/music/songwriting" />
+            <SummaryCard title="Completed songs" value={stats.completed} icon={ListMusic} to="/music/songs" />
+            <SummaryCard title="Need practice" value={stats.needsPractice} icon={Guitar} to="/music/practice" />
+            <SummaryCard title="Recording ready" value={stats.recordingReady} icon={Disc3} to="/music/recording" />
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            <WorkflowCard title="Current songs" description="Continue writing or choose songs to practise next." to="/music/songs">
+              {(songsQuery.data ?? []).slice(0, 4).map((song) => (
+                <li key={song.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                  <span className="truncate font-medium">{song.title}</span>
+                  <Badge variant="outline">{song.status ?? "draft"}</Badge>
+                </li>
+              ))}
+            </WorkflowCard>
+            <WorkflowCard title="Recording" description="Review recent or booked studio sessions." to="/music/recording">
+              {(recordingsQuery.data ?? []).slice(0, 4).map((session: any) => (
+                <li key={session.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                  <span className="truncate font-medium">{session.songs?.title ?? "Studio session"}</span>
+                  <Badge variant="secondary">{session.status}</Badge>
+                </li>
+              ))}
+            </WorkflowCard>
+            <WorkflowCard title="Releases" description="Check recent drafts, planned releases and live releases." to="/music/releases">
+              {(releasesQuery.data ?? []).slice(0, 4).map((release) => (
+                <li key={release.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                  <span className="truncate font-medium">{release.title}</span>
+                  <Badge>{release.release_status}</Badge>
+                </li>
+              ))}
+            </WorkflowCard>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Creation-to-release workflow</CardTitle>
+              <CardDescription>Use the existing systems in order, or jump to the step you need.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+              {[
+                ["Songwriting", "/music/songwriting", Sparkles],
+                ["Practice", "/music/practice", Guitar],
+                ["Rehearsals", "/music/rehearsals", Users],
+                ["Jam Sessions", "/music/jam-sessions", Mic2],
+                ["Recording", "/music/recording", Disc3],
+                ["Releases", "/music/releases", Radio],
+              ].map(([label, to, Icon]: any) => (
+                <Button key={to} asChild variant="outline" className="gap-2">
+                  <Link to={to}><Icon className="h-4 w-4" />{label}</Link>
+                </Button>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
+    </HubLayout>
+  );
+};
+
+function SummaryCard({ title, value, icon: Icon, to }: { title: string; value: number; icon: typeof Music; to: string }) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        <Button asChild variant="link" className="h-auto p-0 text-xs"><Link to={to}>Open</Link></Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function WorkflowCard({ title, description, to, children }: { title: string; description: string; to: string; children: ReactNode }) {
+  const hasItems = Array.isArray(children) ? children.length > 0 : true;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <ul className="space-y-2">{hasItems ? children : <li className="text-sm text-muted-foreground">Nothing to show yet.</li>}</ul>
+        <Button asChild variant="secondary" size="sm"><Link to={to}>View {title}</Link></Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default MusicOverview;


### PR DESCRIPTION
### Motivation

- Provide a single, predictable Music landing page so the player sees an overview-first flow (Songwriting → Practice → Rehearsal → Recording → Release → Performance) instead of scattered flat routes or last-visited children. 
- Group existing music creation and distribution surfaces under a logical Music hub without changing gameplay systems or starting the Band hub work. 
- Preserve existing deep links and gating while improving route ownership, breadcrumbs, titles and contextual movement between existing pages.

### Description

- Adds a Music Overview component at `src/pages/hubs/MusicOverview.tsx` that uses existing query keys to summarise recent songs, recording sessions and releases and exposes quick actions and contextual workflow links to real pages. 
- Introduces `musicHubNavigation` in `src/config/hubNavigation.ts` and updates `FM_MODULES` in `src/config/fmNavigation.ts` so Music uses `/music` as the stable overview root and exposes child items (Songs, Songwriting, Practice, Rehearsals, Jam Sessions, Recording, Releases, Setlists) with legacy matchPaths. 
- Updates routing and aliases in `src/App.tsx` to render `/music` for the hub overview and add safe redirect aliases from canonical `/music/*` child paths to the existing flat implementations (e.g. `/music/songwriting` → `/songwriting`, `/music/recording` → `/recording-studio`, `/music/songs` → `/song-manager`) while preserving query strings. 
- Adds a small navigation unit test `src/config/__tests__/fmNavigation.music.test.ts` and documents the final Music hub hierarchy and migration decisions in `docs/navigation-and-hub-refactor.md`.

### Testing

- Ran static type checks with `npm run typecheck` and it completed successfully. 
- Attempted to install dependencies and run unit tests, but `npm install` failed due to a registry `403 Forbidden` for `@react-three/fiber`, so `vitest`, lint and build could not be executed in this environment. 
- Added a targeted unit test for Music navigation selection (`src/config/__tests__/fmNavigation.music.test.ts`) but automated unit test execution could not be completed here because dependencies were not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54c30915e08325868d415f0957c31f)