### PR TITLE
Add storage-agnostic marketplace & contract framework

### DIFF
--- a/docs/marketplace-contract-framework.md
+++ b/docs/marketplace-contract-framework.md
@@ -1,0 +1,115 @@
+# Marketplace and Contract Framework
+
+RockMundo's MMO economy uses a shared marketplace and contract framework so gameplay systems can trade, hire, commission and collaborate without each feature inventing bespoke transaction logic.
+
+## Architecture
+
+The framework separates these concepts:
+
+- **Marketplace listings** describe availability or intent: instruments for sale, venue hire, session work, teaching, artwork commissions, studio time and future non-physical services.
+- **Contract offers** are proposed agreements between two entities. They may originate from a listing or be direct offers.
+- **Negotiations** are contract revisions. Every counter offer increments the revision and records a negotiation history event.
+- **Accepted contracts** are commitments that have passed permission, availability and funds checks.
+- **Completed, cancelled and expired contracts** are terminal operational states that can later be archived as historical contracts.
+- **Historical contracts** preserve the audit trail for reputation, disputes and analytics.
+
+The pure TypeScript service in `src/utils/marketplaceFramework.ts` is intentionally storage-agnostic. Database tables, Supabase RPCs or server actions can call the same validation and transition helpers.
+
+## Entity model
+
+All owners and counterparties use a generic entity reference:
+
+```ts
+{ type: "player" | "band" | "company" | "venue" | "festival" | "studio" | "organisation" | "npc" | string, id: string }
+```
+
+This supports Player, Band, Company, Venue, Festival, Studio, Organisation, NPC and future entity types without schema redesign.
+
+## Listing lifecycle
+
+Supported listing states are:
+
+1. `draft`
+2. `published`
+3. `hidden`
+4. `paused`
+5. `accepted`
+6. `completed`
+7. `cancelled`
+8. `expired`
+
+Allowed transitions are encoded in `listingTransitions`. Invalid transitions throw `MarketplaceTransitionError` and every valid transition writes a `MarketplaceHistoryEvent`.
+
+## Contract architecture
+
+Contract templates define reusable defaults for categories such as session musician, producer, songwriter, transport hire, venue hire, teaching, artwork, security or tour management.
+
+Supported payment and agreement shapes include:
+
+- Fixed price
+- Salary
+- Revenue share
+- Royalty percentage
+- Commission
+- Time-based employment
+- One-off agreement
+- Ongoing agreement
+- Recurring payment
+
+Contract states are `offer`, `negotiating`, `accepted`, `completed`, `cancelled`, `expired` and `historical`.
+
+## Permission model
+
+The server must never trust client ownership. Actors carry server-derived roles for specific entities. Examples:
+
+- Band leaders can create band listings when granted `listing:create`.
+- Company managers can negotiate company service contracts when granted `contract:negotiate`.
+- Festival organisers and venue managers can publish listings only for their authorised entities.
+- Delegates can receive narrow permissions without becoming owners.
+
+All creation and transition helpers call permission checks before changing state.
+
+## Security checks
+
+Server-side callers should validate:
+
+- Ownership and delegated permissions.
+- Listing availability windows and capacity.
+- Existing commitments before acceptance.
+- Funds for payment-bearing terms.
+- State transition legality.
+
+The framework includes permission, availability, funds and transition guards. Future persistence adapters should execute these checks in trusted server contexts and mirror critical constraints in database RLS or RPC functions.
+
+## Negotiation support
+
+`reviseContractOffer` replaces terms, increments `revision`, records a negotiation audit event and moves the contract to `negotiating`. This supports future counter offers, price negotiation, duration negotiation, payment negotiation and multiple revisions.
+
+## Notifications and social integration
+
+The framework emits integration events rather than sending messages directly:
+
+- `messages` for direct contract offers.
+- `notifications` for listing state changes.
+- `activity_feed` for accepted contracts.
+- `social_hub` is reserved for future public collaboration updates.
+
+Existing messaging, notification, activity feed and social hub systems should consume these events instead of duplicating communication logic.
+
+## Reputation hooks
+
+The framework exposes reputation hook events for:
+
+- Successful contracts
+- Cancelled contracts
+- Late delivery
+- Failed work
+- Reliability
+- Professionalism
+- Player reviews
+
+This PR records success and cancellation hooks. Later review and dispute systems can consume the same event shape.
+
+## Extension points
+
+Future gameplay features should add domain-specific metadata while reusing core listings, templates, terms, permission checks, negotiation revisions, notifications and audit history. Examples include instrument sales, clothing, cosmetics, song rights, publishing rights, merchandise, studio bookings, recruitment, transport hire, festival bookings, equipment rental, lessons, designers, photographers, journalists, agencies, security, tour managers and crew.

--- a/src/utils/__tests__/marketplaceFramework.test.ts
+++ b/src/utils/__tests__/marketplaceFramework.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MarketplaceSecurityError,
+  MarketplaceTransitionError,
+  createContractOffer,
+  createEmptyMarketplaceState,
+  createMarketplaceListing,
+  reviseContractOffer,
+  transitionContract,
+  transitionListing,
+  type MarketplaceActor,
+  type MarketplaceEntityRef,
+} from "@/utils/marketplaceFramework";
+
+const band: MarketplaceEntityRef = { type: "band", id: "band-1" };
+const company: MarketplaceEntityRef = { type: "company", id: "company-1" };
+
+const leader: MarketplaceActor = {
+  playerId: "player-1",
+  funds: 5000,
+  roles: [
+    {
+      entity: band,
+      role: "leader",
+      permissions: ["listing:create", "listing:manage", "contract:create", "contract:negotiate", "contract:accept", "contract:cancel"],
+    },
+  ],
+};
+
+const manager: MarketplaceActor = {
+  playerId: "player-2",
+  funds: 10000,
+  roles: [
+    {
+      entity: company,
+      role: "manager",
+      permissions: ["listing:create", "listing:manage", "contract:create", "contract:negotiate", "contract:accept", "contract:cancel"],
+    },
+  ],
+};
+
+const outsider: MarketplaceActor = { playerId: "player-3", roles: [] };
+
+const fixedTerms = {
+  paymentType: "fixed_price" as const,
+  durationType: "one_off" as const,
+  amount: 1200,
+  currency: "RM$",
+  deliverables: ["record guitar session"],
+};
+
+describe("marketplace framework", () => {
+  it("records the listing lifecycle and prevents invalid transitions", () => {
+    const state = createEmptyMarketplaceState();
+    const listing = createMarketplaceListing(state, leader, { owner: band, kind: "session_musician", title: "Lead guitarist for hire", terms: fixedTerms });
+
+    expect(listing.status).toBe("draft");
+    transitionListing(state, leader, listing.id, "published");
+    transitionListing(state, leader, listing.id, "paused");
+    transitionListing(state, leader, listing.id, "published");
+    transitionListing(state, leader, listing.id, "accepted");
+    transitionListing(state, leader, listing.id, "completed");
+
+    expect(state.history.map((event) => event.toStatus)).toEqual(["draft", "published", "paused", "published", "accepted", "completed"]);
+    expect(() => transitionListing(state, leader, listing.id, "published")).toThrow(MarketplaceTransitionError);
+  });
+
+  it("validates delegated permissions server-side instead of trusting client ownership", () => {
+    const state = createEmptyMarketplaceState();
+
+    expect(() =>
+      createMarketplaceListing(state, outsider, { owner: band, kind: "instrument_sale", title: "Vintage bass", terms: fixedTerms })
+    ).toThrow(MarketplaceSecurityError);
+
+    const listing = createMarketplaceListing(state, leader, { owner: band, kind: "instrument_sale", title: "Vintage bass", terms: fixedTerms });
+    expect(() => transitionListing(state, outsider, listing.id, "published")).toThrow(MarketplaceSecurityError);
+  });
+
+  it("creates, negotiates, accepts, cancels and histories contract offers", () => {
+    const state = createEmptyMarketplaceState();
+    const contract = createContractOffer(state, leader, { from: band, to: company, terms: fixedTerms, templateId: "session-player-v1" });
+
+    expect(contract.status).toBe("offer");
+    expect(state.notifications).toContainEqual(expect.objectContaining({ channel: "messages", type: "contract.offer_created" }));
+
+    reviseContractOffer(state, manager, contract.id, { ...fixedTerms, amount: 1500 });
+    transitionContract(state, manager, contract.id, "accepted");
+    transitionContract(state, leader, contract.id, "cancelled", "artist unavailable");
+
+    expect(contract.revision).toBe(2);
+    expect(state.history.map((event) => event.toStatus)).toEqual(["offer", "negotiating", "accepted", "cancelled"]);
+    expect(state.reputationEvents).toContainEqual(expect.objectContaining({ type: "contract_cancelled", contractId: contract.id }));
+  });
+
+  it("checks funds and availability before commitments", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T00:00:00Z"));
+    const state = createEmptyMarketplaceState();
+    const brokeActor: MarketplaceActor = { ...leader, funds: 100 };
+
+    expect(() => createContractOffer(state, brokeActor, { from: band, to: company, terms: fixedTerms })).toThrow(MarketplaceSecurityError);
+
+    const listing = createMarketplaceListing(state, leader, {
+      owner: band,
+      kind: "studio_booking",
+      title: "Studio A evening slot",
+      terms: fixedTerms,
+      availability: { endsAt: "2026-07-12T23:59:59Z", capacity: 1, committed: 0 },
+    });
+
+    expect(() => transitionListing(state, leader, listing.id, "published")).toThrow(MarketplaceSecurityError);
+    vi.useRealTimers();
+  });
+
+  it("emits notification and reputation integration hooks without duplicating those systems", () => {
+    const state = createEmptyMarketplaceState();
+    const contract = createContractOffer(state, leader, { from: band, to: company, terms: fixedTerms });
+
+    transitionContract(state, manager, contract.id, "accepted");
+    transitionContract(state, leader, contract.id, "completed");
+
+    expect(state.notifications.some((event) => event.channel === "activity_feed" && event.type === "contract.accepted")).toBe(true);
+    expect(state.reputationEvents).toEqual([expect.objectContaining({ type: "contract_succeeded", contractId: contract.id })]);
+  });
+});

--- a/src/utils/marketplaceFramework.ts
+++ b/src/utils/marketplaceFramework.ts
@@ -1,0 +1,244 @@
+export type MarketplaceEntityType =
+  | "player"
+  | "band"
+  | "company"
+  | "venue"
+  | "festival"
+  | "studio"
+  | "organisation"
+  | "npc"
+  | (string & {});
+
+export interface MarketplaceEntityRef {
+  type: MarketplaceEntityType;
+  id: string;
+}
+
+export type MarketplaceActorRole = "owner" | "leader" | "manager" | "organiser" | "delegate";
+
+export interface MarketplaceActor {
+  playerId: string;
+  funds?: number;
+  roles: Array<{ entity: MarketplaceEntityRef; role: MarketplaceActorRole; permissions: MarketplacePermission[] }>;
+}
+
+export type MarketplacePermission =
+  | "listing:create"
+  | "listing:manage"
+  | "listing:accept"
+  | "contract:create"
+  | "contract:negotiate"
+  | "contract:accept"
+  | "contract:cancel";
+
+export type ListingStatus = "draft" | "published" | "hidden" | "paused" | "accepted" | "completed" | "cancelled" | "expired";
+export type ContractStatus = "offer" | "negotiating" | "accepted" | "completed" | "cancelled" | "expired" | "historical";
+export type ContractPaymentType =
+  | "fixed_price"
+  | "salary"
+  | "revenue_share"
+  | "royalty_percentage"
+  | "commission"
+  | "recurring_payment";
+export type ContractDurationType = "one_off" | "time_based_employment" | "ongoing_agreement";
+
+export interface ContractTerms {
+  paymentType: ContractPaymentType;
+  durationType: ContractDurationType;
+  amount?: number;
+  percentage?: number;
+  currency?: string;
+  startsAt?: string;
+  endsAt?: string;
+  recurrence?: "daily" | "weekly" | "monthly";
+  deliverables?: string[];
+}
+
+export interface ContractTemplate {
+  id: string;
+  name: string;
+  category: string;
+  defaultTerms: ContractTerms;
+  requiredPermissions?: MarketplacePermission[];
+}
+
+export interface MarketplaceListing {
+  id: string;
+  kind: string;
+  owner: MarketplaceEntityRef;
+  createdBy: string;
+  status: ListingStatus;
+  title: string;
+  terms: ContractTerms;
+  availability?: { startsAt?: string; endsAt?: string; capacity?: number; committed?: number };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ContractOffer {
+  id: string;
+  listingId?: string;
+  templateId?: string;
+  from: MarketplaceEntityRef;
+  to: MarketplaceEntityRef;
+  terms: ContractTerms;
+  status: ContractStatus;
+  revision: number;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MarketplaceHistoryEvent {
+  id: string;
+  targetType: "listing" | "contract" | "negotiation";
+  targetId: string;
+  fromStatus?: ListingStatus | ContractStatus;
+  toStatus: ListingStatus | ContractStatus;
+  actorId: string;
+  reason?: string;
+  at: string;
+}
+
+export interface MarketplaceNotificationEvent {
+  channel: "messages" | "notifications" | "activity_feed" | "social_hub";
+  type: string;
+  target: MarketplaceEntityRef;
+  payload: Record<string, unknown>;
+}
+
+export interface ReputationHookEvent {
+  type: "contract_succeeded" | "contract_cancelled" | "late_delivery" | "failed_work" | "reliability" | "professionalism" | "player_review";
+  contractId: string;
+  actors: MarketplaceEntityRef[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MarketplaceState {
+  listings: MarketplaceListing[];
+  contracts: ContractOffer[];
+  history: MarketplaceHistoryEvent[];
+  notifications: MarketplaceNotificationEvent[];
+  reputationEvents: ReputationHookEvent[];
+}
+
+export class MarketplaceSecurityError extends Error {}
+export class MarketplaceTransitionError extends Error {}
+
+const listingTransitions: Record<ListingStatus, ListingStatus[]> = {
+  draft: ["published", "cancelled"],
+  published: ["hidden", "paused", "accepted", "cancelled", "expired"],
+  hidden: ["published", "cancelled", "expired"],
+  paused: ["published", "cancelled", "expired"],
+  accepted: ["completed", "cancelled"],
+  completed: [],
+  cancelled: [],
+  expired: [],
+};
+
+const contractTransitions: Record<ContractStatus, ContractStatus[]> = {
+  offer: ["negotiating", "accepted", "cancelled", "expired"],
+  negotiating: ["offer", "accepted", "cancelled", "expired"],
+  accepted: ["completed", "cancelled"],
+  completed: ["historical"],
+  cancelled: ["historical"],
+  expired: ["historical"],
+  historical: [],
+};
+
+const sameEntity = (a: MarketplaceEntityRef, b: MarketplaceEntityRef) => a.type === b.type && a.id === b.id;
+const nowIso = () => new Date().toISOString();
+const id = (prefix: string) => `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+
+export function hasMarketplacePermission(actor: MarketplaceActor, entity: MarketplaceEntityRef, permission: MarketplacePermission): boolean {
+  return actor.roles.some((role) => sameEntity(role.entity, entity) && role.permissions.includes(permission));
+}
+
+export function assertMarketplacePermission(actor: MarketplaceActor, entity: MarketplaceEntityRef, permission: MarketplacePermission): void {
+  if (!hasMarketplacePermission(actor, entity, permission)) {
+    throw new MarketplaceSecurityError(`Player ${actor.playerId} is not authorised to ${permission} for ${entity.type}:${entity.id}`);
+  }
+}
+
+export function validateAvailability(listing: MarketplaceListing): void {
+  const { availability } = listing;
+  if (!availability) return;
+  if (availability.endsAt && new Date(availability.endsAt).getTime() < Date.now()) throw new MarketplaceSecurityError("Listing availability has expired");
+  if (availability.capacity !== undefined && (availability.committed ?? 0) >= availability.capacity) throw new MarketplaceSecurityError("Listing has no remaining availability");
+}
+
+export function validateFunds(actor: MarketplaceActor, terms: ContractTerms): void {
+  const required = terms.amount ?? 0;
+  if (required > 0 && actor.funds !== undefined && actor.funds < required) throw new MarketplaceSecurityError("Actor has insufficient funds");
+}
+
+function pushHistory(state: MarketplaceState, targetType: MarketplaceHistoryEvent["targetType"], targetId: string, toStatus: ListingStatus | ContractStatus, actorId: string, fromStatus?: ListingStatus | ContractStatus, reason?: string) {
+  state.history.push({ id: id("hist"), targetType, targetId, fromStatus, toStatus, actorId, reason, at: nowIso() });
+}
+
+export function createMarketplaceListing(state: MarketplaceState, actor: MarketplaceActor, input: Omit<MarketplaceListing, "id" | "createdBy" | "status" | "createdAt" | "updatedAt"> & { status?: ListingStatus }): MarketplaceListing {
+  assertMarketplacePermission(actor, input.owner, "listing:create");
+  const at = nowIso();
+  const listing: MarketplaceListing = { ...input, id: id("list"), createdBy: actor.playerId, status: input.status ?? "draft", createdAt: at, updatedAt: at };
+  state.listings.push(listing);
+  pushHistory(state, "listing", listing.id, listing.status, actor.playerId, undefined, "created");
+  return listing;
+}
+
+export function transitionListing(state: MarketplaceState, actor: MarketplaceActor, listingId: string, toStatus: ListingStatus, reason?: string): MarketplaceListing {
+  const listing = state.listings.find((item) => item.id === listingId);
+  if (!listing) throw new MarketplaceTransitionError("Listing not found");
+  assertMarketplacePermission(actor, listing.owner, "listing:manage");
+  if (!listingTransitions[listing.status].includes(toStatus)) throw new MarketplaceTransitionError(`Cannot move listing from ${listing.status} to ${toStatus}`);
+  if (toStatus === "published" || toStatus === "accepted") validateAvailability(listing);
+  const from = listing.status;
+  listing.status = toStatus;
+  listing.updatedAt = nowIso();
+  pushHistory(state, "listing", listing.id, toStatus, actor.playerId, from, reason);
+  state.notifications.push({ channel: "notifications", type: `listing.${toStatus}`, target: listing.owner, payload: { listingId } });
+  return listing;
+}
+
+export function createContractOffer(state: MarketplaceState, actor: MarketplaceActor, input: Omit<ContractOffer, "id" | "createdBy" | "status" | "revision" | "createdAt" | "updatedAt"> & { status?: ContractStatus }): ContractOffer {
+  assertMarketplacePermission(actor, input.from, "contract:create");
+  validateFunds(actor, input.terms);
+  const at = nowIso();
+  const contract: ContractOffer = { ...input, id: id("contract"), createdBy: actor.playerId, status: input.status ?? "offer", revision: 1, createdAt: at, updatedAt: at };
+  state.contracts.push(contract);
+  pushHistory(state, "contract", contract.id, contract.status, actor.playerId, undefined, "created");
+  state.notifications.push({ channel: "messages", type: "contract.offer_created", target: input.to, payload: { contractId: contract.id } });
+  return contract;
+}
+
+export function reviseContractOffer(state: MarketplaceState, actor: MarketplaceActor, contractId: string, terms: ContractTerms): ContractOffer {
+  const contract = state.contracts.find((item) => item.id === contractId);
+  if (!contract) throw new MarketplaceTransitionError("Contract not found");
+  if (!hasMarketplacePermission(actor, contract.from, "contract:negotiate") && !hasMarketplacePermission(actor, contract.to, "contract:negotiate")) throw new MarketplaceSecurityError("Actor cannot negotiate this contract");
+  contract.terms = terms;
+  contract.revision += 1;
+  const from = contract.status;
+  contract.status = "negotiating";
+  contract.updatedAt = nowIso();
+  pushHistory(state, "negotiation", contract.id, "negotiating", actor.playerId, from, "revised");
+  return contract;
+}
+
+export function transitionContract(state: MarketplaceState, actor: MarketplaceActor, contractId: string, toStatus: ContractStatus, reason?: string): ContractOffer {
+  const contract = state.contracts.find((item) => item.id === contractId);
+  if (!contract) throw new MarketplaceTransitionError("Contract not found");
+  const permission: MarketplacePermission = toStatus === "accepted" ? "contract:accept" : toStatus === "cancelled" ? "contract:cancel" : "contract:create";
+  if (!hasMarketplacePermission(actor, contract.from, permission) && !hasMarketplacePermission(actor, contract.to, permission)) throw new MarketplaceSecurityError(`Actor cannot ${toStatus} this contract`);
+  if (!contractTransitions[contract.status].includes(toStatus)) throw new MarketplaceTransitionError(`Cannot move contract from ${contract.status} to ${toStatus}`);
+  const from = contract.status;
+  contract.status = toStatus;
+  contract.updatedAt = nowIso();
+  pushHistory(state, "contract", contract.id, toStatus, actor.playerId, from, reason);
+  if (toStatus === "accepted") state.notifications.push({ channel: "activity_feed", type: "contract.accepted", target: contract.from, payload: { contractId } });
+  if (toStatus === "completed") state.reputationEvents.push({ type: "contract_succeeded", contractId, actors: [contract.from, contract.to] });
+  if (toStatus === "cancelled") state.reputationEvents.push({ type: "contract_cancelled", contractId, actors: [contract.from, contract.to], metadata: { reason } });
+  return contract;
+}
+
+export function createEmptyMarketplaceState(): MarketplaceState {
+  return { listings: [], contracts: [], history: [], notifications: [], reputationEvents: [] };
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable, storage-agnostic foundation for a global player marketplace and contract system to power all future economy features (sales, hires, bookings, services, royalties, etc.).
- Avoid duplicated transaction logic across gameplay systems by centralising listings, contract offers, negotiation primitives, permissions and audit history.
- Ensure server-side security and validation so client ownership is never trusted and extension points are available for reputation and notification integration.

### Description

- Add core TypeScript framework in `src/utils/marketplaceFramework.ts` implementing entity refs, actor roles/permissions, listing and contract types, contract templates/terms, lifecycle transition guards, availability/funds validation, history events, notification events and reputation hook events.
- Add unit tests in `src/utils/__tests__/marketplaceFramework.test.ts` covering listing lifecycle transitions, delegated permission checks, contract creation/negotiation/acceptance/cancellation, funds and availability validation, notifications and reputation hooks.
- Add developer documentation `docs/marketplace-contract-framework.md` describing architecture, listing lifecycle, contract shapes, permission model, security checks, negotiation flow, notifications and extension points for future economy items.
- Export small error types (`MarketplaceSecurityError`, `MarketplaceTransitionError`) and helper functions (`createMarketplaceListing`, `transitionListing`, `createContractOffer`, `reviseContractOffer`, `transitionContract`, `createEmptyMarketplaceState`) intended for server-side adapters or persistence layers.

### Testing

- Added unit coverage via `src/utils/__tests__/marketplaceFramework.test.ts` which exercises lifecycle, permission, notification and reputation flows (tests included in the PR).
- Attempted to run `npm run test:unit -- src/utils/__tests__/marketplaceFramework.test.ts` but execution was blocked because `vitest` was not available in the environment (`sh: 1: vitest: not found`).
- Attempted `npm install` to provision deps but it failed due to registry access returning `403 Forbidden` for `@react-three/fiber`, preventing running the test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ed11bf608325b8de28b686111484)