### PR TITLE
Add navigation search, favourites and recent destinations

### DIFF
--- a/docs/navigation-and-hub-refactor.md
+++ b/docs/navigation-and-hub-refactor.md
@@ -809,3 +809,59 @@ The repository still uses a large explicit route table rather than generated rou
 ### Completed PR sequence
 
 The navigation programme is complete: PRs 1–8 established the hub structure and PR 9 finalises polish, accessibility, selected-state reliability, legacy route documentation and regression protection.
+
+## PR 10 post-programme enhancement — navigation search, favourites and recent destinations
+
+PR 10 adds optional navigation-productivity tools on top of the stable hub structure. It does not replace primary module tabs, hub child navigation, breadcrumbs, or route-level authorisation.
+
+### Navigation search scope
+
+The global search entry point in the FM shell opens a command-style navigation dialog with `Ctrl+K` on Windows/Linux or `Cmd+K` on macOS. The search scope is intentionally limited to trusted navigation destinations: top-level hubs, hub child pages, sidebar destinations, quick actions with stable routes, and previously stored favourites or recent destinations that still match allowed navigation metadata. It is not a gameplay-wide search over every player, band, song, company, message, city, transaction, or forum post.
+
+### Searchable destination metadata
+
+Search metadata is derived from `FM_MODULES` in `src/config/fmNavigation.ts`, which is the canonical global navigation configuration used by the primary shell. Each destination carries a label, canonical route, hub label, icon, destination kind, eligibility for favourites/recents, and optional keywords. Developers should extend existing navigation metadata first, then add only small aliases in `src/lib/navigationProductivity.ts` when player terminology differs from visible labels.
+
+Static route example: the Music module contributes `Songwriting` at `/music/songwriting`, so searching `songwriting`, `songs`, or `write song` navigates to the canonical Music-owned route.
+
+Supported dynamic-route example: a recently visited entity page may be stored only as minimal metadata such as label plus canonical internal route, for example `Abbey Road Studios` at `/recording-studio-business/studio-123`, after that route has already been reached through normal authorised navigation. The store must not contain the full studio record.
+
+### Search aliases
+
+Aliases are deliberately small and documented close to the search metadata. Current examples include Health → Wellness, Mail → Messages, Calendar → Schedule, Gig Prep → Band Gigs, Company Money → Business Finances, Songs → Songwriting, and Location → Current City. Aliases must reduce genuine ambiguity and must not be broad enough to return unrelated gameplay data.
+
+### Permission and feature-flag filtering
+
+Search uses the same client navigation visibility rule as the module tabs for admin routes: admin destinations are omitted unless the user role is admin. Feature-flag metadata can be attached to destinations and disabled flags remove those destinations from the searchable set. Search filtering is only a discoverability safeguard; page-level and server-side authorisation remain authoritative.
+
+### Contextual destinations
+
+Context-free hub and page routes are always safe to list when visible in navigation. Contextual destinations are listed only when the client has a stable canonical route. Unknown entity IDs are never invented. Dynamic favourites and recents are accepted only as sanitized internal paths with readable labels, and unavailable entries are hidden when they no longer match currently allowed metadata.
+
+### Favourite eligibility
+
+Players can pin eligible navigation destinations from search results or from the current page control. Favourites are deduplicated by canonical path, newest pins appear first, and the local list is capped. Admin, sensitive, or invalid destinations should opt out or be filtered by the same metadata that hides them from navigation.
+
+### Recent-page eligibility and exclusions
+
+Recent destinations track a short list of useful pages, not browser history. Consecutive duplicates are ignored, revisits move to the top, and the list is capped. Recent tracking excludes login, logout, callbacks, 404/not-found, permission denied, confirmation/payment pages, destructive or transient routes, redirect-only aliases where known, and routes containing sensitive token or password parameters.
+
+### Persistence model
+
+PR 10 uses namespaced, versioned local storage as a limited fallback because no cross-device user-preference backend is established for this feature. Keys include the authenticated user id when available, so favourites and recents are browser-local and account-isolated on shared browsers. They are not account-synchronised across devices.
+
+### Privacy and security rules
+
+Stored entries contain only minimal route metadata: id, label, canonical internal path, hub label, kind, and non-sensitive keywords. External URLs, protocol URLs, double-slash URLs, and unsafe query parameters are rejected or stripped before storage. Search queries are not persisted. Raw message bodies, auth tokens, password-reset links, payment details, return URLs, full entity records, and private profile fields must never be stored.
+
+### Keyboard, mobile and accessibility behaviour
+
+The global header exposes a visible Search control with an accessible name and a shortcut hint. The dialog focuses the search input when opened, uses the existing accessible command/dialog primitives, supports Escape to close, arrow-key result movement and Enter selection through `cmdk`, and returns focus according to the existing Radix dialog behaviour. The shortcut listener is registered once by the shell and does not fire while the player is typing in inputs, textareas, selects, or editable fields. On mobile-sized layouts, the same header control and command dialog are used so the primary navigation structure is not redesigned or duplicated.
+
+### Analytics behaviour
+
+No route analytics facility was present for navigation-productivity events during this PR, so no new analytics calls were added. Future analytics should avoid raw search terms and should count open/select/favourite events without sensitive route data.
+
+### Known limitations and follow-up
+
+Favourites and recents are browser-local, not cross-device. Dynamic entity favourites are limited to canonical internal routes already known to the client; this PR does not introduce a backend search service or gameplay-wide entity index. Future navigation enhancements should be driven by player analytics and usability feedback rather than further structural expansion.

--- a/src/components/fm/FMCommandPalette.tsx
+++ b/src/components/fm/FMCommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Pin, PinOff, Search, Star } from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -9,26 +10,48 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-import { FM_MODULES } from "@/config/fmNavigation";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth-context";
 import { useUserRole } from "@/hooks/useUserRole";
+import {
+  getNavigationDestinations,
+  readNavigationStore,
+  recordRecentDestination,
+  searchNavigationDestinations,
+  toggleFavourite,
+  type NavigationDestination,
+  type StoredNavigationDestination,
+} from "@/lib/navigationProductivity";
 
-type Entry = {
-  label: string;
-  path: string;
-  group: string;
-  Icon?: React.ElementType;
+const isTypingTarget = (target: EventTarget | null) => {
+  const element = target as HTMLElement | null;
+  if (!element) return false;
+  return Boolean(element.closest("input, textarea, select, [contenteditable='true'], [contenteditable='']"));
 };
+
+const toStored = (destination: NavigationDestination | StoredNavigationDestination): StoredNavigationDestination => ({
+  id: destination.id,
+  label: destination.label,
+  path: destination.path,
+  hubLabel: destination.hubLabel,
+  kind: destination.kind,
+});
 
 export const FMCommandPalette = () => {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [storeVersion, setStoreVersion] = useState(0);
   const navigate = useNavigate();
-  const { isAdmin } = useUserRole();
+  const { pathname } = useLocation();
+  const { user } = useAuth();
+  const { userRole } = useUserRole();
+  const userId = user?.id ?? null;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k" && !isTypingTarget(e.target)) {
         e.preventDefault();
-        setOpen((v) => !v);
+        setOpen(true);
       }
     };
     const onOpen = () => setOpen(true);
@@ -40,70 +63,98 @@ export const FMCommandPalette = () => {
     };
   }, []);
 
-  const { quick, byModule } = useMemo(() => {
-    const modules = FM_MODULES.filter((m) => m.id !== "admin" || isAdmin());
-    const quick: Entry[] = [];
-    const byModule: { module: string; entries: Entry[] }[] = [];
-    for (const mod of modules) {
-      for (const a of mod.quickActions ?? []) {
-        quick.push({ label: a.label, path: a.path, group: mod.label, Icon: a.icon });
-      }
-      const seen = new Set<string>();
-      const entries: Entry[] = [];
-      for (const t of mod.subTabs) {
-        if (seen.has(t.path)) continue;
-        seen.add(t.path);
-        entries.push({ label: t.label, path: t.path, group: mod.label, Icon: t.icon });
-      }
-      for (const s of mod.sidebar) {
-        for (const it of s.items) {
-          if (seen.has(it.path)) continue;
-          seen.add(it.path);
-          entries.push({ label: it.label, path: it.path, group: mod.label, Icon: it.icon });
-        }
-      }
-      byModule.push({ module: mod.label, entries });
-    }
-    return { quick, byModule };
-  }, [isAdmin]);
+  const destinations = useMemo(() => getNavigationDestinations(userRole), [userRole]);
+  const store = useMemo(() => readNavigationStore(userId), [userId, storeVersion]);
+  const allowedPaths = useMemo(() => new Set(destinations.map((destination) => destination.path)), [destinations]);
+  const favouritePaths = useMemo(() => new Set(store.favourites.map((fav) => fav.path)), [store.favourites]);
+  const currentDestination = useMemo(() => destinations.find((destination) => destination.path === pathname), [destinations, pathname]);
 
-  const go = (path: string) => {
+  useEffect(() => {
+    const destination = destinations.find((item) => item.path === pathname);
+    if (destination?.recentEligible) {
+      recordRecentDestination(userId, toStored(destination));
+      setStoreVersion((value) => value + 1);
+    }
+  }, [destinations, pathname, userId]);
+
+  const filteredFavourites = store.favourites.filter((item) => allowedPaths.has(item.path));
+  const filteredRecents = store.recents.filter((item) => allowedPaths.has(item.path));
+  const results = useMemo(() => searchNavigationDestinations(destinations, query), [destinations, query]);
+
+  const go = (destination: NavigationDestination | StoredNavigationDestination) => {
+    recordRecentDestination(userId, toStored(destination));
     setOpen(false);
-    navigate(path);
+    setQuery("");
+    if (destination.path !== pathname) navigate(destination.path);
+    setStoreVersion((value) => value + 1);
+  };
+
+  const onToggleFavourite = (event: React.MouseEvent, destination: NavigationDestination | StoredNavigationDestination) => {
+    event.preventDefault();
+    event.stopPropagation();
+    toggleFavourite(userId, toStored(destination));
+    setStoreVersion((value) => value + 1);
+  };
+
+  const renderItem = (destination: NavigationDestination | StoredNavigationDestination, prefix: string) => {
+    const Icon = "Icon" in destination ? destination.Icon : undefined;
+    const pinned = favouritePaths.has(destination.path);
+    return (
+      <CommandItem
+        key={`${prefix}-${destination.path}`}
+        value={`${destination.label} ${destination.hubLabel ?? ""} ${(destination.keywords ?? []).join(" ")}`}
+        onSelect={() => go(destination)}
+        className="gap-2"
+      >
+        {Icon ? <Icon className="h-4 w-4 text-fm-fg-muted" aria-hidden /> : <Search className="h-4 w-4 text-fm-fg-muted" aria-hidden />}
+        <span>{destination.label}</span>
+        {destination.hubLabel && <span className="ml-auto text-[10px] text-fm-fg-muted">{destination.hubLabel}</span>}
+        <button
+          type="button"
+          className="ml-2 rounded p-1 text-fm-fg-muted hover:bg-fm-panel-2 hover:text-fm-accent"
+          aria-label={pinned ? `Remove ${destination.label} from favourites` : `Add ${destination.label} to favourites`}
+          onClick={(event) => onToggleFavourite(event, destination)}
+        >
+          {pinned ? <PinOff className="h-3.5 w-3.5" aria-hidden /> : <Pin className="h-3.5 w-3.5" aria-hidden />}
+        </button>
+      </CommandItem>
+    );
   };
 
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Jump to anything — pages, actions, modules…" />
-      <CommandList>
-        <CommandEmpty>No matches.</CommandEmpty>
-        {quick.length > 0 && (
-          <>
-            <CommandGroup heading="Quick Actions">
-              {quick.map((e) => (
-                <CommandItem key={`q-${e.path}-${e.label}`} value={`${e.label} ${e.group} action create`} onSelect={() => go(e.path)}>
-                  {e.Icon && <e.Icon className="mr-2 h-3.5 w-3.5 text-fm-accent" />}
-                  <span>{e.label}</span>
-                  <span className="ml-auto text-[10px] tracking-tight text-fm-fg-muted">{e.group}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-            <CommandSeparator />
-          </>
-        )}
-        {byModule.map((g) => (
-          <CommandGroup key={g.module} heading={g.module}>
-            {g.entries.map((e) => (
-              <CommandItem key={`${g.module}-${e.path}`} value={`${e.label} ${g.module}`} onSelect={() => go(e.path)}>
-                {e.Icon && <e.Icon className="mr-2 h-3.5 w-3.5 text-fm-fg-muted" />}
-                <span>{e.label}</span>
-                <span className="ml-auto text-[10px] text-fm-fg-muted tabular-nums">{e.path}</span>
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        ))}
-      </CommandList>
-    </CommandDialog>
+    <>
+      {currentDestination?.favouriteEligible && (
+        <div className="fixed bottom-14 right-3 z-30 hidden md:block">
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 border-fm-border bg-fm-panel text-xs"
+            onClick={(event) => onToggleFavourite(event, currentDestination)}
+            aria-label={favouritePaths.has(currentDestination.path) ? `Remove ${currentDestination.label} from favourites` : `Add ${currentDestination.label} to favourites`}
+          >
+            <Star className="h-3.5 w-3.5" aria-hidden />
+            {favouritePaths.has(currentDestination.path) ? "Favourited" : "Favourite"}
+          </Button>
+        </div>
+      )}
+      <CommandDialog open={open} onOpenChange={(next) => { setOpen(next); if (!next) setQuery(""); }}>
+        <CommandInput
+          aria-label="Search navigation destinations"
+          placeholder="Search navigation — pages, hubs and actions…"
+          value={query}
+          onValueChange={setQuery}
+        />
+        <div className="border-b px-3 py-2 text-xs text-muted-foreground">Press Ctrl+K or Cmd+K to open. Search covers navigation destinations, not gameplay data.</div>
+        <CommandList className="max-h-[min(65vh,520px)]">
+          <CommandEmpty>No navigation results for “{query}”. Try browsing the closest hub.</CommandEmpty>
+          {!query.trim() && filteredFavourites.length === 0 && <div className="px-4 py-3 text-sm text-muted-foreground">No favourites yet. Pin destinations from results or the current page.</div>}
+          {!query.trim() && filteredFavourites.length > 0 && <CommandGroup heading="Favourites">{filteredFavourites.map((item) => renderItem(item, "fav"))}</CommandGroup>}
+          {!query.trim() && filteredRecents.length > 0 && <CommandGroup heading="Recent">{filteredRecents.map((item) => renderItem(item, "recent"))}</CommandGroup>}
+          {!query.trim() && (filteredFavourites.length > 0 || filteredRecents.length > 0) && <CommandSeparator />}
+          <CommandGroup heading={query.trim() ? "Results" : "Common destinations"}>{results.map((item) => renderItem(item, "result"))}</CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
   );
 };
 

--- a/src/components/fm/TopStatusBar.tsx
+++ b/src/components/fm/TopStatusBar.tsx
@@ -11,7 +11,7 @@ import { HowToPlayDialog } from "@/components/HowToPlayDialog";
 import { ActivityStatusIndicator } from "@/components/ActivityStatusIndicator";
 import { PrisonStatusIndicator } from "@/components/prison/PrisonStatusIndicator";
 import { Button } from "@/components/ui/button";
-import { DollarSign, Flame, Heart, Zap, LogOut, User, Gauge } from "lucide-react";
+import { DollarSign, Flame, Heart, Zap, LogOut, User, Gauge, Search } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -223,6 +223,18 @@ export const TopStatusBar = () => {
 
       <div className="h-6 w-px bg-fm-border mx-1" />
 
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-8 gap-1.5"
+        onClick={() => window.dispatchEvent(new Event("fm:open-command"))}
+        aria-label="Open navigation search"
+        title="Search navigation (Ctrl+K or Cmd+K)"
+      >
+        <Search className="h-4 w-4" aria-hidden="true" />
+        <span className="hidden lg:inline text-xs">Search</span>
+        <kbd className="hidden xl:inline rounded border border-fm-border px-1 text-[10px] text-fm-fg-muted">⌘K</kbd>
+      </Button>
       <CharacterSwitcher />
       <PrisonStatusIndicator />
       <ActivityStatusIndicator />

--- a/src/lib/__tests__/navigationProductivity.test.ts
+++ b/src/lib/__tests__/navigationProductivity.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_FAVOURITES,
+  getNavigationDestinations,
+  isRecentEligiblePath,
+  readNavigationStore,
+  recordRecentDestination,
+  sanitizeInternalPath,
+  searchNavigationDestinations,
+  toggleFavourite,
+} from "../navigationProductivity";
+
+beforeEach(() => localStorage.clear());
+
+describe("navigation productivity metadata", () => {
+  it("searches labels, hubs and aliases without exposing admin destinations", () => {
+    const userDestinations = getNavigationDestinations("user");
+    expect(searchNavigationDestinations(userDestinations, "wellness")[0].path).toBe("/wellness");
+    expect(searchNavigationDestinations(userDestinations, "health")[0].path).toBe("/wellness");
+    expect(searchNavigationDestinations(userDestinations, "calendar")[0].path).toBe("/schedule");
+    expect(searchNavigationDestinations(userDestinations, "admin").some((item) => item.path.startsWith("/admin"))).toBe(false);
+
+    const adminDestinations = getNavigationDestinations("admin");
+    expect(adminDestinations.some((item) => item.path.startsWith("/admin"))).toBe(true);
+  });
+
+  it("sanitizes internal paths and rejects external injection", () => {
+    expect(sanitizeInternalPath("https://evil.example/path")).toBeNull();
+    expect(sanitizeInternalPath("//evil.example/path")).toBeNull();
+    expect(sanitizeInternalPath("/social/messages?token=secret&tab=inbox")).toBe("/social/messages?tab=inbox");
+  });
+
+  it("excludes unsafe routes from recents", () => {
+    expect(isRecentEligiblePath("/auth")).toBe(false);
+    expect(isRecentEligiblePath("/booking/payment-confirmation")).toBe(false);
+    expect(isRecentEligiblePath("/music/songwriting")).toBe(true);
+  });
+});
+
+describe("navigation productivity persistence", () => {
+  it("adds, removes, deduplicates and caps favourites per account", () => {
+    for (let i = 0; i < MAX_FAVOURITES + 2; i += 1) {
+      toggleFavourite("user-a", { id: `item-${i}`, label: `Item ${i}`, path: `/item-${i}` });
+    }
+    expect(readNavigationStore("user-a").favourites).toHaveLength(MAX_FAVOURITES);
+    toggleFavourite("user-a", { id: "item-3", label: "Item 3", path: "/item-3" });
+    expect(readNavigationStore("user-a").favourites.some((item) => item.path === "/item-3")).toBe(false);
+    expect(readNavigationStore("user-b").favourites).toHaveLength(0);
+  });
+
+  it("records safe recents, moves revisits to the top and recovers from corrupted data", () => {
+    recordRecentDestination("user-a", { id: "songwriting", label: "Songwriting", path: "/music/songwriting?draft=secret" });
+    recordRecentDestination("user-a", { id: "wellness", label: "Wellness", path: "/wellness" });
+    recordRecentDestination("user-a", { id: "auth", label: "Auth", path: "/auth" });
+    recordRecentDestination("user-a", { id: "songwriting", label: "Songwriting", path: "/music/songwriting" });
+    expect(readNavigationStore("user-a").recents.map((item) => item.path)).toEqual(["/music/songwriting", "/wellness"]);
+
+    localStorage.setItem("rm-navigation-productivity:v1:user-a", "not json");
+    expect(readNavigationStore("user-a").recents).toEqual([]);
+  });
+});

--- a/src/lib/navigationProductivity.ts
+++ b/src/lib/navigationProductivity.ts
@@ -1,0 +1,178 @@
+import type { LucideIcon } from "lucide-react";
+import { FM_MODULES } from "@/config/fmNavigation";
+import type { UserRole } from "@/hooks/useUserRole";
+
+export type NavigationDestinationKind = "hub" | "page" | "action" | "dynamic";
+export type StoredNavigationDestination = {
+  id: string;
+  label: string;
+  path: string;
+  hubLabel?: string;
+  kind?: NavigationDestinationKind;
+  keywords?: string[];
+  favouriteEligible?: boolean;
+  recentEligible?: boolean;
+};
+export type NavigationDestination = StoredNavigationDestination & {
+  kind: NavigationDestinationKind;
+  Icon?: LucideIcon;
+  adminOnly?: boolean;
+  featureFlag?: string;
+};
+
+export const NAV_PRODUCTIVITY_VERSION = 1;
+export const MAX_FAVOURITES = 12;
+export const MAX_RECENTS = 8;
+const STORAGE_PREFIX = "rm-navigation-productivity";
+
+const aliasByPath: Record<string, string[]> = {
+  "/wellness": ["health"],
+  "/social/messages": ["mail", "inbox", "dm"],
+  "/schedule": ["calendar", "today"],
+  "/band/gigs": ["gig prep", "gig preparation", "shows"],
+  "/business/finances": ["company money", "company finances", "cashflow"],
+  "/career/finances": ["money", "cash"],
+  "/music/songwriting": ["songs", "write song", "compose"],
+  "/world/current-city": ["location", "current city"],
+  "/world/travel": ["trip", "fly"],
+};
+
+const excludedPatterns = [
+  /^\/auth(?:\/|$)/,
+  /^\/logout(?:\/|$)/,
+  /^\/404(?:\/|$)/,
+  /^\/not-found(?:\/|$)/,
+  /^\/permission-denied(?:\/|$)/,
+  /callback/i,
+  /confirmation/i,
+  /token=/i,
+  /access_token=/i,
+  /refresh_token=/i,
+  /password/i,
+  /returnUrl=/i,
+];
+
+const normalize = (value: string) => value.toLowerCase().trim().replace(/[\s_-]+/g, " ");
+
+export const sanitizeInternalPath = (path: string): string | null => {
+  if (!path || !path.startsWith("/") || path.startsWith("//")) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) return null;
+  try {
+    const url = new URL(path, "https://rockmundo.local");
+    if (url.origin !== "https://rockmundo.local") return null;
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (/token|password|secret|return|redirect|draft|recipient|payment|billing/i.test(key)) {
+        url.searchParams.delete(key);
+      }
+    }
+    const search = url.searchParams.toString();
+    return `${url.pathname}${search ? `?${search}` : ""}`;
+  } catch {
+    return null;
+  }
+};
+
+export const isRecentEligiblePath = (path: string) => {
+  const safe = sanitizeInternalPath(path);
+  return Boolean(safe && !excludedPatterns.some((pattern) => pattern.test(safe)));
+};
+
+export const getNavigationDestinations = (role: UserRole | null, flags: Record<string, boolean> = {}): NavigationDestination[] => {
+  const entries = new Map<string, NavigationDestination>();
+  for (const mod of FM_MODULES) {
+    if (mod.id === "admin" && role !== "admin") continue;
+    const add = (entry: Omit<NavigationDestination, "kind"> & { kind?: NavigationDestinationKind }) => {
+      const path = sanitizeInternalPath(entry.path);
+      if (!path) return;
+      if (entry.featureFlag && !flags[entry.featureFlag]) return;
+      if (entries.has(path)) return;
+      entries.set(path, {
+        ...entry,
+        path,
+        kind: entry.kind ?? "page",
+        keywords: [...(entry.keywords ?? []), ...(aliasByPath[path] ?? [])],
+        favouriteEligible: entry.favouriteEligible ?? path !== "/auth",
+        recentEligible: entry.recentEligible ?? isRecentEligiblePath(path),
+        adminOnly: mod.id === "admin" || entry.adminOnly,
+      });
+    };
+    add({ id: `${mod.id}:hub`, label: mod.label, path: mod.rootPath, hubLabel: mod.label, Icon: mod.icon, kind: "hub" });
+    for (const tab of mod.subTabs) add({ id: `${mod.id}:tab:${tab.path}`, label: tab.label, path: tab.path, hubLabel: mod.label, Icon: tab.icon });
+    for (const section of mod.sidebar) {
+      for (const item of section.items) add({ id: `${mod.id}:side:${item.path}`, label: item.label, path: item.path, hubLabel: mod.label, Icon: item.icon, keywords: [section.label] });
+    }
+    for (const action of mod.quickActions ?? []) add({ id: `${mod.id}:action:${action.path}:${action.label}`, label: action.label, path: action.path, hubLabel: mod.label, Icon: action.icon, kind: "action", keywords: action.description ? [action.description] : [] });
+  }
+  return Array.from(entries.values());
+};
+
+const score = (destination: NavigationDestination, query: string) => {
+  const q = normalize(query);
+  if (!q) return 1;
+  const fields = [destination.label, destination.hubLabel ?? "", ...(destination.keywords ?? [])].map(normalize);
+  let best = 0;
+  for (const field of fields) {
+    if (field === q) best = Math.max(best, 100);
+    else if (field.startsWith(q)) best = Math.max(best, 75);
+    else if (field.includes(q)) best = Math.max(best, 45);
+    else if (q.split(" ").every((part) => field.includes(part))) best = Math.max(best, 30);
+  }
+  return best;
+};
+
+export const searchNavigationDestinations = (destinations: NavigationDestination[], query: string, limit = 24) => {
+  const q = query.trim();
+  return destinations
+    .map((destination) => ({ destination, score: score(destination, q) }))
+    .filter((result) => (q ? result.score > 0 : result.destination.kind === "hub" || result.destination.kind === "action"))
+    .sort((a, b) => b.score - a.score || a.destination.label.localeCompare(b.destination.label))
+    .slice(0, limit)
+    .map((result) => result.destination);
+};
+
+type Store = { version: 1; favourites: StoredNavigationDestination[]; recents: StoredNavigationDestination[] };
+const emptyStore = (): Store => ({ version: NAV_PRODUCTIVITY_VERSION, favourites: [], recents: [] });
+const storageKey = (userId?: string | null) => `${STORAGE_PREFIX}:v${NAV_PRODUCTIVITY_VERSION}:${userId || "guest"}`;
+
+const validStored = (value: unknown): StoredNavigationDestination | null => {
+  const item = value as Partial<StoredNavigationDestination>;
+  const path = typeof item.path === "string" ? sanitizeInternalPath(item.path) : null;
+  if (!path || typeof item.label !== "string" || !item.label.trim()) return null;
+  return { id: typeof item.id === "string" ? item.id : path, label: item.label.slice(0, 80), path, hubLabel: item.hubLabel?.slice(0, 50), kind: item.kind, keywords: [] };
+};
+
+export const readNavigationStore = (userId?: string | null): Store => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(storageKey(userId)) || "null");
+    if (!parsed || parsed.version !== NAV_PRODUCTIVITY_VERSION) return emptyStore();
+    return {
+      version: NAV_PRODUCTIVITY_VERSION,
+      favourites: Array.isArray(parsed.favourites) ? parsed.favourites.map(validStored).filter(Boolean).slice(0, MAX_FAVOURITES) as StoredNavigationDestination[] : [],
+      recents: Array.isArray(parsed.recents) ? parsed.recents.map(validStored).filter(Boolean).slice(0, MAX_RECENTS) as StoredNavigationDestination[] : [],
+    };
+  } catch { return emptyStore(); }
+};
+
+const writeStore = (userId: string | null | undefined, store: Store) => {
+  try { localStorage.setItem(storageKey(userId), JSON.stringify(store)); } catch { /* ignore */ }
+};
+
+export const toggleFavourite = (userId: string | null | undefined, destination: StoredNavigationDestination) => {
+  const item = validStored(destination);
+  const store = readNavigationStore(userId);
+  if (!item) return store;
+  const exists = store.favourites.some((fav) => fav.path === item.path);
+  store.favourites = exists ? store.favourites.filter((fav) => fav.path !== item.path) : [item, ...store.favourites.filter((fav) => fav.path !== item.path)].slice(0, MAX_FAVOURITES);
+  writeStore(userId, store);
+  return store;
+};
+
+export const recordRecentDestination = (userId: string | null | undefined, destination: StoredNavigationDestination) => {
+  const item = validStored(destination);
+  if (!item || !isRecentEligiblePath(item.path)) return readNavigationStore(userId);
+  const store = readNavigationStore(userId);
+  if (store.recents[0]?.path === item.path) return store;
+  store.recents = [item, ...store.recents.filter((recent) => recent.path !== item.path)].slice(0, MAX_RECENTS);
+  writeStore(userId, store);
+  return store;
+};


### PR DESCRIPTION
### Motivation

- Provide a lightweight, optional navigation-productivity layer so players can quickly reach frequently used destinations without changing the primary module/hub navigation structure.  
- Surface a single, permission-aware global navigation search with keyboard access that only searches canonical navigation destinations (hubs, hub pages, quick actions and supported dynamic destinations) and not gameplay data.  
- Add browser-local favourites and a small recent-pages history, with safe sanitisation and per-user namespaced persistence, to improve return-paths without introducing cross-device sync or new backend services.

### Description

- Added a new library `src/lib/navigationProductivity.ts` that derives searchable destinations from `FM_MODULES`, applies admin/feature-flag filtering, provides small alias keywords, performs safe internal-path sanitisation, ranks matches with a simple scorer, and implements versioned namespaced local-storage for favourites and recents.  
- Reworked `src/components/fm/FMCommandPalette.tsx` into a navigation command dialog that uses the new library, supports `Ctrl+K`/`Cmd+K` (with typing-target safeguards), shows grouped `Favourites`/`Recent`/`Results`, allows pin/unpin actions, and records eligible recents on route changes.  
- Added a visible, accessible Search trigger to the global header `src/components/fm/TopStatusBar.tsx` that dispatches the existing command open event and documents the shortcut, preserving the existing shell layout and mobile behaviour.  
- Added unit tests `src/lib/__tests__/navigationProductivity.test.ts` covering alias/search behaviour, sanitisation, recent eligibility, per-account favourite isolation/capping, recents deduping and corrupted-store recovery, and documented the feature in `docs/navigation-and-hub-refactor.md` with scope, persistence and privacy rules.

### Testing

- Type-checking passed via `npm run typecheck` (TypeScript `tsc --noEmit`).  
- New unit tests were added at `src/lib/__tests__/navigationProductivity.test.ts`, but running them in this environment failed because test runner installation failed (`vitest` registry access returned `403 Forbidden`) so they were not executed here.  
- Linting and build commands could not be completed in this environment because dependency installation was incomplete (`@eslint/js` and `vite` were unavailable), so `npx eslint` and `npm run build` did not run to completion.  
- The commit includes all code, tests and documentation required to run the unit tests and full validation locally or in CI once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e8b6416c8325bb91f05abed4786b)