### PR TITLE
Consolidate business management and career progression hubs

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -552,3 +552,114 @@ The Social hub uses shared `HubLayout` child navigation, including horizontal mo
 - Twaater account DMs and friend direct messages remain separate systems to avoid a risky messaging rewrite.
 - Recruitment application-management screens remain in Band.
 - Business and Career consolidation is the planned next navigation PR.
+
+## PR 7 update — Business and Career hub consolidation
+
+PR 7 splits the former combined Career & Business area into two predictable hub entry points that use the shared `HubLayout` pattern from PR 2:
+
+- `/business` renders the Business Overview.
+- `/career` renders the Career Overview.
+- `/business/overview` and `/career/overview` are compatibility aliases that preserve query strings and redirect to the base overview routes.
+- `/hub/career-business` and `/hub/career` now resolve to `/career`; `/hub/commerce` resolves to `/business`.
+
+### Final Business hierarchy
+
+Business owns company operations and only surfaces existing routes:
+
+| Business child | Canonical route | Existing implementation or alias |
+| --- | --- | --- |
+| Overview | `/business` | New overview using existing company and company-finance summary hooks. |
+| Companies | `/business/companies` | Existing `MyCompanies` page; `/my-companies` remains valid. |
+| Staff | `/business/staff` | Alias to company management because staff is still handled inside existing company/entity management pages. |
+| Recruitment / Job adverts | `/business/recruitment`, `/business/job-adverts` | Alias to the existing employment/application surface; advert creation and application review remain in the current workflow. |
+| Finances | `/business/finances` | Alias to the existing company dashboard finance summary rather than the personal/band finance ledger. |
+| Advertising | `/business/advertising` | Alias to the existing PR/advertising workflow. |
+| Labels | `/business/labels` | Existing record label pages; `/labels` and `/labels/:labelId/manage` remain valid. |
+| Reports | `/business/reports` | Alias to the existing company dashboard/reporting context. |
+
+No placeholder tabs were added for contracts, company inventory or standalone settings because the current repository does not expose stable standalone pages for those systems across all company types.
+
+### Final Career hierarchy
+
+Career owns personal professional progression and only surfaces existing routes:
+
+| Career child | Canonical route | Existing implementation or alias |
+| --- | --- | --- |
+| Overview | `/career` | New hub shell around the existing career overview data from `src/pages/dashboard/career.tsx`. |
+| Employment | `/career/employment` | Existing `Employment` page; `/employment` and `/jobs` remain valid entry points. |
+| Personal Finances | `/career/finances` | Alias to `/finances` for the existing personal finance ledger and non-company money surfaces. |
+| Fame & Fans | `/career/fame` | Alias to the existing statistics/progression surface. |
+| Charts | `/career/charts` | Alias to competitive charts; full chart browsing remains outside Career. |
+| Awards | `/career/awards` | Existing awards page; `/awards` remains valid. |
+| Achievements | `/career/achievements` | Alias to the existing Hall of Immortals/achievement surface. |
+| Discography | `/career/discography` | Alias to release management as a contextual career entry; Music remains the owner of creation and editing workflows. |
+| History | `/career/history` | Alias to the existing legacy/career-history surface. |
+
+### Canonical Business route model
+
+Business management uses hub-owned routes for navigation (`/business/*`) while preserving entity-specific legacy management URLs such as `/company/:companyId`, `/security-firm/:companyId`, `/merch-factory/:companyId`, `/venue-business/:venueId`, `/rehearsal-studio-business/:studioId` and `/recording-studio-business/:studioId`. Public discovery stays under World at `/world/companies`, `/world-companies`, `/companies/directory` and public company profile routes where they are used as discovery surfaces.
+
+Active-company context remains the current repository model: the company list and individual management pages own their entity IDs, refresh behaviour and permission handling. PR 7 does not introduce a new global company selector or transient navigation-state dependency.
+
+### Canonical Career route model
+
+Career progression uses `/career` for the overview and `/career/*` for predictable child entry points. Existing flat URLs remain aliases or direct routes to avoid breaking bookmarks, activity feed links, messages, notifications and older hub links.
+
+### Route migration table and legacy aliases
+
+| Legacy route | New logical owner | Behaviour |
+| --- | --- | --- |
+| `/hub/career-business` | Career | Redirects to `/career`. |
+| `/hub/career` | Career | Redirects to `/career`. |
+| `/hub/commerce` | Business | Redirects to `/business`. |
+| `/my-companies` | Business | Still renders the existing company dashboard; selected under Business. |
+| `/company/:companyId` and company-type management routes | Business | Remain direct entity management links; selected under Business. |
+| `/world-companies`, `/companies/directory`, `/world/companies` | World | Remain public discovery links; not selected as Business management. |
+| `/employment`, `/jobs` | Career | Remain valid and selected as Employment. |
+| `/awards`, `/competitive-charts`, `/release-manager`, `/legacy`, `/statistics` | Career | Remain valid career progression aliases. |
+| `/finances` | Career | Remains the personal/band finance ledger; Business uses company-dashboard finance context instead. |
+
+### Ownership boundaries
+
+- World owns public company discovery, public profiles, local vacancies and commercial browsing.
+- Business owns company operations: owned-company overview, staff-management entry points, recruitment/adverts, company financial summaries, advertising/PR entry points, labels and reports.
+- Career owns the player's current employment, progression, fame/fans context, awards, achievements, charts participation, discography summary links and history.
+- Character remains identity, skills, wellness, inventory, wardrobe and lifestyle.
+- Social remains community interaction, friends, messages, player discovery and social recruitment contact points.
+- Band remains band roles, band finances, crew/equipment and band-specific performance preparation.
+- Music remains songs, recording, release creation and release editing; Career links to discography only as a progression context.
+
+### Business Overview content
+
+The Business Overview uses existing company hooks and shows only supported data: managed-company count, aggregate company cash, 30-day company revenue and 30-day company profit/loss from the existing company financial summary. The no-company state links to real actions: create/manage companies, browse public companies and find a job.
+
+### Career Overview content
+
+The Career Overview reuses the existing career dashboard data and displays supported progression summaries: gigs completed, average gig rating, lifetime performance revenue, band fame, skill highlights, venue/promoter highlights and recent performance history. Employment, awards, charts, achievements, discography and history are exposed through the Career child navigation without duplicating their underlying systems.
+
+### Recruitment and employment ownership
+
+Business manages company-side recruitment entry points and advert/application review links. World and Social remain discovery/contact surfaces. Career owns the player's employment status, applications and employment history through the existing Employment page. PR 7 does not duplicate the application workflow or change location, salary, contract or suitability rules.
+
+### Finance boundaries
+
+Business routes label company money as company cash, company revenue and company profit/loss. `/finances` remains the existing personal/band ledger and is surfaced through Career as personal finances. Band-specific finances remain in the Band hub. PR 7 does not merge balances, create new finance formulas or alter weekly cost/profit calculations.
+
+### Permission behaviour
+
+Existing pages continue to enforce company owner, manager, staff-role and VIP checks. Business child routes that alias to current pages preserve their existing read-only, locked or denied states. Settings and dangerous company actions are not made default hub routes.
+
+### Mobile and accessibility considerations
+
+Both new hubs use `HubLayout`, so child navigation keeps the shared horizontally scrollable mobile pattern and `aria-current` active-link semantics. Overview cards use text labels for profit/loss and avoid colour-only meaning. Existing tables, forms and confirmation dialogs remain owned by their source pages.
+
+### Known limitations and deferred defects
+
+- Staff, recruitment, job adverts and reports still share existing company/employment pages where the repository has not implemented standalone hub-owned pages.
+- Contracts and company inventory are omitted from navigation because no stable cross-company standalone pages were identified.
+- `/finances` still includes personal and band finance tabs; Business deliberately routes to company-dashboard finance context instead of moving that ledger in this PR.
+- Some entity-specific management pages keep their original breadcrumbs until the broader route metadata cleanup in a later navigation-polish PR.
+
+### Follow-up
+
+The next planned navigation PR remains Schedule and Home improvements. PR 7 intentionally does not start Schedule or Home work.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { RadioProvider } from "./components/radio/RMRadioPlayer";
 import Auth from "./pages/Auth";
 import { lazyWithRetry } from "./utils/lazyWithRetry";
 import { FM_MODULES, findModuleForPath } from "./config/fmNavigation";
-import { bandHubNavigation, characterHubNavigation, musicHubNavigation, scheduleHubNavigation, socialHubNavigation, worldHubNavigation } from "./config/hubNavigation";
+import { bandHubNavigation, businessHubNavigation, careerHubNavigation, characterHubNavigation, musicHubNavigation, scheduleHubNavigation, socialHubNavigation, worldHubNavigation } from "./config/hubNavigation";
 import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
@@ -324,6 +324,8 @@ const MediaHub = lazyWithRetry(() => import("./pages/hubs/MediaHub"));
 const SocialHubUnified = lazyWithRetry(() => import("./pages/SocialHub"));
 const CityLandmarks = lazyWithRetry(() => import("./pages/CityLandmarks"));
 const CareerBusinessHub = lazyWithRetry(() => import("./pages/hubs/CareerBusinessHub"));
+const BusinessOverview = lazyWithRetry(() => import("./pages/BusinessOverview"));
+const CareerOverviewPage = lazyWithRetry(() => import("./pages/CareerOverview"));
 const PremiumStoreHub = lazyWithRetry(() => import("./pages/hubs/PremiumStoreHub"));
 const BlindBoxStore = lazyWithRetry(() => import("./pages/BlindBoxStore"));
 const BlindBoxAnalytics = lazyWithRetry(() => import("./pages/BlindBoxAnalytics"));
@@ -375,6 +377,8 @@ const HUB_TITLE_CONFIGS = [
   { title: "Band", overviewPath: "/band", items: bandHubNavigation },
   { title: "Schedule", overviewPath: "/schedule", items: scheduleHubNavigation },
   { title: "World", overviewPath: "/world", items: worldHubNavigation },
+  { title: "Business", overviewPath: "/business", items: businessHubNavigation },
+  { title: "Career", overviewPath: "/career", items: careerHubNavigation },
   { title: "Social", overviewPath: "/social", items: socialHubNavigation },
 ];
 
@@ -588,6 +592,26 @@ function App() {
                     <Route path="journal" element={<Journal />} />
                     <Route path="version-history" element={<VersionHistory />} />
                     <Route path="donation-success" element={<DonationSuccess />} />
+                    <Route path="business" element={<BusinessOverview />} />
+                    <Route path="business/overview" element={<PreserveQueryRedirect to="/business" />} />
+                    <Route path="business/companies" element={<MyCompanies />} />
+                    <Route path="business/staff" element={<PreserveQueryRedirect to="/business/companies" />} />
+                    <Route path="business/recruitment" element={<Navigate to="/employment?tab=applications" replace />} />
+                    <Route path="business/job-adverts" element={<Navigate to="/employment?tab=applications" replace />} />
+                    <Route path="business/finances" element={<Navigate to="/my-companies?tab=finances" replace />} />
+                    <Route path="business/advertising" element={<PreserveQueryRedirect to="/pr" />} />
+                    <Route path="business/labels" element={<PreserveQueryRedirect to="/labels" />} />
+                    <Route path="business/reports" element={<Navigate to="/my-companies?tab=reports" replace />} />
+                    <Route path="career" element={<CareerOverviewPage />} />
+                    <Route path="career/overview" element={<PreserveQueryRedirect to="/career" />} />
+                    <Route path="career/employment" element={<Employment />} />
+                    <Route path="career/finances" element={<PreserveQueryRedirect to="/finances" />} />
+                    <Route path="career/fame" element={<PreserveQueryRedirect to="/statistics" />} />
+                    <Route path="career/charts" element={<PreserveQueryRedirect to="/competitive-charts" />} />
+                    <Route path="career/awards" element={<Awards />} />
+                    <Route path="career/achievements" element={<PreserveQueryRedirect to="/hall-of-immortals" />} />
+                    <Route path="career/discography" element={<PreserveQueryRedirect to="/release-manager" />} />
+                    <Route path="career/history" element={<PreserveQueryRedirect to="/legacy" />} />
                     <Route path="my-companies" element={<MyCompanies />} />
                     <Route path="venues" element={<VenueManagement />} />
                     {/* <Route path="community/charity" element={<CharityPage />} /> */}
@@ -671,7 +695,7 @@ function App() {
                     <Route path="hub/character" element={<CharacterHub />} />
                     <Route path="hub/music" element={<PreserveQueryRedirect to="/music" />} />
                     <Route path="hub/band-live" element={<BandLiveHub />} />
-                    <Route path="hub/career-business" element={<CareerBusinessHub />} />
+                    <Route path="hub/career-business" element={<PreserveQueryRedirect to="/career" />} />
                     <Route path="social" element={<SocialHubUnified />} />
                     <Route path="landmarks" element={<CityLandmarks />} />
                     {/* Bare /hub goes to dashboard (no hub index page exists) */}
@@ -685,8 +709,8 @@ function App() {
                     <Route path="hub/live" element={<Navigate to="/hub/band-live" replace />} />
                     <Route path="hub/events" element={<Navigate to="/hub/band-live" replace />} />
                     <Route path="hub/world-social" element={<PreserveQueryRedirect to="/world" />} />
-                    <Route path="hub/career" element={<Navigate to="/hub/career-business" replace />} />
-                    <Route path="hub/commerce" element={<Navigate to="/hub/career-business" replace />} />
+                    <Route path="hub/career" element={<PreserveQueryRedirect to="/career" />} />
+                    <Route path="hub/commerce" element={<PreserveQueryRedirect to="/business" />} />
                     <Route path="modeling" element={<Modeling />} />
                     <Route path="producer-career" element={<ProducerCareer />} />
                     <Route path="clothing-designer" element={<ClothingDesigner />} />

--- a/src/config/__tests__/fmNavigation.business-career.test.ts
+++ b/src/config/__tests__/fmNavigation.business-career.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
+import { businessHubNavigation, careerHubNavigation } from "../hubNavigation";
+import { FM_MODULES, findModuleForPath } from "../fmNavigation";
+
+const businessItem = (id: string) => businessHubNavigation.find((entry) => entry.id === id)!;
+const careerItem = (id: string) => careerHubNavigation.find((entry) => entry.id === id)!;
+
+describe("business and career hub navigation", () => {
+  it("uses stable Business and Career overview landing routes", () => {
+    expect(FM_MODULES.find((module) => module.id === "business")?.rootPath).toBe("/business");
+    expect(FM_MODULES.find((module) => module.id === "career")?.rootPath).toBe("/career");
+    expect(isHubNavigationItemActive("/business", businessItem("overview"))).toBe(true);
+    expect(isHubNavigationItemActive("/career", careerItem("overview"))).toBe(true);
+  });
+
+  it("separates public company discovery from business management selection", () => {
+    expect(findModuleForPath("/world/companies").id).toBe("world");
+    expect(findModuleForPath("/company/company-1").id).toBe("business");
+    expect(isHubNavigationItemActive("/world/companies", businessItem("companies"))).toBe(false);
+    expect(isHubNavigationItemActive("/company/company-1", businessItem("staff"))).toBe(true);
+  });
+
+  it("selects business child routes and legacy management aliases", () => {
+    expect(isHubNavigationItemActive("/business/companies?tab=all", businessItem("companies"))).toBe(true);
+    expect(isHubNavigationItemActive("/my-companies", businessItem("companies"))).toBe(true);
+    expect(isHubNavigationItemActive("/venue-business/venue-1", businessItem("staff"))).toBe(true);
+    expect(isHubNavigationItemActive("/labels/label-1/manage", businessItem("labels"))).toBe(true);
+  });
+
+  it("selects career child routes and legacy progression aliases", () => {
+    expect(isHubNavigationItemActive("/career/employment", careerItem("employment"))).toBe(true);
+    expect(isHubNavigationItemActive("/employment?tab=current", careerItem("employment"))).toBe(true);
+    expect(isHubNavigationItemActive("/awards", careerItem("awards"))).toBe(true);
+    expect(isHubNavigationItemActive("/release-manager", careerItem("discography"))).toBe(true);
+    expect(isHubNavigationItemActive("/legacy", careerItem("history"))).toBe(true);
+  });
+});

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -261,24 +261,20 @@ export const FM_MODULES: FMModule[] = [
     id: "career",
     label: "Career",
     icon: Briefcase,
-    rootPath: "/hub/career-business",
+    rootPath: "/career",
     matchPaths: [
-      "/hub/career-business", "/hub/career", "/hub/commerce",
+      "/career", "/career/overview", "/career/employment", "/career/finances", "/career/fame", "/career/charts", "/career/awards", "/career/achievements", "/career/discography", "/career/history", "/hub/career-business", "/hub/career",
       "/finances", "/sponsorships", "/employment", "/teaching",
       "/education", "/booking", "/offers-dashboard",
       "/public-relations", "/pr",
       "/producer-career", "/modeling", "/acting", "/clothing-designer",
-      "/labels", "/record-label", "/my-companies", "/company",
-      "/venues", "/venue-business", "/recording-studio-business",
-      "/rehearsal-studio-business", "/merch-factory", "/logistics-company",
-      "/security-firm", "/merchandise",
     ],
     subTabs: [
-      { label: "Hub", path: "/hub/career-business", icon: Briefcase },
+      { label: "Overview", path: "/career", icon: Trophy },
       { label: "Finances", path: "/finances", icon: DollarSign },
-      { label: "Employment", path: "/employment", icon: Briefcase },
-      { label: "Companies", path: "/my-companies", icon: Building2 },
-      { label: "PR", path: "/pr", icon: Megaphone },
+      { label: "Employment", path: "/career/employment", icon: Briefcase },
+      { label: "Awards", path: "/career/awards", icon: Award },
+      { label: "Charts", path: "/career/charts", icon: BarChart3 },
       { label: "Offers", path: "/offers-dashboard", icon: Handshake },
     ],
     sidebar: [
@@ -310,25 +306,63 @@ export const FM_MODULES: FMModule[] = [
           { label: "Clothing Designer", path: "/clothing-designer", icon: Scissors },
         ],
       },
-      {
-        label: "Companies",
-        items: [
-          { label: "My Companies", path: "/my-companies", icon: Building2 },
-          { label: "Record Labels", path: "/labels", icon: Disc3 },
-          { label: "Venues", path: "/venues", icon: Building2 },
-          { label: "Merchandise", path: "/merchandise", icon: ShoppingBag },
-        ],
-      },
     ],
     quickActions: [
       { label: "View Finances", path: "/finances", icon: DollarSign, description: "Cash flow & ledger" },
       { label: "Find a Job", path: "/employment", icon: Briefcase },
       { label: "Review Offers", path: "/offers-dashboard", icon: Handshake },
-      { label: "Manage Companies", path: "/my-companies", icon: Building2 },
       { label: "Sign Sponsors", path: "/sponsorships", icon: Handshake },
     ],
   },
-  // 6. MEDIA — consumer media browsing
+
+  // 6. BUSINESS — company ownership and operations
+  {
+    id: "business",
+    label: "Business",
+    icon: Building2,
+    rootPath: "/business",
+    matchPaths: [
+      "/business", "/business/overview", "/business/companies", "/business/staff",
+      "/business/recruitment", "/business/job-adverts", "/business/finances",
+      "/business/advertising", "/business/labels", "/business/reports", "/hub/commerce",
+      "/labels", "/record-label", "/my-companies", "/company",
+      "/venues", "/venue-business", "/recording-studio-business",
+      "/rehearsal-studio-business", "/merch-factory", "/logistics-company",
+      "/security-firm", "/merchandise",
+    ],
+    subTabs: [
+      { label: "Overview", path: "/business", icon: Building2 },
+      { label: "Companies", path: "/business/companies", icon: Building2 },
+      { label: "Recruitment", path: "/business/recruitment", icon: Briefcase },
+      { label: "Finances", path: "/business/finances", icon: DollarSign },
+      { label: "Advertising", path: "/business/advertising", icon: Megaphone },
+      { label: "Labels", path: "/business/labels", icon: Disc3 },
+    ],
+    sidebar: [
+      { label: "Operations", items: [
+        { label: "Companies", path: "/business/companies", icon: Building2 },
+        { label: "Staff", path: "/business/staff", icon: Users },
+        { label: "Recruitment", path: "/business/recruitment", icon: Briefcase },
+        { label: "Advertising", path: "/business/advertising", icon: Megaphone },
+      ] },
+      { label: "Finance & reports", items: [
+        { label: "Company Finances", path: "/business/finances", icon: DollarSign },
+        { label: "Reports", path: "/business/reports", icon: BarChart3 },
+      ] },
+      { label: "Business types", items: [
+        { label: "Record Labels", path: "/business/labels", icon: Disc3 },
+        { label: "Venues", path: "/venues", icon: Building2 },
+        { label: "Merchandise", path: "/merchandise", icon: ShoppingBag },
+      ] },
+    ],
+    quickActions: [
+      { label: "Manage Companies", path: "/business/companies", icon: Building2 },
+      { label: "Review Finances", path: "/business/finances", icon: DollarSign },
+      { label: "Create Job Advert", path: "/business/recruitment", icon: Briefcase },
+      { label: "Browse Public Companies", path: "/world/companies", icon: Globe },
+    ],
+  },
+  // 7. MEDIA — consumer media browsing
   {
     id: "media",
     label: "Media",

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -1,4 +1,4 @@
-import { Backpack, BookOpen, Briefcase, Globe2, Building2, Calendar, Compass, Disc3, DollarSign, GraduationCap, Guitar, Heart, History, Inbox, Landmark, ListMusic, MapPin, MessageSquare, Mic2, Music, Newspaper, Package, Palette, Plane, Radio, Search, Settings, Sparkles, Star, Trophy, Users, Zap } from "lucide-react";
+import { Award, Backpack, BarChart3, BookOpen, Briefcase, Globe2, Building2, Calendar, Compass, Disc3, DollarSign, GraduationCap, Guitar, Heart, History, Inbox, Landmark, ListMusic, MapPin, Megaphone, MessageSquare, Mic2, Music, Newspaper, Package, Palette, Plane, Radio, ReceiptText, Search, Settings, Sparkles, Star, Trophy, Users, Zap } from "lucide-react";
 import type { HubNavigationItem } from "@/components/hub/HubLayout";
 
 export const characterHubNavigation: HubNavigationItem[] = [
@@ -55,6 +55,29 @@ export const socialHubNavigation: HubNavigationItem[] = [
   { id: "twaater", label: "Twaater", path: "/social/twaater", icon: Newspaper, matchPaths: ["/twaater", "/twaater/:handle", "/twaater/tag/:hashtag", "/twaater/twaat/:twaatId", "/twaater/notifications", "/twaater/analytics"] },
   { id: "recruitment", label: "Recruitment", path: "/social/recruitment", icon: Compass, matchPaths: ["/bands/finder", "/bands/browse", "/bands/search", "/band/:bandId"] },
   { id: "invitations", label: "Invitations", path: "/social/invitations", icon: Inbox, matchPaths: ["/social?tab=invites"] },
+];
+
+export const businessHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/business", icon: Building2, matchPaths: ["/business/overview", "/hub/commerce"] },
+  { id: "companies", label: "Companies", path: "/business/companies", icon: Building2, matchPaths: ["/my-companies"] },
+  { id: "staff", label: "Staff", path: "/business/staff", icon: Users, matchPaths: ["/company/:companyId", "/security-firm/:companyId", "/merch-factory/:companyId", "/venue-business/:venueId", "/rehearsal-studio-business/:studioId", "/recording-studio-business/:studioId"] },
+  { id: "recruitment", label: "Recruitment", path: "/business/recruitment", icon: Briefcase, matchPaths: ["/business/job-adverts"] },
+  { id: "finances", label: "Finances", path: "/business/finances", icon: DollarSign },
+  { id: "advertising", label: "Advertising", path: "/business/advertising", icon: Megaphone, matchPaths: ["/pr", "/public-relations"] },
+  { id: "labels", label: "Labels", path: "/business/labels", icon: Disc3, matchPaths: ["/labels", "/record-label", "/labels/:labelId/manage"] },
+  { id: "reports", label: "Reports", path: "/business/reports", icon: BarChart3 },
+];
+
+export const careerHubNavigation: HubNavigationItem[] = [
+  { id: "overview", label: "Overview", path: "/career", icon: Trophy, matchPaths: ["/career/overview", "/hub/career", "/hub/career-business"] },
+  { id: "employment", label: "Employment", path: "/career/employment", icon: Briefcase, matchPaths: ["/employment", "/jobs"] },
+  { id: "finances", label: "Personal Finances", path: "/career/finances", icon: DollarSign, matchPaths: ["/finances", "/sponsorships", "/offers-dashboard"] },
+  { id: "fame", label: "Fame & Fans", path: "/career/fame", icon: Star, matchPaths: ["/fan-management"] },
+  { id: "charts", label: "Charts", path: "/career/charts", icon: BarChart3, matchPaths: ["/competitive-charts", "/country-charts", "/music/charts"] },
+  { id: "awards", label: "Awards", path: "/career/awards", icon: Award, matchPaths: ["/awards"] },
+  { id: "achievements", label: "Achievements", path: "/career/achievements", icon: Trophy, matchPaths: ["/hall-of-immortals"] },
+  { id: "discography", label: "Discography", path: "/career/discography", icon: Disc3, matchPaths: ["/release-manager", "/release/:id"] },
+  { id: "history", label: "History", path: "/career/history", icon: ReceiptText, matchPaths: ["/legacy", "/statistics", "/journal"] },
 ];
 
 export const bandHubNavigation: HubNavigationItem[] = [

--- a/src/pages/BusinessOverview.tsx
+++ b/src/pages/BusinessOverview.tsx
@@ -1,0 +1,53 @@
+import { Link } from "react-router-dom";
+import { Building2, Briefcase, DollarSign, Megaphone, Search, Users } from "lucide-react";
+import HubLayout from "@/components/hub/HubLayout";
+import { businessHubNavigation } from "@/config/hubNavigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useCompanies, useCompanyFinancialSummary } from "@/hooks/useCompanies";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const formatCurrency = (amount: number) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(amount);
+
+export default function BusinessOverview() {
+  const { data: companies, isLoading: companiesLoading } = useCompanies();
+  const { data: financialSummary, isLoading: summaryLoading } = useCompanyFinancialSummary();
+  const hasCompanies = Boolean(companies?.length);
+
+  const actions = [
+    { label: "Browse companies", path: "/world/companies", icon: Search },
+    { label: "Find a job", path: "/career/employment", icon: Briefcase },
+    { label: "Manage companies", path: "/business/companies", icon: Building2 },
+  ];
+
+  return (
+    <HubLayout
+      title="Business"
+      description="Manage owned companies, staff, recruitment, company finances, advertising, labels and operational reports without mixing them with public discovery or personal career progress."
+      icon={Building2}
+      overviewPath="/business"
+      navigation={businessHubNavigation}
+      actions={actions}
+    >
+      {companiesLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">{Array.from({ length: 4 }).map((_, index) => <Skeleton key={index} className="h-32" />)}</div>
+      ) : hasCompanies ? (
+        <div className="space-y-6">
+          <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <Card><CardHeader><CardTitle className="text-sm">Companies managed</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold">{companies?.length ?? 0}</p><p className="text-sm text-muted-foreground">Active company context remains entity-specific on legacy management routes.</p></CardContent></Card>
+            <Card><CardHeader><CardTitle className="text-sm">Company cash</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold">{summaryLoading ? "—" : formatCurrency(financialSummary?.total_balance ?? 0)}</p><p className="text-sm text-muted-foreground">Company balances only.</p></CardContent></Card>
+            <Card><CardHeader><CardTitle className="text-sm">30-day revenue</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold">{summaryLoading ? "—" : formatCurrency(financialSummary?.monthly_income ?? 0)}</p><p className="text-sm text-muted-foreground">Authoritative company income summary.</p></CardContent></Card>
+            <Card><CardHeader><CardTitle className="text-sm">30-day profit/loss</CardTitle></CardHeader><CardContent><p className="text-3xl font-bold">{summaryLoading ? "—" : formatCurrency(financialSummary?.monthly_net ?? 0)}</p><p className="text-sm text-muted-foreground">Includes existing company expenses.</p></CardContent></Card>
+          </section>
+          <section className="grid gap-4 md:grid-cols-3">
+            <Button asChild variant="outline"><Link to="/business/companies"><Building2 className="mr-2 h-4 w-4" />Open companies</Link></Button>
+            <Button asChild variant="outline"><Link to="/business/finances"><DollarSign className="mr-2 h-4 w-4" />Review company finances</Link></Button>
+            <Button asChild variant="outline"><Link to="/business/recruitment"><Users className="mr-2 h-4 w-4" />Review recruitment</Link></Button>
+          </section>
+        </div>
+      ) : (
+        <Card className="border-dashed"><CardContent className="py-10 text-center"><Building2 className="mx-auto mb-4 h-10 w-10 text-primary" /><h2 className="text-xl font-semibold">No business to manage yet</h2><p className="mx-auto mt-2 max-w-2xl text-muted-foreground">Business is for company operations. Discover public companies in World, look for employment in Career, or create a company from the Companies page when you are ready.</p><div className="mt-6 flex flex-wrap justify-center gap-3"><Button asChild><Link to="/business/companies">Create or manage companies</Link></Button><Button asChild variant="outline"><Link to="/world/companies">Browse public companies</Link></Button><Button asChild variant="outline"><Link to="/career/employment">Find a job</Link></Button></div></CardContent></Card>
+      )}
+    </HubLayout>
+  );
+}

--- a/src/pages/CareerOverview.tsx
+++ b/src/pages/CareerOverview.tsx
@@ -1,0 +1,25 @@
+import { Briefcase, DollarSign, Trophy } from "lucide-react";
+import HubLayout from "@/components/hub/HubLayout";
+import { careerHubNavigation } from "@/config/hubNavigation";
+import CareerDashboardPage from "./dashboard/career";
+
+export default function CareerOverview() {
+  const actions = [
+    { label: "View employment", path: "/career/employment", icon: Briefcase },
+    { label: "Review awards", path: "/career/awards", icon: Trophy },
+    { label: "Personal finances", path: "/career/finances", icon: DollarSign },
+  ];
+
+  return (
+    <HubLayout
+      title="Career"
+      description="Track personal progression, employment, fame, awards, achievements, charts, discography milestones and career history separately from character identity and company operations."
+      icon={Trophy}
+      overviewPath="/career"
+      navigation={careerHubNavigation}
+      actions={actions}
+    >
+      <CareerDashboardPage />
+    </HubLayout>
+  );
+}

--- a/src/pages/Employment.tsx
+++ b/src/pages/Employment.tsx
@@ -527,8 +527,8 @@ export default function Employment() {
     <FMPageScaffold
       title="Employment"
       subtitle={currentCityName ? `Find jobs to earn money while pursuing your music career • Currently in: ${currentCityName}` : "Find jobs to earn money while pursuing your music career"}
-      backTo="/hub/career-business"
-      backLabel="Back to Career & Business"
+      backTo="/career"
+      backLabel="Back to Career"
       icon={Briefcase}
     >
 

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -33,7 +33,7 @@ const Finances = () => {
 
   if (isLoading) {
     return (
-      <FMPageScaffold title="Financial Command Center" icon={DollarSign} backTo="/hub/career-business">
+      <FMPageScaffold title="Financial Command Center" icon={DollarSign} backTo="/career">
         <div className="flex items-center justify-center min-h-[400px]">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>
@@ -46,7 +46,7 @@ const Finances = () => {
       title="Financial Command Center"
       subtitle="Monitor personal and band finances, track investments, and explore funding pathways."
       icon={DollarSign}
-      backTo="/hub/career-business"
+      backTo="/career"
     >
 
 

--- a/src/pages/MyCompanies.tsx
+++ b/src/pages/MyCompanies.tsx
@@ -301,7 +301,7 @@ const MyCompanies = () => {
       title="My Companies"
       subtitle="Manage your business empire — revenue, expenses, taxes, and growth"
       icon={Building2}
-      backTo="/hub/career-business"
+      backTo="/business"
     >
       <VipGate
         feature="Company ownership"


### PR DESCRIPTION
### Motivation

- Separate public world discovery, company ownership/operations and personal career progression so players can find the right surface for discovery, management or personal career tasks. 
- Provide stable, predictable hub landing routes that render an overview directly instead of restoring a last-nested path. 
- Preserve existing finance, employment and progression systems while grouping their navigation and ownership into coherent `Business` and `Career` hubs.

### Description

- Added hub navigation metadata for Business and Career in `src/config/hubNavigation.ts` and registered Business/Career modules in `src/config/fmNavigation.ts` so hub selection, legacy aliases and page-title context are consistent. 
- Introduced `BusinessOverview` and `CareerOverview` pages under `src/pages/` that reuse the existing `HubLayout` and existing hooks/summary components for company and career data (`src/pages/BusinessOverview.tsx`, `src/pages/CareerOverview.tsx`). 
- Registered canonical routes and compatibility redirects in `src/App.tsx` for `/business` and `/career` (and child aliases), and preserved legacy entity management routes such as `/company/:companyId`, `/my-companies`, `/world/companies`, `/employment` and similar. 
- Updated existing pages and back-links to point to the new hub ownership where appropriate (`src/pages/MyCompanies.tsx`, `src/pages/Finances.tsx`, `src/pages/Employment.tsx`), added a navigation unit test (`src/config/__tests__/fmNavigation.business-career.test.ts`), and documented the final hierarchy and migration notes in `docs/navigation-and-hub-refactor.md`.

### Testing

- Ran type checks with `npm run typecheck` which completed successfully. 
- Ran a repository diff check (`git diff --check`) with no new whitespace/formatting errors. 
- Added a navigation unit test file `src/config/__tests__/fmNavigation.business-career.test.ts`, but running unit tests was blocked in this environment because `vitest` is not installed. 
- Lint and build were attempted but blocked due to missing local tooling in the environment (`@eslint/js` for `npm run lint`, `vite` for `npm run build`), so those steps are listed as attempted but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54dc11a31c8325adb1306a0615d55a)