### PR TITLE
Repair start_songwriting_session RPC signature

### DIFF
--- a/supabase/migrations/20260713150000_repair_start_songwriting_session_rpc_signature.sql
+++ b/supabase/migrations/20260713150000_repair_start_songwriting_session_rpc_signature.sql
@@ -1,0 +1,36 @@
+-- Repair public.start_songwriting_session RPC signature for the live frontend.
+--
+-- The authoritative implementation is the scheduling-aware RPC from
+-- 20260713143000_authoritative_songwriting_scheduling.sql.  PostgREST matches RPCs
+-- by the named argument set supplied by the client, and the current frontend calls
+-- this RPC with exactly:
+--   p_profile_id, p_project_id, p_effort_hours, p_idempotency_key
+-- The scheduling-aware implementation also accepts p_session_type and p_activity_id,
+-- so expose a four-argument compatibility signature that delegates to the
+-- authoritative flow using the default balanced session type and no scheduled
+-- activity handoff.
+
+CREATE OR REPLACE FUNCTION public.start_songwriting_session(
+  p_profile_id uuid,
+  p_project_id uuid,
+  p_effort_hours integer DEFAULT 1,
+  p_idempotency_key text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.start_songwriting_session(
+    p_profile_id := p_profile_id,
+    p_project_id := p_project_id,
+    p_effort_hours := p_effort_hours,
+    p_session_type := 'balanced',
+    p_idempotency_key := p_idempotency_key,
+    p_activity_id := NULL::uuid
+  );
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- The frontend calls `public.start_songwriting_session` with the named parameters `p_profile_id`, `p_project_id`, `p_effort_hours`, `p_idempotency_key`, but the live DB exposed a scheduling-aware implementation with additional named arguments, causing PostgREST to fail RPC lookup.
- Add a targeted, idempotent repair so PostgREST can resolve the exact signature the frontend uses without modifying historical migrations.

### Description
- Add `supabase/migrations/20260713150000_repair_start_songwriting_session_rpc_signature.sql` which creates a four-argument compatibility wrapper `public.start_songwriting_session(p_profile_id uuid, p_project_id uuid, p_effort_hours integer DEFAULT 1, p_idempotency_key text DEFAULT NULL) RETURNS jsonb`.
- The wrapper delegates to the authoritative scheduling-aware implementation by passing `p_session_type := 'balanced'` and `p_activity_id := NULL::uuid` so behavior remains consistent.
- The migration emits `NOTIFY pgrst, 'reload schema'` to prompt PostgREST to refresh its schema cache after deployment.

### Testing
- Verified presence and signatures with `rg -n "CREATE OR REPLACE FUNCTION public\.start_songwriting_session|p_session_type|p_activity_id|NOTIFY pgrst"` across the relevant migrations, which returned the authoritative implementation and the new repair migration (succeeded).
- Confirmed the new migration file contents with `sed -n` and added/committed the file with `git status --short` and `git commit`, which showed the new file staged and committed (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54db96eb108325993c3245d07002cf)