### PR TITLE
Add realtime player presence & discovery (presence service, UI panels, indicators)

### DIFF
--- a/src/components/presence/PresenceDirectoryPanel.tsx
+++ b/src/components/presence/PresenceDirectoryPanel.tsx
@@ -1,0 +1,64 @@
+import { Link } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Users, Radio, Music2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/integrations/supabase/client";
+import { useGameData } from "@/hooks/useGameData";
+import { fetchPresenceDirectory, type PresencePlayer } from "@/services/presenceService";
+import { PresenceIndicator } from "./PresenceIndicator";
+
+export function PresenceDirectoryPanel({ cityId, title = "Live players" }: { cityId?: string | null; title?: string }) {
+  const { profile, currentCity } = useGameData();
+  const [onlineUserIds, setOnlineUserIds] = useState<Set<string>>(new Set());
+  const queryClient = useQueryClient();
+  const effectiveCityId = cityId ?? currentCity?.id ?? null;
+  const queryKey = useMemo(() => ["presence-directory", profile?.id, effectiveCityId, Array.from(onlineUserIds).sort().join(",")], [profile?.id, effectiveCityId, onlineUserIds]);
+  const query = useQuery({ queryKey, queryFn: () => fetchPresenceDirectory(profile?.id, effectiveCityId, onlineUserIds), staleTime: 30_000 });
+
+  useEffect(() => {
+    const channel = supabase.channel("online-users");
+    channel.on("presence", { event: "sync" }, () => {
+      const state = channel.presenceState<{ user_id?: string }>();
+      setOnlineUserIds(new Set(Object.values(state).flat().map((p: any) => p.user_id).filter(Boolean)));
+    }).subscribe();
+    return () => { void supabase.removeChannel(channel); };
+  }, []);
+
+  useEffect(() => {
+    const channel = supabase.channel(`presence-directory:${effectiveCityId ?? "global"}`)
+      .on("postgres_changes", { event: "*", schema: "public", table: "profile_activity_statuses" }, () => queryClient.invalidateQueries({ queryKey: ["presence-directory"] }))
+      .on("postgres_changes", { event: "*", schema: "public", table: "activity_feed" }, () => queryClient.invalidateQueries({ queryKey: ["presence-directory"] }))
+      .subscribe();
+    return () => { void supabase.removeChannel(channel); };
+  }, [effectiveCityId, queryClient]);
+
+  const data = query.data;
+  const visible = data?.friends.length ? data.friends : data?.city.length ? data.city : data?.recentlyActive ?? [];
+  return <Card>
+    <CardHeader><CardTitle className="flex items-center gap-2"><Radio className="h-5 w-5 text-primary" />{title}</CardTitle><CardDescription>Friends, nearby players and active sessions update live without polling.</CardDescription></CardHeader>
+    <CardContent className="space-y-4">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {Object.entries(data?.counts ?? {}).filter(([, n]) => n > 0).slice(0, 8).map(([state, count]) => <Badge key={state} variant="outline" className="justify-between capitalize"><span>{state.replace("_", " ")}</span><span>{count}</span></Badge>)}
+        {!data && <span className="text-sm text-muted-foreground">Loading live population…</span>}
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {visible.slice(0, 9).map((player) => <PresencePlayerRow key={player.id} player={player} />)}
+      </div>
+      {visible.length === 0 && <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">No friends are live right now — showing recently active and nearby players as soon as they appear.</div>}
+      <div className="flex flex-wrap gap-2"><Button asChild size="sm" variant="secondary"><Link to="/players/search"><Users className="mr-1 h-4 w-4" />Find players</Link></Button><Button asChild size="sm" variant="outline"><Link to="/social/recruitment"><Music2 className="mr-1 h-4 w-4" />Collaborate</Link></Button></div>
+    </CardContent>
+  </Card>;
+}
+
+function PresencePlayerRow({ player }: { player: PresencePlayer }) {
+  const name = player.displayName || player.username || "Player";
+  return <Link to={`/players/${player.id}`} className="flex min-w-0 items-center gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50">
+    <Avatar className="h-10 w-10"><AvatarImage src={player.avatarUrl ?? undefined} /><AvatarFallback>{name.slice(0, 2).toUpperCase()}</AvatarFallback></Avatar>
+    <span className="min-w-0 flex-1"><span className="block truncate font-medium">{name}</span><span className="block truncate text-xs text-muted-foreground">{player.activity || player.cityName || "Available to meet"}</span></span>
+    <PresenceIndicator state={player.presence} showLabel={false} />
+  </Link>;
+}

--- a/src/components/presence/PresenceIndicator.tsx
+++ b/src/components/presence/PresenceIndicator.tsx
@@ -1,0 +1,10 @@
+import { cn } from "@/lib/utils";
+import { PRESENCE_LABELS, type PlayerPresenceState } from "@/services/presenceService";
+
+const COLORS: Record<PlayerPresenceState, string> = {
+  online: "bg-emerald-500", idle: "bg-amber-400", busy: "bg-rose-500", travelling: "bg-sky-500", recording: "bg-purple-500", rehearsing: "bg-indigo-500", performing: "bg-pink-500", working: "bg-blue-500", offline: "bg-muted-foreground/40", recently_online: "bg-lime-500",
+};
+
+export function PresenceIndicator({ state, className, showLabel = true }: { state: PlayerPresenceState; className?: string; showLabel?: boolean }) {
+  return <span className={cn("inline-flex items-center gap-1.5 text-xs font-medium", className)} aria-label={`Presence: ${PRESENCE_LABELS[state]}`}><span className={cn("h-2.5 w-2.5 rounded-full ring-2 ring-background", COLORS[state])} aria-hidden="true" />{showLabel ? PRESENCE_LABELS[state] : <span className="sr-only">{PRESENCE_LABELS[state]}</span>}</span>;
+}

--- a/src/pages/City.tsx
+++ b/src/pages/City.tsx
@@ -34,6 +34,7 @@ import { CityTransportSection } from "@/components/city/CityTransportSection";
 import { CityMusicSceneCard } from "@/components/city/CityMusicSceneCard";
 import { CityCostBreakdown } from "@/components/city/CityCostBreakdown";
 import { CityGovernanceSection } from "@/components/city/CityGovernanceSection";
+import { PresenceDirectoryPanel } from "@/components/presence/PresenceDirectoryPanel";
 
 type CityRouteParams = {
   cityId?: string;
@@ -327,6 +328,8 @@ export const CityContent = ({
           </div>
         </div>
       </header>
+
+      <PresenceDirectoryPanel cityId={city.id} title={`${city.name} live population`} />
 
       {/* Music Scene & Cost Cards */}
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { sendBandInvitation } from "@/services/bandInvitations";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -21,6 +20,8 @@ import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { sendFriendRequest } from "@/integrations/supabase/friends";
 import { getPublicProfileDetail } from "@/services/publicProfileDetail";
 import { sendBandInvitation, friendlyBandInvitationError } from "@/services/bandInvitations";
+import { PresenceIndicator } from "@/components/presence/PresenceIndicator";
+import { mergePresenceProfiles } from "@/services/presenceService";
 
 const INSTRUMENTS = ['Guitar', 'Bass', 'Drums', 'Keyboard', 'Other'];
 const VOCAL_ROLES = ['Lead Vocals', 'Backing Vocals', 'None'];
@@ -58,6 +59,16 @@ export default function PlayerProfile() {
   });
 
   // Friendship status
+  const { data: profilePresence } = useQuery({
+    queryKey: ["player-profile-presence", playerId],
+    queryFn: async () => {
+      if (!playerId || !profile) return null;
+      const { data } = await supabase.from("profile_activity_statuses").select("profile_id,activity_type,status,started_at,updated_at,ends_at,metadata").eq("profile_id", playerId).is("completed_at", null).order("updated_at", { ascending: false }).limit(1).maybeSingle();
+      return mergePresenceProfiles([{ id: profile.id, user_id: profile.user_id, username: profile.username, display_name: profile.display_name, avatar_url: profile.avatar_url, city_name: profile.city_name, updated_at: profile.created_at } as any], data ? [data as any] : [], new Set())[0];
+    },
+    enabled: !!playerId && !!profile,
+  });
+
   const { data: friendship } = useQuery({
     queryKey: ["friendship-status", currentUser?.id, playerId],
     queryFn: async () => {
@@ -239,6 +250,7 @@ export default function PlayerProfile() {
                     <h1 className="text-2xl font-bold">
                       {profile.display_name || profile.username}
                     </h1>
+                    {profilePresence && <PresenceIndicator state={profilePresence.presence} />}
                   </div>
                   {profile.display_name && (
                     <p className="text-muted-foreground text-sm">@{profile.username}</p>
@@ -359,6 +371,7 @@ export default function PlayerProfile() {
                 </span>
               </div>
 
+              {profilePresence?.activity && <p className="text-sm font-medium text-primary">{profilePresence.activity}</p>}
               {profile.bio && <p className="text-sm">{profile.bio}</p>}
             </div>
           </div>

--- a/src/pages/hubs/SocialHub.tsx
+++ b/src/pages/hubs/SocialHub.tsx
@@ -1,4 +1,5 @@
 import { CategoryHub } from "@/components/CategoryHub";
+import { PresenceDirectoryPanel } from "@/components/presence/PresenceDirectoryPanel";
 import {
   Users, Twitter, Video, HandHeart, MessageSquare, Sparkles, Dices,
   Ticket, Skull, Crown, Package, Star,
@@ -6,6 +7,8 @@ import {
 
 export default function SocialHub() {
   return (
+    <div className="space-y-4">
+      <PresenceDirectoryPanel title="Friends online now" />
     <CategoryHub
       titleKey="nav.social"
       description="People, peer platforms, nightlife, and premium goods."
@@ -44,5 +47,6 @@ export default function SocialHub() {
         },
       ]}
     />
+    </div>
   );
 }

--- a/src/pages/hubs/WorldOverview.tsx
+++ b/src/pages/hubs/WorldOverview.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageErrorState, PageLoadingState } from "@/components/ui/page-state";
+import { PresenceDirectoryPanel } from "@/components/presence/PresenceDirectoryPanel";
 import { worldHubNavigation } from "@/config/hubNavigation";
 import { useGameData } from "@/hooks/useGameData";
 import { useTravelStatus } from "@/hooks/useTravelStatus";
@@ -61,6 +62,7 @@ export default function WorldOverview() {
       {error ? <PageErrorState title="World data could not be loaded" description="The hub is still available; retry to reload local discovery cards." onRetry={() => { void localQuery.refetch(); void citiesQuery.refetch(); }} /> : null}
       {!isLoading && !error ? (
         <div className="space-y-4">
+          <PresenceDirectoryPanel cityId={currentCityId} title={cityName ? `${cityName} live population` : "Live population"} />
           <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
             <Card>
               <CardHeader><CardTitle className="flex items-center gap-2"><MapPin className="h-5 w-5" /> Current location</CardTitle><CardDescription>Authoritative profile location and current travel state.</CardDescription></CardHeader>

--- a/src/services/__tests__/presenceService.test.ts
+++ b/src/services/__tests__/presenceService.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { describeActivity, mergePresenceProfiles, normalizePresenceState } from "../presenceService";
+
+describe("presenceService", () => {
+  it("normalizes gameplay activities into consistent presence states", () => {
+    expect(normalizePresenceState("travel", "active", false)).toBe("travelling");
+    expect(normalizePresenceState("studio_recording", "active", false)).toBe("recording");
+    expect(normalizePresenceState("band_rehearsal", "active", false)).toBe("rehearsing");
+    expect(normalizePresenceState("gig", "performing", false)).toBe("performing");
+    expect(normalizePresenceState(null, null, true)).toBe("online");
+  });
+
+  it("keeps recently seen players out of the offline bucket", () => {
+    expect(normalizePresenceState(null, null, false, new Date().toISOString())).toBe("recently_online");
+  });
+
+  it("builds privacy-safe activity summaries from public metadata", () => {
+    expect(describeActivity({ profile_id: "p1", activity_type: "recording", status: "active", metadata: { song_title: "Static Hearts" } })).toBe("Recording “Static Hearts”");
+    expect(describeActivity({ profile_id: "p1", activity_type: "travel", status: "active", metadata: { destination_city_name: "London" } })).toBe("Travelling to London");
+  });
+
+  it("merges profiles, realtime presence, activity status and collaboration availability", () => {
+    const players = mergePresenceProfiles(
+      [{ id: "p1", user_id: "u1", username: "riley", city_name: "London", looking_for_band: true }],
+      [{ profile_id: "p1", activity_type: "practice", status: "active", metadata: { skill_name: "guitar" } }],
+      new Set(["u1"]),
+    );
+    expect(players[0]).toMatchObject({ id: "p1", presence: "rehearsing", activity: "Practising guitar", availableForCollaboration: true });
+  });
+});

--- a/src/services/presenceService.ts
+++ b/src/services/presenceService.ts
@@ -1,0 +1,120 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type PlayerPresenceState = "online" | "idle" | "busy" | "travelling" | "recording" | "rehearsing" | "performing" | "working" | "offline" | "recently_online";
+
+export interface PresencePlayer {
+  id: string;
+  userId?: string | null;
+  username?: string | null;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  cityName?: string | null;
+  presence: PlayerPresenceState;
+  activity?: string | null;
+  activityDetail?: string | null;
+  lastSeenAt?: string | null;
+  availableForCollaboration?: boolean;
+}
+
+export interface PresenceDirectory {
+  friends: PresencePlayer[];
+  city: PresencePlayer[];
+  recentlyActive: PresencePlayer[];
+  collaborating: PresencePlayer[];
+  counts: Record<Exclude<PlayerPresenceState, "offline">, number>;
+}
+
+type StatusRow = { profile_id: string; activity_type: string; status: string; started_at?: string | null; updated_at?: string | null; ends_at?: string | null; metadata?: any };
+type ProfileRow = { id: string; user_id?: string | null; username?: string | null; display_name?: string | null; avatar_url?: string | null; city_name?: string | null; current_city_id?: string | null; updated_at?: string | null; looking_for_band?: boolean | null; available_for_collaboration?: boolean | null };
+
+export const PRESENCE_LABELS: Record<PlayerPresenceState, string> = {
+  online: "Online",
+  idle: "Idle",
+  busy: "Busy",
+  travelling: "Travelling",
+  recording: "Recording",
+  rehearsing: "Rehearsing",
+  performing: "Performing",
+  working: "Working",
+  offline: "Offline",
+  recently_online: "Recently Online",
+};
+
+const RECENT_MINUTES = 60 * 24;
+
+export function normalizePresenceState(activityType?: string | null, status?: string | null, isRealtimeOnline = false, lastSeenAt?: string | null): PlayerPresenceState {
+  const raw = `${activityType ?? ""} ${status ?? ""}`.toLowerCase();
+  if (raw.includes("travel")) return "travelling";
+  if (raw.includes("record")) return "recording";
+  if (raw.includes("rehears") || raw.includes("practice")) return "rehearsing";
+  if (raw.includes("gig") || raw.includes("perform") || raw.includes("concert")) return "performing";
+  if (raw.includes("work") || raw.includes("job") || raw.includes("company")) return "working";
+  if (raw.includes("busy")) return "busy";
+  if (raw.includes("idle") || raw.includes("away")) return "idle";
+  if (isRealtimeOnline) return "online";
+  if (lastSeenAt && Date.now() - new Date(lastSeenAt).getTime() < RECENT_MINUTES * 60_000) return "recently_online";
+  return "offline";
+}
+
+export function describeActivity(row?: StatusRow | null): string | null {
+  if (!row) return null;
+  const raw = `${row.activity_type} ${row.status}`.toLowerCase();
+  const meta = row.metadata && typeof row.metadata === "object" ? row.metadata : {};
+  if (raw.includes("travel")) return meta.destination_city_name ? `Travelling to ${meta.destination_city_name}` : "Travelling";
+  if (raw.includes("record")) return meta.song_title ? `Recording “${meta.song_title}”` : "Recording new music";
+  if (raw.includes("rehears") || raw.includes("practice")) return meta.skill_name ? `Practising ${meta.skill_name}` : "Rehearsing";
+  if (raw.includes("gig") || raw.includes("perform")) return meta.venue_name ? `Playing a gig at ${meta.venue_name}` : "Performing a gig";
+  if (raw.includes("company")) return "Working at a company";
+  if (raw.includes("band_recruitment")) return "Looking for members";
+  return row.status ? row.status.replace(/_/g, " ") : row.activity_type.replace(/_/g, " ");
+}
+
+export function mergePresenceProfiles(profiles: ProfileRow[], statuses: StatusRow[], onlineUserIds: Set<string>): PresencePlayer[] {
+  const statusByProfile = new Map(statuses.map((status) => [status.profile_id, status]));
+  return profiles.map((profile) => {
+    const status = statusByProfile.get(profile.id);
+    const lastSeenAt = status?.updated_at ?? status?.started_at ?? profile.updated_at ?? null;
+    return {
+      id: profile.id,
+      userId: profile.user_id,
+      username: profile.username,
+      displayName: profile.display_name,
+      avatarUrl: profile.avatar_url,
+      cityName: profile.city_name,
+      presence: normalizePresenceState(status?.activity_type, status?.status, !!profile.user_id && onlineUserIds.has(profile.user_id), lastSeenAt),
+      activity: describeActivity(status),
+      activityDetail: status?.activity_type ?? null,
+      lastSeenAt,
+      availableForCollaboration: Boolean(profile.available_for_collaboration ?? profile.looking_for_band),
+    };
+  });
+}
+
+export async function fetchPresenceDirectory(viewerProfileId?: string | null, cityId?: string | null, onlineUserIds: Set<string> = new Set()): Promise<PresenceDirectory> {
+  const friendIds = new Set<string>();
+  if (viewerProfileId) {
+    const { data } = await supabase.from("friendships").select("requestor_id, addressee_id, status").or(`requestor_id.eq.${viewerProfileId},addressee_id.eq.${viewerProfileId}`).eq("status", "accepted");
+    (data ?? []).forEach((row: any) => friendIds.add(row.requestor_id === viewerProfileId ? row.addressee_id : row.requestor_id));
+  }
+
+  const profileIds = Array.from(friendIds);
+  let profilesQuery = supabase.from("profiles").select("id,user_id,username,display_name,avatar_url,city_name,current_city_id,updated_at,looking_for_band").limit(36);
+  if (cityId) profilesQuery = profilesQuery.eq("current_city_id", cityId);
+  const [cityProfiles, friendProfiles, statusesResult] = await Promise.all([
+    profilesQuery,
+    profileIds.length ? supabase.from("profiles").select("id,user_id,username,display_name,avatar_url,city_name,current_city_id,updated_at,looking_for_band").in("id", profileIds) : Promise.resolve({ data: [], error: null }),
+    supabase.from("profile_activity_statuses").select("profile_id,activity_type,status,started_at,updated_at,ends_at,metadata").is("completed_at", null).order("updated_at", { ascending: false }).limit(120),
+  ]);
+  if (cityProfiles.error) throw cityProfiles.error;
+  if ((friendProfiles as any).error) throw (friendProfiles as any).error;
+  if (statusesResult.error) throw statusesResult.error;
+  const statuses = (statusesResult.data ?? []) as StatusRow[];
+  const map = new Map<string, ProfileRow>();
+  [...((cityProfiles.data ?? []) as ProfileRow[]), ...(((friendProfiles as any).data ?? []) as ProfileRow[])].forEach((p) => map.set(p.id, p));
+  const players = mergePresenceProfiles(Array.from(map.values()), statuses, onlineUserIds).filter((p) => p.id !== viewerProfileId);
+  const activeRank = (p: PresencePlayer) => p.presence === "offline" ? 2 : p.presence === "recently_online" ? 1 : 0;
+  const sorted = [...players].sort((a, b) => activeRank(a) - activeRank(b));
+  const counts = { online: 0, idle: 0, busy: 0, travelling: 0, recording: 0, rehearsing: 0, performing: 0, working: 0, recently_online: 0 };
+  sorted.forEach((p) => { if (p.presence !== "offline") counts[p.presence] += 1; });
+  return { friends: sorted.filter((p) => friendIds.has(p.id)).slice(0, 12), city: sorted.filter((p) => p.presence !== "offline").slice(0, 18), recentlyActive: sorted.filter((p) => p.presence === "recently_online" || p.presence === "offline").slice(0, 8), collaborating: sorted.filter((p) => p.availableForCollaboration).slice(0, 8), counts };
+}


### PR DESCRIPTION
### Motivation

- Make the world feel alive by surfacing who is online, where they are, and what they are doing using existing realtime infrastructure. 
- Provide a reusable presence abstraction so multiple surfaces (hubs, city pages, profiles) can consume a single source of truth for presence and activity. 

### Description

- Added a reusable presence service `src/services/presenceService.ts` that normalizes activity rows into consistent states (`online`, `idle`, `busy`, `travelling`, `recording`, `rehearsing`, `performing`, `working`, `offline`, `recently_online`), builds privacy-safe activity descriptions, merges realtime online users with profile/status rows, and returns discovery buckets and counts via `fetchPresenceDirectory` and `mergePresenceProfiles`.
- Added an accessible presence indicator component `src/components/presence/PresenceIndicator.tsx` with screen-reader labels and color-coded states for consistent UI across the app.
- Added a reusable live presence directory panel `src/components/presence/PresenceDirectoryPanel.tsx` that subscribes to the Supabase `online-users` presence channel and watches `profile_activity_statuses` / `activity_feed` Postgres changes to invalidate and refresh discovery results without polling.
- Surface presence across the UI by embedding the panel or indicator in existing pages: Social hub (`src/pages/hubs/SocialHub.tsx`), World overview (`src/pages/hubs/WorldOverview.tsx`), City page (`src/pages/City.tsx`), and Player profile (`src/pages/PlayerProfile.tsx`).
- Added unit tests covering normalization, activity description generation, and merging logic in `src/services/__tests__/presenceService.test.ts`.

### Testing

- `npm run typecheck` (`tsc --noEmit`) passed locally in this environment.
- Unit tests could not be executed here because the test runner (`vitest`) is not available in the execution environment; the new unit file `src/services/__tests__/presenceService.test.ts` is included for CI/maintainers to run with `npm run test:unit` or `vitest`.
- Linting was not fully run here because `npm install` failed to complete in the environment (external registry/permission issues) so ESLint dependencies were not available; maintainers should run `npm install` and `npm run lint` in CI or locally to validate formatting and lint rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54eb06d2a48325be37876662e5d7e3)