### PR TITLE
feat(social): add player blocking reporting and safety controls

### DIFF
--- a/docs/social/social-safety.md
+++ b/docs/social/social-safety.md
@@ -1,0 +1,23 @@
+# Social safety controls
+
+RockMundo centralises player-to-player restrictions through `player_blocks`, `get_social_permissions`, `are_profiles_blocked`, and the player report workflow.
+
+## Blocking behaviour
+
+A block is directional for audit purposes but symmetric for direct interactions. If either player has an active block, friend requests, private messaging, band and activity invitations, employment offers, money transfers, item gifting, social-feed interactions, discovery appearance and friend suggestions must be rejected by server-side checks.
+
+When a player blocks another player, pending friendship requests between the pair are cancelled and accepted friendships are removed. Unblocking removes only the active block; it does not restore friendships, recreate requests, reopen invitations or bypass future cooldowns.
+
+The blocked player is not notified. If a restricted player attempts an action, the UI and server should use neutral wording such as `This player is unavailable.` and must not reveal which player created the block.
+
+## Shared bands, companies and gameplay history
+
+Blocking is not a destructive domain action. It must not delete historical messages, valid completed transactions, song or recording credits, gig history, contracts, band membership, company employment or shared bookings. Those domains keep the gameplay data needed for the world to function while suppressing optional direct social contact and private profile information.
+
+Operational, system-generated updates that are required for a shared band, company, recording, gig or booking may still be shown without exposing private social information or opening direct messaging.
+
+## Reporting behaviour
+
+Reports use centrally configured categories, immutable evidence snapshots and limited reporter-facing status. A report does not automatically punish the reported player. Reporter identity, moderator notes, internal risk signals and exact disciplinary details remain hidden from normal players.
+
+For threats or immediate real-world danger, the UI tells players to contact emergency services or local authorities because RockMundo moderation cannot provide emergency intervention.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ const PublicRelations = lazyWithRetry(() => import("./pages/PublicRelations"));
 const PRSubmissionsHistory = lazyWithRetry(() => import("./pages/media/PRSubmissionsHistory"));
 const Legacy = lazyWithRetry(() => import("./pages/legacy"));
 const AdminPlayerManagement = lazyWithRetry(() => import("./pages/admin/PlayerManagement"));
+const AdminPlayerReports = lazyWithRetry(() => import("./pages/admin/PlayerReports"));
 const AdminAchievements = lazyWithRetry(() => import("./pages/admin/Achievements"));
 const AdminAnalytics = lazyWithRetry(() => import("./pages/admin/Analytics"));
 const AwardsAdmin = lazyWithRetry(() => import("./pages/admin/AwardsAdmin"));
@@ -208,6 +209,8 @@ const SkillDefinitionsAdmin = lazyWithRetry(() => import("./pages/admin/SkillDef
 const PlayerSearch = lazyWithRetry(() => import("./pages/PlayerSearch"));
 const PlayerDiscovery = lazyWithRetry(() => import("./pages/PlayerDiscovery"));
 const FriendsPage = lazyWithRetry(() => import("./pages/Friends"));
+const BlockedPlayersPage = lazyWithRetry(() => import("./pages/settings/BlockedPlayers"));
+const MyReportsPage = lazyWithRetry(() => import("./pages/settings/MyReports"));
 const PlayerProfile = lazyWithRetry(() => import("./pages/PlayerProfile"));
 const PlayerProfileEdit = lazyWithRetry(() => import("./pages/PlayerProfileEdit"));
 const BandBrowser = lazyWithRetry(() => import("./pages/BandBrowser"));
@@ -675,6 +678,8 @@ function App() {
                     <Route path="inventory" element={<InventoryManager />} />
                     <Route path="players/search" element={<PreserveQueryRedirect to="/community/players" />} />
                     <Route path="community/friends" element={<FriendsPage />} />
+                    <Route path="settings/privacy/blocked-players" element={<BlockedPlayersPage />} />
+                    <Route path="settings/safety/reports" element={<MyReportsPage />} />
                     <Route path="community/players" element={<PlayerDiscovery />} />
                     <Route path="player/:playerId" element={<PlayerProfile />} />
                     <Route path="players/:playerId" element={<PlayerProfile />} />
@@ -736,6 +741,7 @@ function App() {
                     <Route path="gigs/advanced/:gigId" element={<AdvancedGigSystem />} />
                     <Route path="admin" element={<Admin />} />
                     <Route path="admin/players" element={<AdminPlayerManagement />} />
+                    <Route path="admin/player-reports" element={<AdminPlayerReports />} />
                     <Route path="admin/achievements" element={<AdminAchievements />} />
                     <Route path="admin/analytics" element={<AdminAnalytics />} />
                     <Route path="university/:id" element={<UniversityDetail />} />

--- a/src/components/social-safety/SafetyActions.tsx
+++ b/src/components/social-safety/SafetyActions.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { AlertTriangle, Ban, ShieldAlert, Undo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { BLOCK_REASON_OPTIONS, REPORT_CATEGORIES, type BlockReasonCategory, type ReportCategory } from "@/services/socialSafety";
+import { usePlayerBlockActions, useReportPlayer } from "@/hooks/useSocialSafety";
+
+export function SafetyActions({ targetProfileId, targetName = "this player", isBlockedByViewer = false, compact = false }: { targetProfileId: string; targetName?: string; isBlockedByViewer?: boolean; compact?: boolean }) {
+  const [blockOpen, setBlockOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reason, setReason] = useState<BlockReasonCategory | "">("");
+  const [note, setNote] = useState("");
+  const [category, setCategory] = useState<ReportCategory | "">("");
+  const [description, setDescription] = useState("");
+  const [blockAfterReport, setBlockAfterReport] = useState(false);
+  const actions = usePlayerBlockActions(targetProfileId);
+  const report = useReportPlayer();
+  const emergency = REPORT_CATEGORIES.find((item) => item.value === category)?.emergency;
+  const submitReportDisabled = !category || description.trim().length < 10 || description.length > 2000 || report.isPending;
+
+  return <>
+    {isBlockedByViewer ? <Button size="sm" variant="outline" onClick={() => window.confirm("Unblock this player? Previous friendships and requests will not be restored.") && actions.unblock.mutate()} disabled={actions.unblock.isPending}><Undo2 className="mr-1 h-4 w-4" />Unblock player</Button> : <Button size="sm" variant={compact ? "outline" : "destructive"} onClick={() => setBlockOpen(true)} disabled={actions.block.isPending}><Ban className="mr-1 h-4 w-4" />Block player</Button>}
+    <Button size="sm" variant="outline" onClick={() => setReportOpen(true)}><ShieldAlert className="mr-1 h-4 w-4" />Report</Button>
+    <Dialog open={blockOpen} onOpenChange={setBlockOpen}><DialogContent aria-describedby="block-player-effects"><DialogHeader><DialogTitle>Block {targetName}?</DialogTitle><DialogDescription id="block-player-effects">Blocking removes any friendship, cancels pending requests, keeps both players out of social discovery, prevents direct social interaction, and does not notify the blocked player.</DialogDescription></DialogHeader><div className="space-y-3"><div className="space-y-1"><Label>Private reason (optional)</Label><Select value={reason} onValueChange={(value) => setReason(value as BlockReasonCategory)}><SelectTrigger><SelectValue placeholder="Choose a reason" /></SelectTrigger><SelectContent>{BLOCK_REASON_OPTIONS.map((item) => <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>)}</SelectContent></Select></div><div className="space-y-1"><Label htmlFor="block-note">Private note (optional)</Label><Textarea id="block-note" maxLength={500} value={note} onChange={(event) => setNote(event.target.value)} placeholder="Only you and authorised moderators can see this note." /></div></div><DialogFooter><Button variant="outline" onClick={() => setBlockOpen(false)}>Cancel</Button><Button variant="destructive" onClick={() => actions.block.mutate({ reasonCategory: reason || undefined, privateNote: note }, { onSuccess: () => setBlockOpen(false) })} disabled={actions.block.isPending}>Block player</Button></DialogFooter></DialogContent></Dialog>
+    <Dialog open={reportOpen} onOpenChange={setReportOpen}><DialogContent aria-describedby="report-player-help"><DialogHeader><DialogTitle>Report {targetName}</DialogTitle><DialogDescription id="report-player-help">Reports are reviewed by moderation. Reporting is separate from blocking; the reported player is not told who reported them.</DialogDescription></DialogHeader><div className="space-y-3"><div className="space-y-1"><Label>Report category</Label><Select value={category} onValueChange={(value) => setCategory(value as ReportCategory)}><SelectTrigger><SelectValue placeholder="Choose a category" /></SelectTrigger><SelectContent>{REPORT_CATEGORIES.map((item) => <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>)}</SelectContent></Select></div>{emergency && <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm"><AlertTriangle className="mr-2 inline h-4 w-4" />If anyone is in immediate danger, contact emergency services or local authorities. RockMundo moderation cannot provide emergency intervention.</div>}<div className="space-y-1"><Label htmlFor="report-description">Description</Label><Textarea id="report-description" minLength={10} maxLength={2000} value={description} onChange={(event) => setDescription(event.target.value)} placeholder="Describe what happened. Do not include unnecessary sensitive personal information." /><p className="text-xs text-muted-foreground" aria-live="polite">{description.length}/2000 characters. Minimum 10.</p></div><label className="flex items-start gap-2 text-sm"><Checkbox checked={blockAfterReport} onCheckedChange={(checked) => setBlockAfterReport(Boolean(checked))} />Block this player after submitting the report.</label></div><DialogFooter><Button variant="outline" onClick={() => setReportOpen(false)}>Cancel</Button><Button onClick={() => report.mutate({ targetProfileId, category: category as ReportCategory, description, blockAfterReport, evidence: { targetName, capturedFrom: "player_profile" } }, { onSuccess: () => { setReportOpen(false); setDescription(""); setCategory(""); } })} disabled={submitReportDisabled}>Submit report</Button></DialogFooter></DialogContent></Dialog>
+  </>;
+}

--- a/src/features/player-discovery/components/PlayerDiscoveryCard.tsx
+++ b/src/features/player-discovery/components/PlayerDiscoveryCard.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Clock, MapPin, Music, Star, User, UserPlus, Zap } from "lucide-react";
 import { usePlayerConnection } from "@/hooks/usePlayerConnections";
+import { SafetyActions } from "@/components/social-safety/SafetyActions";
 import type { PlayerDiscoveryResult } from "../services/playerDiscovery";
 
 export function PlayerDiscoveryCard({ player, view = "grid", onOpen }: { player: PlayerDiscoveryResult; view?: "grid" | "list"; onOpen?: () => void }) {
@@ -29,7 +30,7 @@ export function PlayerDiscoveryCard({ player, view = "grid", onOpen }: { player:
         {player.statusMessage && <p className="line-clamp-2 text-sm text-muted-foreground">{player.statusMessage}</p>}
         <div className="flex flex-wrap gap-1">{[...player.availability, ...player.preferredGenres, ...player.badges].slice(0, 7).map((label) => <Badge key={label} variant="outline" className="text-xs">{label}</Badge>)}</div>
         <ul className="grid gap-1 text-sm text-muted-foreground" aria-label="Match reasons">{player.match.reasons.slice(0, 4).map((reason) => <li key={reason}>• {reason}</li>)}</ul>
-        <div className="flex flex-wrap justify-end gap-2">{connection.data === "not_connected" && <Button size="sm" variant="outline" disabled={connection.send.isPending} onClick={() => connection.send.mutate()}><UserPlus className="mr-1 h-4 w-4" />Add friend</Button>}{connection.data === "outgoing_pending" && <Button size="sm" variant="secondary" disabled><Clock className="mr-1 h-4 w-4" />Pending</Button>}{connection.data === "incoming_pending" && <Badge variant="secondary">Request received</Badge>}{connection.data === "friends" && <Badge>Friends</Badge>}<Button asChild size="sm" onClick={onOpen}><Link to={`/player/${player.id}`}>Open profile</Link></Button></div>
+        <div className="flex flex-wrap justify-end gap-2">{connection.data === "not_connected" && <Button size="sm" variant="outline" disabled={connection.send.isPending} onClick={() => connection.send.mutate()}><UserPlus className="mr-1 h-4 w-4" />Add friend</Button>}{connection.data === "outgoing_pending" && <Button size="sm" variant="secondary" disabled><Clock className="mr-1 h-4 w-4" />Pending</Button>}{connection.data === "incoming_pending" && <Badge variant="secondary">Request received</Badge>}{connection.data === "friends" && <Badge>Friends</Badge>}<SafetyActions targetProfileId={player.id} targetName={player.characterName} compact /><Button asChild size="sm" onClick={onOpen}><Link to={`/player/${player.id}`}>Open profile</Link></Button></div>
       </div>
     </CardContent>
   </Card>;

--- a/src/hooks/useSocialSafety.ts
+++ b/src/hooks/useSocialSafety.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { blockPlayer, getSocialPermissions, listBlockedPlayers, listMyReports, submitPlayerReport, unblockPlayer, type BlockReasonCategory, type ReportCategory } from "@/services/socialSafety";
+
+export function useSocialPermission(targetProfileId?: string | null) {
+  return useQuery({ queryKey: ["social-permission", targetProfileId], queryFn: () => getSocialPermissions(targetProfileId!), enabled: !!targetProfileId });
+}
+
+export function useBlockedPlayers(search = "") {
+  const queryClient = useQueryClient();
+  const query = useQuery({ queryKey: ["blocked-players", search], queryFn: () => listBlockedPlayers(search) });
+  const unblock = useMutation({ mutationFn: (targetProfileId: string) => unblockPlayer(targetProfileId), onSuccess: () => { toast.success("Player unblocked"); queryClient.invalidateQueries({ queryKey: ["blocked-players"] }); queryClient.invalidateQueries({ queryKey: ["social-permission"] }); queryClient.invalidateQueries({ queryKey: ["player-discovery"] }); }, onError: (e: Error) => toast.error(e.message) });
+  return { ...query, unblock };
+}
+
+export function usePlayerBlockActions(targetProfileId?: string | null) {
+  const queryClient = useQueryClient();
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["social-permission"] });
+    queryClient.invalidateQueries({ queryKey: ["player-connection"] });
+    queryClient.invalidateQueries({ queryKey: ["friendships"] });
+    queryClient.invalidateQueries({ queryKey: ["friend-request-counts"] });
+    queryClient.invalidateQueries({ queryKey: ["player-discovery"] });
+    queryClient.invalidateQueries({ queryKey: ["blocked-players"] });
+  };
+  const block = useMutation({ mutationFn: (input?: { reasonCategory?: BlockReasonCategory | null; privateNote?: string | null }) => blockPlayer(targetProfileId!, input?.reasonCategory, input?.privateNote), onSuccess: () => { toast.success("Player blocked. They were not notified."); invalidate(); }, onError: (e: Error) => toast.error(e.message) });
+  const unblock = useMutation({ mutationFn: () => unblockPlayer(targetProfileId!), onSuccess: () => { toast.success("Player unblocked"); invalidate(); }, onError: (e: Error) => toast.error(e.message) });
+  return { block, unblock };
+}
+
+export function useReportPlayer() {
+  const queryClient = useQueryClient();
+  return useMutation({ mutationFn: (input: { targetProfileId: string; category: ReportCategory; description: string; contentType?: string; contentId?: string | null; subcategory?: string | null; blockAfterReport?: boolean; evidence?: Record<string, unknown>; }) => submitPlayerReport(input), onSuccess: () => { toast.success("Your report has been submitted for review."); queryClient.invalidateQueries({ queryKey: ["my-player-reports"] }); queryClient.invalidateQueries({ queryKey: ["blocked-players"] }); }, onError: (e: Error) => toast.error(e.message) });
+}
+
+export function useMyReports() {
+  return useQuery({ queryKey: ["my-player-reports"], queryFn: listMyReports });
+}

--- a/src/integrations/supabase/playerConnections.ts
+++ b/src/integrations/supabase/playerConnections.ts
@@ -42,7 +42,9 @@ export async function listFriendships(profileId: string, kind: FriendListKind, s
 
 export async function listFriendSuggestions(profileId: string): Promise<FriendSummary[]> {
   const existing = await listFriendships(profileId, "friends");
-  const exclude = new Set([profileId, ...existing.map((f) => f.id)]);
+  const { data: blockRows } = await (supabase as any).from("player_blocks").select("blocker_id, blocked_id").or(`blocker_id.eq.${profileId},blocked_id.eq.${profileId}`).is("removed_at", null);
+  const blockedIds = ((blockRows ?? []) as any[]).map((row) => row.blocker_id === profileId ? row.blocked_id : row.blocker_id);
+  const exclude = new Set([profileId, ...existing.map((f) => f.id), ...blockedIds]);
   const { data, error } = await (supabase as any).from("profiles").select("id, username, display_name, avatar_url, city_name").limit(12);
   if (error) throw error;
   return ((data ?? []) as any[]).filter((p) => !exclude.has(p.id)).slice(0, 6).map((p) => ({ id: p.id, friendshipId: "", characterName: p.display_name || p.username || "Player", username: p.username, avatarUrl: p.avatar_url, cityName: p.city_name, status: "pending", requestedAt: new Date().toISOString(), mutualFriendCount: 0, primaryRole: "Suggested because they are active in the community" }));

--- a/src/pages/PlayerProfile.tsx
+++ b/src/pages/PlayerProfile.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 import { usePlayerConnection } from "@/hooks/usePlayerConnections";
+import { useSocialPermission } from "@/hooks/useSocialSafety";
+import { SafetyActions } from "@/components/social-safety/SafetyActions";
 import { respondToFriendship } from "@/integrations/supabase/playerConnections";
 import {
   User, Music, Calendar, MapPin, Star, Clock, TrendingUp, Users, UserPlus, UserMinus, AlertCircle, Edit
@@ -57,6 +59,7 @@ export default function PlayerProfile() {
   });
 
   const connection = usePlayerConnection(playerId);
+  const socialPermission = useSocialPermission(playerId);
 
   const { data: friendship } = useQuery({
     queryKey: ["friendship-status", currentUser?.id, playerId],
@@ -170,6 +173,8 @@ export default function PlayerProfile() {
   }
 
   const isOwnProfile = currentUser?.id === playerId;
+  const restrictedBySafety = Boolean(socialPermission.data?.is_interaction_restricted);
+  const blockedByViewer = Boolean(socialPermission.data?.is_blocked_by_viewer);
   const isFriend = friendship?.status === "accepted";
   const isPendingSent = friendship?.status === "pending" && friendship?.requestor_id === currentUser?.id;
   const isPendingReceived = friendship?.status === "pending" && friendship?.addressee_id === currentUser?.id;
@@ -199,12 +204,14 @@ export default function PlayerProfile() {
           <Button asChild size="sm"><Link to="/character/profile/edit"><Edit className="mr-1 h-4 w-4" />Edit profile</Link></Button>
         ) : (
           <>
-            {(connection.data === "not_connected" || !friendship) && <Button size="sm" onClick={() => sendRequest.mutate()} disabled={sendRequest.isPending || connection.send.isPending}><UserPlus className="h-4 w-4 mr-1" /> Add Friend</Button>}
+            {restrictedBySafety && <Button size="sm" variant="secondary" disabled>{blockedByViewer ? "You blocked this player" : "This player is unavailable."}</Button>}
+            {!restrictedBySafety && (connection.data === "not_connected" || !friendship) && <Button size="sm" onClick={() => sendRequest.mutate()} disabled={sendRequest.isPending || connection.send.isPending || socialPermission.data?.can_send_friend_request === false}><UserPlus className="h-4 w-4 mr-1" /> Add Friend</Button>}
             {(connection.data === "outgoing_pending" || isPendingSent) && <Button size="sm" variant="secondary" disabled><Clock className="h-4 w-4 mr-1" /> Request Sent</Button>}
             {(connection.data === "incoming_pending" || isPendingReceived) && <><Button size="sm" onClick={() => acceptRequest.mutate()} disabled={acceptRequest.isPending}><UserPlus className="h-4 w-4 mr-1" /> Accept Request</Button><Button size="sm" variant="outline" onClick={() => friendship?.id && respondToFriendship(friendship.id, "declined").then(() => queryClient.invalidateQueries({ queryKey: ["friendship-status"] }))}>Decline</Button></>}
             {(connection.data === "friends" || isFriend) && <Button size="sm" variant="destructive" onClick={() => window.confirm("Remove this friend? Friends-only profile access will be lost.") && removeFriend.mutate()} disabled={removeFriend.isPending}><UserMinus className="h-4 w-4 mr-1" /> Remove Friend</Button>}
             {connection.data === "restricted" && <Button size="sm" variant="secondary" disabled>This player is not accepting requests</Button>}
-            <FutureProfileActions />
+            <SafetyActions targetProfileId={playerId!} targetName={profile.display_name || profile.username || "this player"} isBlockedByViewer={blockedByViewer} />
+            {!restrictedBySafety && <FutureProfileActions />}
           </>
         )}
       />

--- a/src/pages/admin/PlayerReports.tsx
+++ b/src/pages/admin/PlayerReports.tsx
@@ -1,0 +1,27 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ShieldAlert } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { REPORT_CATEGORIES } from "@/services/socialSafety";
+
+const STATUSES = ["submitted", "triage", "under_review", "awaiting_information", "action_taken", "no_action", "duplicate", "closed"];
+const PRIORITIES = ["low", "normal", "high", "urgent"];
+
+export default function AdminPlayerReports() {
+  const queryClient = useQueryClient();
+  const reports = useQuery({ queryKey: ["admin-player-reports"], queryFn: async () => {
+    const { data, error } = await (supabase as any).from("player_reports").select("id, category, description, content_type, status, priority, submitted_at, reporter:profiles!player_reports_reporter_id_fkey(display_name, username), reported:profiles!player_reports_reported_player_id_fkey(display_name, username), player_report_evidence(id, evidence_type, snapshot, metadata, created_at)").order("submitted_at", { ascending: false }).limit(100);
+    if (error) throw error;
+    return data ?? [];
+  }});
+  const update = useMutation({ mutationFn: async ({ id, patch }: { id: string; patch: Record<string, string> }) => {
+    const { error } = await (supabase as any).from("player_reports").update({ ...patch, updated_at: new Date().toISOString() }).eq("id", id);
+    if (error) throw error;
+  }, onSuccess: () => queryClient.invalidateQueries({ queryKey: ["admin-player-reports"] }) });
+  const label = (value: string) => REPORT_CATEGORIES.find((item) => item.value === value)?.label ?? value;
+  return <FMPageScaffold title="Player reports" subtitle="Moderation queue for player safety reports, evidence snapshots and triage state." icon={ShieldAlert} backTo="/admin" backLabel="Back to Admin"><div className="space-y-3">{reports.isLoading && <Card><CardContent className="p-6">Loading moderation queue…</CardContent></Card>}{reports.isError && <Card role="alert"><CardContent className="p-6 text-destructive">Report queue unavailable.</CardContent></Card>}{(reports.data ?? []).map((report: any) => <Card key={report.id}><CardContent className="space-y-3 p-4"><div className="flex flex-wrap justify-between gap-2"><div><p className="font-medium">{label(report.category)}</p><p className="text-sm text-muted-foreground">Reported: {report.reported?.display_name || report.reported?.username || "Unknown"} · Reporter: {report.reporter?.display_name || report.reporter?.username || "Unknown"}</p></div><div className="flex gap-2"><Badge>{report.priority}</Badge><Badge variant="outline">{report.status}</Badge></div></div><p className="rounded-md bg-muted/40 p-3 text-sm">{report.description}</p><div className="grid gap-2 sm:grid-cols-2"><Select value={report.status} onValueChange={(status) => update.mutate({ id: report.id, patch: { status } })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{STATUSES.map((status) => <SelectItem key={status} value={status}>{status.replace(/_/g, " ")}</SelectItem>)}</SelectContent></Select><Select value={report.priority} onValueChange={(priority) => update.mutate({ id: report.id, patch: { priority } })}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent>{PRIORITIES.map((priority) => <SelectItem key={priority} value={priority}>{priority}</SelectItem>)}</SelectContent></Select></div><details className="text-sm"><summary className="cursor-pointer">Evidence snapshots</summary><pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-3">{JSON.stringify(report.player_report_evidence ?? [], null, 2)}</pre></details><Button size="sm" variant="outline" disabled={update.isPending} onClick={() => update.mutate({ id: report.id, patch: { status: "under_review" } })}>Assign to review</Button></CardContent></Card>)}{!reports.isLoading && !(reports.data ?? []).length && <Card><CardContent className="p-6 text-center">No player reports in the queue.</CardContent></Card>}</div></FMPageScaffold>;
+}

--- a/src/pages/settings/BlockedPlayers.tsx
+++ b/src/pages/settings/BlockedPlayers.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Shield } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { BLOCK_REASON_OPTIONS } from "@/services/socialSafety";
+import { useBlockedPlayers } from "@/hooks/useSocialSafety";
+
+export default function BlockedPlayersPage() {
+  const [search, setSearch] = useState("");
+  const blocked = useBlockedPlayers(search);
+  const reasonLabel = (value?: string | null) => BLOCK_REASON_OPTIONS.find((item) => item.value === value)?.label ?? "No reason stored";
+  return <FMPageScaffold title="Blocked players" subtitle="Manage players you have blocked. Unblocking does not restore friendships or previous invitations." icon={Shield} backTo="/social" backLabel="Back to Social"><div className="space-y-4"><Input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search blocked players" aria-label="Search blocked players" />{blocked.isLoading && <Card><CardContent className="p-6" aria-live="polite">Loading blocked players…</CardContent></Card>}{blocked.isError && <Card role="alert"><CardContent className="p-6 text-destructive">Safety settings unavailable. Please try again.</CardContent></Card>}{!blocked.isLoading && !blocked.isError && !(blocked.data ?? []).length && <Card><CardContent className="space-y-2 p-6 text-center"><p className="font-medium">No blocked players</p><p className="text-sm text-muted-foreground">Players you block will appear here. They will not be notified.</p></CardContent></Card>}<div className="space-y-3">{(blocked.data ?? []).map((row) => <Card key={row.id}><CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"><div className="flex items-center gap-3"><Avatar><AvatarImage src={row.avatarUrl ?? undefined} /><AvatarFallback>{row.characterName.slice(0, 2).toUpperCase()}</AvatarFallback></Avatar><div><p className="font-medium">{row.characterName}</p><p className="text-sm text-muted-foreground">Blocked {new Date(row.createdAt).toLocaleDateString()}</p><Badge variant="outline">{reasonLabel(row.reasonCategory)}</Badge></div></div><div className="flex gap-2"><Button asChild variant="outline" size="sm"><Link to={`/player/${row.blockedProfileId}`}>Limited profile</Link></Button><Button size="sm" variant="destructive" onClick={() => window.confirm("Unblock this player? Previous friendships and requests will not be restored.") && blocked.unblock.mutate(row.blockedProfileId)} disabled={blocked.unblock.isPending}>Unblock</Button></div></CardContent></Card>)}</div></div></FMPageScaffold>;
+}

--- a/src/pages/settings/MyReports.tsx
+++ b/src/pages/settings/MyReports.tsx
@@ -1,0 +1,12 @@
+import { FileWarning } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { REPORT_CATEGORIES } from "@/services/socialSafety";
+import { useMyReports } from "@/hooks/useSocialSafety";
+
+export default function MyReportsPage() {
+  const reports = useMyReports();
+  const label = (value: string) => REPORT_CATEGORIES.find((item) => item.value === value)?.label ?? value;
+  return <FMPageScaffold title="My reports" subtitle="View limited status for reports you submitted. Moderator notes, identities and disciplinary details are private." icon={FileWarning} backTo="/social" backLabel="Back to Social">{reports.isLoading && <Card><CardContent className="p-6" aria-live="polite">Loading reports…</CardContent></Card>}{reports.isError && <Card role="alert"><CardContent className="p-6 text-destructive">Moderation status unavailable.</CardContent></Card>}{!reports.isLoading && !reports.isError && !(reports.data ?? []).length && <Card><CardContent className="p-6 text-center">No previous reports.</CardContent></Card>}<div className="space-y-3">{(reports.data ?? []).map((report) => <Card key={report.id}><CardContent className="space-y-2 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><div><p className="font-medium">{label(report.category)}</p><p className="text-sm text-muted-foreground">{report.reportedPlayerName} · submitted {new Date(report.submittedAt).toLocaleDateString()}</p></div><Badge variant="outline">{report.status.replace(/_/g, " ")}</Badge></div>{report.resolutionSummary && <p className="text-sm">{report.resolutionSummary}</p>}<p className="text-xs text-muted-foreground">Last updated {new Date(report.updatedAt).toLocaleDateString()}</p></CardContent></Card>)}</div></FMPageScaffold>;
+}

--- a/src/services/__tests__/socialSafety.test.ts
+++ b/src/services/__tests__/socialSafety.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { BLOCK_REASON_OPTIONS, REPORT_CATEGORIES } from "@/services/socialSafety";
+
+describe("social safety configuration", () => {
+  it("keeps block reasons private and optional by providing prefer-not-to-say", () => {
+    expect(BLOCK_REASON_OPTIONS.map((option) => option.value)).toContain("prefer_not_to_say");
+    expect(BLOCK_REASON_OPTIONS.every((option) => option.label.length > 0)).toBe(true);
+  });
+
+  it("marks urgent report categories that require real-world safety messaging", () => {
+    const urgent = REPORT_CATEGORIES.filter((category) => category.emergency).map((category) => category.value);
+    expect(urgent).toContain("threats_intimidation");
+    expect(REPORT_CATEGORIES.map((category) => category.value)).toContain("personal_information");
+  });
+
+  it("centralizes report categories so forms can reuse the same list", () => {
+    expect(new Set(REPORT_CATEGORIES.map((category) => category.value)).size).toBe(REPORT_CATEGORIES.length);
+    expect(REPORT_CATEGORIES.length).toBeGreaterThanOrEqual(12);
+  });
+});

--- a/src/services/socialSafety.ts
+++ b/src/services/socialSafety.ts
@@ -1,0 +1,107 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export const BLOCK_REASON_OPTIONS = [
+  { value: "unwanted_contact", label: "Unwanted contact" },
+  { value: "harassment", label: "Harassment" },
+  { value: "spam", label: "Spam" },
+  { value: "scam_attempt", label: "Scam attempt" },
+  { value: "inappropriate_content", label: "Inappropriate content" },
+  { value: "threatening_behaviour", label: "Threatening behaviour" },
+  { value: "impersonation", label: "Impersonation" },
+  { value: "other", label: "Other" },
+  { value: "prefer_not_to_say", label: "Prefer not to say" },
+] as const;
+
+export const REPORT_CATEGORIES = [
+  { value: "harassment_bullying", label: "Harassment or bullying", priority: "normal" },
+  { value: "threats_intimidation", label: "Threats or intimidation", priority: "high", emergency: true },
+  { value: "hate_discriminatory_abuse", label: "Hate or discriminatory abuse", priority: "high" },
+  { value: "sexual_inappropriate_content", label: "Sexual or inappropriate content", priority: "normal" },
+  { value: "spam", label: "Spam", priority: "low" },
+  { value: "scam_fraud", label: "Scam or fraud attempt", priority: "high" },
+  { value: "impersonation", label: "Impersonation", priority: "normal" },
+  { value: "cheating_exploit_abuse", label: "Cheating or exploit abuse", priority: "normal" },
+  { value: "offensive_profile_content", label: "Offensive profile content", priority: "normal" },
+  { value: "inappropriate_name", label: "Inappropriate character or band name", priority: "normal" },
+  { value: "personal_information", label: "Real-world personal information", priority: "high" },
+  { value: "ban_evasion", label: "Ban evasion", priority: "high" },
+  { value: "other", label: "Other", priority: "normal" },
+] as const;
+
+export type BlockReasonCategory = (typeof BLOCK_REASON_OPTIONS)[number]["value"];
+export type ReportCategory = (typeof REPORT_CATEGORIES)[number]["value"];
+
+export interface SocialPermissions {
+  can_view_profile: boolean;
+  can_send_friend_request: boolean;
+  can_message: boolean;
+  can_invite_to_band: boolean;
+  can_invite_to_activity: boolean;
+  can_offer_job: boolean;
+  can_send_money: boolean;
+  can_send_item: boolean;
+  can_report: boolean;
+  is_blocked_by_viewer: boolean;
+  is_interaction_restricted: boolean;
+  neutral_message?: string | null;
+}
+
+export interface BlockedPlayerSummary {
+  id: string;
+  blockedProfileId: string;
+  characterName: string;
+  username?: string | null;
+  avatarUrl?: string | null;
+  reasonCategory?: BlockReasonCategory | null;
+  createdAt: string;
+}
+
+export interface MyReportSummary {
+  id: string;
+  category: ReportCategory;
+  contentType: string;
+  status: string;
+  priority: string;
+  submittedAt: string;
+  updatedAt: string;
+  resolutionSummary?: string | null;
+  reportedPlayerName?: string | null;
+}
+
+export async function getSocialPermissions(targetProfileId: string): Promise<SocialPermissions> {
+  const { data, error } = await (supabase as any).rpc("get_social_permissions", { target_profile_id: targetProfileId });
+  if (error) throw new Error("This player is unavailable.");
+  return data as SocialPermissions;
+}
+
+export async function blockPlayer(targetProfileId: string, reasonCategory?: BlockReasonCategory | null, privateNote?: string | null) {
+  const { data, error } = await (supabase as any).rpc("block_player", { target_profile_id: targetProfileId, reason_category: reasonCategory ?? null, private_note: privateNote ?? null });
+  if (error) throw new Error(/self/i.test(error.message) ? "You cannot block yourself." : "We couldn't block this player. Please try again.");
+  window.dispatchEvent(new CustomEvent("rockmundo:analytics", { detail: { event: "player_blocked", area: "social_safety" } }));
+  return data;
+}
+
+export async function unblockPlayer(targetProfileId: string) {
+  const { error } = await (supabase as any).rpc("unblock_player", { target_profile_id: targetProfileId });
+  if (error) throw new Error("We couldn't unblock this player. Please try again.");
+  window.dispatchEvent(new CustomEvent("rockmundo:analytics", { detail: { event: "player_unblocked", area: "social_safety" } }));
+}
+
+export async function listBlockedPlayers(search = ""): Promise<BlockedPlayerSummary[]> {
+  const { data, error } = await (supabase as any).from("player_blocks").select("id, blocked_id, reason_category, created_at, blocked:profiles!player_blocks_blocked_id_fkey(id, username, display_name, avatar_url)").is("removed_at", null).order("created_at", { ascending: false }).limit(100);
+  if (error) throw new Error("Safety settings are unavailable.");
+  return ((data ?? []) as any[]).map((row) => ({ id: row.id, blockedProfileId: row.blocked_id, characterName: row.blocked?.display_name || row.blocked?.username || "Unavailable player", username: row.blocked?.username, avatarUrl: row.blocked?.avatar_url, reasonCategory: row.reason_category, createdAt: row.created_at })).filter((row) => !search || `${row.characterName} ${row.username ?? ""}`.toLowerCase().includes(search.toLowerCase()));
+}
+
+export async function submitPlayerReport(input: { targetProfileId: string; category: ReportCategory; description: string; contentType?: string; contentId?: string | null; subcategory?: string | null; blockAfterReport?: boolean; evidence?: Record<string, unknown>; }) {
+  const { data, error } = await (supabase as any).rpc("submit_player_report", { target_profile_id: input.targetProfileId, category: input.category, description: input.description, content_type: input.contentType ?? "player_profile", content_id: input.contentId ?? null, subcategory: input.subcategory ?? null, evidence: input.evidence ?? {}, block_after_report: input.blockAfterReport ?? false });
+  if (error) throw new Error(/wait|duplicate/i.test(error.message) ? error.message : "We couldn't submit this report. Please review the form and try again.");
+  window.dispatchEvent(new CustomEvent("rockmundo:analytics", { detail: { event: input.blockAfterReport ? "block_and_report_selected" : "report_submitted", area: "social_safety", category: input.category } }));
+  return data;
+}
+
+export async function listMyReports(): Promise<MyReportSummary[]> {
+  const { data, error } = await (supabase as any).from("player_reports").select("id, category, content_type, status, priority, submitted_at, updated_at, resolution_summary, reported:profiles!player_reports_reported_player_id_fkey(display_name, username)").order("submitted_at", { ascending: false }).limit(100);
+  if (error) throw new Error("Reports are unavailable.");
+  return ((data ?? []) as any[]).map((row) => ({ id: row.id, category: row.category, contentType: row.content_type, status: row.status, priority: row.priority, submittedAt: row.submitted_at, updatedAt: row.updated_at, resolutionSummary: row.resolution_summary, reportedPlayerName: row.reported?.display_name || row.reported?.username || "Reported content" }));
+}

--- a/supabase/migrations/20291203090000_player_social_safety.sql
+++ b/supabase/migrations/20291203090000_player_social_safety.sql
@@ -1,0 +1,227 @@
+-- Player blocking, reporting and social-safety foundation.
+
+CREATE TABLE IF NOT EXISTS public.player_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  blocker_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  blocked_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  reason_category text,
+  private_note text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  removed_at timestamptz,
+  CONSTRAINT player_blocks_no_self_block CHECK (blocker_id <> blocked_id),
+  CONSTRAINT player_blocks_reason_category_check CHECK (reason_category IS NULL OR reason_category IN ('unwanted_contact','harassment','spam','scam_attempt','inappropriate_content','threatening_behaviour','impersonation','other','prefer_not_to_say'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS player_blocks_one_active_direction_idx ON public.player_blocks(blocker_id, blocked_id) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS player_blocks_blocker_active_idx ON public.player_blocks(blocker_id, created_at DESC) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS player_blocks_blocked_active_idx ON public.player_blocks(blocked_id, created_at DESC) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS player_blocks_pair_active_idx ON public.player_blocks(LEAST(blocker_id, blocked_id), GREATEST(blocker_id, blocked_id)) WHERE removed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.player_reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reporter_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE SET NULL,
+  reported_player_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  category text NOT NULL,
+  subcategory text,
+  description text NOT NULL,
+  content_type text NOT NULL DEFAULT 'player_profile',
+  content_id text,
+  status text NOT NULL DEFAULT 'submitted',
+  priority text NOT NULL DEFAULT 'normal',
+  assigned_moderator_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  submitted_at timestamptz NOT NULL DEFAULT now(),
+  reviewed_at timestamptz,
+  resolved_at timestamptz,
+  resolution text,
+  resolution_summary text,
+  duplicate_of_report_id uuid REFERENCES public.player_reports(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT player_reports_no_self_report CHECK (reported_player_id IS NULL OR reporter_id <> reported_player_id),
+  CONSTRAINT player_reports_category_check CHECK (category IN ('harassment_bullying','threats_intimidation','hate_discriminatory_abuse','sexual_inappropriate_content','spam','scam_fraud','impersonation','cheating_exploit_abuse','offensive_profile_content','inappropriate_name','personal_information','ban_evasion','other')),
+  CONSTRAINT player_reports_status_check CHECK (status IN ('submitted','triage','under_review','awaiting_information','action_taken','no_action','duplicate','closed')),
+  CONSTRAINT player_reports_priority_check CHECK (priority IN ('low','normal','high','urgent')),
+  CONSTRAINT player_reports_description_length CHECK (char_length(description) BETWEEN 10 AND 2000)
+);
+
+CREATE INDEX IF NOT EXISTS player_reports_reporter_idx ON public.player_reports(reporter_id, submitted_at DESC);
+CREATE INDEX IF NOT EXISTS player_reports_reported_idx ON public.player_reports(reported_player_id, submitted_at DESC);
+CREATE INDEX IF NOT EXISTS player_reports_queue_idx ON public.player_reports(status, priority, submitted_at DESC);
+CREATE INDEX IF NOT EXISTS player_reports_duplicate_lookup_idx ON public.player_reports(reporter_id, reported_player_id, category, content_type, COALESCE(content_id, ''), submitted_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.player_report_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id uuid NOT NULL REFERENCES public.player_reports(id) ON DELETE CASCADE,
+  evidence_type text NOT NULL,
+  source_reference text,
+  snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS player_report_evidence_report_idx ON public.player_report_evidence(report_id, created_at);
+
+ALTER TABLE public.player_blocks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_report_evidence ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Players can read their own active blocks" ON public.player_blocks FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = blocker_id AND p.user_id = auth.uid()) OR public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Players can create their own blocks" ON public.player_blocks FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = blocker_id AND p.user_id = auth.uid()) AND blocker_id <> blocked_id);
+CREATE POLICY "Players can soft delete their own blocks" ON public.player_blocks FOR UPDATE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = blocker_id AND p.user_id = auth.uid()) OR public.has_role(auth.uid(), 'admin'::public.app_role))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = blocker_id AND p.user_id = auth.uid()) OR public.has_role(auth.uid(), 'admin'::public.app_role));
+
+CREATE POLICY "Reporters can read limited own reports" ON public.player_reports FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = reporter_id AND p.user_id = auth.uid()) OR public.has_role(auth.uid(), 'admin'::public.app_role));
+CREATE POLICY "Players can submit own reports" ON public.player_reports FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = reporter_id AND p.user_id = auth.uid()));
+CREATE POLICY "Only moderators update player reports" ON public.player_reports FOR UPDATE TO authenticated
+  USING (public.has_role(auth.uid(), 'admin'::public.app_role) OR public.has_role(auth.uid(), 'moderator'::public.app_role))
+  WITH CHECK (public.has_role(auth.uid(), 'admin'::public.app_role) OR public.has_role(auth.uid(), 'moderator'::public.app_role));
+CREATE POLICY "Report evidence restricted" ON public.player_report_evidence FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.player_reports r JOIN public.profiles p ON p.id = r.reporter_id WHERE r.id = report_id AND p.user_id = auth.uid()) OR public.has_role(auth.uid(), 'admin'::public.app_role) OR public.has_role(auth.uid(), 'moderator'::public.app_role));
+CREATE POLICY "Reporters can insert evidence via submission" ON public.player_report_evidence FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (SELECT 1 FROM public.player_reports r JOIN public.profiles p ON p.id = r.reporter_id WHERE r.id = report_id AND p.user_id = auth.uid()));
+
+CREATE OR REPLACE FUNCTION public.current_profile_id()
+RETURNS uuid LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT id FROM public.profiles WHERE user_id = auth.uid() AND COALESCE(is_active, true) IS TRUE AND died_at IS NULL ORDER BY created_at LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_social_block_state(viewer_profile_id uuid, target_profile_id uuid)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT jsonb_build_object(
+    'viewer_blocked_target', EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = viewer_profile_id AND blocked_id = target_profile_id AND removed_at IS NULL),
+    'viewer_is_blocked_by_target', EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = target_profile_id AND blocked_id = viewer_profile_id AND removed_at IS NULL),
+    'mutual_block', EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = viewer_profile_id AND blocked_id = target_profile_id AND removed_at IS NULL) AND EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = target_profile_id AND blocked_id = viewer_profile_id AND removed_at IS NULL)
+  )
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_social_permissions(target_profile_id uuid)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+DECLARE viewer uuid := public.current_profile_id(); blocked boolean; viewer_blocked boolean;
+BEGIN
+  IF viewer IS NULL OR target_profile_id IS NULL OR viewer = target_profile_id THEN
+    RETURN jsonb_build_object('can_view_profile', viewer = target_profile_id, 'can_send_friend_request', false, 'can_message', false, 'can_invite_to_band', false, 'can_invite_to_activity', false, 'can_offer_job', false, 'can_send_money', false, 'can_send_item', false, 'can_report', viewer IS NOT NULL AND viewer <> target_profile_id, 'is_blocked_by_viewer', false, 'is_interaction_restricted', viewer IS NULL);
+  END IF;
+  SELECT EXISTS (SELECT 1 FROM public.player_blocks WHERE removed_at IS NULL AND blocker_id = viewer AND blocked_id = target_profile_id),
+         EXISTS (SELECT 1 FROM public.player_blocks WHERE removed_at IS NULL AND blocker_id = target_profile_id AND blocked_id = viewer)
+    INTO viewer_blocked, blocked;
+  RETURN jsonb_build_object('can_view_profile', NOT blocked, 'can_send_friend_request', NOT (blocked OR viewer_blocked), 'can_message', NOT (blocked OR viewer_blocked), 'can_invite_to_band', NOT (blocked OR viewer_blocked), 'can_invite_to_activity', NOT (blocked OR viewer_blocked), 'can_offer_job', NOT (blocked OR viewer_blocked), 'can_send_money', NOT (blocked OR viewer_blocked), 'can_send_item', NOT (blocked OR viewer_blocked), 'can_report', true, 'is_blocked_by_viewer', viewer_blocked, 'is_interaction_restricted', (blocked OR viewer_blocked), 'neutral_message', CASE WHEN blocked THEN 'This player is unavailable.' ELSE NULL END);
+END $$;
+
+CREATE OR REPLACE FUNCTION public.block_player(target_profile_id uuid, reason_category text DEFAULT NULL, private_note text DEFAULT NULL)
+RETURNS public.player_blocks LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE viewer uuid := public.current_profile_id(); row public.player_blocks;
+BEGIN
+  IF viewer IS NULL THEN RAISE EXCEPTION 'Sign in with an active player profile.'; END IF;
+  IF target_profile_id IS NULL OR viewer = target_profile_id THEN RAISE EXCEPTION 'You cannot block yourself.'; END IF;
+  INSERT INTO public.player_blocks(blocker_id, blocked_id, reason_category, private_note)
+  VALUES (viewer, target_profile_id, reason_category, NULLIF(left(COALESCE(private_note, ''), 500), ''))
+  ON CONFLICT (blocker_id, blocked_id) WHERE removed_at IS NULL DO UPDATE SET updated_at = now(), reason_category = EXCLUDED.reason_category, private_note = EXCLUDED.private_note
+  RETURNING * INTO row;
+  UPDATE public.friendships SET status = CASE WHEN status = 'accepted' THEN 'removed'::public.friendship_status ELSE 'cancelled'::public.friendship_status END, responded_at = now(), updated_at = now()
+    WHERE ((requestor_id = viewer AND addressee_id = target_profile_id) OR (requestor_id = target_profile_id AND addressee_id = viewer)) AND status IN ('pending','accepted');
+  UPDATE public.notifications SET read_at = now() WHERE (user_id IN (SELECT user_id FROM public.profiles WHERE id IN (viewer, target_profile_id))) AND COALESCE(profile_id::text, metadata->>'profile_id', metadata->>'target_profile_id') IN (viewer::text, target_profile_id::text) AND read_at IS NULL;
+  INSERT INTO public.admin_action_audit(actor_user_id, action, target_table, target_id, metadata) SELECT auth.uid(), 'player_blocked', 'player_blocks', row.id::text, jsonb_build_object('blocker_id', viewer, 'blocked_id', target_profile_id) WHERE to_regclass('public.admin_action_audit') IS NOT NULL;
+  RETURN row;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.unblock_player(target_profile_id uuid)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE viewer uuid := public.current_profile_id(); changed int;
+BEGIN
+  IF viewer IS NULL THEN RAISE EXCEPTION 'Sign in with an active player profile.'; END IF;
+  UPDATE public.player_blocks SET removed_at = now(), updated_at = now() WHERE blocker_id = viewer AND blocked_id = target_profile_id AND removed_at IS NULL;
+  GET DIAGNOSTICS changed = ROW_COUNT;
+  RETURN changed > 0;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.submit_player_report(target_profile_id uuid, category text, description text, content_type text DEFAULT 'player_profile', content_id text DEFAULT NULL, subcategory text DEFAULT NULL, evidence jsonb DEFAULT '{}'::jsonb, block_after_report boolean DEFAULT false)
+RETURNS public.player_reports LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE viewer uuid := public.current_profile_id(); report_row public.player_reports; recent_count int; initial_priority text := 'normal';
+BEGIN
+  IF viewer IS NULL THEN RAISE EXCEPTION 'Sign in with an active player profile.'; END IF;
+  IF target_profile_id IS NULL OR target_profile_id = viewer THEN RAISE EXCEPTION 'Choose a valid player to report.'; END IF;
+  IF char_length(trim(description)) < 10 OR char_length(description) > 2000 THEN RAISE EXCEPTION 'Reports need 10 to 2000 characters.'; END IF;
+  SELECT count(*) INTO recent_count FROM public.player_reports WHERE reporter_id = viewer AND submitted_at > now() - interval '10 minutes';
+  IF recent_count >= 5 THEN RAISE EXCEPTION 'Please wait before submitting another report.'; END IF;
+  IF category IN ('threats_intimidation','personal_information','hate_discriminatory_abuse','ban_evasion','scam_fraud') THEN initial_priority := 'high'; END IF;
+  INSERT INTO public.player_reports(reporter_id, reported_player_id, category, subcategory, description, content_type, content_id, priority)
+  VALUES (viewer, target_profile_id, category, NULLIF(left(COALESCE(subcategory,''), 80), ''), trim(description), COALESCE(NULLIF(content_type,''), 'player_profile'), NULLIF(left(COALESCE(content_id,''), 120), ''), initial_priority)
+  RETURNING * INTO report_row;
+  INSERT INTO public.player_report_evidence(report_id, evidence_type, source_reference, snapshot, metadata)
+  VALUES (report_row.id, COALESCE(NULLIF(content_type,''), 'player_profile'), content_id, COALESCE(evidence, '{}'::jsonb), jsonb_build_object('captured_at', now(), 'reporter_id', viewer, 'reported_player_id', target_profile_id));
+  IF block_after_report THEN PERFORM public.block_player(target_profile_id, 'prefer_not_to_say', 'Blocked after submitting a report.'); END IF;
+  RETURN report_row;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.are_profiles_blocked(left_profile_id uuid, right_profile_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.player_blocks WHERE removed_at IS NULL AND ((blocker_id = left_profile_id AND blocked_id = right_profile_id) OR (blocker_id = right_profile_id AND blocked_id = left_profile_id))) OR EXISTS (SELECT 1 FROM public.social_profile_blocks WHERE (blocker_profile_id = left_profile_id AND blocked_profile_id = right_profile_id) OR (blocker_profile_id = right_profile_id AND blocked_profile_id = left_profile_id))
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_send_friend_request(sender_profile_id uuid, recipient_profile_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT sender_profile_id IS NOT NULL AND recipient_profile_id IS NOT NULL AND sender_profile_id <> recipient_profile_id
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = sender_profile_id)
+    AND EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = recipient_profile_id)
+    AND NOT public.are_profiles_blocked(sender_profile_id, recipient_profile_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_connection_state(target_profile_id uuid)
+RETURNS text LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public AS $$
+DECLARE viewer uuid := public.current_profile_id(); f public.friendships; target_exists boolean; allow_mode text; viewer_blocked boolean; target_blocked boolean;
+BEGIN
+  IF viewer IS NULL OR target_profile_id IS NULL THEN RETURN 'unavailable'; END IF;
+  IF viewer = target_profile_id THEN RETURN 'self'; END IF;
+  SELECT EXISTS (SELECT 1 FROM public.profiles WHERE id = target_profile_id) INTO target_exists;
+  IF NOT target_exists THEN RETURN 'unavailable'; END IF;
+  SELECT EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = viewer AND blocked_id = target_profile_id AND removed_at IS NULL), EXISTS (SELECT 1 FROM public.player_blocks WHERE blocker_id = target_profile_id AND blocked_id = viewer AND removed_at IS NULL) INTO viewer_blocked, target_blocked;
+  IF viewer_blocked THEN RETURN 'blocked_by_viewer'; END IF;
+  IF target_blocked THEN RETURN 'viewer_blocked'; END IF;
+  SELECT * INTO f FROM public.friendships WHERE (requestor_id = viewer AND addressee_id = target_profile_id) OR (requestor_id = target_profile_id AND addressee_id = viewer) LIMIT 1;
+  IF f.status = 'accepted'::public.friendship_status THEN RETURN 'friends'; END IF;
+  IF f.status = 'pending'::public.friendship_status AND f.requestor_id = viewer THEN RETURN 'outgoing_pending'; END IF;
+  IF f.status = 'pending'::public.friendship_status AND f.addressee_id = viewer THEN RETURN 'incoming_pending'; END IF;
+  IF f.status = 'blocked'::public.friendship_status THEN RETURN 'restricted'; END IF;
+  SELECT COALESCE(fs.allow_friend_requests, 'everyone') INTO allow_mode FROM public.friendship_settings fs WHERE fs.profile_id = target_profile_id;
+  IF allow_mode = 'none' THEN RETURN 'restricted'; END IF;
+  RETURN 'not_connected';
+END $$;
+
+CREATE OR REPLACE FUNCTION public.search_player_discovery(viewer_profile_id uuid DEFAULT NULL, query jsonb DEFAULT '{}'::jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE actor_profile_id uuid; q text := NULLIF(BTRIM(COALESCE(query->>'search','')), ''); filters jsonb := COALESCE(query->'filters','{}'::jsonb); lim int := LEAST(GREATEST(COALESCE((query->>'pageSize')::int, 18),1),48); pg int := GREATEST(COALESCE((query->>'page')::int,1),1); off int; actor_city uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'Authentication required' USING ERRCODE='42501'; END IF;
+  SELECT id, current_city_id INTO actor_profile_id, actor_city FROM public.profiles WHERE user_id = auth.uid() AND (viewer_profile_id IS NULL OR id = viewer_profile_id) ORDER BY created_at LIMIT 1;
+  IF actor_profile_id IS NULL THEN RAISE EXCEPTION 'Active profile required' USING ERRCODE='42501'; END IF;
+  off := (pg - 1) * lim;
+  RETURN (WITH candidates AS (
+    SELECT p.id, p.user_id, COALESCE(p.display_name,p.username) character_name, p.avatar_url,
+      CASE WHEN COALESCE(pps.city_visibility,'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope THEN c.name ELSE NULL END city_name,
+      CASE WHEN COALESCE(pps.city_visibility,'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope THEN p.current_city_id ELSE NULL END visible_city_id,
+      COALESCE(b.name, NULL) current_band, pdp.primary_instrument, pdp.musical_roles, pdp.preferred_genres, COALESCE(p.fame,0) fame, COALESCE(pdp.career_level, 'Level ' || COALESCE(p.level,1)::text) career_level,
+      pdp.availability, pdp.status_message, public.player_discovery_match_score(pdp, filters, actor_city, CASE WHEN COALESCE(pps.city_visibility,'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope THEN p.current_city_id ELSE NULL END) match
+    FROM public.profiles p
+    JOIN public.player_discovery_profiles pdp ON pdp.profile_id = p.id
+    LEFT JOIN public.profile_privacy_settings pps ON pps.profile_id = p.id
+    LEFT JOIN public.cities c ON c.id = p.current_city_id
+    LEFT JOIN public.band_members bm ON bm.user_id = p.user_id
+    LEFT JOIN public.bands b ON b.id = bm.band_id
+    WHERE public.can_view_public_profile_summary(actor_profile_id, p.id)
+      AND NOT public.are_profiles_blocked(actor_profile_id, p.id)
+      AND (q IS NULL OR COALESCE(p.display_name,p.username,'') ILIKE '%'||q||'%' OR COALESCE(pdp.primary_instrument,'') ILIKE '%'||q||'%' OR EXISTS (SELECT 1 FROM unnest(pdp.preferred_genres || pdp.musical_roles || pdp.secondary_instruments) term WHERE term ILIKE '%'||q||'%') OR (COALESCE(pps.city_visibility,'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope AND c.name ILIKE '%'||q||'%') OR COALESCE(pdp.status_message,'') ILIKE '%'||q||'%')
+      AND (filters->>'instrument' IS NULL OR lower(pdp.primary_instrument) = lower(filters->>'instrument') OR lower(filters->>'instrument') = ANY(SELECT lower(x) FROM unnest(pdp.secondary_instruments) x))
+      AND (filters->>'genre' IS NULL OR lower(filters->>'genre') = ANY(SELECT lower(x) FROM unnest(pdp.preferred_genres) x))
+      AND (filters->>'role' IS NULL OR lower(filters->>'role') = ANY(SELECT lower(x) FROM unnest(pdp.musical_roles) x))
+      AND (filters->>'city' IS NULL OR (COALESCE(pps.city_visibility,'friends'::public.profile_visibility_scope) = 'public'::public.profile_visibility_scope AND c.name ILIKE filters->>'city'))
+      AND (filters->>'lookingForBand' IS NULL OR COALESCE((pdp.availability->>'lookingForBand')::boolean,false) = (filters->>'lookingForBand')::boolean)
+      AND (filters->>'sessionAvailable' IS NULL OR COALESCE((pdp.availability->>'sessionAvailable')::boolean,false) = (filters->>'sessionAvailable')::boolean)
+  ), sorted AS (SELECT * FROM candidates ORDER BY (match->>'percentage')::int DESC, character_name ASC OFFSET off LIMIT lim + 1)
+  SELECT jsonb_build_object('results', COALESCE(jsonb_agg(jsonb_build_object('profile_id', id, 'user_id', user_id, 'character_name', character_name, 'avatar_url', avatar_url, 'city_name', city_name, 'activity_state', 'hidden', 'current_band', current_band, 'primary_instrument', primary_instrument, 'primary_role', musical_roles[1], 'preferred_genres', preferred_genres, 'fame', fame, 'career_level', career_level, 'availability', (SELECT COALESCE(jsonb_agg(key), '[]'::jsonb) FROM jsonb_each_text(availability) WHERE value = 'true'), 'status_message', status_message, 'badges', '[]'::jsonb, 'match', match)) FILTER (WHERE rn <= lim), '[]'::jsonb), 'has_more', COUNT(*) > lim, 'approximate_total', CASE WHEN COUNT(*) < 10 THEN NULL ELSE COUNT(*) END) FROM (SELECT *, row_number() over () AS rn FROM sorted) s);
+END; $$;


### PR DESCRIPTION
### Motivation
- Provide a central, server-enforced social-safety layer so all player-to-player features use a single source of truth for blocking and reporting decisions.
- Ensure blocks and reports are auditable, privacy-preserving, and enforceable across profiles, discovery, friendships and notifications without leaking reporter/blocker identities.
- Prepare a reusable API surface for future systems (messaging, invitations, transfers) to ask permission via the same guards.

### Description
- Database and server: add migration `supabase/migrations/20291203090000_player_social_safety.sql` introducing `player_blocks`, `player_reports`, `player_report_evidence`, indexes, RLS policies, and RPCs including `get_social_permissions`, `block_player`, `unblock_player`, `submit_player_report`, `are_profiles_blocked`, plus discovery and friend-request guards to exclude blocked pairs.
- Client services and hooks: add centralized service `src/services/socialSafety.ts` (block reasons, report categories, RPC wrappers) and React-Query hooks `src/hooks/useSocialSafety.ts` for permission checks, block/report mutations, blocked-player listing and reporter-facing report retrieval.
- UI and integration: add reusable block/report UI `src/components/social-safety/SafetyActions.tsx`, integrate into `PlayerProfile` and `PlayerDiscoveryCard`, add management pages `src/pages/settings/BlockedPlayers.tsx` and `src/pages/settings/MyReports.tsx`, and admin moderation queue `src/pages/admin/PlayerReports.tsx` and routes in `src/App.tsx`.
- Other integrations and docs: filter friend suggestions to exclude blocked players (`src/integrations/supabase/playerConnections.ts`), add unit coverage for safety configuration `src/services/__tests__/socialSafety.test.ts`, and document behavior in `docs/social/social-safety.md`.

### Testing
- `npm run typecheck` ran successfully (no TypeScript errors).
- `npm run lint` failed in this environment due to a missing local ESLint dependency (`@eslint/js`) causing the lint step to error.
- `npm run test:unit -- src/services/__tests__/socialSafety.test.ts` could not run here because the `vitest` binary is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a551ee3a07483259ccb9b98ba15d9dd)