### PR TITLE
Consolidate player interaction and community features into the Social hub

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -475,3 +475,80 @@ The World Overview uses the shared hub child navigation, semantic breadcrumbs, v
 - Venue details and studio details remain limited to the currently implemented pages; no placeholder detail pages were added.
 - World Pulse remains lazy-loaded on its own dashboard route, so the overview does not subscribe to or render the full live dashboard.
 - Follow-up PR 6 is Social hub consolidation.
+
+## PR 6 update — Social hub consolidation
+
+PR 6 makes `/social` the predictable Social landing route and renders a real Social Overview with the shared `HubLayout` pattern. The Social top-level navigation now opens the overview rather than restoring a nested friends, messages or Twaater page.
+
+### Final Social hub hierarchy
+
+Only implemented Social surfaces are exposed:
+
+- `/social` — Social Overview.
+- `/social/friends` — existing relationships/friends surface.
+- `/social/players` — existing player search and discovery surface.
+- `/social/messages` — existing friend direct-message surface.
+- `/social/twaater` — alias to the existing Twaater application at `/twaater`.
+- `/social/recruitment` — existing band-finder/recruitment discovery surface.
+- `/social/invitations` — existing social invites inbox.
+
+Forums are not added because no complete forum route exists in the current route table. Gettit remains an existing community platform link, but it is not duplicated as a generic Social feed because Twaater already owns the primary social activity/feed experience.
+
+### Canonical route model, aliases and migrations
+
+| Legacy or existing route | PR 6 route treatment | Notes |
+| --- | --- | --- |
+| `/social` | Canonical overview render route | Stable Social landing page. |
+| `/hub/social` | Redirects to `/social` preserving query strings | Legacy tile-hub entry remains bookmark-safe. |
+| `/social/overview` | Redirects to `/social` preserving query strings | Compatibility alias only. |
+| `/relationships` | Redirects to `/social/friends` preserving query strings | Existing friends implementation is retained. |
+| `/players/search` | Redirects to `/social/players` preserving query strings | Player search query state now uses `q` where supplied. |
+| `/player/:playerId` | Remains canonical profile route | Social navigation metadata treats direct profile links as Players context. |
+| `/twaater` and nested Twaater routes | Remain canonical Twaater routes | `/social/twaater` redirects to `/twaater`; post, hashtag, handle, analytics and notification routes remain intact. |
+| `/twaater/messages` | Remains a Twaater-specific message route | Social Messages uses the existing friend direct-message surface; Twaater messages remain available for Twaater account DMs. |
+| `/bands/finder`, `/bands/browse`, `/bands/search`, `/band/:bandId` | Remain canonical band discovery/profile routes | Social Recruitment links to the finder without moving Band management workflows. |
+| `/social/invitations` | Canonical social-invite review route | Uses the existing social invites inbox and realtime invalidation. |
+
+### Ownership boundaries
+
+- **Social owns** finding other players, friends, player discovery entry points, friend direct messages, Twaater entry, social invitations and recruitment discovery.
+- **Character owns** the authenticated player’s self-management, skills, wellness, inventory, wardrobe, family timeline and personal settings.
+- **Band owns** active-band management, member roles, applicant review, rehearsals, gigs, equipment, finances and settings.
+- **Music owns** songs, songwriting, practice, recording and releases.
+- **Business/Career** consolidation is explicitly deferred to PR 7.
+- **Global Notifications** remain global; Social only summarises social invite/request state and keeps Twaater notifications in Twaater.
+
+### Social Overview content
+
+The overview uses existing query hooks and data only:
+
+- accepted-friend count and pending friend-request count from the relationships cache,
+- pending social-invite count from `social_invites`,
+- Twaater trending-topic count and topic chips from the existing Twaater trending query,
+- quick links to player search, messages, friends, Twaater, recruitment and invitations when relevant.
+
+No fake online status, recommendations, forum posts, activity metrics or placeholder community data are introduced.
+
+### Messaging terminology and live updates
+
+The hub uses **Messages** for the existing friend direct-message experience because that is the player-facing label already used in the Social tab. Twaater account DMs remain labelled and routed as Twaater Messages. PR 6 does not add another message service or SSE subscription; it reuses existing relationship-message components and keeps the invite realtime hook scoped to the Social hub.
+
+### Recruitment and invitations
+
+Social owns discovery of bands and musicians through the existing finder/search routes. Band continues to own applicant management, invitations from band officers, member roles and settings. The Social Invitations page surfaces existing social invites without forcing band, job, transfer or collaboration workflows into one incompatible request screen.
+
+### Player profiles, privacy, blocking and moderation
+
+Direct player profiles remain stable at `/player/:playerId`; Social owns discovery and interaction entry points rather than moving self-character pages. Existing profile privacy, blocked-user visibility, friendship permissions, message permissions, Twaater moderation states and server-side RLS remain authoritative because PR 6 reuses the existing services and components instead of changing backend rules.
+
+### Mobile and accessibility considerations
+
+The Social hub uses shared `HubLayout` child navigation, including horizontal mobile scrolling, `aria-current` selected states, metadata-driven breadcrumbs and existing button/link focus styles. Overview cards use text labels rather than colour-only state, and child failures remain scoped to their own existing components where practical.
+
+### Known limitations and deferred defects
+
+- No forums tab is exposed because there is no complete forum implementation in the current route table.
+- Global Notifications are not moved into Social.
+- Twaater account DMs and friend direct messages remain separate systems to avoid a risky messaging rewrite.
+- Recruitment application-management screens remain in Band.
+- Business and Career consolidation is the planned next navigation PR.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import { FM_MODULES, findModuleForPath } from "./config/fmNavigation";
-import { bandHubNavigation, characterHubNavigation, musicHubNavigation, scheduleHubNavigation, worldHubNavigation } from "./config/hubNavigation";
+import { bandHubNavigation, characterHubNavigation, musicHubNavigation, scheduleHubNavigation, socialHubNavigation, worldHubNavigation } from "./config/hubNavigation";
 import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
@@ -375,6 +375,7 @@ const HUB_TITLE_CONFIGS = [
   { title: "Band", overviewPath: "/band", items: bandHubNavigation },
   { title: "Schedule", overviewPath: "/schedule", items: scheduleHubNavigation },
   { title: "World", overviewPath: "/world", items: worldHubNavigation },
+  { title: "Social", overviewPath: "/social", items: socialHubNavigation },
 ];
 
 const getRouteTitle = (pathname: string) => {
@@ -580,7 +581,7 @@ function App() {
                     <Route path="setlists" element={<SetlistManager />} />
                     <Route path="travel" element={<Travel />} />
                     <Route path="band-vehicles" element={<BandVehicles />} />
-                    <Route path="relationships" element={<Navigate to="/social?tab=friends" replace />} />
+                    <Route path="relationships" element={<PreserveQueryRedirect to="/social/friends" />} />
                     <Route path="public-relations" element={<PublicRelations />} />
                     <Route path="pr" element={<PublicRelations />} />
                     <Route path="legacy" element={<Legacy />} />
@@ -619,6 +620,13 @@ function App() {
                     <Route path="jobs" element={<Jobs />} />
                     <Route path="release/:id" element={<ReleaseDetail />} />
                     <Route path="twaater" element={<Twaater />} />
+                    <Route path="social/overview" element={<PreserveQueryRedirect to="/social" />} />
+                    <Route path="social/friends" element={<SocialHubUnified />} />
+                    <Route path="social/players" element={<SocialHubUnified />} />
+                    <Route path="social/messages" element={<SocialHubUnified />} />
+                    <Route path="social/invitations" element={<SocialHubUnified />} />
+                    <Route path="social/recruitment" element={<SocialHubUnified />} />
+                    <Route path="social/twaater" element={<PreserveQueryRedirect to="/twaater" />} />
                     <Route path="twaater/notifications" element={<TwaaterNotifications />} />
                     <Route path="twaater/analytics" element={<TwaaterAnalytics />} />
                     <Route path="twaater/tag/:hashtag" element={<TwaaterHashtagView />} />
@@ -629,7 +637,7 @@ function App() {
                     <Route path="events/narratives/:storyId" element={<NarrativeStoryPage />} />
                     <Route path="employment" element={<Employment />} />
                     <Route path="inventory" element={<InventoryManager />} />
-                    <Route path="players/search" element={<Navigate to="/social?tab=discover" replace />} />
+                    <Route path="players/search" element={<PreserveQueryRedirect to="/social/players" />} />
                     <Route path="player/:playerId" element={<PlayerProfile />} />
                     <Route path="bands/browse" element={<BandBrowser />} />
                     <Route path="bands/search" element={<BandSearch />} />
@@ -670,7 +678,7 @@ function App() {
                     <Route path="hub" element={<Navigate to="/dashboard" replace />} />
                     {/* New split hubs */}
                     <Route path="hub/world" element={<PreserveQueryRedirect to="/world" />} />
-                    <Route path="hub/social" element={<SocialHubLanding />} />
+                    <Route path="hub/social" element={<PreserveQueryRedirect to="/social" />} />
                     <Route path="hub/media" element={<MediaHub />} />
                     {/* Old hub redirects */}
                     <Route path="hub/band" element={<Navigate to="/hub/band-live" replace />} />

--- a/src/config/__tests__/fmNavigation.social.test.ts
+++ b/src/config/__tests__/fmNavigation.social.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
+import { socialHubNavigation } from "../hubNavigation";
+import { FM_MODULES } from "../fmNavigation";
+
+const item = (id: string) => socialHubNavigation.find((entry) => entry.id === id)!;
+
+describe("social hub navigation", () => {
+  it("uses /social as the stable top-level landing route", () => {
+    const socialModule = FM_MODULES.find((module) => module.id === "social");
+
+    expect(socialModule?.rootPath).toBe("/social");
+    expect(socialModule?.subTabs[0]?.path).toBe("/social");
+    expect(isHubNavigationItemActive("/social", item("overview"))).toBe(true);
+  });
+
+  it("selects the correct Social child for canonical routes and legacy aliases", () => {
+    expect(isHubNavigationItemActive("/social/friends", item("friends"))).toBe(true);
+    expect(isHubNavigationItemActive("/relationships", item("friends"))).toBe(true);
+    expect(isHubNavigationItemActive("/social/players", item("players"))).toBe(true);
+    expect(isHubNavigationItemActive("/player/abc", item("players"))).toBe(true);
+    expect(isHubNavigationItemActive("/social/messages", item("messages"))).toBe(true);
+    expect(isHubNavigationItemActive("/twaater/messages", item("messages"))).toBe(true);
+    expect(isHubNavigationItemActive("/twaater/twaat/abc", item("twaater"))).toBe(true);
+    expect(isHubNavigationItemActive("/bands/finder", item("recruitment"))).toBe(true);
+    expect(isHubNavigationItemActive("/social/invitations", item("invitations"))).toBe(true);
+  });
+});

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -448,7 +448,7 @@ export const FM_MODULES: FMModule[] = [
     id: "social",
     label: "Social",
     icon: MessageSquare,
-    rootPath: "/hub/social",
+    rootPath: "/social",
     matchPaths: [
       "/hub/social", "/social",
       "/twaater", "/dikcok", "/gettit",
@@ -457,7 +457,7 @@ export const FM_MODULES: FMModule[] = [
       "/premium-store", "/blind-boxes", "/vip-subscribe",
     ],
     subTabs: [
-      { label: "Hub", path: "/hub/social", icon: MessageSquare },
+      { label: "Overview", path: "/social", icon: MessageSquare },
       { label: "Twaater", path: "/twaater", icon: Newspaper },
       { label: "DikCok", path: "/dikcok", icon: Tv },
       { label: "Nightlife", path: "/nightclubs", icon: Sparkles },
@@ -468,7 +468,11 @@ export const FM_MODULES: FMModule[] = [
         label: "People",
         items: [
           { label: "Social Hub", path: "/social", icon: MessageSquare },
-          { label: "Friends", path: "/social?tab=friends", icon: Heart },
+          { label: "Friends", path: "/social/friends", icon: Heart },
+          { label: "Players", path: "/social/players", icon: Users },
+          { label: "Messages", path: "/social/messages", icon: MessageSquare },
+          { label: "Recruitment", path: "/social/recruitment", icon: Users },
+          { label: "Invitations", path: "/social/invitations", icon: InboxIcon },
         ],
       },
       {
@@ -501,7 +505,7 @@ export const FM_MODULES: FMModule[] = [
     quickActions: [
       { label: "Post on Twaater", path: "/twaater", icon: Newspaper, description: "Share with fans" },
       { label: "Hit a Nightclub", path: "/nightclubs", icon: Sparkles },
-      { label: "Open Messages", path: "/twaater/messages", icon: MessageSquare },
+      { label: "Open Messages", path: "/social/messages", icon: MessageSquare },
       { label: "Browse Premium Store", path: "/premium-store", icon: Crown },
     ],
   },

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -1,4 +1,4 @@
-import { Backpack, BookOpen, Briefcase, Globe2, Building2, Calendar, Disc3, DollarSign, GraduationCap, Guitar, Heart, History, Landmark, ListMusic, MapPin, Mic2, Music, Package, Palette, Plane, Radio, Settings, Sparkles, Star, Trophy, Users, Zap } from "lucide-react";
+import { Backpack, BookOpen, Briefcase, Globe2, Building2, Calendar, Compass, Disc3, DollarSign, GraduationCap, Guitar, Heart, History, Inbox, Landmark, ListMusic, MapPin, MessageSquare, Mic2, Music, Newspaper, Package, Palette, Plane, Radio, Search, Settings, Sparkles, Star, Trophy, Users, Zap } from "lucide-react";
 import type { HubNavigationItem } from "@/components/hub/HubLayout";
 
 export const characterHubNavigation: HubNavigationItem[] = [
@@ -45,6 +45,16 @@ export const worldHubNavigation: HubNavigationItem[] = [
   { id: "pulse", label: "World Pulse", path: "/world/pulse", icon: Radio, matchPaths: ["/world-pulse"] },
   { id: "leaderboards", label: "Leaderboards", path: "/world/leaderboards", icon: Trophy, matchPaths: ["/band-rankings", "/band-fame-map", "/song-rankings"] },
   { id: "treasuries", label: "Treasuries", path: "/world/treasuries", icon: Landmark, matchPaths: ["/cities/treasury"], mobileVisible: false },
+];
+
+export const socialHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/social", icon: Users, matchPaths: ["/social/overview", "/hub/social"] },
+  { id: "friends", label: "Friends", path: "/social/friends", icon: Heart, matchPaths: ["/relationships", "/social?tab=friends"] },
+  { id: "players", label: "Players", path: "/social/players", icon: Search, matchPaths: ["/players/search", "/player/:playerId", "/social?tab=discover"] },
+  { id: "messages", label: "Messages", path: "/social/messages", icon: MessageSquare, matchPaths: ["/twaater/messages", "/social?tab=messages"] },
+  { id: "twaater", label: "Twaater", path: "/social/twaater", icon: Newspaper, matchPaths: ["/twaater", "/twaater/:handle", "/twaater/tag/:hashtag", "/twaater/twaat/:twaatId", "/twaater/notifications", "/twaater/analytics"] },
+  { id: "recruitment", label: "Recruitment", path: "/social/recruitment", icon: Compass, matchPaths: ["/bands/finder", "/bands/browse", "/bands/search", "/band/:bandId"] },
+  { id: "invitations", label: "Invitations", path: "/social/invitations", icon: Inbox, matchPaths: ["/social?tab=invites"] },
 ];
 
 export const bandHubNavigation: HubNavigationItem[] = [

--- a/src/pages/PlayerSearch.tsx
+++ b/src/pages/PlayerSearch.tsx
@@ -7,7 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Search, User, Music, Star, MapPin, Clock, Users, UserPlus, MessageSquare, Check } from "lucide-react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { useGameData } from "@/hooks/useGameData";
 import { useFriendships } from "@/features/relationships/hooks/useFriendships";
 import { resolveRelationshipPairKey } from "@/features/relationships/api";
@@ -20,8 +20,10 @@ type PlayerProfile = PublicProfileSearchResult;
 type FriendState = "none" | "friends" | "pending_sent" | "pending_received";
 
 export default function PlayerSearch() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialQuery = searchParams.get("q") ?? "";
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
   const [dmTarget, setDmTarget] = useState<{ profileId: string; displayName: string } | null>(null);
   const { profile } = useGameData();
   const { friendships, sendRequest, acceptRequest } = useFriendships(profile?.id);
@@ -56,7 +58,9 @@ export default function PlayerSearch() {
   }, [friendships, profile?.id]);
 
   const handleSearch = () => {
-    setDebouncedQuery(searchQuery);
+    const trimmed = searchQuery.trim();
+    setDebouncedQuery(trimmed);
+    setSearchParams(trimmed ? { q: trimmed } : {}, { replace: true });
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -92,7 +96,8 @@ export default function PlayerSearch() {
       title="Search Players"
       subtitle="Find other musicians and view their profiles"
       icon={Search}
-      backTo="/hub/world-social"
+      backTo="/social"
+      backLabel="Back to Social"
     >
 
 

--- a/src/pages/SocialHub.tsx
+++ b/src/pages/SocialHub.tsx
@@ -1,115 +1,124 @@
-import { Suspense, lazy, useEffect } from "react";
-import { useSearchParams, Link } from "react-router-dom";
-import { Card, CardContent } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { Loader2, Users, MessageSquare, Heart, Compass, Inbox } from "lucide-react";
+import { Suspense, lazy, useMemo } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+import HubLayout from "@/components/hub/HubLayout";
+import { socialHubNavigation } from "@/config/hubNavigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Users, MessageSquare, Compass, Inbox, Newspaper, Music2 } from "lucide-react";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { useFriendships } from "@/features/relationships/hooks/useFriendships";
 import { MessagesTab } from "@/features/social-hub/components/MessagesTab";
 import { InvitesInbox } from "@/features/social-hub/components/InvitesInbox";
-import { useInviteRealtime } from "@/hooks/useSocialInvites";
+import { useIncomingInvites, useInviteRealtime } from "@/hooks/useSocialInvites";
+import { useTwaaterTrending } from "@/hooks/useTwaaterTrending";
 
-// Heavier pieces — lazy to keep initial bundle slim
 const Relationships = lazy(() => import("./Relationships"));
 const PlayerSearch = lazy(() => import("./PlayerSearch"));
-const FamilyDashboard = lazy(() =>
-  import("@/components/family/FamilyDashboard").then((m) => ({ default: m.FamilyDashboard })),
-);
-
-const TABS = ["friends", "messages", "family", "discover", "invites"] as const;
-type TabValue = (typeof TABS)[number];
-
-const TAB_LABELS: Record<TabValue, { label: string; icon: typeof Users }> = {
-  friends: { label: "Friends", icon: Users },
-  messages: { label: "Messages", icon: MessageSquare },
-  family: { label: "Family", icon: Heart },
-  discover: { label: "Discover", icon: Compass },
-  invites: { label: "Invites", icon: Inbox },
-};
+const BandFinder = lazy(() => import("./BandFinder"));
 
 const Fallback = () => (
   <div className="flex h-40 items-center justify-center text-muted-foreground">
-    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading…
+    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading Social page…
   </div>
 );
 
+function SocialOverview({ profileId }: { profileId: string | null | undefined }) {
+  const { friendships, loading: friendshipsLoading } = useFriendships(profileId ?? null);
+  const incoming = useIncomingInvites(profileId);
+  const { trendingTopics, isLoading: trendingLoading } = useTwaaterTrending();
+
+  const acceptedFriends = useMemo(() => friendships.filter((f) => f.friendship.status === "accepted"), [friendships]);
+  const pendingFriendRequests = useMemo(
+    () => friendships.filter((f) => f.friendship.status === "pending" && !f.isRequester),
+    [friendships],
+  );
+  const pendingInvites = useMemo(() => (incoming.data ?? []).filter((i) => i.status === "pending"), [incoming.data]);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" aria-label="Social summary">
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Friends</CardTitle><CardDescription>Accepted contacts</CardDescription></CardHeader><CardContent><div className="text-2xl font-semibold">{friendshipsLoading ? "…" : acceptedFriends.length}</div></CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Friend requests</CardTitle><CardDescription>Waiting for you</CardDescription></CardHeader><CardContent><div className="text-2xl font-semibold">{friendshipsLoading ? "…" : pendingFriendRequests.length}</div></CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Invitations</CardTitle><CardDescription>Open social invites</CardDescription></CardHeader><CardContent><div className="text-2xl font-semibold">{incoming.isLoading ? "…" : pendingInvites.length}</div></CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Twaater trends</CardTitle><CardDescription>Current topics</CardDescription></CardHeader><CardContent><div className="text-2xl font-semibold">{trendingLoading ? "…" : trendingTopics.length}</div></CardContent></Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Start connecting</CardTitle>
+          <CardDescription>Use the existing Social tools without leaving this hub.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Button asChild><Link to="/social/players"><Compass className="mr-2 h-4 w-4" />Find players</Link></Button>
+          <Button asChild variant="outline"><Link to="/social/messages"><MessageSquare className="mr-2 h-4 w-4" />Open messages</Link></Button>
+          <Button asChild variant="outline"><Link to="/social/friends"><Users className="mr-2 h-4 w-4" />View friends</Link></Button>
+          <Button asChild variant="outline"><Link to="/social/twaater"><Newspaper className="mr-2 h-4 w-4" />Open Twaater</Link></Button>
+          <Button asChild variant="outline"><Link to="/social/recruitment"><Music2 className="mr-2 h-4 w-4" />Browse recruitment</Link></Button>
+          {pendingInvites.length > 0 && <Button asChild variant="secondary"><Link to="/social/invitations"><Inbox className="mr-2 h-4 w-4" />Review invitations</Link></Button>}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader><CardTitle>Requests and invitations</CardTitle><CardDescription>Friend requests and social invites are surfaced here; each workflow remains in its original system.</CardDescription></CardHeader>
+          <CardContent className="space-y-3">
+            {pendingFriendRequests.length === 0 && pendingInvites.length === 0 ? <p className="text-sm text-muted-foreground">No pending social requests. You can search for players or browse recruitment to meet more musicians.</p> : null}
+            {pendingFriendRequests.slice(0, 3).map((f) => <div key={f.friendship.id} className="flex items-center justify-between rounded-md border p-3 text-sm"><span>{f.otherProfile?.display_name ?? f.otherProfile?.username ?? "Player"} sent a friend request.</span><Badge>Friend</Badge></div>)}
+            {pendingInvites.slice(0, 3).map((i) => <div key={i.id} className="flex items-center justify-between rounded-md border p-3 text-sm"><span>{i.kind} invitation received.</span><Badge variant="secondary">Invite</Badge></div>)}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle>Twaater activity</CardTitle><CardDescription>Trending topics from the existing Twaater feed.</CardDescription></CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            {trendingLoading ? <p className="text-sm text-muted-foreground">Loading Twaater trends…</p> : trendingTopics.length === 0 ? <p className="text-sm text-muted-foreground">No Twaater topics are trending yet. Open Twaater to post or explore.</p> : trendingTopics.slice(0, 8).map((topic) => <Badge key={topic.tag} variant="outline">{topic.tag}</Badge>)}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
 export default function SocialHub() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const tab = (searchParams.get("tab") as TabValue) || "friends";
+  const { pathname, search } = useLocation();
   const { profileId } = useActiveProfile();
   useInviteRealtime(profileId);
 
-  useEffect(() => {
-    if (!TABS.includes(tab)) {
-      setSearchParams({ tab: "friends" }, { replace: true });
-    }
-  }, [tab, setSearchParams]);
+  const legacyParams = new URLSearchParams(search);
+  const legacyTab = legacyParams.get("tab");
+  if (pathname === "/social" && legacyTab) {
+    const tabTargets: Record<string, string> = {
+      friends: "/social/friends",
+      messages: "/social/messages",
+      discover: "/social/players",
+      players: "/social/players",
+      invites: "/social/invitations",
+      invitations: "/social/invitations",
+    };
+    legacyParams.delete("tab");
+    const preservedSearch = legacyParams.toString();
+    const target = tabTargets[legacyTab] ?? "/social";
+    return <Navigate to={`${target}${preservedSearch ? `?${preservedSearch}` : ""}`} replace />;
+  }
+
+  const child = pathname.replace(/\/$/, "").split("/")[2] ?? "overview";
+  const content = child === "friends" ? <Suspense fallback={<Fallback />}><Relationships /></Suspense>
+    : child === "messages" ? <MessagesTab myProfileId={profileId} />
+    : child === "players" ? <Suspense fallback={<Fallback />}><PlayerSearch /></Suspense>
+    : child === "invitations" ? <InvitesInbox profileId={profileId} />
+    : child === "recruitment" ? <Suspense fallback={<Fallback />}><BandFinder /></Suspense>
+    : <SocialOverview profileId={profileId} />;
 
   return (
-    <FMPageScaffold
+    <HubLayout
       title="Social"
-      subtitle="Friends, family, chat & invites — all in one place."
+      description="Find players, maintain friendships, message contacts, follow Twaater and discover recruitment opportunities."
       icon={Users}
-      backTo="/hub/social"
+      overviewPath="/social"
+      navigation={socialHubNavigation}
+      actions={[{ label: "Find players", path: "/social/players", icon: Compass }, { label: "Messages", path: "/social/messages", icon: MessageSquare }]}
     >
-
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setSearchParams({ tab: v }, { replace: true })}
-        className="space-y-4"
-      >
-        <TabsList className="flex w-full overflow-x-auto">
-          {TABS.map((t) => {
-            const { label, icon: Icon } = TAB_LABELS[t];
-            return (
-              <TabsTrigger key={t} value={t} className="flex items-center gap-1.5 text-xs">
-                <Icon className="h-3.5 w-3.5" /> {label}
-              </TabsTrigger>
-            );
-          })}
-        </TabsList>
-
-        <TabsContent value="friends" className="space-y-4">
-          <Suspense fallback={<Fallback />}>
-            <Relationships />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="messages">
-          <MessagesTab myProfileId={profileId} />
-        </TabsContent>
-
-        <TabsContent value="family">
-          <Suspense fallback={<Fallback />}>
-            {profileId ? (
-              <FamilyDashboard />
-            ) : (
-              <Card>
-                <CardContent className="p-6 text-sm text-muted-foreground">
-                  Sign in to view your family.
-                </CardContent>
-              </Card>
-            )}
-          </Suspense>
-          <div className="mt-3 text-xs text-muted-foreground">
-            Need more? Visit the{" "}
-            <Link to="/family/timeline" className="underline">
-              family timeline
-            </Link>
-            .
-          </div>
-        </TabsContent>
-
-        <TabsContent value="discover">
-          <Suspense fallback={<Fallback />}>
-            <PlayerSearch />
-          </Suspense>
-        </TabsContent>
-
-        <TabsContent value="invites">
-          <InvitesInbox profileId={profileId} />
-        </TabsContent>
-      </Tabs>
-    </FMPageScaffold>
+      {content}
+    </HubLayout>
   );
 }


### PR DESCRIPTION
### Motivation

- Make Social a predictable, discoverable hub by consolidating existing friend, player-discovery, messaging, Twaater and recruitment surfaces under a single `/social` landing route. 
- Preserve existing canonical routes, deep links and backend ownership (Character, Band, Music, global Notifications) while improving navigation and breadcrumbs.

### Description

- Added a real Social hub overview and child navigation using the shared `HubLayout` pattern and a new `socialHubNavigation` entry in `src/config/hubNavigation.ts`.
- Implemented `src/pages/SocialHub.tsx` to render an overview (friends count, pending requests, invites, Twaater trends) and to route child pages (`/social/friends`, `/social/players`, `/social/messages`, `/social/twaater`, `/social/recruitment`, `/social/invitations`) using existing components and hooks.
- Updated app routing and metadata in `src/App.tsx` to add preserved redirects/aliases (e.g. `/hub/social` → `/social`, `/relationships` → `/social/friends`, `/players/search` → `/social/players`) and to ensure hub-aware page titles via `HUB_TITLE_CONFIGS`.
- Adjusted FM navigation in `src/config/fmNavigation.ts` so the Social top-level item opens `/social` and exposes only implemented social entries; updated `PlayerSearch` to persist the `q` query parameter for refreshable searches.
- Added a small unit test `src/config/__tests__/fmNavigation.social.test.ts` verifying the canonical `/social` landing and legacy-alias matching, and documented the Social hub migration and decisions in `docs/navigation-and-hub-refactor.md`.

### Testing

- `npm run typecheck` (`tsc --noEmit`) — passed.
- `npm run lint` — blocked because dev dependencies were not installed in this environment and ESLint could not resolve `@eslint/js`.
- `npm run test:unit -- src/config/__tests__/fmNavigation.social.test.ts` — test file added but execution was blocked because `vitest` was not available in the environment.
- `npm run build` / `npm install` — blocked by environment/npm registry restrictions (403 for `@react-three/fiber`), so full install/build and browser verification could not be completed.

Files changed (summary): `src/pages/SocialHub.tsx`, `src/config/hubNavigation.ts`, `src/config/fmNavigation.ts`, `src/App.tsx`, `src/pages/PlayerSearch.tsx`, `src/config/__tests__/fmNavigation.social.test.ts`, and `docs/navigation-and-hub-refactor.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54cd1e751483258e9669a1cb08325d)