### PR TITLE
Consolidate band management systems into the Band hub

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -336,3 +336,67 @@ Existing restrictions remain owned by the migrated pages: band membership for re
 ### Follow-up
 
 The next planned navigation PR is Band hub consolidation. That work should decide whether rehearsals, setlists, gigs, band recording participation and performance preparation receive band-owned canonical routes while continuing to share implementations with Music where appropriate.
+
+## PR 4 update — Band hub consolidation
+
+PR 4 makes `/band` the stable Band landing route. The top-level Band & Live navigation now opens the Band overview instead of the legacy category hub or a narrow management tab. The implementation reuses `HubLayout` and keeps existing gameplay components for membership, roles, repertoire, finances, chemistry, history and settings.
+
+### Final Band hub hierarchy
+
+The Band hub surfaces existing systems only:
+
+| Hub item | Canonical route | Implementation / ownership |
+| --- | --- | --- |
+| Overview | `/band` | Existing band overview, status, current member count, invitations and quick actions. |
+| Members & Roles | `/band/members` | Existing member cards, invitations, applications, touring members and role management controls. |
+| Fame & Fans | `/band/fame` | Existing fame/fans overview from the band manager. |
+| Repertoire | `/band/repertoire` | Existing band repertoire tab; setlist aliases continue to the shared setlist manager. |
+| Rehearsals | `/band/rehearsals` | Alias to the existing rehearsal page so booking and attendance rules remain unchanged. |
+| Gigs | `/band/gigs` | Alias to the existing gigs page and gig-preparation flow. |
+| Tours | `/band/tours` | Alias to the existing tour manager; vehicle and rider legacy links remain compatible. |
+| Equipment & Crew | `/band/equipment` | Alias to existing band crew/stage equipment entry points. |
+| Finances | `/band/finances` | Existing band finance tab. |
+| Chemistry | `/band/chemistry` | Existing chemistry display. |
+| History | `/band/history` | Existing gig history tab. |
+| Settings | `/band/settings` | Existing permission-gated settings tab. |
+
+### Canonical Band route model
+
+`/band` is the canonical active-band overview. Child routes under `/band/*` either render the existing band-management tab in the shared hub shell or redirect with query parameters preserved to the existing shared implementation. Direct profile/entity routes such as `/band/:bandId` and `/bands/:bandId/management` remain in place for public profiles and deep management links.
+
+### Active-band context behaviour
+
+The Band hub preserves the existing `getUserBands(profileId)` selection model. It selects the first active band, then the first non-disbanded band if no active band exists. When a player belongs to multiple bands, the existing selector remains visible in the hub header and switches the selected band without inventing a new global active-band store. No-band players stay on `/band` and see invitations, create-band, browse-band and find-musician actions instead of being redirected to an error page.
+
+### Route migration table and legacy aliases
+
+| Legacy / alternate route | PR 4 behaviour |
+| --- | --- |
+| `/hub/band-live`, `/hub/band`, `/hub/live` | Treated as Band overview aliases for selection/title purposes; existing hub route compatibility remains. |
+| `/band/overview` | Redirects to `/band`. |
+| `/chemistry` | Remains valid and selects the Band Chemistry item. |
+| `/setlists` | Remains the shared setlist manager and selects Band Repertoire/Setlists when viewed in Band context. |
+| `/rehearsals`, `/jam-sessions`, `/jams` | Remain shared activity pages and select Band Rehearsals/Jam Sessions aliases. |
+| `/gigs`, `/gig-booking`, `/gigs/perform/:gigId` | Remain existing gig and performance routes and select Band Gigs. |
+| `/tour-manager`, `/band-vehicles`, `/band-riders` | Remain existing tour/support routes and select Band Tours. |
+| `/stage-setup`, `/stage-equipment`, `/band-crew` | Remain existing preparation/support routes and select Equipment & Crew. |
+
+### Music and Band ownership decisions
+
+Music continues to own songwriting, practice, recording, releases, albums and the general song catalogue. Band owns member management, roles, chemistry, band-specific preparation, repertoire, rehearsals in a band context, gig preparation, tours, equipment, crew, finances, settings and history. Shared rehearsals, jam sessions, setlists, recordings and releases are not duplicated; Band links to existing shared routes and preserves the underlying booking, attendance, setlist, recording and release permission rules.
+
+### Band Overview content, alerts and quick actions
+
+The overview uses the existing band overview component and real selected-band data: identity, genre, logo, status, member count, leader state, invitations, status banners, repertoire and performance summaries exposed by the existing components. Quick actions link to existing member invitation, rehearsal and gig-preparation entry points. Hiatus/reactivation alerts and permission handling remain owned by the existing band status and settings components.
+
+### Permission behaviour
+
+Leader-only actions such as accepting applications, inviting members, adding touring members, removing members and editing restricted settings still use the existing `isLeader` checks. The hub shell remains visible for non-leaders so read-only areas such as overview, members, chemistry, history and finances can continue to use their established access treatment.
+
+### Known limitations and deferred work
+
+PR 4 intentionally does not add a new active-band persistence layer, does not redesign rehearsal or gig-preparation services and does not merge public band profiles into the private Band hub. Some shared pages still render their legacy page shell after the Band alias redirects; this keeps the PR low-risk while preserving deep links and existing loading/error states.
+
+### Follow-up
+
+The next planned navigation PR is World and Travel hub consolidation. World consolidation is not started in PR 4.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import { FM_MODULES, findModuleForPath } from "./config/fmNavigation";
-import { characterHubNavigation, musicHubNavigation, scheduleHubNavigation } from "./config/hubNavigation";
+import { bandHubNavigation, characterHubNavigation, musicHubNavigation, scheduleHubNavigation } from "./config/hubNavigation";
 import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
@@ -366,6 +366,7 @@ for (const module of FM_MODULES) {
 const HUB_TITLE_CONFIGS = [
   { title: "Character", overviewPath: "/character", items: characterHubNavigation },
   { title: "Music", overviewPath: "/music", items: musicHubNavigation },
+  { title: "Band", overviewPath: "/band", items: bandHubNavigation },
   { title: "Schedule", overviewPath: "/schedule", items: scheduleHubNavigation },
 ];
 
@@ -474,7 +475,19 @@ function App() {
                     <Route path="slot-purchase-success" element={<SlotPurchaseSuccess />} />
                     <Route path="onboarding" element={<Onboarding />} />
                     <Route path="band" element={<BandManager />} />
-                    <Route path="band/repertoire" element={<BandRepertoire />} />
+                    <Route path="band/overview" element={<PreserveQueryRedirect to="/band" />} />
+                    <Route path="band/members" element={<BandManager />} />
+                    <Route path="band/fame" element={<BandManager />} />
+                    <Route path="band/repertoire" element={<BandManager />} />
+                    <Route path="band/history" element={<BandManager />} />
+                    <Route path="band/finances" element={<BandManager />} />
+                    <Route path="band/chemistry" element={<BandManager />} />
+                    <Route path="band/settings" element={<BandManager />} />
+                    <Route path="band/rehearsals" element={<PreserveQueryRedirect to="/rehearsals" />} />
+                    <Route path="band/setlists" element={<PreserveQueryRedirect to="/setlists" />} />
+                    <Route path="band/gigs" element={<PreserveQueryRedirect to="/gigs" />} />
+                    <Route path="band/tours" element={<PreserveQueryRedirect to="/tour-manager" />} />
+                    <Route path="band/equipment" element={<PreserveQueryRedirect to="/band-crew" />} />
                     <Route path="bands/:bandId/management" element={<BandManagementPage />} />
                     <Route path="gigs" element={<GigBooking />} />
                     <Route path="jams" element={<JamSessions />} />

--- a/src/config/__tests__/fmNavigation.band.test.ts
+++ b/src/config/__tests__/fmNavigation.band.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
+import { bandHubNavigation } from "../hubNavigation";
+
+const byId = (id: string) => {
+  const item = bandHubNavigation.find((entry) => entry.id === id);
+  if (!item) throw new Error(`Missing band navigation item ${id}`);
+  return item;
+};
+
+describe("band hub navigation consolidation", () => {
+  it("uses /band as the canonical overview landing route", () => {
+    const overview = byId("overview");
+    expect(overview.path).toBe("/band");
+    expect(isHubNavigationItemActive("/band", overview)).toBe(true);
+    expect(isHubNavigationItemActive("/band/overview", overview)).toBe(true);
+  });
+
+  it("selects consolidated child pages and legacy aliases", () => {
+    expect(isHubNavigationItemActive("/band/members", byId("members"))).toBe(true);
+    expect(isHubNavigationItemActive("/band/repertoire", byId("repertoire"))).toBe(true);
+    expect(isHubNavigationItemActive("/setlists", byId("repertoire"))).toBe(true);
+    expect(isHubNavigationItemActive("/rehearsals", byId("rehearsals"))).toBe(true);
+    expect(isHubNavigationItemActive("/gigs/perform/gig-1", byId("gigs"))).toBe(true);
+    expect(isHubNavigationItemActive("/tour-manager", byId("tours"))).toBe(true);
+    expect(isHubNavigationItemActive("/band-crew", byId("equipment"))).toBe(true);
+    expect(isHubNavigationItemActive("/chemistry", byId("chemistry"))).toBe(true);
+  });
+
+  it("keeps music-owned creation routes out of band navigation", () => {
+    const paths = bandHubNavigation.flatMap((item) => [item.path, ...(item.matchPaths ?? [])]);
+    expect(paths).not.toContain("/songwriting");
+    expect(paths).not.toContain("/recording-studio");
+    expect(paths).not.toContain("/release-manager");
+  });
+});

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -185,7 +185,7 @@ export const FM_MODULES: FMModule[] = [
     id: "band-live",
     label: "Band & Live",
     icon: Mic2,
-    rootPath: "/hub/band-live",
+    rootPath: "/band",
     matchPaths: [
       "/hub/band-live", "/hub/band", "/hub/live", "/hub/events",
       "/band", "/chemistry", "/bands", "/setlists", "/rehearsals",
@@ -196,8 +196,7 @@ export const FM_MODULES: FMModule[] = [
       "/awards", "/stage-setup", "/stage-equipment",
     ],
     subTabs: [
-      { label: "Hub", path: "/hub/band-live", icon: Mic2 },
-      { label: "Band", path: "/band", icon: Users },
+      { label: "Overview", path: "/band", icon: Users },
       { label: "Book Gigs", path: "/gig-booking", icon: Calendar },
       { label: "Tours", path: "/tour-manager", icon: Plane },
       { label: "Festivals", path: "/festivals", icon: Trophy },
@@ -207,12 +206,12 @@ export const FM_MODULES: FMModule[] = [
       {
         label: "Your Band",
         items: [
-          { label: "Band Manager", path: "/band", icon: Users },
+          { label: "Overview", path: "/band", icon: Users },
           { label: "Repertoire", path: "/band/repertoire", icon: ListMusic },
-          { label: "Chemistry", path: "/chemistry", icon: Sparkles },
-          { label: "Setlists", path: "/setlists", icon: ListMusic },
-          { label: "Rehearsals", path: "/rehearsals", icon: Guitar },
-          { label: "Crew", path: "/band-crew", icon: Users },
+          { label: "Chemistry", path: "/band/chemistry", icon: Sparkles },
+          { label: "Setlists", path: "/band/setlists", icon: ListMusic },
+          { label: "Rehearsals", path: "/band/rehearsals", icon: Guitar },
+          { label: "Equipment & Crew", path: "/band/equipment", icon: Users },
           { label: "Riders", path: "/band-riders", icon: ListMusic },
           { label: "Vehicles", path: "/band-vehicles", icon: Plane },
         ],
@@ -230,7 +229,7 @@ export const FM_MODULES: FMModule[] = [
         label: "Perform",
         items: [
           { label: "Book Gigs", path: "/gig-booking", icon: Calendar },
-          { label: "My Gigs", path: "/gigs", icon: Mic2 },
+          { label: "My Gigs", path: "/band/gigs", icon: Mic2 },
           { label: "Open Mic", path: "/open-mic", icon: Mic },
           { label: "Jam Sessions", path: "/jam-sessions", icon: Music },
           { label: "Busking", path: "/busking", icon: Music },
@@ -254,7 +253,7 @@ export const FM_MODULES: FMModule[] = [
       { label: "Start a Tour", path: "/tour-manager", icon: Plane },
       { label: "Hit Open Mic", path: "/open-mic", icon: Mic },
       { label: "Find Bandmates", path: "/bands/finder", icon: Users },
-      { label: "Rehearse", path: "/rehearsals", icon: Guitar },
+      { label: "Rehearse", path: "/band/rehearsals", icon: Guitar },
     ],
   },
   // 5. CAREER — money, work, companies, creative side-careers

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -1,4 +1,4 @@
-import { Backpack, BookOpen, Calendar, Disc3, GraduationCap, Guitar, Heart, ListMusic, Mic2, Music, Package, Palette, Radio, Sparkles, Trophy, Users, Zap } from "lucide-react";
+import { Backpack, BookOpen, Calendar, Disc3, DollarSign, GraduationCap, Guitar, Heart, History, ListMusic, Mic2, Music, Package, Palette, Radio, Settings, Sparkles, Trophy, Users, Zap } from "lucide-react";
 import type { HubNavigationItem } from "@/components/hub/HubLayout";
 
 export const characterHubNavigation: HubNavigationItem[] = [
@@ -30,4 +30,20 @@ export const musicHubNavigation: HubNavigationItem[] = [
   { id: "recording", label: "Recording", path: "/music/recording", icon: Disc3, matchPaths: ["/recording-studio"] },
   { id: "releases", label: "Releases", path: "/music/releases", icon: Radio, matchPaths: ["/release-manager", "/release/:id"] },
   { id: "setlists", label: "Setlists", path: "/music/setlists", icon: ListMusic, matchPaths: ["/setlists"] },
+];
+
+
+export const bandHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/band", icon: Music, matchPaths: ["/band/overview", "/hub/band", "/hub/live", "/hub/band-live"] },
+  { id: "members", label: "Members & Roles", path: "/band/members", icon: Users },
+  { id: "fame", label: "Fame & Fans", path: "/band/fame", icon: Trophy, matchPaths: ["/band-rankings", "/band-fame-map"] },
+  { id: "repertoire", label: "Repertoire", path: "/band/repertoire", icon: ListMusic, matchPaths: ["/setlists"] },
+  { id: "rehearsals", label: "Rehearsals", path: "/band/rehearsals", icon: Mic2, matchPaths: ["/rehearsals", "/jam-sessions", "/jams"] },
+  { id: "gigs", label: "Gigs", path: "/band/gigs", icon: Zap, matchPaths: ["/gigs", "/gig-booking", "/gigs/perform/:gigId", "/performance/gig/:gigId"] },
+  { id: "tours", label: "Tours", path: "/band/tours", icon: Calendar, matchPaths: ["/tour-manager", "/band-vehicles", "/band-riders"] },
+  { id: "equipment", label: "Equipment & Crew", path: "/band/equipment", icon: Package, matchPaths: ["/stage-setup", "/stage-equipment", "/band-crew"] },
+  { id: "finances", label: "Finances", path: "/band/finances", icon: DollarSign, matchPaths: ["/finances"] },
+  { id: "chemistry", label: "Chemistry", path: "/band/chemistry", icon: Sparkles, matchPaths: ["/chemistry"] },
+  { id: "history", label: "History", path: "/band/history", icon: History },
+  { id: "settings", label: "Settings", path: "/band/settings", icon: Settings },
 ];

--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -1,43 +1,71 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useTranslation } from '@/hooks/useTranslation';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase/client';
-import { useActiveProfile } from '@/hooks/useActiveProfile';
-import { BandCreationForm } from '@/components/band/BandCreationForm';
-import { BandOverview } from '@/components/band/BandOverview';
-import { BandMemberCard } from '@/components/band/BandMemberCard';
-import { AddTouringMember } from '@/components/band/AddTouringMember';
-import { ChemistryDisplay } from '@/components/band/ChemistryDisplay';
-import { BandChat } from '@/components/band/BandChat';
-import { BandEarnings } from '@/components/band/BandEarnings';
-import { BandFinancesTab } from '@/components/bands/BandFinancesTab';
-import { InviteFriendToBand } from '@/components/band/InviteFriendToBand';
-import { BandSettingsTab } from '@/components/band/BandSettingsTab';
-import { BandStatusBanner } from '@/components/band/BandStatusBanner';
-import { BandApplicationsList } from '@/components/band/BandApplicationsList';
-import { BandInvitations } from '@/components/band/BandInvitations';
+import { useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTranslation } from "@/hooks/useTranslation";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { supabase } from "@/integrations/supabase/client";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { BandCreationForm } from "@/components/band/BandCreationForm";
+import { BandOverview } from "@/components/band/BandOverview";
+import { BandMemberCard } from "@/components/band/BandMemberCard";
+import { AddTouringMember } from "@/components/band/AddTouringMember";
+import { ChemistryDisplay } from "@/components/band/ChemistryDisplay";
+import { BandChat } from "@/components/band/BandChat";
+import { BandEarnings } from "@/components/band/BandEarnings";
+import { BandFinancesTab } from "@/components/bands/BandFinancesTab";
+import { InviteFriendToBand } from "@/components/band/InviteFriendToBand";
+import { BandSettingsTab } from "@/components/band/BandSettingsTab";
+import { BandStatusBanner } from "@/components/band/BandStatusBanner";
+import { BandApplicationsList } from "@/components/band/BandApplicationsList";
+import { BandInvitations } from "@/components/band/BandInvitations";
 
-import { GigHistoryTab } from '@/components/band/GigHistoryTab';
-import { BandRepertoireTab } from '@/components/band/BandRepertoireTab';
-import { FameFansOverview } from '@/components/fame/FameFansOverview';
-import { Users, Music, Star, Library } from 'lucide-react';
-import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { useToast } from '@/hooks/use-toast';
-import { getUserBands } from '@/utils/bandStatus';
-import { reactivateBand } from '@/utils/bandHiatus';
-import { getBandStatusLabel, getBandStatusColor } from '@/utils/bandStatus';
-import { useAutoGigExecution } from '@/hooks/useAutoGigExecution';
+import { GigHistoryTab } from "@/components/band/GigHistoryTab";
+import { BandRepertoireTab } from "@/components/band/BandRepertoireTab";
+import { FameFansOverview } from "@/components/fame/FameFansOverview";
+import {
+  Calendar,
+  DollarSign,
+  History,
+  Mic2,
+  Package,
+  Plus,
+  Settings,
+  Users,
+  Music,
+  Star,
+  Library,
+  Zap,
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { getUserBands } from "@/utils/bandStatus";
+import { reactivateBand } from "@/utils/bandHiatus";
+import { getBandStatusLabel, getBandStatusColor } from "@/utils/bandStatus";
+import { useAutoGigExecution } from "@/hooks/useAutoGigExecution";
+import HubLayout from "@/components/hub/HubLayout";
+import { bandHubNavigation } from "@/config/hubNavigation";
+import { PageLoadingState } from "@/components/ui/page-state";
 
 export default function BandManager() {
   const { profileId, userId } = useActiveProfile();
   const { toast } = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
   const [userBands, setUserBands] = useState<any[]>([]);
   const [selectedBandId, setSelectedBandId] = useState<string | null>(null);
   const [selectedBand, setSelectedBand] = useState<any>(null);
@@ -64,20 +92,24 @@ export default function BandManager() {
 
     try {
       const bands = await getUserBands(profileId);
-      
+
       // Filter out disbanded bands
-      const activeBands = bands.filter((b: any) => b.bands.status !== 'disbanded');
+      const activeBands = bands.filter(
+        (b: any) => b.bands.status !== "disbanded",
+      );
       setUserBands(activeBands);
 
       // Auto-select first active band, or first hiatus band
-      const activeFirst = activeBands.find((b: any) => b.bands.status === 'active');
+      const activeFirst = activeBands.find(
+        (b: any) => b.bands.status === "active",
+      );
       const defaultBand = activeFirst || activeBands[0];
-      
+
       if (defaultBand) {
         setSelectedBandId(defaultBand.band_id);
       }
     } catch (error) {
-      console.error('Error loading bands:', error);
+      console.error("Error loading bands:", error);
     } finally {
       setLoading(false);
     }
@@ -87,9 +119,9 @@ export default function BandManager() {
     try {
       // Load band data
       const { data: band } = await supabase
-        .from('bands')
-        .select('*')
-        .eq('id', bandId)
+        .from("bands")
+        .select("*")
+        .eq("id", bandId)
         .single();
 
       if (band) {
@@ -97,17 +129,17 @@ export default function BandManager() {
         await loadBandMembers(bandId);
       }
     } catch (error) {
-      console.error('Error loading band details:', error);
+      console.error("Error loading band details:", error);
     }
   };
 
   const loadBandMembers = async (bandId: string) => {
     // First get all band members (including touring members with null user_id)
     const { data: bandMembersData } = await supabase
-      .from('band_members')
-      .select('*')
-      .eq('band_id', bandId)
-      .order('joined_at', { ascending: true });
+      .from("band_members")
+      .select("*")
+      .eq("band_id", bandId)
+      .order("joined_at", { ascending: true });
 
     if (!bandMembersData) {
       setMembers([]);
@@ -116,23 +148,23 @@ export default function BandManager() {
 
     // Get profile_ids that are not null (use profile_id to get the correct character)
     const profileIds = bandMembersData
-      .map(m => m.profile_id)
+      .map((m) => m.profile_id)
       .filter((id): id is string => id !== null);
 
     // Fetch profiles for human members only
     let profilesData: any[] = [];
     if (profileIds.length > 0) {
       const { data } = await supabase
-        .from('profiles')
-        .select('id, user_id, display_name, username')
-        .in('id', profileIds);
+        .from("profiles")
+        .select("id, user_id, display_name, username")
+        .in("id", profileIds);
       profilesData = data || [];
     }
 
     // Attach profile data to members using profile_id
-    const membersWithProfiles = bandMembersData.map(member => {
+    const membersWithProfiles = bandMembersData.map((member) => {
       if (member.profile_id) {
-        const profile = profilesData.find(p => p.id === member.profile_id);
+        const profile = profilesData.find((p) => p.id === member.profile_id);
         return { ...member, profiles: profile || null };
       }
       return { ...member, profiles: null };
@@ -144,15 +176,15 @@ export default function BandManager() {
   const handleRemoveMember = async (memberId: string) => {
     try {
       const { error } = await supabase
-        .from('band_members')
+        .from("band_members")
         .delete()
-        .eq('id', memberId);
+        .eq("id", memberId);
 
       if (error) throw error;
 
       toast({
-        title: 'Member Removed',
-        description: 'The band member has been removed',
+        title: "Member Removed",
+        description: "The band member has been removed",
       });
 
       if (selectedBandId) {
@@ -160,9 +192,9 @@ export default function BandManager() {
       }
     } catch (error: any) {
       toast({
-        title: 'Error',
-        description: error.message || 'Failed to remove member',
-        variant: 'destructive',
+        title: "Error",
+        description: error.message || "Failed to remove member",
+        variant: "destructive",
       });
     }
   };
@@ -172,50 +204,110 @@ export default function BandManager() {
 
     try {
       const result = await reactivateBand(selectedBandId, profileId);
-      
+
       if (result.success) {
         toast({
-          title: 'Band Reactivated',
-          description: 'Your band is now active again',
+          title: "Band Reactivated",
+          description: "Your band is now active again",
         });
         await loadUserBands();
       } else if (result.conflicts && result.conflicts.length > 0) {
         toast({
-          title: 'Conflicts Detected',
+          title: "Conflicts Detected",
           description: `${result.conflicts.length} member(s) need to resolve conflicts with other bands`,
-          variant: 'destructive',
+          variant: "destructive",
         });
       }
     } catch (error: any) {
       toast({
-        title: 'Error',
-        description: error.message || 'Failed to reactivate band',
-        variant: 'destructive',
+        title: "Error",
+        description: error.message || "Failed to reactivate band",
+        variant: "destructive",
       });
     }
   };
 
+  const activeSection = (() => {
+    const path = location.pathname;
+    if (path.endsWith("/members")) return "members";
+    if (path.endsWith("/fame")) return "fame";
+    if (path.endsWith("/repertoire")) return "repertoire";
+    if (path.endsWith("/history")) return "history";
+    if (path.endsWith("/finances")) return "finances";
+    if (path.endsWith("/chemistry")) return "chemistry";
+    if (path.endsWith("/settings")) return "settings";
+    return "overview";
+  })();
+
+  const selectSection = (section: string) => {
+    const target = section === "overview" ? "/band" : `/band/${section}`;
+    if (location.pathname !== target) navigate(target);
+  };
+
   if (loading) {
     return (
-      <FMPageScaffold title="Band Manager" icon={Users} backTo="/hub/band-live">
-        <div className="text-center">Loading...</div>
-      </FMPageScaffold>
+      <HubLayout
+        title="Band"
+        description="Manage your band, preparation and live performance workflow."
+        icon={Users}
+        overviewPath="/band"
+        navigation={bandHubNavigation}
+      >
+        <PageLoadingState
+          title="Loading Band"
+          description="Finding your active band and membership details."
+        />
+      </HubLayout>
     );
   }
 
   if (!selectedBand || userBands.length === 0) {
     return (
-      <FMPageScaffold
-        title="Band Manager"
-        subtitle="Create a band or become a solo artist to begin"
+      <HubLayout
+        title="Band"
+        description="Create a band, review invitations or find musicians before managing rehearsals and gigs."
         icon={Users}
-        backTo="/hub/band-live"
+        overviewPath="/band"
+        navigation={bandHubNavigation}
+        actions={[
+          {
+            label: "Browse bands",
+            path: "/bands/browse",
+            icon: Users,
+            variant: "outline",
+          },
+          {
+            label: "Find musicians",
+            path: "/bands/finder",
+            icon: Plus,
+            variant: "outline",
+          },
+        ]}
       >
-        <div className="space-y-4">
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>No active band yet</CardTitle>
+              <CardDescription>
+                Create a band, browse existing bands or respond to invitations
+                to unlock band management.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+              <Button asChild variant="outline">
+                <Link to="/bands/browse">Browse bands</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/bands/finder">Find musicians</Link>
+              </Button>
+            </CardContent>
+          </Card>
           <BandInvitations />
-          <BandCreationForm onBandCreated={loadUserBands} />
+          <div className="lg:col-span-2">
+            <BandCreationForm onBandCreated={loadUserBands} />
+          </div>
         </div>
-      </FMPageScaffold>
+      </HubLayout>
     );
   }
 
@@ -225,65 +317,81 @@ export default function BandManager() {
 
   const isLeader = Boolean(
     (profileId && selectedBand.leader_id === profileId) ||
-      (userId && selectedBand.leader_id === userId) ||
-      currentMembership?.role === 'leader' ||
-      (profileId && currentMembership?.bands?.leader_id === profileId) ||
-      (userId && currentMembership?.bands?.leader_id === userId)
+    (userId && selectedBand.leader_id === userId) ||
+    currentMembership?.role === "leader" ||
+    (profileId && currentMembership?.bands?.leader_id === profileId) ||
+    (userId && currentMembership?.bands?.leader_id === userId),
   );
 
+  const bandTitle = selectedBand.is_solo_artist
+    ? selectedBand.artist_name || selectedBand.name
+    : selectedBand.name;
+  const hubActions = [
+    {
+      label: "Invite member",
+      path: "/band/members",
+      icon: Plus,
+      variant: "outline" as const,
+    },
+    {
+      label: "Schedule rehearsal",
+      path: "/band/rehearsals",
+      icon: Mic2,
+      variant: "outline" as const,
+    },
+    {
+      label: "Prepare gig",
+      path: "/band/gigs",
+      icon: Zap,
+      variant: "secondary" as const,
+    },
+  ];
+
   return (
-    <FMPageScaffold
-      title={selectedBand.is_solo_artist ? (selectedBand.artist_name || selectedBand.name) : selectedBand.name}
-      subtitle={`${selectedBand.genre || ''} • ${selectedBand.is_solo_artist ? 'Solo Artist' : 'Band'}`}
+    <HubLayout
+      title={bandTitle}
+      description={`${selectedBand.genre || "Genre unset"} • ${selectedBand.is_solo_artist ? "Solo Artist" : "Band"}`}
       icon={Music}
-      backTo="/hub/band-live"
-      backLabel="Back to Band & Live"
+      overviewPath="/band"
+      navigation={bandHubNavigation}
+      actions={hubActions}
+      breadcrumbs={[{ label: "Band", path: "/band" }, { label: bandTitle }]}
+      status={
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border bg-card/70 p-3">
+          <Avatar className="h-12 w-12 border-2 border-primary/20">
+            <AvatarImage src={selectedBand.logo_url} alt={selectedBand.name} />
+            <AvatarFallback className="bg-primary/10 text-primary">
+              {selectedBand.name?.charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-medium">{bandTitle}</p>
+            <p className="text-sm text-muted-foreground">
+              {members.length} of {selectedBand.max_members} members •{" "}
+              {selectedBand.status}
+            </p>
+          </div>
+          {userBands.length > 1 && (
+            <Select
+              value={selectedBandId || ""}
+              onValueChange={setSelectedBandId}
+            >
+              <SelectTrigger className="w-full sm:w-64">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {userBands.map((band) => (
+                  <SelectItem key={band.band_id} value={band.band_id}>
+                    {band.bands.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      }
     >
       <div className="mb-6 space-y-4">
-        <div className="flex items-center justify-between">
-          {/* Band Info with Logo */}
-          <div className="flex items-center gap-4">
-            <Avatar className="h-14 w-14 border-2 border-primary/20">
-              <AvatarImage src={selectedBand.logo_url} alt={selectedBand.name} />
-              <AvatarFallback className="text-xl bg-primary/10 text-primary">
-                {selectedBand.name?.charAt(0)}
-              </AvatarFallback>
-            </Avatar>
-            <div>
-              <h1 className="text-3xl font-bold flex items-center gap-2">
-                <Music className="h-7 w-7" />
-                {selectedBand.is_solo_artist ? (selectedBand.artist_name || selectedBand.name) : selectedBand.name}
-              </h1>
-              <p className="text-muted-foreground">
-                {selectedBand.genre} • {selectedBand.is_solo_artist ? 'Solo Artist' : 'Band'}
-              </p>
-            </div>
-          </div>
-          
-          <div className="flex items-center gap-3">
-            {/* Band Selector (if user has multiple bands) */}
-            {userBands.length > 1 && (
-              <Select value={selectedBandId || ''} onValueChange={setSelectedBandId}>
-                <SelectTrigger className="w-64">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {userBands.map((band) => (
-                    <SelectItem key={band.band_id} value={band.band_id}>
-                      <div className="flex items-center gap-2">
-                        <span>{band.bands.name}</span>
-                        <Badge className={getBandStatusColor(band.bands.status)}>
-                          {getBandStatusLabel(band.bands.status)}
-                        </Badge>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          </div>
-        </div>
-
         {/* Status Banner for Hiatus */}
         <BandStatusBanner
           status={selectedBand.status}
@@ -295,34 +403,58 @@ export default function BandManager() {
         />
       </div>
 
-      <Tabs defaultValue="overview" className="space-y-6">
-          <TabsList className="h-auto flex flex-wrap gap-1 bg-muted/50 p-1">
-            <TabsTrigger value="overview" className="text-xs sm:text-sm">Overview</TabsTrigger>
-            <TabsTrigger value="fame" className="flex items-center gap-1 text-xs sm:text-sm">
-              <Star className="h-3 w-3" />
-              <span className="hidden sm:inline">Fame & Fans</span>
-              <span className="sm:hidden">Fame</span>
-            </TabsTrigger>
-            <TabsTrigger value="members" className="text-xs sm:text-sm">Members</TabsTrigger>
-            <TabsTrigger value="repertoire" className="flex items-center gap-1 text-xs sm:text-sm">
-              <Library className="h-3 w-3" />
-              <span className="hidden sm:inline">Repertoire</span>
-              <span className="sm:hidden">Rep</span>
-            </TabsTrigger>
-            <TabsTrigger value="history" className="text-xs sm:text-sm">
-              <span className="hidden sm:inline">Gig History</span>
-              <span className="sm:hidden">History</span>
-            </TabsTrigger>
-            <TabsTrigger value="chat" className="text-xs sm:text-sm">Chat</TabsTrigger>
-            <TabsTrigger value="earnings" className="text-xs sm:text-sm">Earnings</TabsTrigger>
-            <TabsTrigger value="finances" className="text-xs sm:text-sm">Finances</TabsTrigger>
-            <TabsTrigger value="chemistry" className="text-xs sm:text-sm">Chemistry</TabsTrigger>
-            <TabsTrigger value="settings" className="text-xs sm:text-sm">Settings</TabsTrigger>
-          </TabsList>
+      <Tabs
+        value={activeSection}
+        onValueChange={selectSection}
+        className="space-y-6"
+      >
+        <TabsList className="h-auto flex flex-wrap gap-1 bg-muted/50 p-1">
+          <TabsTrigger value="overview" className="text-xs sm:text-sm">
+            Overview
+          </TabsTrigger>
+          <TabsTrigger
+            value="fame"
+            className="flex items-center gap-1 text-xs sm:text-sm"
+          >
+            <Star className="h-3 w-3" />
+            <span className="hidden sm:inline">Fame & Fans</span>
+            <span className="sm:hidden">Fame</span>
+          </TabsTrigger>
+          <TabsTrigger value="members" className="text-xs sm:text-sm">
+            Members
+          </TabsTrigger>
+          <TabsTrigger
+            value="repertoire"
+            className="flex items-center gap-1 text-xs sm:text-sm"
+          >
+            <Library className="h-3 w-3" />
+            <span className="hidden sm:inline">Repertoire</span>
+            <span className="sm:hidden">Rep</span>
+          </TabsTrigger>
+          <TabsTrigger value="history" className="text-xs sm:text-sm">
+            <span className="hidden sm:inline">Gig History</span>
+            <span className="sm:hidden">History</span>
+          </TabsTrigger>
+          <TabsTrigger value="chat" className="text-xs sm:text-sm">
+            Chat
+          </TabsTrigger>
+          <TabsTrigger value="earnings" className="text-xs sm:text-sm">
+            Earnings
+          </TabsTrigger>
+          <TabsTrigger value="finances" className="text-xs sm:text-sm">
+            Finances
+          </TabsTrigger>
+          <TabsTrigger value="chemistry" className="text-xs sm:text-sm">
+            Chemistry
+          </TabsTrigger>
+          <TabsTrigger value="settings" className="text-xs sm:text-sm">
+            Settings
+          </TabsTrigger>
+        </TabsList>
 
         <TabsContent value="overview" className="space-y-4">
-          <BandOverview 
-            bandId={selectedBand.id} 
+          <BandOverview
+            bandId={selectedBand.id}
             isLeader={isLeader}
             logoUrl={selectedBand.logo_url}
             soundDescription={selectedBand.sound_description}
@@ -339,10 +471,10 @@ export default function BandManager() {
           <BandInvitations />
 
           {/* Pending Applications (Leader only) */}
-          {isLeader && selectedBand.status === 'active' && (
-            <BandApplicationsList 
-              bandId={selectedBand.id} 
-              onMemberAdded={() => loadBandMembers(selectedBand.id)} 
+          {isLeader && selectedBand.status === "active" && (
+            <BandApplicationsList
+              bandId={selectedBand.id}
+              onMemberAdded={() => loadBandMembers(selectedBand.id)}
             />
           )}
 
@@ -355,16 +487,16 @@ export default function BandManager() {
                     {members.length} of {selectedBand.max_members} members
                   </CardDescription>
                 </div>
-                {isLeader && selectedBand.status === 'active' && (
+                {isLeader && selectedBand.status === "active" && (
                   <div className="flex gap-2">
                     <InviteFriendToBand
                       bandId={selectedBand.id}
                       bandName={selectedBand.name}
                       currentUserId={profileId!}
                     />
-                    <AddTouringMember 
-                      bandId={selectedBand.id} 
-                      onAdded={() => loadBandMembers(selectedBand.id)} 
+                    <AddTouringMember
+                      bandId={selectedBand.id}
+                      onAdded={() => loadBandMembers(selectedBand.id)}
                     />
                   </div>
                 )}
@@ -375,10 +507,12 @@ export default function BandManager() {
                 <BandMemberCard
                   key={member.id}
                   member={member}
-                  isLeader={member.role === 'leader'}
-                  canManage={isLeader && selectedBand.status === 'active'}
+                  isLeader={member.role === "leader"}
+                  canManage={isLeader && selectedBand.status === "active"}
                   onRemove={
-                    isLeader && member.role !== 'leader' && selectedBand.status === 'active'
+                    isLeader &&
+                    member.role !== "leader" &&
+                    selectedBand.status === "active"
                       ? () => handleRemoveMember(member.id)
                       : undefined
                   }
@@ -389,7 +523,10 @@ export default function BandManager() {
         </TabsContent>
 
         <TabsContent value="repertoire" className="space-y-4">
-          <BandRepertoireTab bandId={selectedBand.id} bandName={selectedBand.name} />
+          <BandRepertoireTab
+            bandId={selectedBand.id}
+            bandName={selectedBand.name}
+          />
         </TabsContent>
 
         <TabsContent value="history" className="space-y-4">
@@ -427,6 +564,6 @@ export default function BandManager() {
           />
         </TabsContent>
       </Tabs>
-    </FMPageScaffold>
+    </HubLayout>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide a single, predictable Band hub so `/band` is the canonical landing and players can see overview, membership, preparation and quick actions in one place.
- Group existing band-management, rehearsals/setlists, gigs, tours, equipment and finances under a shared hub shell while preserving Music ownership of songwriting/recording and existing deep links.
- Keep the change low-risk by reusing existing components and routes and only adding safe redirects/aliases and small navigation helpers.

### Description

- Added a Band hub navigation set by introducing `bandHubNavigation` in `src/config/hubNavigation.ts` and registered it in the app hub configs so the shared `HubLayout` can render Band child items and breadcrumbs.
- Migrated the Band manager into the shared hub shell by refactoring `src/pages/BandManager.tsx` to use `HubLayout` with `overviewPath: "/band"`, per-tab selection driven by route-aware `activeSection`, header status summary, hub `actions` (quick actions), and a useful no-band state exposing existing create/browse/find/invitations flows.
- Preserved existing gameplay pages and deep links by adding canonical child routes and safe redirects in `src/App.tsx` (e.g. child routes under `/band/*` either render the hub-managed `BandManager` or `PreserveQueryRedirect` to the legacy implementation like `/rehearsals`, `/setlists`, `/gigs`, `/tour-manager`, `/band-crew`).
- Updated the FM navigation metadata in `src/config/fmNavigation.ts` so the Band & Live module surfaces the Band overview and maps legacy sidebar items to the new canonical `/band` child routes where practical.
- Added a focused unit test `src/config/__tests__/fmNavigation.band.test.ts` asserting the canonical overview route, legacy alias matching, and that Music-owned creation routes remain out of Band navigation.
- Documented the Band hub hierarchy, canonical route model, legacy aliases and ownership decisions in `docs/navigation-and-hub-refactor.md`.

### Testing

- Type-check: `npm run typecheck` (TypeScript) passed.
- Unit tests: attempted `npm run test:unit -- src/config/__tests__/fmNavigation.band.test.ts` but the environment lacks `vitest`, so the test could not be executed here.
- Lint: attempted `npm run lint` but the environment lacks the ESLint peer dependency (`@eslint/js`), so linting could not be completed here.
- Build: attempted `npm run build` but the environment lacks `vite`, so a full build could not be executed here.

Files of primary interest: `src/pages/BandManager.tsx`, `src/config/hubNavigation.ts`, `src/config/fmNavigation.ts`, `src/App.tsx`, `src/config/__tests__/fmNavigation.band.test.ts`, and `docs/navigation-and-hub-refactor.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54c5f1a8148325a69023279ad08435)