### PR TITLE
Authoritative songwriting scheduling: add scheduling RPC, repair migrations, and client wiring

### DIFF
--- a/src/components/songwriting/SongwritingScheduleDialog.test.tsx
+++ b/src/components/songwriting/SongwritingScheduleDialog.test.tsx
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dialogSource = readFileSync("src/components/songwriting/SongwritingScheduleDialog.tsx", "utf8");
+const hookSource = readFileSync("src/hooks/useSongwritingData.tsx", "utf8");
+const scheduledSource = readFileSync("src/hooks/useScheduledActivities.ts", "utf8");
+const migrationSource = readFileSync("supabase/migrations/20260713143000_authoritative_songwriting_scheduling.sql", "utf8");
+
+describe("authoritative songwriting scheduling flow", () => {
+  it("offers only 1, 2, and 4 hour scheduled songwriting durations", () => {
+    expect(dialogSource).toContain('<SelectItem value="1">1 hour</SelectItem>');
+    expect(dialogSource).toContain('<SelectItem value="2">2 hours</SelectItem>');
+    expect(dialogSource).toContain('<SelectItem value="4">4 hours</SelectItem>');
+    expect(dialogSource).not.toContain('value="3"');
+    expect(dialogSource).not.toContain('value="6"');
+  });
+
+  it("uses dedicated songwriting RPCs instead of generic scheduled activity creation", () => {
+    expect(dialogSource).toContain('rpc("schedule_songwriting_session"');
+    expect(dialogSource).not.toContain("createScheduledActivity");
+    expect(hookSource).toContain("rpc('start_songwriting_session'");
+    expect(hookSource).toContain("p_idempotency_key");
+  });
+
+  it("routes scheduled songwriting starts through the songwriting RPC lifecycle", () => {
+    expect(scheduledSource).toContain("activity?.activity_type === 'songwriting'");
+    expect(scheduledSource).toContain("p_activity_id: activityId");
+    expect(migrationSource).toContain("status IN ('scheduled','in_progress','completed','missed','cancelled')");
+  });
+
+  it("repairs required schema drift and enforces supported durations server-side", () => {
+    for (const column of ["profile_id", "is_locked", "locked_until", "duration_minutes", "idempotency_key"]) {
+      expect(migrationSource).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+    expect(migrationSource).toContain("p_effort_hours NOT IN (1,2,4)");
+    expect(migrationSource).toContain("schedule_songwriting_session");
+  });
+
+  it("preserves project/session/activity links and avoids early project locks for scheduled sessions", () => {
+    expect(migrationSource).toContain("'project_id', p_project_id, 'session_id', v_session_id");
+    const scheduleFunction = migrationSource.slice(migrationSource.indexOf("CREATE OR REPLACE FUNCTION public.schedule_songwriting_session"));
+    expect(scheduleFunction).not.toContain("SET is_locked=true");
+  });
+});

--- a/src/components/songwriting/SongwritingScheduleDialog.tsx
+++ b/src/components/songwriting/SongwritingScheduleDialog.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Calendar } from "@/components/ui/calendar";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { createScheduledActivity } from "@/hooks/useActivityBooking";
 import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { useQueryClient } from "@tanstack/react-query";
+import logger from "@/lib/logger";
 import { addDurationHours, buildScheduledDateTime, validateBookingWindow } from "@/utils/activityBookingTime";
 
 interface SongwritingScheduleDialogProps {
@@ -13,19 +15,38 @@ interface SongwritingScheduleDialogProps {
   onOpenChange: (open: boolean) => void;
   projectId?: string;
   projectTitle?: string;
+  projectStatus?: string;
+  profileId?: string | null;
 }
 
 export function SongwritingScheduleDialog({
   open,
   onOpenChange,
   projectId,
-  projectTitle
+  projectTitle,
+  projectStatus,
+  profileId
 }: SongwritingScheduleDialogProps) {
   const [date, setDate] = useState<Date | undefined>(new Date());
   const [hour, setHour] = useState("9");
-  const [duration, setDuration] = useState("3");
+  const [duration, setDuration] = useState("1");
+  const [isSaving, setIsSaving] = useState(false);
+  const queryClient = useQueryClient();
 
   const handleSchedule = async () => {
+    if (isSaving) return;
+    if (!profileId) {
+      toast.error("Select an active character before scheduling songwriting.");
+      return;
+    }
+    if (!projectId) {
+      toast.error("Select a songwriting project before scheduling.");
+      return;
+    }
+    if (projectStatus === "completed" || projectStatus === "converted") {
+      toast.error("The selected project is no longer available.");
+      return;
+    }
     if (!date) {
       toast.error("Please select a date");
       return;
@@ -33,26 +54,57 @@ export function SongwritingScheduleDialog({
 
     const scheduledStart = buildScheduledDateTime(date, parseInt(hour));
     const scheduledEnd = addDurationHours(scheduledStart, Number(duration));
+    if (scheduledStart <= new Date()) {
+      toast.error("That time is in the past.");
+      return;
+    }
     const bookingError = validateBookingWindow(scheduledStart, scheduledEnd);
     if (bookingError) {
       toast.error(bookingError);
       return;
     }
 
+    setIsSaving(true);
     try {
-      await createScheduledActivity({
-        activityType: 'songwriting',
-        scheduledStart,
-        scheduledEnd,
-        title: projectTitle ? `Songwriting: ${projectTitle}` : 'Songwriting Session',
-        description: projectId ? `Working on ${projectTitle}` : 'General songwriting session',
-        metadata: projectId ? { projectId } : undefined,
+      const { data: { user } } = await supabase.auth.getUser();
+      const { data, error } = await (supabase as any).rpc("schedule_songwriting_session", {
+        p_profile_id: profileId,
+        p_project_id: projectId,
+        p_scheduled_start: scheduledStart.toISOString(),
+        p_effort_hours: Number(duration),
+        p_session_type: "balanced",
+        p_idempotency_key: `schedule-${profileId}-${projectId}-${scheduledStart.toISOString()}-${duration}`,
       });
+      if (error) {
+        logger.error("Songwriting schedule RPC failed", {
+          action: "schedule_songwriting_session",
+          rpc: "schedule_songwriting_session",
+          profileId,
+          projectId,
+          userId: user?.id,
+          duration: Number(duration),
+          scheduledStart: scheduledStart.toISOString(),
+          postgrestCode: (error as any).code,
+          httpStatus: (error as any).status,
+          domainError: error.message,
+          details: (error as any).details,
+        });
+        throw new Error(error.message || "Failed to schedule session");
+      }
 
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["songwriting-projects"] }),
+        queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["weekly-schedule"] }),
+        queryClient.invalidateQueries({ queryKey: ["activity-status"] }),
+      ]);
       toast.success("Songwriting session scheduled!");
       onOpenChange(false);
+      return data;
     } catch (error: any) {
       toast.error(error.message || "Failed to schedule session");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -100,18 +152,16 @@ export function SongwritingScheduleDialog({
               <SelectContent>
                 <SelectItem value="1">1 hour</SelectItem>
                 <SelectItem value="2">2 hours</SelectItem>
-                <SelectItem value="3">3 hours (Standard)</SelectItem>
                 <SelectItem value="4">4 hours</SelectItem>
-                <SelectItem value="6">6 hours</SelectItem>
               </SelectContent>
             </Select>
           </div>
 
           <div className="flex gap-2">
-            <Button onClick={handleSchedule} className="flex-1">
-              Schedule Session
+            <Button onClick={handleSchedule} className="flex-1" disabled={isSaving || !projectId || projectStatus === "completed" || projectStatus === "converted"}>
+              {isSaving ? "Scheduling..." : "Schedule Session"}
             </Button>
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
               Cancel
             </Button>
           </div>

--- a/src/hooks/useScheduledActivities.ts
+++ b/src/hooks/useScheduledActivities.ts
@@ -394,6 +394,28 @@ export function useStartActivity() {
 
   return useMutation({
     mutationFn: async (activityId: string) => {
+      const { data: activity, error: loadError } = await (supabase as any)
+        .from('player_scheduled_activities')
+        .select('*')
+        .eq('id', activityId)
+        .single();
+      if (loadError) throw loadError;
+
+      if (activity?.activity_type === 'songwriting') {
+        const projectId = activity.metadata?.project_id || activity.metadata?.projectId;
+        const effortHours = Number(activity.metadata?.duration_hours || activity.duration_minutes / 60 || 1);
+        const { data: rpcData, error: rpcError } = await (supabase as any).rpc('start_songwriting_session', {
+          p_profile_id: activity.profile_id,
+          p_project_id: projectId,
+          p_effort_hours: effortHours,
+          p_session_type: activity.metadata?.session_type || 'balanced',
+          p_idempotency_key: `start-scheduled-${activityId}`,
+          p_activity_id: activityId,
+        });
+        if (rpcError) throw new Error(rpcError.message || 'Failed to start scheduled songwriting session');
+        return { ...activity, status: 'in_progress', metadata: { ...activity.metadata, ...rpcData } } as ScheduledActivity;
+      }
+
       const { data, error } = await (supabase as any)
         .from('player_scheduled_activities')
         .update({

--- a/src/hooks/useSongwritingData.tsx
+++ b/src/hooks/useSongwritingData.tsx
@@ -331,8 +331,23 @@ export const useSongwritingData = (profileId?: string | null, userId?: string | 
         p_profile_id: profileId,
         p_project_id: projectId,
         p_effort_hours: effortHours,
+        p_idempotency_key: `start-${profileId}-${projectId}-${Date.now()}`,
       });
-      if (error) throw error;
+      if (error) {
+        logger.error('Songwriting start RPC failed', {
+          action: 'start_songwriting_session',
+          rpc: 'start_songwriting_session',
+          profileId,
+          projectId,
+          userId: user.id,
+          duration: effortHours,
+          postgrestCode: (error as any).code,
+          httpStatus: (error as any).status,
+          domainError: error.message,
+          details: (error as any).details,
+        });
+        throw new Error(error.message || 'Failed to start session');
+      }
 
       logGameActivity({
         userId: user.id,
@@ -347,7 +362,11 @@ export const useSongwritingData = (profileId?: string | null, userId?: string | 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['songwriting-projects', profileId, userId] });
       queryClient.invalidateQueries({ queryKey: ['scheduled-activities'] });
+      queryClient.invalidateQueries({ queryKey: ['activity-status'] });
       toast({ title: "Session Started", description: "Songwriting session in progress" });
+    },
+    onError: (error: Error) => {
+      toast({ title: "Could not start session", description: error.message, variant: "destructive" });
     }
   });
 

--- a/src/pages/Songwriting.tsx
+++ b/src/pages/Songwriting.tsx
@@ -2871,6 +2871,8 @@ const Songwriting = () => {
         onOpenChange={setScheduleDialogOpen}
         projectId={scheduleProject?.id}
         projectTitle={scheduleProject?.title}
+        projectStatus={scheduleProject?.status}
+        profileId={profileId}
       />
     </FMPageScaffold>
   );

--- a/supabase/migrations/20260713143000_authoritative_songwriting_scheduling.sql
+++ b/supabase/migrations/20260713143000_authoritative_songwriting_scheduling.sql
@@ -1,0 +1,190 @@
+-- Authoritative songwriting start/schedule flow and schema drift repair.
+
+ALTER TABLE public.songwriting_projects
+  ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS is_locked boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS locked_until timestamptz,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'draft';
+
+ALTER TABLE public.songwriting_sessions
+  ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES public.profiles(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS user_id uuid,
+  ADD COLUMN IF NOT EXISTS session_start timestamptz,
+  ADD COLUMN IF NOT EXISTS session_end timestamptz,
+  ADD COLUMN IF NOT EXISTS locked_until timestamptz,
+  ADD COLUMN IF NOT EXISTS effort_hours integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS session_type text NOT NULL DEFAULT 'balanced',
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'in_progress',
+  ADD COLUMN IF NOT EXISTS idempotency_key text,
+  ADD COLUMN IF NOT EXISTS music_progress_gained integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS lyrics_progress_gained integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS arrangement_progress_gained integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS polish_gained integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS consistency_gained integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS xp_earned integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS xp_awards jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS progress_breakdown jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.player_scheduled_activities
+  ADD COLUMN IF NOT EXISTS duration_minutes integer,
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+DO $$ BEGIN
+  ALTER TABLE public.songwriting_sessions
+    DROP CONSTRAINT IF EXISTS songwriting_sessions_effort_hours_check;
+  ALTER TABLE public.songwriting_sessions
+    ADD CONSTRAINT songwriting_sessions_effort_hours_check CHECK (effort_hours IN (1,2,4));
+  ALTER TABLE public.songwriting_sessions
+    DROP CONSTRAINT IF EXISTS songwriting_sessions_status_check;
+  ALTER TABLE public.songwriting_sessions
+    ADD CONSTRAINT songwriting_sessions_status_check CHECK (status IN ('scheduled','in_progress','completed','missed','cancelled'));
+  ALTER TABLE public.songwriting_sessions
+    DROP CONSTRAINT IF EXISTS songwriting_sessions_session_type_check;
+  ALTER TABLE public.songwriting_sessions
+    ADD CONSTRAINT songwriting_sessions_session_type_check CHECK (session_type IN ('balanced','music','lyrics','arrangement','polish'));
+EXCEPTION WHEN others THEN
+  RAISE NOTICE 'songwriting constraint repair skipped: %', SQLERRM;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS songwriting_sessions_idempotency_idx
+  ON public.songwriting_sessions(project_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS songwriting_sessions_activity_unique_idx
+  ON public.songwriting_sessions(((progress_breakdown->>'activity_id')))
+  WHERE progress_breakdown ? 'activity_id';
+
+CREATE OR REPLACE FUNCTION public.start_songwriting_session(
+  p_profile_id uuid,
+  p_project_id uuid,
+  p_effort_hours integer DEFAULT 1,
+  p_session_type text DEFAULT 'balanced',
+  p_idempotency_key text DEFAULT NULL,
+  p_activity_id uuid DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_user uuid := auth.uid();
+  v_project public.songwriting_projects%ROWTYPE;
+  v_start timestamptz := timezone('utc', now());
+  v_end timestamptz;
+  v_session_id uuid;
+  v_activity_id uuid;
+  v_existing public.songwriting_sessions%ROWTYPE;
+  v_conflict uuid;
+BEGIN
+  IF v_user IS NULL THEN RAISE EXCEPTION 'Not authenticated' USING ERRCODE='P0001'; END IF;
+  IF p_effort_hours NOT IN (1,2,4) THEN RAISE EXCEPTION 'Only 1, 2 or 4-hour songwriting sessions are supported.' USING ERRCODE='P0001'; END IF;
+  IF p_session_type NOT IN ('balanced','music','lyrics','arrangement','polish') THEN RAISE EXCEPTION 'Unsupported songwriting session type.' USING ERRCODE='P0001'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = p_profile_id AND user_id = v_user) THEN RAISE EXCEPTION 'This project belongs to another character.' USING ERRCODE='P0001'; END IF;
+
+  SELECT * INTO v_project FROM public.songwriting_projects WHERE id = p_project_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'The selected project is no longer available.' USING ERRCODE='P0001'; END IF;
+  IF v_project.profile_id IS NULL AND v_project.user_id = v_user THEN
+    UPDATE public.songwriting_projects SET profile_id = p_profile_id WHERE id = p_project_id RETURNING * INTO v_project;
+  END IF;
+  IF v_project.profile_id <> p_profile_id THEN RAISE EXCEPTION 'This project belongs to another character.' USING ERRCODE='P0001'; END IF;
+  IF v_project.status IN ('completed','converted') OR v_project.completed_at IS NOT NULL OR v_project.song_id IS NOT NULL THEN RAISE EXCEPTION 'This songwriting project is already complete.' USING ERRCODE='P0001'; END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_existing FROM public.songwriting_sessions WHERE project_id = p_project_id AND idempotency_key = p_idempotency_key;
+    IF FOUND THEN RETURN jsonb_build_object('session_id', v_existing.id, 'activity_id', v_existing.progress_breakdown->>'activity_id', 'duplicate', true, 'locked_until', v_existing.locked_until, 'project_id', p_project_id); END IF;
+  END IF;
+
+  IF p_activity_id IS NOT NULL THEN
+    SELECT * INTO v_existing FROM public.songwriting_sessions WHERE progress_breakdown->>'activity_id' = p_activity_id::text FOR UPDATE;
+    IF FOUND AND v_existing.status = 'in_progress' THEN RAISE EXCEPTION 'This project already has an active session.' USING ERRCODE='P0001'; END IF;
+    IF FOUND AND v_existing.status <> 'scheduled' THEN RAISE EXCEPTION 'This scheduled songwriting session can no longer be started.' USING ERRCODE='P0001'; END IF;
+    IF FOUND THEN p_effort_hours := v_existing.effort_hours; p_session_type := v_existing.session_type; v_session_id := v_existing.id; END IF;
+  END IF;
+
+  v_end := v_start + make_interval(hours => p_effort_hours);
+  SELECT id INTO v_conflict FROM public.player_scheduled_activities
+  WHERE profile_id = p_profile_id AND status = 'in_progress' AND (p_activity_id IS NULL OR id <> p_activity_id) LIMIT 1;
+  IF v_conflict IS NOT NULL THEN RAISE EXCEPTION 'You already have an activity in progress.' USING ERRCODE='P0001'; END IF;
+  SELECT id INTO v_conflict FROM public.player_scheduled_activities
+  WHERE profile_id = p_profile_id AND status IN ('scheduled','in_progress') AND (p_activity_id IS NULL OR id <> p_activity_id)
+    AND tstzrange(scheduled_start, scheduled_end, '[)') && tstzrange(v_start, v_end, '[)') LIMIT 1;
+  IF v_conflict IS NOT NULL THEN RAISE EXCEPTION 'This overlaps with another scheduled activity.' USING ERRCODE='P0001'; END IF;
+  IF v_project.is_locked AND v_project.locked_until > v_start THEN RAISE EXCEPTION 'This project already has an active session.' USING ERRCODE='P0001'; END IF;
+
+  IF v_session_id IS NULL THEN
+    INSERT INTO public.songwriting_sessions(project_id, profile_id, user_id, session_start, session_end, locked_until, effort_hours, session_type, status, idempotency_key)
+    VALUES (p_project_id, p_profile_id, v_user, v_start, NULL, v_end, p_effort_hours, p_session_type, 'in_progress', p_idempotency_key) RETURNING id INTO v_session_id;
+  ELSE
+    UPDATE public.songwriting_sessions SET session_start = v_start, session_end = NULL, locked_until = v_end, status = 'in_progress', idempotency_key = COALESCE(p_idempotency_key, idempotency_key) WHERE id = v_session_id;
+  END IF;
+
+  IF p_activity_id IS NULL THEN
+    INSERT INTO public.player_scheduled_activities(user_id, profile_id, activity_type, scheduled_start, scheduled_end, duration_minutes, status, title, description, metadata)
+    VALUES (v_user, p_profile_id, 'songwriting', v_start, v_end, p_effort_hours*60, 'in_progress', 'Songwriting: ' || COALESCE(v_project.title,'Untitled'), 'Working on song composition', jsonb_build_object('project_id', p_project_id, 'session_id', v_session_id, 'duration_hours', p_effort_hours, 'session_type', p_session_type)) RETURNING id INTO v_activity_id;
+  ELSE
+    v_activity_id := p_activity_id;
+    UPDATE public.player_scheduled_activities SET status='in_progress', scheduled_start=v_start, scheduled_end=v_end, duration_minutes=p_effort_hours*60, metadata=COALESCE(metadata,'{}'::jsonb)||jsonb_build_object('project_id', p_project_id, 'session_id', v_session_id, 'duration_hours', p_effort_hours, 'session_type', p_session_type) WHERE id=p_activity_id AND profile_id=p_profile_id AND status='scheduled';
+    IF NOT FOUND THEN RAISE EXCEPTION 'This scheduled songwriting session can no longer be started.' USING ERRCODE='P0001'; END IF;
+  END IF;
+
+  UPDATE public.songwriting_sessions SET progress_breakdown = COALESCE(progress_breakdown,'{}'::jsonb) || jsonb_build_object('activity_id', v_activity_id) WHERE id = v_session_id;
+  UPDATE public.songwriting_projects SET is_locked=true, locked_until=v_end, status='writing' WHERE id=p_project_id;
+  RETURN jsonb_build_object('session_id', v_session_id, 'activity_id', v_activity_id, 'locked_until', v_end, 'effort_hours', p_effort_hours, 'project_id', p_project_id, 'status', 'in_progress');
+EXCEPTION WHEN others THEN
+  RAISE LOG 'songwriting_rpc_failure action=% profile_id=% project_id=% user_id=% duration=% activity_id=% sqlstate=% error=%', 'start_songwriting_session', p_profile_id, p_project_id, v_user, p_effort_hours, p_activity_id, SQLSTATE, SQLERRM;
+  RAISE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.schedule_songwriting_session(
+  p_profile_id uuid,
+  p_project_id uuid,
+  p_scheduled_start timestamptz,
+  p_effort_hours integer,
+  p_session_type text DEFAULT 'balanced',
+  p_idempotency_key text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_user uuid := auth.uid();
+  v_project public.songwriting_projects%ROWTYPE;
+  v_end timestamptz;
+  v_session_id uuid;
+  v_activity_id uuid;
+  v_existing public.songwriting_sessions%ROWTYPE;
+  v_conflict uuid;
+BEGIN
+  IF v_user IS NULL THEN RAISE EXCEPTION 'Not authenticated' USING ERRCODE='P0001'; END IF;
+  IF p_effort_hours NOT IN (1,2,4) THEN RAISE EXCEPTION 'Only 1, 2 or 4-hour songwriting sessions are supported.' USING ERRCODE='P0001'; END IF;
+  IF p_session_type NOT IN ('balanced','music','lyrics','arrangement','polish') THEN RAISE EXCEPTION 'Unsupported songwriting session type.' USING ERRCODE='P0001'; END IF;
+  IF p_scheduled_start <= timezone('utc', now()) THEN RAISE EXCEPTION 'That time is in the past.' USING ERRCODE='P0001'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id = p_profile_id AND user_id = v_user) THEN RAISE EXCEPTION 'This project belongs to another character.' USING ERRCODE='P0001'; END IF;
+
+  SELECT * INTO v_project FROM public.songwriting_projects WHERE id = p_project_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'The selected project is no longer available.' USING ERRCODE='P0001'; END IF;
+  IF v_project.profile_id IS NULL AND v_project.user_id = v_user THEN UPDATE public.songwriting_projects SET profile_id=p_profile_id WHERE id=p_project_id RETURNING * INTO v_project; END IF;
+  IF v_project.profile_id <> p_profile_id THEN RAISE EXCEPTION 'This project belongs to another character.' USING ERRCODE='P0001'; END IF;
+  IF v_project.status IN ('completed','converted') OR v_project.completed_at IS NOT NULL OR v_project.song_id IS NOT NULL THEN RAISE EXCEPTION 'The selected project is no longer available.' USING ERRCODE='P0001'; END IF;
+
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_existing FROM public.songwriting_sessions WHERE project_id=p_project_id AND idempotency_key=p_idempotency_key;
+    IF FOUND THEN RETURN jsonb_build_object('session_id', v_existing.id, 'activity_id', v_existing.progress_breakdown->>'activity_id', 'duplicate', true, 'scheduled_start', v_existing.session_start, 'scheduled_end', v_existing.locked_until, 'project_id', p_project_id); END IF;
+  END IF;
+
+  v_end := p_scheduled_start + make_interval(hours => p_effort_hours);
+  SELECT id INTO v_conflict FROM public.player_scheduled_activities
+  WHERE profile_id=p_profile_id AND status IN ('scheduled','in_progress') AND tstzrange(scheduled_start, scheduled_end, '[)') && tstzrange(p_scheduled_start, v_end, '[)') LIMIT 1;
+  IF v_conflict IS NOT NULL THEN RAISE EXCEPTION 'This overlaps with another scheduled activity.' USING ERRCODE='P0001'; END IF;
+
+  SELECT id INTO v_conflict FROM public.songwriting_sessions
+  WHERE project_id=p_project_id AND status IN ('scheduled','in_progress') AND tstzrange(session_start, COALESCE(locked_until, session_end), '[)') && tstzrange(p_scheduled_start, v_end, '[)') LIMIT 1;
+  IF v_conflict IS NOT NULL THEN RAISE EXCEPTION 'This project already has a session planned at that time.' USING ERRCODE='P0001'; END IF;
+
+  INSERT INTO public.songwriting_sessions(project_id, profile_id, user_id, session_start, session_end, locked_until, effort_hours, session_type, status, idempotency_key)
+  VALUES (p_project_id, p_profile_id, v_user, p_scheduled_start, NULL, v_end, p_effort_hours, p_session_type, 'scheduled', p_idempotency_key) RETURNING id INTO v_session_id;
+  INSERT INTO public.player_scheduled_activities(user_id, profile_id, activity_type, scheduled_start, scheduled_end, duration_minutes, status, title, description, metadata)
+  VALUES (v_user, p_profile_id, 'songwriting', p_scheduled_start, v_end, p_effort_hours*60, 'scheduled', 'Songwriting: ' || COALESCE(v_project.title,'Untitled'), 'Planned songwriting session', jsonb_build_object('project_id', p_project_id, 'session_id', v_session_id, 'duration_hours', p_effort_hours, 'session_type', p_session_type, 'lifecycle', 'scheduled_in_progress_completed')) RETURNING id INTO v_activity_id;
+  UPDATE public.songwriting_sessions SET progress_breakdown = COALESCE(progress_breakdown,'{}'::jsonb) || jsonb_build_object('activity_id', v_activity_id) WHERE id=v_session_id;
+  RETURN jsonb_build_object('activity_id', v_activity_id, 'session_id', v_session_id, 'scheduled_start', p_scheduled_start, 'scheduled_end', v_end, 'project_id', p_project_id, 'status', 'scheduled');
+EXCEPTION WHEN others THEN
+  RAISE LOG 'songwriting_rpc_failure action=% profile_id=% project_id=% user_id=% duration=% scheduled_start=% sqlstate=% error=%', 'schedule_songwriting_session', p_profile_id, p_project_id, v_user, p_effort_hours, p_scheduled_start, SQLSTATE, SQLERRM;
+  RAISE;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation

- Immediate-start failures were traced to migration/schema drift around the authoritative `start_songwriting_session` RPC and missing columns/constraints in the live schema, causing database/PostgREST errors instead of domain errors. 
- The scheduling UI used the generic `createScheduledActivity` helper with a 3-hour default and 1/2/3/4/6-hour choices, which created only an unrelated `player_scheduled_activities` row and never reserved a `songwriting_sessions` record. 
- The goal is a single server-authoritative flow for starting now, scheduling for later, and starting scheduled songwriting sessions while preventing conflicts, duplicate sessions, and early project locks.

### Description

- Added an idempotent repair migration `supabase/migrations/20260713143000_authoritative_songwriting_scheduling.sql` that ensures required `songwriting_projects`, `songwriting_sessions`, and `player_scheduled_activities` columns/constraints exist and creates hardened RPCs. 
- Implemented a new scheduling RPC `public.schedule_songwriting_session` and hardened `public.start_songwriting_session` in the migration to enforce only `1`, `2`, or `4` hours, validate ownership (including legacy `user_id` → backfill `profile_id`), check conflicts, create linked `songwriting_sessions` + `player_scheduled_activities` atomically, support idempotency keys, and log structured failures. 
- Client-side changes: replaced the generic path in `src/components/songwriting/SongwritingScheduleDialog.tsx` to call `rpc('schedule_songwriting_session')`, restricted durations to `1/2/4` hours, added profile/project validation, past-date blocking, double-submit prevention, structured logging, and query refreshes; passed `profileId` and `projectStatus` from `src/pages/Songwriting.tsx`. 
- Lifecycle wiring: updated `src/hooks/useScheduledActivities.ts` so starting a scheduled songwriting activity routes through `rpc('start_songwriting_session')` with the scheduled activity id, and updated `src/hooks/useSongwritingData.tsx` to send an idempotency key and record structured RPC failures and UI-friendly domain errors; added a static regression test `src/components/songwriting/SongwritingScheduleDialog.test.tsx` to assert the new flows.

### Testing

- `npm run typecheck` completed successfully. 
- Static assertions (Node script checking that the dialog uses `rpc("schedule_songwriting_session")`, that only `1/2/4` durations exist, and that the migration contains the new RPCs/constraints) passed. 
- `npm run test:unit` for the new test could not be executed in this environment because `vitest` is not installed. 
- `npm run lint` could not be executed here because `@eslint/js` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ceee24108325b46e46d01f3eb98e)