### PR TITLE
feat(social): add player blocking reporting and safety controls

### DIFF
--- a/docs/social-safety-controls.md
+++ b/docs/social-safety-controls.md
@@ -1,0 +1,9 @@
+# Social safety controls
+
+Player blocks are symmetric interaction restrictions even though only one player creates the block. Direct player-to-player actions should call the central social permission RPC/service before creating invitations, messages, transfers, gifts, teaching offers, employment offers or feed interactions.
+
+Blocking removes accepted friendships, cancels pending friend requests, disables pending social notification actions and excludes the pair from server-side discovery/profile queries. The blocked player is not notified and receives neutral unavailable responses.
+
+Blocking does **not** delete historical messages, completed transactions, song/recording/gig credits, band membership, company employment, shared bookings or contracts. Shared gameplay entities should preserve operational records and allow only system-generated updates required for the entity to function while suppressing optional private social context.
+
+Reports are separate from blocks. Reports create immutable evidence snapshots for moderation review, apply duplicate/rate-limit controls, and never disclose reporter identity to the reported player.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,8 @@ const PlayerSearch = lazyWithRetry(() => import("./pages/PlayerSearch"));
 const PlayerDiscovery = lazyWithRetry(() => import("./pages/PlayerDiscovery"));
 const PlayerProfile = lazyWithRetry(() => import("./pages/PlayerProfile"));
 const PlayerProfileEdit = lazyWithRetry(() => import("./pages/PlayerProfileEdit"));
+const BlockedPlayersPage = lazyWithRetry(() => import("./pages/settings/privacy/BlockedPlayersPage"));
+const MyReportsPage = lazyWithRetry(() => import("./pages/settings/safety/MyReportsPage"));
 const BandBrowser = lazyWithRetry(() => import("./pages/BandBrowser"));
 const BandProfile = lazyWithRetry(() => import("./pages/BandProfile"));
 const BandSearch = lazyWithRetry(() => import("./pages/BandSearch"));
@@ -460,6 +462,8 @@ function App() {
                     <Route path="character" element={<CharacterOverview />} />
                     <Route path="character/overview" element={<PreserveQueryRedirect to="/character" />} />
                     <Route path="character/profile/edit" element={<PlayerProfileEdit />} />
+                    <Route path="settings/privacy/blocked-players" element={<BlockedPlayersPage />} />
+                    <Route path="settings/safety/reports" element={<MyReportsPage />} />
                     <Route path="character/wellness" element={<PreserveQueryRedirect to="/wellness" />} />
                     <Route path="character/skills" element={<PreserveQueryRedirect to="/skills" />} />
                     <Route path="character/inventory" element={<PreserveQueryRedirect to="/inventory" />} />

--- a/src/components/social-safety/BlockPlayerDialog.tsx
+++ b/src/components/social-safety/BlockPlayerDialog.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { blockPlayer } from "@/services/social-safety/PlayerBlockService";
+import { BLOCK_CONFIRMATION_COPY, BLOCK_REASON_OPTIONS, type BlockReasonCategory } from "@/services/social-safety/config";
+
+export function BlockPlayerDialog({ targetProfileId, playerName, trigger }: { targetProfileId: string; playerName: string; trigger: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState<BlockReasonCategory | "">("");
+  const [note, setNote] = useState("");
+  const qc = useQueryClient();
+  const { toast } = useToast();
+  const mutation = useMutation({
+    mutationFn: () => blockPlayer({ targetProfileId, reasonCategory: reason || null, privateNote: note }),
+    onSuccess: () => {
+      toast({ title: "Player blocked", description: "Direct social interaction is now restricted." });
+      qc.invalidateQueries({ queryKey: ["friendship-status"] });
+      qc.invalidateQueries({ queryKey: ["player-search"] });
+      qc.invalidateQueries({ queryKey: ["social-permission", targetProfileId] });
+      qc.invalidateQueries({ queryKey: ["blocked-players"] });
+      setOpen(false);
+    },
+    onError: (e: Error) => toast({ title: "Block failed", description: e.message, variant: "destructive" }),
+  });
+  return <Dialog open={open} onOpenChange={setOpen}><DialogTrigger asChild>{trigger}</DialogTrigger><DialogContent aria-describedby="block-player-description"><DialogHeader><DialogTitle>Block {playerName}?</DialogTitle><DialogDescription id="block-player-description">{BLOCK_CONFIRMATION_COPY}</DialogDescription></DialogHeader><div className="space-y-3"><div><Label>Private reason (optional)</Label><Select value={reason} onValueChange={(v) => setReason(v as BlockReasonCategory)}><SelectTrigger><SelectValue placeholder="Select a reason" /></SelectTrigger><SelectContent>{BLOCK_REASON_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}</SelectContent></Select></div><div><Label>Private note (optional)</Label><Textarea maxLength={500} value={note} onChange={(e) => setNote(e.target.value)} placeholder="Only you and authorised moderators can see this." /></div></div><DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button variant="destructive" onClick={() => mutation.mutate()} disabled={mutation.isPending}>{mutation.isPending ? "Blocking…" : "Block player"}</Button></DialogFooter></DialogContent></Dialog>;
+}

--- a/src/components/social-safety/ReportPlayerDialog.tsx
+++ b/src/components/social-safety/ReportPlayerDialog.tsx
@@ -1,0 +1,21 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useToast } from "@/hooks/use-toast";
+import { submitPlayerReport } from "@/services/social-safety/PlayerReportService";
+import { EMERGENCY_SAFETY_COPY, REPORT_CATEGORY_OPTIONS, type ReportCategory } from "@/services/social-safety/config";
+
+export function ReportPlayerDialog({ targetProfileId, playerName, trigger }: { targetProfileId: string; playerName: string; trigger: React.ReactNode }) {
+  const [open, setOpen] = useState(false); const [category, setCategory] = useState<ReportCategory | "">(""); const [description, setDescription] = useState(""); const [accurate, setAccurate] = useState(false); const [blockAfter, setBlockAfter] = useState(false);
+  const qc = useQueryClient(); const { toast } = useToast();
+  const selected = REPORT_CATEGORY_OPTIONS.find((o) => o.value === category);
+  const mutation = useMutation({ mutationFn: () => submitPlayerReport({ reportedProfileId: targetProfileId, category: category as ReportCategory, description, blockAfterReport: blockAfter, context: { surface: "player_profile", submitted_from: window.location.pathname } }), onSuccess: () => { toast({ title: "Your report has been submitted for review." }); qc.invalidateQueries({ queryKey: ["my-reports"] }); qc.invalidateQueries({ queryKey: ["blocked-players"] }); setOpen(false); }, onError: (e: Error) => toast({ title: "Report submission failed", description: e.message, variant: "destructive" }) });
+  const canSubmit = !!category && description.trim().length >= 10 && accurate;
+  return <Dialog open={open} onOpenChange={setOpen}><DialogTrigger asChild>{trigger}</DialogTrigger><DialogContent><DialogHeader><DialogTitle>Report {playerName}</DialogTitle><DialogDescription>Reporting sends information to moderators. Blocking is optional and separate.</DialogDescription></DialogHeader><div className="space-y-3"><div><Label>Report category</Label><Select value={category} onValueChange={(v) => setCategory(v as ReportCategory)}><SelectTrigger><SelectValue placeholder="Choose a category" /></SelectTrigger><SelectContent>{REPORT_CATEGORY_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}</SelectContent></Select></div>{selected?.emergency && <Alert><AlertDescription>{EMERGENCY_SAFETY_COPY}</AlertDescription></Alert>}<div><Label>Description</Label><Textarea value={description} onChange={(e) => setDescription(e.target.value.replace(/[<>]/g, ""))} maxLength={2000} aria-describedby="report-description-help" /><p id="report-description-help" className="text-xs text-muted-foreground">10–2,000 characters. Do not include unnecessary personal information.</p></div><label className="flex items-center gap-2 text-sm"><Checkbox checked={accurate} onCheckedChange={(v) => setAccurate(v === true)} /> I confirm this report is accurate.</label><label className="flex items-center gap-2 text-sm"><Checkbox checked={blockAfter} onCheckedChange={(v) => setBlockAfter(v === true)} /> Also block this player after reporting.</label></div><DialogFooter><Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button><Button onClick={() => mutation.mutate()} disabled={!canSubmit || mutation.isPending}>{mutation.isPending ? "Submitting…" : "Submit report"}</Button></DialogFooter></DialogContent></Dialog>;
+}

--- a/src/hooks/social-safety/useBlockedPlayers.ts
+++ b/src/hooks/social-safety/useBlockedPlayers.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchBlockedPlayers } from "@/services/social-safety/PlayerBlockService";
+
+export function useBlockedPlayers(search: string, page: number) {
+  return useQuery({ queryKey: ["blocked-players", search, page], queryFn: () => fetchBlockedPlayers(search, page) });
+}

--- a/src/hooks/social-safety/useSocialPermission.ts
+++ b/src/hooks/social-safety/useSocialPermission.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSocialPermissions } from "@/services/social-safety/SocialPermissionService";
+
+export function useSocialPermission(targetProfileId?: string | null) {
+  return useQuery({
+    queryKey: ["social-permission", targetProfileId],
+    queryFn: () => getSocialPermissions(targetProfileId!),
+    enabled: !!targetProfileId,
+    staleTime: 30_000,
+  });
+}

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 import {
-  User, Music, Calendar, MapPin, Star, Clock, TrendingUp, Users, UserPlus, UserMinus, AlertCircle, Edit
+  User, Music, Calendar, MapPin, Star, Clock, TrendingUp, Users, UserPlus, UserMinus, AlertCircle, Edit, Ban, Flag
 } from "lucide-react";
 import { format } from "date-fns";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
@@ -16,6 +16,10 @@ import { getPublicProfileDetail } from "@/services/publicProfileDetail";
 import { PlayerProfileHeader, FutureProfileActions } from "@/components/player-profile/PlayerProfileHeader";
 import { ProfileInfoCard, BandProfileCard, EmploymentProfileCard, OpenStatusBadges } from "@/components/player-profile/ProfileCards";
 import { mergePresenceProfiles } from "@/services/presenceService";
+import { useSocialPermission } from "@/hooks/social-safety/useSocialPermission";
+import { BlockPlayerDialog } from "@/components/social-safety/BlockPlayerDialog";
+import { ReportPlayerDialog } from "@/components/social-safety/ReportPlayerDialog";
+import { unblockPlayer } from "@/services/social-safety/PlayerBlockService";
 
 export default function PlayerProfile() {
   const { playerId } = useParams();
@@ -67,6 +71,14 @@ export default function PlayerProfile() {
       return data;
     },
     enabled: !!currentUser?.id && !!playerId && currentUser?.id !== playerId,
+  });
+
+  const { data: socialPermissions } = useSocialPermission(!isCurrentUserLoading && currentUser?.id !== playerId ? playerId : null);
+
+  const unblockMutation = useMutation({
+    mutationFn: async () => { if (!playerId) throw new Error("Missing player"); await unblockPlayer(playerId); },
+    onSuccess: () => { toast({ title: "Player unblocked" }); queryClient.invalidateQueries({ queryKey: ["social-permission", playerId] }); queryClient.invalidateQueries({ queryKey: ["friendship-status"] }); },
+    onError: (e: any) => toast({ title: "Unblock failed", description: e.message, variant: "destructive" }),
   });
 
   // Send friend request
@@ -168,6 +180,8 @@ export default function PlayerProfile() {
   }
 
   const isOwnProfile = currentUser?.id === playerId;
+  const isInteractionRestricted = !!socialPermissions?.is_interaction_restricted;
+  const viewerBlockedTarget = !!socialPermissions?.is_blocked_by_viewer;
   const isFriend = friendship?.status === "accepted";
   const isPendingSent = friendship?.status === "pending" && friendship?.requestor_id === currentUser?.id;
   const isPendingReceived = friendship?.status === "pending" && friendship?.addressee_id === currentUser?.id;
@@ -197,11 +211,14 @@ export default function PlayerProfile() {
           <Button asChild size="sm"><Link to="/character/profile/edit"><Edit className="mr-1 h-4 w-4" />Edit profile</Link></Button>
         ) : (
           <>
-            {!friendship && <Button size="sm" onClick={() => sendRequest.mutate()} disabled={sendRequest.isPending}><UserPlus className="h-4 w-4 mr-1" /> Add Friend</Button>}
-            {isPendingSent && <Button size="sm" variant="secondary" disabled><Clock className="h-4 w-4 mr-1" /> Request Sent</Button>}
-            {isPendingReceived && <Button size="sm" onClick={() => acceptRequest.mutate()} disabled={acceptRequest.isPending}><UserPlus className="h-4 w-4 mr-1" /> Accept Request</Button>}
-            {isFriend && <Button size="sm" variant="destructive" onClick={() => removeFriend.mutate()} disabled={removeFriend.isPending}><UserMinus className="h-4 w-4 mr-1" /> Remove Friend</Button>}
-            <FutureProfileActions />
+            {isInteractionRestricted && <Badge variant="secondary">This player is unavailable.</Badge>}
+            {!isInteractionRestricted && !friendship && <Button size="sm" onClick={() => sendRequest.mutate()} disabled={sendRequest.isPending}><UserPlus className="h-4 w-4 mr-1" /> Add Friend</Button>}
+            {!isInteractionRestricted && isPendingSent && <Button size="sm" variant="secondary" disabled><Clock className="h-4 w-4 mr-1" /> Request Sent</Button>}
+            {!isInteractionRestricted && isPendingReceived && <Button size="sm" onClick={() => acceptRequest.mutate()} disabled={acceptRequest.isPending}><UserPlus className="h-4 w-4 mr-1" /> Accept Request</Button>}
+            {!isInteractionRestricted && isFriend && <Button size="sm" variant="destructive" onClick={() => removeFriend.mutate()} disabled={removeFriend.isPending}><UserMinus className="h-4 w-4 mr-1" /> Remove Friend</Button>}
+            {viewerBlockedTarget ? <Button size="sm" variant="outline" onClick={() => unblockMutation.mutate()} disabled={unblockMutation.isPending}>Unblock player</Button> : <BlockPlayerDialog targetProfileId={playerId!} playerName={profile.display_name || profile.username || "this player"} trigger={<Button size="sm" variant="destructive"><Ban className="mr-1 h-4 w-4" />Block</Button>} />}
+            <ReportPlayerDialog targetProfileId={playerId!} playerName={profile.display_name || profile.username || "this player"} trigger={<Button size="sm" variant="outline"><Flag className="mr-1 h-4 w-4" />Report</Button>} />
+            {!isInteractionRestricted && <FutureProfileActions />}
           </>
         )}
       />

--- a/src/pages/PlayerSearch.tsx
+++ b/src/pages/PlayerSearch.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Search, User, Music, Star, MapPin, Clock, Users, UserPlus, MessageSquare, Check } from "lucide-react";
+import { Search, User, Music, Star, MapPin, Clock, Users, UserPlus, MessageSquare, Check, Ban, Flag } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useGameData } from "@/hooks/useGameData";
 import { useFriendships } from "@/features/relationships/hooks/useFriendships";
@@ -15,6 +15,8 @@ import { DirectMessagePanel } from "@/features/relationships/components/DirectMe
 import { useToast } from "@/hooks/use-toast";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { searchPublicProfiles, type PublicProfileSearchResult } from "@/services/publicProfileSearch";
+import { BlockPlayerDialog } from "@/components/social-safety/BlockPlayerDialog";
+import { ReportPlayerDialog } from "@/components/social-safety/ReportPlayerDialog";
 
 type PlayerProfile = PublicProfileSearchResult;
 type FriendState = "none" | "friends" | "pending_sent" | "pending_received";
@@ -270,6 +272,8 @@ export default function PlayerSearch() {
                           <MessageSquare className="mr-1 h-4 w-4" />
                           Message
                         </Button>
+                        <BlockPlayerDialog targetProfileId={player.id} playerName={player.display_name || player.username} trigger={<Button variant="destructive" size="sm"><Ban className="mr-1 h-4 w-4" />Block</Button>} />
+                        <ReportPlayerDialog targetProfileId={player.id} playerName={player.display_name || player.username} trigger={<Button variant="outline" size="sm"><Flag className="mr-1 h-4 w-4" />Report</Button>} />
                       </>
                     )}
                   </div>

--- a/src/pages/settings/privacy/BlockedPlayersPage.tsx
+++ b/src/pages/settings/privacy/BlockedPlayersPage.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { ShieldOff, User } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useBlockedPlayers } from "@/hooks/social-safety/useBlockedPlayers";
+import { unblockPlayer } from "@/services/social-safety/PlayerBlockService";
+import { BLOCK_REASON_OPTIONS } from "@/services/social-safety/config";
+
+export default function BlockedPlayersPage() {
+  const [search, setSearch] = useState(""); const [page, setPage] = useState(0); const { data = [], isLoading, isError } = useBlockedPlayers(search, page); const qc = useQueryClient(); const { toast } = useToast();
+  const unblock = useMutation({ mutationFn: unblockPlayer, onSuccess: () => { toast({ title: "Player unblocked", description: "Previous friendships and requests were not restored." }); qc.invalidateQueries({ queryKey: ["blocked-players"] }); }, onError: (e: Error) => toast({ title: "Unblock failed", description: e.message, variant: "destructive" }) });
+  return <FMPageScaffold title="Blocked Players" subtitle="Manage players you have blocked. Private activity, city and online state are hidden here." icon={ShieldOff} backTo="/settings"><Card><CardHeader><CardTitle>Search blocked players</CardTitle></CardHeader><CardContent><Input value={search} onChange={(e) => { setSearch(e.target.value); setPage(0); }} placeholder="Search by name" /></CardContent></Card>{isLoading && <Card><CardContent className="p-6 text-center text-muted-foreground">Loading blocked players…</CardContent></Card>}{isError && <Card role="alert"><CardContent className="p-6 text-center text-destructive">Safety settings are unavailable right now.</CardContent></Card>}{!isLoading && !isError && data.length === 0 && <Card><CardContent className="p-6 text-center text-muted-foreground">You have not blocked any players.</CardContent></Card>}{data.map((player) => { const label = BLOCK_REASON_OPTIONS.find((o) => o.value === player.reason_category)?.label; return <Card key={player.blocked_profile_id}><CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"><div className="flex items-center gap-3"><Avatar><AvatarImage src={player.avatar_url ?? undefined} /><AvatarFallback><User className="h-4 w-4" /></AvatarFallback></Avatar><div><div className="font-medium">{player.display_name ?? player.username}</div><div className="text-sm text-muted-foreground">Blocked {format(new Date(player.created_at), "PP")}</div>{label && <Badge variant="secondary">{label}</Badge>}</div></div><Button variant="outline" disabled={unblock.isPending} onClick={() => window.confirm("Unblock this player? Previous friendships and requests will not be restored.") && unblock.mutate(player.blocked_profile_id)}>Unblock</Button></CardContent></Card>; })}<div className="flex justify-end gap-2"><Button variant="outline" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>Previous</Button><Button variant="outline" disabled={data.length < 20} onClick={() => setPage((p) => p + 1)}>Next</Button></div></FMPageScaffold>;
+}

--- a/src/pages/settings/safety/MyReportsPage.tsx
+++ b/src/pages/settings/safety/MyReportsPage.tsx
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { FileWarning } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { fetchMyReports } from "@/services/social-safety/PlayerReportService";
+
+const statusLabel: Record<string, string> = { open: "Submitted", triaged: "Under review", actioned: "Resolved", dismissed: "Closed" };
+export default function MyReportsPage() { const { data = [], isLoading, isError } = useQuery({ queryKey: ["my-reports"], queryFn: fetchMyReports }); return <FMPageScaffold title="My Reports" subtitle="View limited status for reports you submitted." icon={FileWarning} backTo="/settings">{isLoading && <Card><CardContent className="p-6 text-center text-muted-foreground">Loading reports…</CardContent></Card>}{isError && <Card role="alert"><CardContent className="p-6 text-center text-destructive">Report status is unavailable right now.</CardContent></Card>}{!isLoading && !isError && data.length === 0 && <Card><CardContent className="p-6 text-center text-muted-foreground">No previous reports.</CardContent></Card>}{data.map((report: any) => <Card key={report.id}><CardContent className="flex items-center justify-between gap-3 p-4"><div><div className="font-medium capitalize">{String(report.category).replace(/_/g, " ")}</div><div className="text-sm text-muted-foreground">Submitted {format(new Date(report.created_at), "PP")}</div></div><Badge>{statusLabel[report.status] ?? "Submitted"}</Badge></CardContent></Card>)}</FMPageScaffold>; }

--- a/src/services/social-safety/PlayerBlockService.ts
+++ b/src/services/social-safety/PlayerBlockService.ts
@@ -1,0 +1,65 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { BlockReasonCategory } from "./config";
+
+export interface BlockedPlayerSummary {
+  blocked_profile_id: string;
+  username: string;
+  display_name: string | null;
+  avatar_url: string | null;
+  reason_category: BlockReasonCategory | null;
+  private_note: string | null;
+  created_at: string;
+}
+
+export interface BlockPlayerInput {
+  targetProfileId: string;
+  reasonCategory?: BlockReasonCategory | null;
+  privateNote?: string | null;
+}
+
+export async function blockPlayer(input: BlockPlayerInput) {
+  const { data, error } = await (supabase as any).rpc("block_profile", {
+    target_profile_id: input.targetProfileId,
+    note: input.privateNote?.trim() || null,
+    reason_category: input.reasonCategory ?? null,
+  });
+  if (error) throw new Error(normalizeBlockError(error.message));
+  return data;
+}
+
+export async function unblockPlayer(targetProfileId: string) {
+  const { error } = await (supabase as any).rpc("unblock_profile", { target_profile_id: targetProfileId });
+  if (error) throw new Error(normalizeBlockError(error.message));
+}
+
+export async function fetchBlockedPlayers(search = "", page = 0, pageSize = 20): Promise<BlockedPlayerSummary[]> {
+  let query = (supabase as any)
+    .from("social_profile_blocks")
+    .select("blocked_profile_id, reason_category, private_note, created_at, profiles!social_profile_blocks_blocked_profile_id_fkey(username, display_name, avatar_url)")
+    .is("removed_at", null)
+    .order("created_at", { ascending: false })
+    .range(page * pageSize, page * pageSize + pageSize - 1);
+
+  if (search.trim()) {
+    query = query.or(`profiles.username.ilike.%${search.trim()}%,profiles.display_name.ilike.%${search.trim()}%`);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error("Blocked players are unavailable right now.");
+  return ((data ?? []) as any[]).map((row) => ({
+    blocked_profile_id: row.blocked_profile_id,
+    username: row.profiles?.username ?? "unknown",
+    display_name: row.profiles?.display_name ?? null,
+    avatar_url: row.profiles?.avatar_url ?? null,
+    reason_category: row.reason_category ?? null,
+    private_note: row.private_note ?? null,
+    created_at: row.created_at,
+  }));
+}
+
+function normalizeBlockError(message?: string) {
+  if (!message) return "Safety settings are unavailable right now.";
+  if (/another player|self|yourself/i.test(message)) return "Choose another player for this safety action.";
+  if (/active profile|auth|jwt/i.test(message)) return "Sign in with an active player profile first.";
+  return "This safety action could not be completed. Please try again.";
+}

--- a/src/services/social-safety/PlayerReportService.ts
+++ b/src/services/social-safety/PlayerReportService.ts
@@ -1,0 +1,48 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ReportCategory } from "./config";
+
+export interface SubmitPlayerReportInput {
+  reportedProfileId: string;
+  category: ReportCategory;
+  description: string;
+  contentType?: "profile" | "direct_message" | "social_invite" | "band" | "company" | "twaater_post" | "chat_message" | "other";
+  contentId?: string | null;
+  context?: Record<string, unknown>;
+  blockAfterReport?: boolean;
+}
+
+export async function submitPlayerReport(input: SubmitPlayerReportInput) {
+  const description = input.description.trim();
+  if (description.length < 10) throw new Error("Describe what happened in at least 10 characters.");
+  if (description.length > 2000) throw new Error("Reports must be 2,000 characters or fewer.");
+
+  const { data, error } = await (supabase as any).rpc("report_social_target", {
+    reported_profile_id: input.reportedProfileId,
+    target_type: input.contentType ?? "profile",
+    target_id: input.contentId ?? null,
+    category: input.category,
+    reason: description.replace(/[<>]/g, ""),
+    context: input.context ?? {},
+    block_after_report: input.blockAfterReport ?? false,
+  });
+  if (error) throw new Error(normalizeReportError(error.message));
+  return data;
+}
+
+export async function fetchMyReports() {
+  const { data, error } = await (supabase as any)
+    .from("social_reports")
+    .select("id, reported_profile_id, target_type, category, status, created_at, updated_at, resolved_at, context")
+    .order("created_at", { ascending: false })
+    .limit(50);
+  if (error) throw new Error("Reports are unavailable right now.");
+  return data ?? [];
+}
+
+function normalizeReportError(message?: string) {
+  if (!message) return "Report submission failed. Please try again.";
+  if (/already|duplicate|23505/i.test(message)) return "Your report has already been submitted for review.";
+  if (/wait|429/i.test(message)) return "Please wait before submitting another report.";
+  if (/yourself/i.test(message)) return "You cannot report yourself.";
+  return message.replace(/[<>]/g, "");
+}

--- a/src/services/social-safety/SocialPermissionService.ts
+++ b/src/services/social-safety/SocialPermissionService.ts
@@ -1,0 +1,26 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface SocialPermissions {
+  can_view_profile: boolean;
+  can_send_friend_request: boolean;
+  can_message: boolean;
+  can_invite_to_band: boolean;
+  can_invite_to_activity: boolean;
+  can_offer_job: boolean;
+  can_send_money: boolean;
+  can_send_item: boolean;
+  can_report: boolean;
+  is_blocked_by_viewer: boolean;
+  is_interaction_restricted: boolean;
+  message: string | null;
+}
+
+export async function getSocialPermissions(targetProfileId: string): Promise<SocialPermissions> {
+  const { data, error } = await (supabase as any).rpc("get_social_permissions", { target_profile_id: targetProfileId });
+  if (error) throw new Error("This player is unavailable.");
+  return data as SocialPermissions;
+}
+
+export function canInteractSocially(permissions?: SocialPermissions | null) {
+  return !!permissions && !permissions.is_interaction_restricted;
+}

--- a/src/services/social-safety/config.ts
+++ b/src/services/social-safety/config.ts
@@ -1,0 +1,31 @@
+export const BLOCK_REASON_OPTIONS = [
+  { value: "unwanted_contact", label: "Unwanted contact" },
+  { value: "harassment", label: "Harassment" },
+  { value: "spam", label: "Spam" },
+  { value: "scam", label: "Scam attempt" },
+  { value: "inappropriate_content", label: "Inappropriate content" },
+  { value: "threatening_behaviour", label: "Threatening behaviour" },
+  { value: "impersonation", label: "Impersonation" },
+  { value: "other", label: "Other" },
+  { value: "prefer_not_to_say", label: "Prefer not to say" },
+] as const;
+
+export const REPORT_CATEGORY_OPTIONS = [
+  { value: "harassment", label: "Harassment or bullying", priority: "normal" },
+  { value: "threats", label: "Threats or intimidation", priority: "high", emergency: true },
+  { value: "hate", label: "Hate or discriminatory abuse", priority: "high" },
+  { value: "sexual_content", label: "Sexual or inappropriate content", priority: "high" },
+  { value: "spam", label: "Spam", priority: "normal" },
+  { value: "scam", label: "Scam or fraud attempt", priority: "high" },
+  { value: "impersonation", label: "Impersonation", priority: "normal" },
+  { value: "other", label: "Other", priority: "normal" },
+] as const;
+
+export type BlockReasonCategory = (typeof BLOCK_REASON_OPTIONS)[number]["value"];
+export type ReportCategory = (typeof REPORT_CATEGORY_OPTIONS)[number]["value"];
+
+export const BLOCK_CONFIRMATION_COPY =
+  "Blocking removes any friendship, cancels pending requests, hides both of you from social discovery, prevents direct social interaction, and does not notify the other player.";
+
+export const EMERGENCY_SAFETY_COPY =
+  "If this involves immediate danger or a real-world threat, contact emergency services or local authorities now. RockMundo moderation cannot provide emergency intervention.";

--- a/src/services/social-safety/socialSafety.test.ts
+++ b/src/services/social-safety/socialSafety.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { BLOCK_CONFIRMATION_COPY, EMERGENCY_SAFETY_COPY, REPORT_CATEGORY_OPTIONS } from "./config";
+import { canInteractSocially } from "./SocialPermissionService";
+
+describe("social safety configuration", () => {
+  it("explains block consequences without saying the target is notified", () => {
+    expect(BLOCK_CONFIRMATION_COPY).toContain("removes any friendship");
+    expect(BLOCK_CONFIRMATION_COPY).toContain("does not notify");
+  });
+
+  it("marks real-world threats as emergency-adjacent reports", () => {
+    expect(REPORT_CATEGORY_OPTIONS.find((c) => c.value === "threats")?.emergency).toBe(true);
+    expect(EMERGENCY_SAFETY_COPY).toContain("emergency services");
+  });
+
+  it("rejects direct social interactions when permissions are restricted", () => {
+    expect(canInteractSocially({ is_interaction_restricted: true } as any)).toBe(false);
+    expect(canInteractSocially({ is_interaction_restricted: false } as any)).toBe(true);
+  });
+});

--- a/supabase/migrations/20260713120000_player_blocking_reporting_safety_controls.sql
+++ b/supabase/migrations/20260713120000_player_blocking_reporting_safety_controls.sql
@@ -1,0 +1,150 @@
+BEGIN;
+
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'report_duplicate_denied';
+ALTER TYPE public.social_action_audit_kind ADD VALUE IF NOT EXISTS 'report_rate_limited';
+
+ALTER TABLE public.social_profile_blocks
+  ADD COLUMN IF NOT EXISTS reason_category text,
+  ADD COLUMN IF NOT EXISTS private_note text,
+  ADD COLUMN IF NOT EXISTS removed_at timestamptz;
+
+ALTER TABLE public.social_profile_blocks DROP CONSTRAINT IF EXISTS social_profile_blocks_private_note_length;
+ALTER TABLE public.social_profile_blocks ADD CONSTRAINT social_profile_blocks_private_note_length CHECK (private_note IS NULL OR char_length(private_note) <= 500);
+ALTER TABLE public.social_profile_blocks DROP CONSTRAINT IF EXISTS social_profile_blocks_reason_category_allowed;
+ALTER TABLE public.social_profile_blocks ADD CONSTRAINT social_profile_blocks_reason_category_allowed CHECK (reason_category IS NULL OR reason_category IN ('unwanted_contact','harassment','spam','scam','inappropriate_content','threatening_behaviour','impersonation','other','prefer_not_to_say'));
+
+CREATE INDEX IF NOT EXISTS social_profile_blocks_active_pair_idx ON public.social_profile_blocks (blocker_profile_id, blocked_profile_id) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS social_profile_blocks_active_blocked_idx ON public.social_profile_blocks (blocked_profile_id, blocker_profile_id) WHERE removed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.social_report_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id uuid NOT NULL REFERENCES public.social_reports(id) ON DELETE CASCADE,
+  evidence_type text NOT NULL,
+  source_reference text,
+  snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT social_report_evidence_snapshot_object CHECK (jsonb_typeof(snapshot) = 'object'),
+  CONSTRAINT social_report_evidence_metadata_object CHECK (jsonb_typeof(metadata) = 'object')
+);
+ALTER TABLE public.social_report_evidence ENABLE ROW LEVEL SECURITY;
+CREATE INDEX IF NOT EXISTS social_report_evidence_report_idx ON public.social_report_evidence(report_id, created_at);
+
+DROP POLICY IF EXISTS "Reporters can read own report evidence" ON public.social_report_evidence;
+CREATE POLICY "Reporters can read own report evidence" ON public.social_report_evidence
+FOR SELECT USING (EXISTS (SELECT 1 FROM public.social_reports r WHERE r.id = report_id AND public.profile_belongs_to_current_user(r.reporter_profile_id)));
+
+CREATE OR REPLACE FUNCTION public.social_block_state(viewer_profile_id uuid, target_profile_id uuid)
+RETURNS TABLE (
+  viewer_blocked_target boolean,
+  viewer_is_blocked_by_target boolean,
+  mutual_block boolean,
+  relation text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  WITH s AS (
+    SELECT
+      EXISTS (SELECT 1 FROM public.social_profile_blocks b WHERE b.blocker_profile_id = viewer_profile_id AND b.blocked_profile_id = target_profile_id AND b.removed_at IS NULL) AS out_block,
+      EXISTS (SELECT 1 FROM public.social_profile_blocks b WHERE b.blocker_profile_id = target_profile_id AND b.blocked_profile_id = viewer_profile_id AND b.removed_at IS NULL) AS in_block
+  )
+  SELECT out_block, in_block, out_block AND in_block,
+    CASE WHEN out_block AND in_block THEN 'mutual_block' WHEN out_block THEN 'viewer_blocked_target' WHEN in_block THEN 'viewer_is_blocked_by_target' ELSE 'none' END
+  FROM s;
+$$;
+
+CREATE OR REPLACE FUNCTION public.are_profiles_blocked(first_profile_id uuid, second_profile_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.social_profile_blocks b
+    WHERE b.removed_at IS NULL AND ((b.blocker_profile_id = first_profile_id AND b.blocked_profile_id = second_profile_id) OR (b.blocker_profile_id = second_profile_id AND b.blocked_profile_id = first_profile_id))
+  ) OR EXISTS (
+    SELECT 1 FROM public.friendships f WHERE f.status = 'blocked'::public.friendship_status
+      AND ((f.requestor_id = first_profile_id AND f.addressee_id = second_profile_id) OR (f.requestor_id = second_profile_id AND f.addressee_id = first_profile_id))
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_social_permissions(target_profile_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_profile_id uuid; blocked boolean; blocked_by_viewer boolean;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required' USING ERRCODE='42501'; END IF;
+  IF target_profile_id IS NULL OR target_profile_id = actor_profile_id THEN
+    RETURN jsonb_build_object('can_view_profile', true, 'can_report', false, 'is_blocked_by_viewer', false, 'is_interaction_restricted', false, 'message', null);
+  END IF;
+  blocked := public.are_profiles_blocked(actor_profile_id, target_profile_id);
+  SELECT viewer_blocked_target INTO blocked_by_viewer FROM public.social_block_state(actor_profile_id, target_profile_id);
+  RETURN jsonb_build_object(
+    'can_view_profile', NOT blocked, 'can_send_friend_request', NOT blocked, 'can_message', NOT blocked,
+    'can_invite_to_band', NOT blocked, 'can_invite_to_activity', NOT blocked, 'can_offer_job', NOT blocked,
+    'can_send_money', NOT blocked, 'can_send_item', NOT blocked, 'can_report', true,
+    'is_blocked_by_viewer', COALESCE(blocked_by_viewer,false), 'is_interaction_restricted', blocked,
+    'message', CASE WHEN blocked THEN 'This player is unavailable.' ELSE NULL END
+  );
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.block_profile(target_profile_id uuid, note text DEFAULT NULL, reason_category text DEFAULT NULL)
+RETURNS public.social_profile_blocks LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_profile_id uuid; block_row public.social_profile_blocks;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  IF target_profile_id IS NULL OR target_profile_id = actor_profile_id THEN RAISE EXCEPTION 'Choose another player to block'; END IF;
+  IF note IS NOT NULL AND char_length(note) > 500 THEN RAISE EXCEPTION 'Block note must be 500 characters or fewer'; END IF;
+  INSERT INTO public.social_profile_blocks(blocker_profile_id, blocked_profile_id, reason, reason_category, private_note, removed_at)
+  VALUES(actor_profile_id, target_profile_id, NULLIF(btrim(note), ''), reason_category, NULLIF(btrim(note), ''), NULL)
+  ON CONFLICT (blocker_profile_id, blocked_profile_id) DO UPDATE SET reason=EXCLUDED.reason, reason_category=EXCLUDED.reason_category, private_note=EXCLUDED.private_note, removed_at=NULL, updated_at=timezone('utc', now()) RETURNING * INTO block_row;
+  DELETE FROM public.friendships WHERE (requestor_id=actor_profile_id AND addressee_id=target_profile_id) OR (requestor_id=target_profile_id AND addressee_id=actor_profile_id);
+  UPDATE public.notifications SET read_at = COALESCE(read_at, timezone('utc', now())), metadata = COALESCE(metadata,'{}'::jsonb) || jsonb_build_object('social_action_disabled', true, 'resolved_by_block', true)
+  WHERE profile_id IN (actor_profile_id, target_profile_id) AND (metadata->>'requestor_profile_id' IN (actor_profile_id::text,target_profile_id::text) OR metadata->>'addressee_profile_id' IN (actor_profile_id::text,target_profile_id::text));
+  INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,metadata) VALUES(actor_profile_id,target_profile_id,'block',jsonb_build_object('reason_category', reason_category));
+  RETURN block_row;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.unblock_profile(target_profile_id uuid)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_profile_id uuid;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  UPDATE public.social_profile_blocks SET removed_at=timezone('utc', now()), updated_at=timezone('utc', now()) WHERE blocker_profile_id=actor_profile_id AND blocked_profile_id=target_profile_id AND removed_at IS NULL;
+  INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action) VALUES(actor_profile_id,target_profile_id,'unblock');
+  RETURN true;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.report_social_target(p_reported_profile_id uuid, p_target_type public.social_report_target_type, p_target_id uuid, p_category public.social_report_category, p_reason text, p_context jsonb DEFAULT '{}'::jsonb, p_block_after_report boolean DEFAULT false)
+RETURNS public.social_reports LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_profile_id uuid; report_row public.social_reports; profile_snapshot jsonb; recent_count int; priority text;
+BEGIN
+  SELECT p.id INTO actor_profile_id FROM public.profiles p WHERE p.user_id = auth.uid() ORDER BY p.created_at ASC LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile is required'; END IF;
+  IF p_reported_profile_id IS NULL AND p_target_id IS NULL THEN RAISE EXCEPTION 'Report target is required'; END IF;
+  IF p_reported_profile_id = actor_profile_id THEN RAISE EXCEPTION 'You cannot report yourself'; END IF;
+  IF p_reason IS NULL OR char_length(btrim(p_reason)) < 10 OR char_length(btrim(p_reason)) > 2000 THEN RAISE EXCEPTION 'Report description must be 10 to 2000 characters'; END IF;
+  SELECT count(*) INTO recent_count FROM public.social_reports sr WHERE sr.reporter_profile_id=actor_profile_id AND sr.created_at > timezone('utc', now()) - interval '10 minutes';
+  IF recent_count >= 5 THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES(actor_profile_id,p_reported_profile_id,'report_rate_limited',p_target_type,p_target_id,jsonb_build_object('category',p_category));
+    RAISE EXCEPTION 'Please wait before submitting another report.' USING ERRCODE='42901';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.social_reports sr WHERE sr.reporter_profile_id=actor_profile_id AND sr.reported_profile_id IS NOT DISTINCT FROM p_reported_profile_id AND sr.target_type=p_target_type AND sr.target_id IS NOT DISTINCT FROM p_target_id AND sr.category=p_category AND sr.created_at > timezone('utc', now()) - interval '24 hours') THEN
+    INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES(actor_profile_id,p_reported_profile_id,'report_duplicate_denied',p_target_type,p_target_id,jsonb_build_object('category',p_category));
+    RAISE EXCEPTION 'Your report has already been submitted for review.' USING ERRCODE='23505';
+  END IF;
+  priority := CASE WHEN p_category IN ('threats','hate','sexual_content','scam','self_harm') THEN 'high' ELSE 'normal' END;
+  INSERT INTO public.social_reports(reporter_profile_id,reported_profile_id,target_type,target_id,category,reason,context,status)
+  VALUES(actor_profile_id,p_reported_profile_id,p_target_type,p_target_id,p_category,btrim(p_reason),COALESCE(p_context,'{}'::jsonb) || jsonb_build_object('initial_priority',priority),'open') RETURNING * INTO report_row;
+  IF p_reported_profile_id IS NOT NULL THEN
+    SELECT jsonb_build_object('profile_id',p.id,'username',p.username,'display_name',p.display_name,'bio',p.bio,'captured_at',timezone('utc',now())) INTO profile_snapshot FROM public.profiles p WHERE p.id=p_reported_profile_id;
+    INSERT INTO public.social_report_evidence(report_id,evidence_type,source_reference,snapshot,metadata) VALUES(report_row.id,'profile_snapshot','profiles:'||p_reported_profile_id::text,COALESCE(profile_snapshot,'{}'::jsonb),jsonb_build_object('immutable',true));
+  END IF;
+  INSERT INTO public.social_action_audit_log(actor_profile_id,target_profile_id,action,target_type,target_id,metadata) VALUES(actor_profile_id,p_reported_profile_id,'report',p_target_type,p_target_id,jsonb_build_object('category',p_category,'priority',priority));
+  IF p_block_after_report AND p_reported_profile_id IS NOT NULL THEN PERFORM public.block_profile(p_reported_profile_id, 'Blocked after report', 'prefer_not_to_say'); END IF;
+  RETURN report_row;
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.social_block_state(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_social_permissions(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.block_profile(uuid, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.report_social_target(uuid, public.social_report_target_type, uuid, public.social_report_category, text, jsonb, boolean) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Provide a single, server-enforced social-safety layer so every player-to-player feature uses the same rules for blocking and reporting.  
- Let players block unwanted interactions across discovery, friendships, notifications and future messaging while preserving historical gameplay records.  
- Give players a privacy-respecting reporting flow that captures immutable contextual evidence and routes reports into the moderation queue with duplicate and rate-limit protections.

### Description
- Database migration: extends `social_profile_blocks` with `reason_category`, `private_note` and `removed_at`, adds `social_report_evidence`, indexed active-pair lookups, RLS policies, and new/updated RPCs and functions (`social_block_state`, `are_profiles_blocked`, `get_social_permissions`, `block_profile`, `unblock_profile`, `report_social_target`) including duplicate/rate-limit controls, evidence snapshotting and audit events (file: `supabase/migrations/20260713120000_player_blocking_reporting_safety_controls.sql`).
- Server-side permission API: `get_social_permissions` RPC and client wrapper `SocialPermissionService` that returns neutral availability states such as `is_interaction_restricted` and `is_blocked_by_viewer` for use across features. 
- Blocking & reporting services and hooks: new client services `PlayerBlockService`, `PlayerReportService`, `SocialPermissionService`, config constants, and React Query hooks `useSocialPermission` and `useBlockedPlayers` to centralise checks and avoid duplicated logic. 
- UI and integration: `BlockPlayerDialog` and `ReportPlayerDialog` components, blocked-player management page (`/settings/privacy/blocked-players`), my-reports page (`/settings/safety/reports`), integrated block/report actions on `PlayerProfile` and `PlayerSearch`, and route registrations in `src/App.tsx`. 
- Documentation and tests: added `docs/social-safety-controls.md` documenting shared-entity behavior and a focused unit test `src/services/social-safety/socialSafety.test.ts` covering configuration and basic permission behaviour.

### Testing
- `npm run typecheck` (`tsc --noEmit`) completed successfully.  
- `git diff --check` reported no whitespace or merge issues.  
- `npm run lint` failed in this environment because dev dependencies are not installed (ESLint could not resolve `@eslint/js`).  
- `npm run test:unit` for the new unit file could not run here because `vitest` is not available in the environment (no `node_modules`); the focused test file was added (`src/services/social-safety/socialSafety.test.ts`) and will run in CI when dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551c6912708325a5f5c64fd24e51a2)