### PR TITLE
Improve Home dashboard and consolidate Schedule navigation

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -663,3 +663,69 @@ Both new hubs use `HubLayout`, so child navigation keeps the shared horizontally
 ### Follow-up
 
 The next planned navigation PR remains Schedule and Home improvements. PR 7 intentionally does not start Schedule or Home work.
+
+## PR 8 update — Home dashboard and Schedule navigation
+
+PR 8 makes `/home` the canonical post-login Home dashboard route and keeps `/dashboard` as a compatibility alias that redirects to `/home` with query parameters preserved. The authenticated index flow now sends players who have completed onboarding to `/home`; unauthenticated root behaviour stays on the public landing page. Existing protected deep links still enter through the existing auth and layout guards rather than being replaced by a last-visited Home child.
+
+### Final Home route and ownership
+
+- Canonical Home route: `/home`.
+- Legacy alias: `/dashboard` redirects to `/home`.
+- Home top-level navigation now opens `/home` directly instead of restoring a previous Overview child.
+- Home owns the cross-system dashboard surface: current/today schedule summaries, notifications, goals and progress, manager recommendations, world news, character status and high-value links into Schedule, Social, Career, Music and World pages.
+- Optional Home summary failures remain scoped to their card, so notifications, goals or news failures do not blank the whole dashboard.
+
+### Post-login route behaviour
+
+Successful landing-page login, onboarding completion, resurrection return and the authenticated index route now target `/home`. `/hub` also redirects to `/home` because there is no hub index. `/dashboard` remains available for bookmarks and old links.
+
+### Final Schedule hierarchy
+
+Schedule continues to use the shared `HubLayout` pattern and now exposes these explicit routes:
+
+| Route | Behaviour |
+| --- | --- |
+| `/schedule` | Canonical Schedule default; renders Today. |
+| `/schedule/today` | Alias/render route for Today. |
+| `/schedule/week` | Week view using existing day schedule data per tab. |
+| `/schedule/calendar` | Compatibility alias/render route for Week-style calendar. |
+| `/schedule/current` | Current Activity status surface. |
+| `/schedule/book` | Booking launcher that links to owning workflows. |
+| `/schedule/upcoming` | Uses the Schedule shell and current agenda implementation pending a richer upcoming split. |
+| `/schedule/history` | Historical activity surface using the existing schedule data source for the selected date. |
+| `/schedule/overview` | Redirects to `/schedule`. |
+| `/booking/education`, `/booking/performance`, `/booking/work`, `/booking/songwriting` | Legacy booking routes preserved and selected under Schedule Book Activity. |
+
+The selected default is Today because it best answers the daily workflow questions and avoids opening a booking form, history page or blank calendar state.
+
+### Booking ownership model
+
+Schedule does not duplicate specialised activity forms. `/schedule/book` is a launcher to the existing education, performance, work and songwriting booking flows plus the canonical Music practice route. Practice, rehearsals, recording, travel, gigs, employment and wellness remain owned by their feature hubs and legacy pages.
+
+### Duration display, past-time booking and conflicts
+
+Schedule and Home schedule summaries use `getDisplayDurationMinutes` and authoritative start/end times where available, preserving multi-hour and cross-midnight display without changing backend duration rules. Past-time booking remains protected by the existing `validateBookingWindow`/`validateFutureBooking` client checks and server-side scheduled-activity creation validation. Existing conflict enforcement still flows through the `check_scheduling_conflict` RPC in `useCreateScheduledActivity`; this PR surfaces schedule status without introducing a new conflict engine.
+
+### Travel-aware scheduling and band attendance
+
+Travel and location context remains sourced from existing schedule rows, tour travel legs, gig venue city data and `GigLocationWarning`. Band attendance and rehearsal/gig membership rules remain owned by Band pages and their server workflows; Schedule links to the owning detail surfaces rather than silently changing multi-member booking behaviour.
+
+### Notifications and message summary ownership
+
+Global notifications and inbox messages remain owned by the notification and Social systems. Home displays counts and concise widgets only, linking onward to Inbox/Social without marking messages read or adding duplicate live subscriptions.
+
+### Performance and live-update considerations
+
+Home reuses existing card-level queries, query keys and schedule components instead of adding a global dashboard store. Schedule reuses `useScheduledActivities` for day-level loads and avoids fetching a full month for the Home summary. Current Activity calculates display state from the loaded daily schedule and clamps remaining time at zero.
+
+### Mobile and accessibility considerations
+
+Schedule keeps shared hub navigation, `aria-current` from `HubLayout`, compact button controls, stacked cards and text labels for status. Current, empty, loading and error states use the shared page-state components, while Week remains a tabbed day-by-day view for small screens instead of introducing a new calendar library.
+
+### Known limitations and deferred defects
+
+- `/schedule/upcoming` and `/schedule/history` intentionally reuse the existing schedule implementation until a dedicated historical/upcoming endpoint is available.
+- Conflict details are limited to existing booking errors and warning components; no new conflict graph was introduced.
+- Travel feasibility still depends on existing travel/gig warnings and does not calculate new routes.
+- Final navigation polish, responsive parity and legacy-route cleanup remain deferred to PR 9.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -449,7 +449,7 @@ function App() {
                   <Route path="/about" element={<About />} />
                   <Route path="/song/:songId" element={<PublicSong />} />
                   <Route element={<Layout />}>
-                    <Route path="home" element={<Index />} />
+                    <Route path="home" element={<Dashboard />} />
                     <Route path="inbox" element={<Inbox />} />
 
 
@@ -470,7 +470,7 @@ function App() {
                     <Route path="christmas-charts" element={<ChristmasCharts />} />
                     <Route path="seasonal-events" element={<SeasonalEventsCalendar />} />
                     {/* <Route path="eurovision" element={<EurovisionResultsPage />} /> */}
-                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="dashboard" element={<PreserveQueryRedirect to="/home" />} />
                     
                     <Route path="offers-dashboard" element={<OffersDashboard />} />
                     <Route path="vip-subscribe" element={<VipSubscribe />} />
@@ -523,6 +523,13 @@ function App() {
                     <Route path="country-charts" element={<CountryCharts />} />
                     <Route path="schedule" element={<Schedule />} />
                     <Route path="schedule/overview" element={<PreserveQueryRedirect to="/schedule" />} />
+                    <Route path="schedule/today" element={<Schedule />} />
+                    <Route path="schedule/week" element={<Schedule />} />
+                    <Route path="schedule/calendar" element={<Schedule />} />
+                    <Route path="schedule/current" element={<Schedule />} />
+                    <Route path="schedule/book" element={<Schedule />} />
+                    <Route path="schedule/upcoming" element={<Schedule />} />
+                    <Route path="schedule/history" element={<Schedule />} />
                     <Route path="booking/education" element={<EducationBooking />} />
                     <Route path="booking/performance" element={<PerformanceBooking />} />
                     <Route path="booking/work" element={<WorkBooking />} />
@@ -699,7 +706,7 @@ function App() {
                     <Route path="social" element={<SocialHubUnified />} />
                     <Route path="landmarks" element={<CityLandmarks />} />
                     {/* Bare /hub goes to dashboard (no hub index page exists) */}
-                    <Route path="hub" element={<Navigate to="/dashboard" replace />} />
+                    <Route path="hub" element={<Navigate to="/home" replace />} />
                     {/* New split hubs */}
                     <Route path="hub/world" element={<PreserveQueryRedirect to="/world" />} />
                     <Route path="hub/social" element={<PreserveQueryRedirect to="/social" />} />

--- a/src/components/family/ComingOfAgeDialog.tsx
+++ b/src/components/family/ComingOfAgeDialog.tsx
@@ -108,7 +108,7 @@ export function ComingOfAgeDialog({ child, trigger, autoPrompt }: Props) {
     setSelectedSlot(null);
     try {
       await switchCharacter.mutateAsync(newProfileId);
-      navigate("/dashboard");
+      navigate("/home");
       setTutorialOpen(true);
     } catch {
       // Stay on current character; user can switch later.

--- a/src/components/hub/HubLayout.tsx
+++ b/src/components/hub/HubLayout.tsx
@@ -74,7 +74,7 @@ const HubBreadcrumbs = ({ items }: { items: HubBreadcrumbItem[] }) => {
 
   return (
     <nav aria-label="Hub breadcrumb" className="flex min-w-0 items-center gap-1 overflow-x-auto text-xs text-muted-foreground">
-      <Link to="/dashboard" aria-label="Home" className="inline-flex items-center gap-1 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+      <Link to="/home" aria-label="Home" className="inline-flex items-center gap-1 rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
         <Home className="h-3.5 w-3.5" aria-hidden />
       </Link>
       {items.map((item, index) => {

--- a/src/components/news/RandomEventsNews.tsx
+++ b/src/components/news/RandomEventsNews.tsx
@@ -75,7 +75,7 @@ export const RandomEventsNews = () => {
               </p>
             </div>
             <Button size="sm" variant="secondary" asChild>
-              <Link to="/dashboard">Respond</Link>
+              <Link to="/home">Respond</Link>
             </Button>
           </div>
         ))}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -215,7 +215,7 @@ export const OnboardingWizard = () => {
       await createReputation.mutateAsync(modifiers);
       await completeOnboarding.mutateAsync();
       
-      navigate("/dashboard");
+      navigate("/home");
     } finally {
       setIsTransitioning(false);
     }

--- a/src/components/ui/Breadcrumbs.tsx
+++ b/src/components/ui/Breadcrumbs.tsx
@@ -113,7 +113,7 @@ export const Breadcrumbs = () => {
       className="mb-3 -mt-1 flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto whitespace-nowrap scrollbar-none"
     >
       <Link
-        to="/dashboard"
+        to="/home"
         className="flex items-center gap-1 hover:text-foreground transition-colors"
         aria-label="Home"
       >

--- a/src/components/ui/HorizontalNavigation.tsx
+++ b/src/components/ui/HorizontalNavigation.tsx
@@ -40,7 +40,7 @@ const HorizontalNavigation = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const hubLinks: HubLink[] = [
-    { icon: Home, labelKey: "nav.home", path: "/dashboard" },
+    { icon: Home, labelKey: "nav.home", path: "/home" },
     { icon: Newspaper, labelKey: "nav.news", path: "/todays-news" },
     { icon: Music, labelKey: "nav.music", path: "/hub/music" },
     { icon: Users, labelKey: "nav.bandLive", path: "/hub/band-live" },
@@ -77,7 +77,7 @@ const HorizontalNavigation = () => {
         {/* Top bar with logo and utilities */}
         <div className="flex items-center justify-between px-4 h-12 border-b border-border/50">
           <div className="flex items-center gap-3">
-            <img src={logo} alt="RockMundo" className="h-10 w-auto object-contain cursor-pointer" onClick={() => handleNavigation("/dashboard")} />
+            <img src={logo} alt="RockMundo" className="h-10 w-auto object-contain cursor-pointer" onClick={() => handleNavigation("/home")} />
             <VersionHeader />
           </div>
           <div className="flex items-center gap-1">
@@ -101,7 +101,7 @@ const HorizontalNavigation = () => {
             <button
               key={link.path}
               className={`px-3 py-1.5 text-xs font-medium tracking-tight rounded-md transition-colors whitespace-nowrap ${
-                link.path === "/dashboard"
+                link.path === "/home"
                   ? `text-yellow-400 ${isActive(link.path) ? "bg-primary/10" : "hover:bg-accent"}`
                   : isActive(link.path)
                     ? "text-primary bg-primary/10"
@@ -176,7 +176,7 @@ const HorizontalNavigation = () => {
       <div className="lg:hidden fixed bottom-0 left-0 right-0 z-40 bg-background/95 backdrop-blur-sm border-t border-sidebar-border shadow-lg safe-area-bottom">
         <div className="flex justify-around items-center py-1.5 px-1">
           {[
-            { icon: Home, labelKey: "nav.home", path: "/dashboard" },
+            { icon: Home, labelKey: "nav.home", path: "/home" },
             { icon: Music, labelKey: "nav.music", path: "/hub/music" },
             { icon: Users, labelKey: "nav.band", path: "/hub/band-live" },
             { icon: Globe, labelKey: "nav.world", path: "/hub/world-social" },

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -40,7 +40,7 @@ const Navigation = () => {
   const { data: unreadInboxCount } = useUnreadInboxCount();
 
   const hubLinks: HubLink[] = [
-    { icon: Home, labelKey: "nav.home", path: "/dashboard" },
+    { icon: Home, labelKey: "nav.home", path: "/home" },
     { icon: User, labelKey: "nav.character", path: "/hub/character" },
     { icon: Briefcase, labelKey: "nav.careerBusiness", path: "/hub/career-business" },
     { icon: ShoppingBag, labelKey: "nav.market", path: "/song-market" },
@@ -53,7 +53,7 @@ const Navigation = () => {
 
   // Persistent bottom tabs — Home, Artist, Career, Market, Menu
   const bottomTabs: { icon: LucideIcon; label: string; path: string }[] = [
-    { icon: Home, label: "Home", path: "/dashboard" },
+    { icon: Home, label: "Home", path: "/home" },
     { icon: User, label: "Artist", path: "/hub/character" },
     { icon: Briefcase, label: "Career", path: "/hub/career-business" },
     { icon: ShoppingBag, label: "Market", path: "/song-market" },

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -29,10 +29,10 @@ export const FM_MODULES: FMModule[] = [
     id: "overview",
     label: "Overview",
     icon: LayoutDashboard,
-    rootPath: "/dashboard",
-    matchPaths: ["/dashboard", "/home", "/inbox", "/schedule", "/journal", "/todays-news", "/statistics", "/advisor"],
+    rootPath: "/home",
+    matchPaths: ["/home", "/dashboard", "/inbox", "/journal", "/todays-news", "/statistics", "/advisor"],
     subTabs: [
-      { label: "Dashboard", path: "/dashboard", icon: LayoutDashboard },
+      { label: "Home", path: "/home", icon: LayoutDashboard },
       { label: "Inbox", path: "/inbox", icon: InboxIcon },
       { label: "Schedule", path: "/schedule", icon: Calendar },
       { label: "News", path: "/todays-news", icon: Newspaper },
@@ -42,7 +42,7 @@ export const FM_MODULES: FMModule[] = [
       {
         label: "Today",
         items: [
-          { label: "Dashboard", path: "/dashboard", icon: LayoutDashboard },
+          { label: "Home", path: "/home", icon: LayoutDashboard },
           { label: "Inbox", path: "/inbox", icon: InboxIcon },
           { label: "Schedule", path: "/schedule", icon: Calendar },
           { label: "Today's News", path: "/todays-news", icon: Newspaper },

--- a/src/config/hubNavigation.ts
+++ b/src/config/hubNavigation.ts
@@ -13,11 +13,11 @@ export const characterHubNavigation: HubNavigationItem[] = [
 ];
 
 export const scheduleHubNavigation: HubNavigationItem[] = [
-  { id: "overview", label: "Overview", path: "/schedule", icon: Calendar },
-  { id: "education", label: "Education", path: "/booking/education", icon: GraduationCap },
-  { id: "performance", label: "Performance", path: "/booking/performance", icon: Zap },
-  { id: "work", label: "Work", path: "/booking/work", icon: Package },
-  { id: "songwriting", label: "Songwriting", path: "/booking/songwriting", icon: Sparkles },
+  { id: "today", label: "Today", path: "/schedule", icon: Calendar, matchPaths: ["/schedule/today", "/schedule/overview"] },
+  { id: "week", label: "Week", path: "/schedule/week", icon: CalendarDays, matchPaths: ["/schedule/calendar"] },
+  { id: "current", label: "Current Activity", path: "/schedule/current", icon: Zap },
+  { id: "book", label: "Book Activity", path: "/schedule/book", icon: Sparkles, matchPaths: ["/booking/education", "/booking/performance", "/booking/work", "/booking/songwriting"] },
+  { id: "history", label: "History", path: "/schedule/history", icon: History },
 ];
 
 export const musicHubNavigation: HubNavigationItem[] = [

--- a/src/pages/DonationSuccess.tsx
+++ b/src/pages/DonationSuccess.tsx
@@ -161,7 +161,7 @@ export default function DonationSuccess() {
           </Badge>
 
           <Button
-            onClick={() => navigate("/dashboard")}
+            onClick={() => navigate("/home")}
             className="w-full bg-gradient-to-r from-pink-500 to-amber-500 hover:from-pink-600 hover:to-amber-600 text-white"
           >
             <Home className="h-4 w-4 mr-2" />

--- a/src/pages/Inbox.tsx
+++ b/src/pages/Inbox.tsx
@@ -82,7 +82,7 @@ export default function InboxPage() {
           ? `${unreadCount} unread message${unreadCount !== 1 ? "s" : ""}`
           : undefined
       }
-      backTo="/dashboard"
+      backTo="/home"
       backLabel="Back to Dashboard"
       icon={InboxIcon}
       headerActions={

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -58,7 +58,7 @@ const Index = () => {
       if (!hasCompletedOnboarding) {
         navigate("/onboarding");
       } else {
-        navigate("/dashboard");
+        navigate("/home");
       }
     }
     // If no living character, the death screen or fresh start will render below
@@ -74,7 +74,7 @@ const Index = () => {
           resurrectCharacter.mutate(profileId, {
             onSuccess: () => {
               // Full reload to clear cached game data
-              window.location.href = "/dashboard";
+              window.location.href = "/home";
             },
           });
         }}

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -119,7 +119,7 @@ const Landing = () => {
     }
     toast({ title: "Welcome back", description: "Loading your career…" });
     setOpen(false);
-    navigate("/dashboard");
+    navigate("/home");
   };
 
   return (
@@ -157,7 +157,7 @@ const Landing = () => {
               variant="ghost"
               size="sm"
               className="h-9 px-2 text-xs font-oswald tracking-wide"
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/home")}
               title="Dev-only: enters the app as a guest with mock data"
             >
               <PlayCircle className="h-4 w-4 sm:mr-1.5" />
@@ -270,7 +270,7 @@ const Landing = () => {
                 size="lg"
                 variant="outline"
                 className="font-oswald tracking-wide w-full sm:w-auto"
-                onClick={() => navigate("/dashboard")}
+                onClick={() => navigate("/home")}
               >
                 <PlayCircle className="h-4 w-4 mr-2" />
                 Demo (Dev)
@@ -524,7 +524,7 @@ const Landing = () => {
                   className="font-oswald tracking-wide text-xs"
                   onClick={() => {
                     setOpen(false);
-                    navigate("/dashboard");
+                    navigate("/home");
                   }}
                 >
                   <PlayCircle className="h-4 w-4 mr-1.5" />

--- a/src/pages/MusicHub.tsx
+++ b/src/pages/MusicHub.tsx
@@ -21,7 +21,7 @@ const MusicHub = () => {
       title="Music Hub"
       subtitle="Your central hub for all music-related activities"
       icon={Music}
-      backTo="/dashboard"
+      backTo="/home"
     >
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {musicSections.map((section) => {

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -19,7 +19,7 @@ const Onboarding = () => {
   useEffect(() => {
     // If onboarding already completed, redirect to dashboard
     if (!isLoading && hasCompletedOnboarding) {
-      navigate("/dashboard");
+      navigate("/home");
     }
   }, [hasCompletedOnboarding, isLoading, navigate]);
 

--- a/src/pages/Prison.tsx
+++ b/src/pages/Prison.tsx
@@ -26,7 +26,7 @@ export default function Prison() {
   }
 
   if (!isImprisoned && !communityService) {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to="/home" replace />;
   }
 
   const handlePayBail = () => {
@@ -59,7 +59,7 @@ export default function Prison() {
         title={t('prison.communityService')}
         subtitle={t('prison.activeAssignment')}
         icon={Scale}
-        backTo="/dashboard"
+        backTo="/home"
       >
         <Alert><AlertTriangle className="h-4 w-4" /><AlertTitle>{t('prison.activeAssignment')}</AlertTitle><AlertDescription>{t('prison.completeSessionsBy').replace('{required}', communityService.required_busking_sessions.toString()).replace('{deadline}', deadline.toLocaleDateString())}</AlertDescription></Alert>
         <Card>
@@ -85,7 +85,7 @@ export default function Prison() {
       title={t('prison.title')}
       subtitle={prison?.name}
       icon={Lock}
-      backTo="/dashboard"
+      backTo="/home"
       headerActions={<Badge variant="destructive" className="text-[10px]">{t('prison.imprisoned')}</Badge>}
     >
 

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,103 +1,117 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Calendar, CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, CalendarDays, ChevronLeft, ChevronRight, Clock, ExternalLink, GraduationCap, Music, Package, Sparkles, Zap } from "lucide-react";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { DaySchedule } from "@/components/schedule/DaySchedule";
 import { addDays, startOfWeek, format } from "date-fns";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useTranslation } from "@/hooks/useTranslation";
 import { GigLocationWarning } from "@/components/notifications/GigLocationWarning";
 import { HubLayout } from "@/components/hub/HubLayout";
 import { scheduleHubNavigation } from "@/config/hubNavigation";
+import { useScheduledActivities } from "@/hooks/useScheduledActivities";
+import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { formatDurationMinutes, getDisplayDurationMinutes } from "@/utils/activityBookingTime";
+
+const bookingOptions = [
+  { label: "Education", description: "Book classes, reading, mentorship and skill study.", path: "/booking/education", icon: GraduationCap },
+  { label: "Performance", description: "Start existing performance booking workflows.", path: "/booking/performance", icon: Zap },
+  { label: "Work", description: "Schedule employment and work activity.", path: "/booking/work", icon: Package },
+  { label: "Songwriting", description: "Reserve time for writing music.", path: "/booking/songwriting", icon: Sparkles },
+  { label: "Practice", description: "Open the Music practice area.", path: "/music/practice", icon: Music },
+];
+
+function CurrentActivityPanel({ userId }: { userId?: string }) {
+  const today = useMemo(() => new Date(), []);
+  const { data: activities = [], isLoading, error, refetch } = useScheduledActivities(today, userId);
+  const now = Date.now();
+  const current = activities.find((activity) => {
+    const start = new Date(activity.scheduled_start).getTime();
+    const end = new Date(activity.scheduled_end).getTime();
+    return activity.status === "in_progress" || (activity.status === "scheduled" && start <= now && end > now);
+  });
+
+  if (isLoading) return <PageLoadingState title="Loading current activity" description="Checking what is active right now..." />;
+  if (error) return <PageErrorState title="Current activity unavailable" description="Schedule data could not be loaded." onRetry={() => void refetch()} />;
+  if (!current) return <PageEmptyState title="No current activity" description="You are free right now. Review today or book your next activity." action={<Button asChild size="sm"><Link to="/schedule/book">Book activity</Link></Button>} />;
+
+  const remainingMs = Math.max(0, new Date(current.scheduled_end).getTime() - now);
+  const remainingMinutes = Math.ceil(remainingMs / 60000);
+  const duration = formatDurationMinutes(getDisplayDurationMinutes(current));
+
+  return (
+    <Card>
+      <CardHeader className="gap-3 pb-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <CardTitle className="flex items-center gap-2 text-base"><Clock className="h-4 w-4 text-primary" />Current activity</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">Server schedule status is authoritative; remaining time never goes below zero.</p>
+        </div>
+        <Badge variant="secondary">{current.status.replace("_", " ")}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold">{current.title || "Scheduled activity"}</h2>
+          <p className="text-sm text-muted-foreground">{format(new Date(current.scheduled_start), "h:mm a")}–{format(new Date(current.scheduled_end), "h:mm a")}{duration ? ` · ${duration}` : ""}</p>
+          {current.location && <p className="text-sm text-muted-foreground">Location: {current.location}</p>}
+          <p className="text-sm font-medium">{remainingMinutes} min remaining</p>
+        </div>
+        <Button asChild size="sm" variant="outline"><Link to="/schedule/today">View in today <ExternalLink className="ml-1 h-3 w-3" /></Link></Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BookingLauncher() {
+  return (
+    <Card>
+      <CardHeader><CardTitle>Book activity</CardTitle></CardHeader>
+      <CardContent className="grid gap-3 sm:grid-cols-2">
+        {bookingOptions.map((option) => {
+          const Icon = option.icon;
+          return <Button key={option.path} asChild variant="outline" className="h-auto justify-start p-4 text-left"><Link to={option.path}><Icon className="mr-3 h-4 w-4" /><span><span className="block font-medium">{option.label}</span><span className="block text-xs font-normal text-muted-foreground">{option.description}</span></span></Link></Button>;
+        })}
+      </CardContent>
+    </Card>
+  );
+}
 
 const Schedule = () => {
-  const { t } = useTranslation();
   const { userId } = useActiveProfile();
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [viewMode, setViewMode] = useState<'day' | 'week'>('day');
-
+  const location = useLocation();
+  const initialDate = new URLSearchParams(location.search).get("date");
+  const [currentDate, setCurrentDate] = useState(initialDate ? new Date(`${initialDate}T12:00:00`) : new Date());
+  const path = location.pathname;
+  const viewMode: "day" | "week" = path.includes("/week") || path.includes("/calendar") ? "week" : "day";
+  const isBook = path.includes("/book");
+  const isCurrent = path.includes("/current");
+  const isHistory = path.includes("/history");
   const weekStart = startOfWeek(currentDate, { weekStartsOn: 1 });
   const weekDays = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
 
   return (
-    <HubLayout
-      title="Schedule"
-      description="Review your booked activities and jump to existing booking flows."
-      icon={Calendar}
-      overviewPath="/schedule"
-      navigation={scheduleHubNavigation}
-      actions={[{ label: "Book activity", path: "/booking/education", variant: "outline" }]}
-    >
-
+    <HubLayout title="Schedule" description="Today is the default schedule view. Review current, upcoming and historical activity, then launch the owning booking workflow." icon={Calendar} overviewPath="/schedule" navigation={scheduleHubNavigation} actions={[{ label: "Book activity", path: "/schedule/book", variant: "outline" }]}>
       <GigLocationWarning />
-      
-      <div className="flex items-center justify-between flex-wrap gap-3 md:gap-4">
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setCurrentDate(addDays(currentDate, viewMode === 'day' ? -1 : -7))}
-          >
-            <ChevronLeft className="h-3 w-3 md:h-4 md:w-4" />
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setCurrentDate(new Date())}
-          >
-            <span className="text-xs md:text-sm">Today</span>
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => setCurrentDate(addDays(currentDate, viewMode === 'day' ? 1 : 7))}
-          >
-            <ChevronRight className="h-3 w-3 md:h-4 md:w-4" />
-          </Button>
-        </div>
-        
-        <div className="flex gap-2">
-          <Button
-            size="sm"
-            variant={viewMode === 'day' ? 'default' : 'outline'}
-            onClick={() => setViewMode('day')}
-          >
-            <Calendar className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
-            <span className="hidden md:inline">Day</span>
-          </Button>
-          <Button
-            size="sm"
-            variant={viewMode === 'week' ? 'default' : 'outline'}
-            onClick={() => setViewMode('week')}
-          >
-            <CalendarDays className="h-3 w-3 md:h-4 md:w-4 md:mr-1" />
-            <span className="hidden md:inline">Week</span>
-          </Button>
-        </div>
-      </div>
-
-      {viewMode === 'day' ? (
-        <DaySchedule date={currentDate} userId={userId ?? undefined} />
+      {isBook ? <BookingLauncher /> : isCurrent ? <CurrentActivityPanel userId={userId ?? undefined} /> : isHistory ? (
+        <Card><CardHeader><CardTitle>Activity history</CardTitle></CardHeader><CardContent><DaySchedule date={currentDate} userId={userId ?? undefined} /></CardContent></Card>
       ) : (
-        <Tabs defaultValue={format(weekDays[0], 'yyyy-MM-dd')} className="w-full">
-          <TabsList className="w-full grid grid-cols-7 h-auto">
-            {weekDays.map(day => (
-              <TabsTrigger 
-                key={day.toISOString()} 
-                value={format(day, 'yyyy-MM-dd')}
-                className="flex flex-col py-1.5 md:py-2"
-              >
-                <span className="text-xs">{format(day, 'EEE')}</span>
-                <span className="text-base md:text-lg font-bold">{format(day, 'd')}</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          {weekDays.map(day => (
-            <TabsContent key={day.toISOString()} value={format(day, 'yyyy-MM-dd')}>
-              <DaySchedule date={day} userId={userId ?? undefined} />
-            </TabsContent>
-          ))}
-        </Tabs>
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3 md:gap-4">
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="outline" onClick={() => setCurrentDate(addDays(currentDate, viewMode === 'day' ? -1 : -7))}><ChevronLeft className="h-3 w-3 md:h-4 md:w-4" /></Button>
+              <Button size="sm" variant="outline" onClick={() => setCurrentDate(new Date())}><span className="text-xs md:text-sm">Today</span></Button>
+              <Button size="sm" variant="outline" onClick={() => setCurrentDate(addDays(currentDate, viewMode === 'day' ? 1 : 7))}><ChevronRight className="h-3 w-3 md:h-4 md:w-4" /></Button>
+            </div>
+            <div className="flex gap-2">
+              <Button asChild size="sm" variant={viewMode === 'day' ? 'default' : 'outline'}><Link to="/schedule/today"><Calendar className="h-3 w-3 md:mr-1" /><span className="hidden md:inline">Today</span></Link></Button>
+              <Button asChild size="sm" variant={viewMode === 'week' ? 'default' : 'outline'}><Link to="/schedule/week"><CalendarDays className="h-3 w-3 md:mr-1" /><span className="hidden md:inline">Week</span></Link></Button>
+            </div>
+          </div>
+          {viewMode === 'day' ? <DaySchedule date={currentDate} userId={userId ?? undefined} /> : (
+            <Tabs defaultValue={format(weekDays[0], 'yyyy-MM-dd')} className="w-full"><TabsList className="grid h-auto w-full grid-cols-7">{weekDays.map(day => <TabsTrigger key={day.toISOString()} value={format(day, 'yyyy-MM-dd')} className="flex flex-col py-1.5 md:py-2"><span className="text-xs">{format(day, 'EEE')}</span><span className="text-base font-bold md:text-lg">{format(day, 'd')}</span></TabsTrigger>)}</TabsList>{weekDays.map(day => <TabsContent key={day.toISOString()} value={format(day, 'yyyy-MM-dd')}><DaySchedule date={day} userId={userId ?? undefined} /></TabsContent>)}</Tabs>
+          )}
+        </>
       )}
     </HubLayout>
   );

--- a/src/pages/SlotPurchaseSuccess.tsx
+++ b/src/pages/SlotPurchaseSuccess.tsx
@@ -58,7 +58,7 @@ export default function SlotPurchaseSuccess() {
                 <p className="text-muted-foreground">Your new character slot is ready. You can now create another character.</p>
                 <div className="flex gap-2 justify-center pt-2">
                   <Button onClick={() => navigate("/characters/new")}>Create Character</Button>
-                  <Button variant="outline" onClick={() => navigate("/dashboard")}>Dashboard</Button>
+                  <Button variant="outline" onClick={() => navigate("/home")}>Dashboard</Button>
                 </div>
               </>
             )}

--- a/src/pages/StagePractice.tsx
+++ b/src/pages/StagePractice.tsx
@@ -38,7 +38,7 @@ const StagePractice = () => {
   }, []);
 
   const handleExit = useCallback(() => {
-    navigate('/dashboard');
+    navigate('/home');
   }, [navigate]);
 
   return (

--- a/src/pages/VipSuccess.tsx
+++ b/src/pages/VipSuccess.tsx
@@ -28,7 +28,7 @@ export default function VipSuccess() {
     const timer = setInterval(() => {
       setCountdown((prev) => {
         if (prev <= 1) {
-          navigate("/dashboard");
+          navigate("/home");
           return 0;
         }
         return prev - 1;
@@ -97,7 +97,7 @@ export default function VipSuccess() {
 
           <div className="space-y-2">
             <Button 
-              onClick={() => navigate("/dashboard")}
+              onClick={() => navigate("/home")}
               className="w-full bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-black font-semibold"
             >
               <Crown className="h-4 w-4 mr-2" />

--- a/src/pages/family/FamilyTimeline.tsx
+++ b/src/pages/family/FamilyTimeline.tsx
@@ -294,7 +294,7 @@ export default function FamilyTimeline() {
     <div className="container mx-auto max-w-3xl p-4 space-y-4">
       <div className="flex items-center gap-2">
         <Button asChild size="sm" variant="ghost">
-          <Link to="/dashboard">
+          <Link to="/home">
             <ArrowLeft className="h-4 w-4 mr-1" /> Back
           </Link>
         </Button>

--- a/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/pages/onboarding/OnboardingWizard.tsx
@@ -222,7 +222,7 @@ const OnboardingWizard = () => {
         title: "Onboarding saved",
         description: "Your profile is ready. Welcome to Rockmundo!",
       });
-      navigate("/dashboard");
+      navigate("/home");
     },
     onError: (error: unknown) => {
       console.error("onboarding.save.error", error);


### PR DESCRIPTION
### Motivation

- Provide a stable post-login landing by making `/home` the canonical dashboard and avoid restoring last-visited child pages.
- Make `Schedule` the authoritative place for current/upcoming/history activities and provide predictable Schedule child routes.
- Surface a lightweight, actionable Home summary (current activity, today’s agenda, quick actions) while keeping feature hubs as owners of detailed workflows.

### Description

- Change post-login and index routing so authenticated players land on `/home` and `/dashboard` is kept as a compatibility alias that redirects to `/home` via `PreserveQueryRedirect`. (`src/pages/Index.tsx`, `src/pages/Landing.tsx`, `src/App.tsx`)
- Update top-level navigation and module config to treat Home as the FM root (`rootPath: '/home'`) and replace Dashboard labels/links with Home where appropriate. (`src/config/fmNavigation.ts`, various nav components)
- Expand the Schedule hub to explicit child routes and predictable paths (`/schedule`, `/schedule/today`, `/schedule/week`, `/schedule/calendar`, `/schedule/current`, `/schedule/book`, `/schedule/upcoming`, `/schedule/history`) and wire them into the router. (`src/App.tsx`, `src/config/hubNavigation.ts`)
- Rework `src/pages/Schedule.tsx` to use the shared `HubLayout` while adding: a booking launcher that links to existing booking workflows, a `CurrentActivityPanel` derived from `useScheduledActivities`, `Activity history` surface, and path-aware day/week rendering; preserve `DaySchedule` data usage. (`src/pages/Schedule.tsx`, `src/components/schedule/DaySchedule.tsx`)
- Keep Schedule booking ownership: `/schedule/book` launches existing booking pages rather than duplicating forms, and legacy `/booking/*` routes remain valid and are selected by the new Schedule book item. (`src/pages/Schedule.tsx`, `src/config/hubNavigation.ts`)
- Ensure breadcrumbs and header Home links point to `/home` and update `backTo`/`navigate` targets across pages to use `/home` so Home is a stable anchor (updated `HubLayout`, assorted pages and components). (`src/components/hub/HubLayout.tsx`, various pages)
- Document the decisions, route map, ownership model, duration and conflict handling, and limitations in `docs/navigation-and-hub-refactor.md` (PR 8 section). (`docs/navigation-and-hub-refactor.md`)

### Testing

- Ran TypeScript type check with `npm run typecheck`, which completed successfully. 
- Linting (`npm run lint`) could not be executed in the validation environment due to missing local ESLint dependency `@eslint/js`. 
- Unit tests (`npm run test:unit` / `vitest`) and `npm run build` could not be executed because local tooling (`vitest`, `vite`) was not available and `npm install` failed in this environment (registry access error for a dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e1f0c2208325a09cc6e444263a4f)