### PR TITLE
feat(bands): add internal roles, permission catalogue, temporary delegations and management UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -349,6 +349,7 @@ const ROUTE_TITLES = new Map<string, string>([
   ["/about", "About"],
   ["/song/:songId", "Song"],
   ["/bands/:bandId/management", "Band Management"],
+  ["/bands/:bandId/manage/roles", "Band Roles"],
   ["/gigs/perform/:gigId", "Perform Gig"],
   ["/streaming/:platformId", "Streaming Platform"],
   ["/cities/:cityId", "City"],
@@ -511,6 +512,7 @@ function App() {
                     <Route path="band/tours" element={<PreserveQueryRedirect to="/tour-manager" />} />
                     <Route path="band/equipment" element={<PreserveQueryRedirect to="/band-crew" />} />
                     <Route path="bands/:bandId/management" element={<BandManagementPage />} />
+                    <Route path="bands/:bandId/manage/roles" element={<BandManagementPage />} />
                     <Route path="bands/:bandId/recruitment" element={<BandRecruitmentManagement />} />
                     <Route path="bands/:bandId/recruitment/new" element={<BandRecruitmentManagement />} />
                     <Route path="gigs" element={<GigBooking />} />

--- a/src/components/bands/BandRolesTab.tsx
+++ b/src/components/bands/BandRolesTab.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { BAND_PERMISSION_CATALOGUE, DEFAULT_BAND_ROLE_TEMPLATES, permissionByKey } from "@/lib/band-permissions";
+import { ShieldCheck, Timer, UserCog, Vote } from "lucide-react";
+
+interface BandRolesTabProps { bandId: string; }
+
+const riskClassName: Record<string, string> = {
+  low: "bg-emerald-500/15 text-emerald-700",
+  standard: "bg-sky-500/15 text-sky-700",
+  sensitive: "bg-amber-500/15 text-amber-700",
+  critical: "bg-red-500/15 text-red-700",
+};
+
+function humanCategory(value: string) {
+  return value.replace("_", " & ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function BandRolesTab({ bandId }: BandRolesTabProps) {
+  const groupedPermissions = useMemo(() => {
+    return BAND_PERMISSION_CATALOGUE.reduce<Record<string, typeof BAND_PERMISSION_CATALOGUE[number][]>>((acc, permission) => {
+      acc[permission.category] = [...(acc[permission.category] ?? []), permission];
+      return acc;
+    }, {});
+  }, []);
+
+  return (
+    <div className="space-y-6" data-band-id={bandId}>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-4 w-4" /> Current authority</CardTitle>
+            <CardDescription>Founder is historical; owner/controller remains the band leader until a transfer workflow completes.</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><UserCog className="h-4 w-4" /> Responsibilities</CardTitle>
+            <CardDescription>Musical position stays separate from one primary leadership role and multiple management roles.</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><Timer className="h-4 w-4" /> Temporary delegation</CardTitle>
+            <CardDescription>Expiring role assignments and overrides are modelled centrally and deny overrides take precedence.</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2"><Vote className="h-4 w-4" /> Approval-ready</CardTitle>
+            <CardDescription>Approval requests support leader, owner, two-person, majority and unanimous policy modes.</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Default role templates</CardTitle>
+          <CardDescription>Reusable system roles seeded by the permission foundation; custom per-band roles use the same permission keys.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Purpose</TableHead>
+                  <TableHead>Protection</TableHead>
+                  <TableHead>Permissions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {DEFAULT_BAND_ROLE_TEMPLATES.map((role) => (
+                  <TableRow key={role.roleType}>
+                    <TableCell className="font-medium">{role.name}</TableCell>
+                    <TableCell className="max-w-md text-sm text-muted-foreground">{role.description}</TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {role.protected && <Badge variant="outline">Protected</Badge>}
+                        {role.primaryLeadership && <Badge variant="secondary">Leadership</Badge>}
+                        {!role.protected && !role.primaryLeadership && <Badge variant="outline">Assignable</Badge>}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex max-w-lg flex-wrap gap-1">
+                        {role.permissions.slice(0, 8).map((key) => (
+                          <Badge key={key} className={riskClassName[permissionByKey.get(key)?.risk ?? "standard"]}>
+                            {permissionByKey.get(key)?.label ?? key}
+                          </Badge>
+                        ))}
+                        {role.permissions.length > 8 && <Badge variant="outline">+{role.permissions.length - 8} more</Badge>}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Permission catalogue and risk levels</CardTitle>
+          <CardDescription>Stable machine-readable keys are grouped by domain. Risk controls who may grant each permission.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-2">
+          {Object.entries(groupedPermissions).map(([category, permissions]) => (
+            <section key={category} className="rounded-lg border p-3">
+              <h3 className="mb-3 font-semibold">{humanCategory(category)}</h3>
+              <div className="space-y-2">
+                {permissions.map((permission) => (
+                  <div key={permission.key} className="flex items-center justify-between gap-3 text-sm">
+                    <div>
+                      <p className="font-medium">{permission.label}</p>
+                      <code className="text-xs text-muted-foreground">{permission.key}</code>
+                    </div>
+                    <Badge className={riskClassName[permission.risk]}>{permission.risk}</Badge>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/__tests__/band-permissions.test.ts
+++ b/src/lib/__tests__/band-permissions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { BAND_PERMISSION_CATALOGUE, BandPermissionService, DEFAULT_BAND_ROLE_TEMPLATES } from "../band-permissions";
+
+describe("band permissions", () => {
+  it("defines stable unique permission keys and default role templates", () => {
+    const keys = BAND_PERMISSION_CATALOGUE.map((permission) => permission.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(DEFAULT_BAND_ROLE_TEMPLATES.map((role) => role.roleType)).toContain("band_leader");
+    expect(DEFAULT_BAND_ROLE_TEMPLATES.map((role) => role.roleType)).toContain("trial_member");
+  });
+
+  it("resolves multiple roles, temporary delegation and direct deny precedence", () => {
+    const result = BandPermissionService.resolveEffectivePermissions({
+      isActiveMember: true,
+      rolePermissions: ["scheduling.create_rehearsal", "finance.view_summary"],
+      temporaryPermissions: [{ key: "tours.book_transport", expiresAt: "2030-01-01" }],
+      overrides: [{ key: "finance.view_summary", effect: "deny" }],
+      now: new Date("2026-07-13"),
+    });
+    expect(result.allowed.has("scheduling.create_rehearsal")).toBe(true);
+    expect(result.allowed.has("tours.book_transport")).toBe(true);
+    expect(result.allowed.has("finance.view_summary")).toBe(false);
+    expect(result.denied.has("finance.view_summary")).toBe(true);
+  });
+
+  it("expires delegations and strips suspended member permissions", () => {
+    expect(BandPermissionService.resolveEffectivePermissions({
+      isActiveMember: true,
+      temporaryPermissions: [{ key: "tours.book_transport", expiresAt: "2026-01-01" }],
+      now: new Date("2026-07-13"),
+    }).allowed.has("tours.book_transport")).toBe(false);
+
+    expect(BandPermissionService.resolveEffectivePermissions({
+      isActiveMember: true,
+      isSuspended: true,
+      isOwner: true,
+    }).allowed.size).toBe(0);
+  });
+
+  it("prevents grants at equal or higher risk by default", () => {
+    expect(BandPermissionService.canGrant(["finance.view_transactions"], "finance.manage_revenue_splits")).toBe(false);
+    expect(BandPermissionService.canGrant(["admin.manage_permissions"], "finance.view_transactions")).toBe(true);
+  });
+});

--- a/src/lib/band-permissions.ts
+++ b/src/lib/band-permissions.ts
@@ -1,0 +1,168 @@
+export type BandPermissionRisk = "low" | "standard" | "sensitive" | "critical";
+export type BandPermissionCategory =
+  | "membership" | "scheduling" | "gigs_tours" | "creative" | "finance" | "publicity" | "merch" | "administration";
+
+export type BandPermissionKey = (typeof BAND_PERMISSION_CATALOGUE)[number]["key"];
+
+export interface BandPermissionDefinition {
+  key: string;
+  label: string;
+  category: BandPermissionCategory;
+  risk: BandPermissionRisk;
+}
+
+export const BAND_PERMISSION_CATALOGUE = [
+  { key: "membership.view_roster", label: "View full member roster", category: "membership", risk: "low" },
+  { key: "membership.invite_player", label: "Invite player", category: "membership", risk: "standard" },
+  { key: "membership.review_applications", label: "Review applications", category: "membership", risk: "standard" },
+  { key: "membership.send_offer", label: "Send membership offer", category: "membership", risk: "standard" },
+  { key: "membership.remove_member", label: "Remove member", category: "membership", risk: "sensitive" },
+  { key: "membership.approve_departure", label: "Approve member departure", category: "membership", risk: "sensitive" },
+  { key: "membership.manage_trials", label: "Manage trial members", category: "membership", risk: "standard" },
+  { key: "membership.change_positions", label: "Change musical positions", category: "membership", risk: "standard" },
+  { key: "membership.assign_responsibilities", label: "Assign responsibilities", category: "membership", risk: "sensitive" },
+  { key: "scheduling.create_rehearsal", label: "Create rehearsal", category: "scheduling", risk: "standard" },
+  { key: "scheduling.edit_rehearsal", label: "Edit rehearsal", category: "scheduling", risk: "standard" },
+  { key: "scheduling.cancel_rehearsal", label: "Cancel rehearsal", category: "scheduling", risk: "sensitive" },
+  { key: "scheduling.create_jam", label: "Create jam session", category: "scheduling", risk: "standard" },
+  { key: "scheduling.schedule_activity", label: "Schedule band activity", category: "scheduling", risk: "standard" },
+  { key: "scheduling.manage_attendance", label: "Manage attendance", category: "scheduling", risk: "standard" },
+  { key: "scheduling.view_private", label: "View private band schedule", category: "scheduling", risk: "low" },
+  { key: "gigs.apply", label: "Apply for gig", category: "gigs_tours", risk: "standard" },
+  { key: "gigs.accept", label: "Accept gig", category: "gigs_tours", risk: "sensitive" },
+  { key: "gigs.decline", label: "Decline gig", category: "gigs_tours", risk: "sensitive" },
+  { key: "gigs.prepare", label: "Create gig preparation", category: "gigs_tours", risk: "standard" },
+  { key: "gigs.edit_setlist", label: "Edit setlist", category: "gigs_tours", risk: "standard" },
+  { key: "tours.schedule", label: "Schedule tour", category: "gigs_tours", risk: "sensitive" },
+  { key: "tours.edit", label: "Edit tour", category: "gigs_tours", risk: "standard" },
+  { key: "tours.cancel", label: "Cancel tour", category: "gigs_tours", risk: "critical" },
+  { key: "tours.book_transport", label: "Book transport", category: "gigs_tours", risk: "sensitive" },
+  { key: "tours.book_accommodation", label: "Book accommodation", category: "gigs_tours", risk: "sensitive" },
+  { key: "creative.propose_song", label: "Propose song", category: "creative", risk: "low" },
+  { key: "creative.approve_song", label: "Approve band song", category: "creative", risk: "sensitive" },
+  { key: "creative.manage_songwriting", label: "Manage songwriting session", category: "creative", risk: "standard" },
+  { key: "creative.assign_contributors", label: "Assign song contributors", category: "creative", risk: "standard" },
+  { key: "creative.approve_recording", label: "Approve recording", category: "creative", risk: "sensitive" },
+  { key: "creative.select_studio", label: "Select recording studio", category: "creative", risk: "standard" },
+  { key: "creative.approve_release", label: "Approve release", category: "creative", risk: "sensitive" },
+  { key: "creative.manage_credits", label: "Manage credits", category: "creative", risk: "sensitive" },
+  { key: "creative.manage_repertoire", label: "Manage repertoire", category: "creative", risk: "standard" },
+  { key: "finance.view_summary", label: "View summary finances", category: "finance", risk: "standard" },
+  { key: "finance.view_transactions", label: "View full transaction history", category: "finance", risk: "sensitive" },
+  { key: "finance.approve_expense", label: "Approve expense", category: "finance", risk: "sensitive" },
+  { key: "finance.make_payment", label: "Make payment", category: "finance", risk: "critical" },
+  { key: "finance.set_spending_limits", label: "Set spending limits", category: "finance", risk: "critical" },
+  { key: "finance.manage_revenue_splits", label: "Manage revenue splits", category: "finance", risk: "critical" },
+  { key: "finance.manage_budget", label: "Manage band budget", category: "finance", risk: "sensitive" },
+  { key: "finance.purchase_equipment", label: "Purchase equipment", category: "finance", risk: "sensitive" },
+  { key: "finance.sell_assets", label: "Sell band assets", category: "finance", risk: "sensitive" },
+  { key: "publicity.edit_profile", label: "Edit band profile", category: "publicity", risk: "low" },
+  { key: "publicity.post_updates", label: "Post band updates", category: "publicity", risk: "standard" },
+  { key: "publicity.manage_twaater", label: "Manage Twaater account", category: "publicity", risk: "standard" },
+  { key: "publicity.manage_campaigns", label: "Manage publicity campaigns", category: "publicity", risk: "standard" },
+  { key: "publicity.update_recruitment", label: "Update recruitment status", category: "publicity", risk: "standard" },
+  { key: "publicity.manage_fans", label: "Manage fan communications", category: "publicity", risk: "standard" },
+  { key: "merch.create", label: "Create merchandise", category: "merch", risk: "standard" },
+  { key: "merch.set_prices", label: "Set prices", category: "merch", risk: "sensitive" },
+  { key: "merch.order_stock", label: "Order stock", category: "merch", risk: "sensitive" },
+  { key: "merch.manage_inventory", label: "Manage inventory", category: "merch", risk: "standard" },
+  { key: "merch.view_finances", label: "View merch finances", category: "merch", risk: "sensitive" },
+  { key: "admin.manage_roles", label: "Manage roles", category: "administration", risk: "sensitive" },
+  { key: "admin.manage_permissions", label: "Manage permissions", category: "administration", risk: "critical" },
+  { key: "admin.transfer_ownership", label: "Transfer ownership", category: "administration", risk: "critical" },
+  { key: "admin.change_settings", label: "Change band settings", category: "administration", risk: "sensitive" },
+  { key: "admin.disband", label: "Disband band", category: "administration", risk: "critical" },
+  { key: "admin.view_audit", label: "View audit history", category: "administration", risk: "sensitive" },
+] as const satisfies readonly BandPermissionDefinition[];
+
+export interface BandRoleTemplate {
+  roleType: string;
+  name: string;
+  description: string;
+  protected: boolean;
+  primaryLeadership: boolean;
+  permissions: string[];
+}
+
+const allOperational = BAND_PERMISSION_CATALOGUE.filter((p) => p.risk !== "critical").map((p) => p.key);
+const memberBase = ["membership.view_roster", "scheduling.view_private", "creative.propose_song"];
+
+export const DEFAULT_BAND_ROLE_TEMPLATES: BandRoleTemplate[] = [
+  { roleType: "founder", name: "Founder", description: "Historical creator marker; not permanently authoritative by itself.", protected: true, primaryLeadership: false, permissions: memberBase },
+  { roleType: "band_leader", name: "Band leader", description: "Broad active operational control without ownership-transfer powers.", protected: true, primaryLeadership: true, permissions: allOperational },
+  { roleType: "co_leader", name: "Co-leader", description: "Shared leadership for sensitive operations and day-to-day control.", protected: false, primaryLeadership: true, permissions: allOperational.filter((k) => !k.startsWith("finance.view_transactions")) },
+  { roleType: "manager", name: "Manager", description: "Recruitment, scheduling, gigs, tours and publicity without ownership or unrestricted finance.", protected: false, primaryLeadership: false, permissions: allOperational.filter((k) => !k.startsWith("finance.") || ["finance.view_summary", "finance.manage_budget"].includes(k)) },
+  { roleType: "musical_director", name: "Musical director", description: "Repertoire, setlists, song approvals, rehearsal planning and recording preparation.", protected: false, primaryLeadership: false, permissions: ["creative.approve_song", "creative.manage_songwriting", "creative.assign_contributors", "creative.select_studio", "creative.manage_repertoire", "gigs.edit_setlist", "scheduling.create_rehearsal", "scheduling.edit_rehearsal"] },
+  { roleType: "recruitment_manager", name: "Recruitment manager", description: "Vacancies, applications, invitations and trial-member management.", protected: false, primaryLeadership: false, permissions: ["membership.invite_player", "membership.review_applications", "membership.send_offer", "membership.manage_trials", "publicity.update_recruitment"] },
+  { roleType: "booking_manager", name: "Booking manager", description: "Gig applications, offer responses, venue communication and tour scheduling.", protected: false, primaryLeadership: false, permissions: ["gigs.apply", "gigs.accept", "gigs.decline", "gigs.prepare", "tours.schedule", "tours.edit"] },
+  { roleType: "tour_manager", name: "Tour manager", description: "Tour planning, logistics, transport, accommodation and attendance coordination.", protected: false, primaryLeadership: false, permissions: ["tours.schedule", "tours.edit", "tours.book_transport", "tours.book_accommodation", "scheduling.manage_attendance"] },
+  { roleType: "finance_manager", name: "Finance manager", description: "Reports, budgets, expense approval and limited payments; no ownership control.", protected: false, primaryLeadership: false, permissions: ["finance.view_summary", "finance.view_transactions", "finance.approve_expense", "finance.manage_budget", "finance.purchase_equipment"] },
+  { roleType: "recording_manager", name: "Recording manager", description: "Recording approvals, studios, sessions and release preparation.", protected: false, primaryLeadership: false, permissions: ["creative.approve_recording", "creative.select_studio", "creative.approve_release", "creative.manage_credits"] },
+  { roleType: "songwriting_coordinator", name: "Songwriting coordinator", description: "Song pipeline, collaboration sessions and contributor assignments.", protected: false, primaryLeadership: false, permissions: ["creative.propose_song", "creative.manage_songwriting", "creative.assign_contributors"] },
+  { roleType: "publicity_manager", name: "Publicity manager", description: "Public profile, social posts, campaigns, gigs, releases and fan announcements.", protected: false, primaryLeadership: false, permissions: ["publicity.edit_profile", "publicity.post_updates", "publicity.manage_twaater", "publicity.manage_campaigns", "publicity.update_recruitment", "publicity.manage_fans"] },
+  { roleType: "merch_manager", name: "Merch manager", description: "Products, sale prices, stock orders, inventory and merch performance.", protected: false, primaryLeadership: false, permissions: ["merch.create", "merch.set_prices", "merch.order_stock", "merch.manage_inventory", "merch.view_finances"] },
+  { roleType: "member", name: "Member", description: "Ordinary member access to roster, private schedule and creative proposals.", protected: false, primaryLeadership: false, permissions: memberBase },
+  { roleType: "trial_member", name: "Trial member", description: "Limited rehearsal and internal access while under review.", protected: false, primaryLeadership: false, permissions: ["scheduling.view_private", "creative.propose_song"] },
+];
+
+const riskWeight: Record<BandPermissionRisk, number> = { low: 1, standard: 2, sensitive: 3, critical: 4 };
+export const permissionByKey = new Map(BAND_PERMISSION_CATALOGUE.map((permission) => [permission.key, permission]));
+
+export interface EffectivePermissionInput {
+  isOwner?: boolean;
+  isActiveMember?: boolean;
+  isSuspended?: boolean;
+  rolePermissions?: string[];
+  temporaryPermissions?: Array<{ key: string; expiresAt?: string | Date | null }>;
+  overrides?: Array<{ key: string; effect: "allow" | "deny"; expiresAt?: string | Date | null }>;
+  now?: Date;
+}
+
+export interface EffectivePermissionResult {
+  allowed: Set<string>;
+  denied: Set<string>;
+  sources: Record<string, string[]>;
+}
+
+function isActiveExpiry(value: string | Date | null | undefined, now: Date) {
+  if (!value) return true;
+  const expires = value instanceof Date ? value : new Date(value);
+  return !Number.isNaN(expires.getTime()) && expires > now;
+}
+
+export class BandPermissionService {
+  static resolveEffectivePermissions(input: EffectivePermissionInput): EffectivePermissionResult {
+    const now = input.now ?? new Date();
+    const allowed = new Set<string>();
+    const denied = new Set<string>();
+    const sources: Record<string, string[]> = {};
+    const add = (key: string, source: string) => {
+      if (!permissionByKey.has(key)) return;
+      allowed.add(key);
+      sources[key] = [...(sources[key] ?? []), source];
+    };
+    if (!input.isActiveMember || input.isSuspended) return { allowed, denied, sources };
+    if (input.isOwner) BAND_PERMISSION_CATALOGUE.forEach((permission) => add(permission.key, "Band owner"));
+    input.rolePermissions?.forEach((key) => add(key, "Assigned role"));
+    input.temporaryPermissions?.filter((entry) => isActiveExpiry(entry.expiresAt, now)).forEach((entry) => add(entry.key, "Temporary delegation"));
+    input.overrides?.filter((entry) => isActiveExpiry(entry.expiresAt, now)).forEach((entry) => {
+      if (entry.effect === "deny") {
+        allowed.delete(entry.key);
+        denied.add(entry.key);
+        sources[entry.key] = ["Direct deny override"];
+      } else if (!denied.has(entry.key)) {
+        add(entry.key, "Direct allow override");
+      }
+    });
+    return { allowed, denied, sources };
+  }
+
+  static canGrant(granterPermissions: Iterable<string>, targetPermission: string, allowPeerGrant = false) {
+    const granterRisks = [...granterPermissions].map((key) => permissionByKey.get(key)?.risk).filter(Boolean) as BandPermissionRisk[];
+    const highest = Math.max(0, ...granterRisks.map((risk) => riskWeight[risk]));
+    const targetRisk = permissionByKey.get(targetPermission)?.risk;
+    if (!targetRisk) return false;
+    const required = riskWeight[targetRisk];
+    return allowPeerGrant ? highest >= required : highest > required;
+  }
+}

--- a/src/pages/bands/[bandId]/management.tsx
+++ b/src/pages/bands/[bandId]/management.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
-import { useParams, Navigate } from "react-router-dom";
+import { useParams, Navigate, useLocation } from "react-router-dom";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BandRosterTab } from "@/components/bands/BandRosterTab";
 import { BandRehearsalsTab } from "@/components/bands/BandRehearsalsTab";
 import { BandFinancesTab } from "@/components/bands/BandFinancesTab";
 import { BandContributionsTab } from "@/components/bands/BandContributionsTab";
+import { BandRolesTab } from "@/components/bands/BandRolesTab";
 import { Card, CardContent } from "@/components/ui/card";
 
 const tabConfig = [
@@ -12,12 +13,14 @@ const tabConfig = [
   { value: "rehearsals", label: "Rehearsals", description: "Oversee rehearsal cadence, costs, and preparation." },
   { value: "finances", label: "Finances", description: "Track band earnings, balance, and transactions." },
   { value: "contributions", label: "Contributions", description: "Review recent participation history without rewards or rankings." },
+  { value: "roles", label: "Roles & permissions", description: "Inspect leadership, responsibilities, risk levels, and approval foundations." },
 ] as const;
 
 export default function BandManagementPage() {
   const { bandId } = useParams<{ bandId: string }>();
+  const location = useLocation();
 
-  const defaultTab = useMemo(() => tabConfig[0]?.value ?? "roster", []);
+  const defaultTab = useMemo(() => location.pathname.endsWith("/manage/roles") ? "roles" : tabConfig[0]?.value ?? "roster", [location.pathname]);
 
   if (!bandId) {
     return <Navigate to="/band" replace />;
@@ -67,6 +70,10 @@ export default function BandManagementPage() {
 
         <TabsContent value="contributions" className="space-y-6">
           <BandContributionsTab bandId={bandId} />
+        </TabsContent>
+
+        <TabsContent value="roles" className="space-y-6">
+          <BandRolesTab bandId={bandId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/supabase/migrations/20260713193000_band_roles_permissions_responsibilities.sql
+++ b/supabase/migrations/20260713193000_band_roles_permissions_responsibilities.sql
@@ -1,0 +1,245 @@
+-- Band roles, scoped permissions, temporary delegations, trial review and approval foundation.
+-- Existing model inspected: bands.leader_id is the current controlling owner/leader,
+-- band_members.role is a legacy membership role, band_members.instrument_role/vocal_role
+-- represent musical positions, and recruitment/gig/rehearsal RLS frequently checks leader/founder strings.
+-- This migration extends that authority model rather than replacing it: leader_id remains the
+-- active owner/controller while founder is preserved as historical membership role metadata.
+
+CREATE TABLE IF NOT EXISTS public.band_permission_catalogue (
+  permission_key text PRIMARY KEY,
+  category text NOT NULL CHECK (category IN ('membership','scheduling','gigs_tours','creative','finance','publicity','merch','administration')),
+  label text NOT NULL,
+  risk_level text NOT NULL CHECK (risk_level IN ('low','standard','sensitive','critical')),
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.band_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid REFERENCES public.bands(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  description text,
+  role_type text NOT NULL,
+  display_colour text,
+  display_icon text,
+  is_system boolean NOT NULL DEFAULT false,
+  is_protected boolean NOT NULL DEFAULT false,
+  is_primary_leadership boolean NOT NULL DEFAULT false,
+  risk_level text NOT NULL DEFAULT 'standard' CHECK (risk_level IN ('low','standard','sensitive','critical')),
+  sort_order integer NOT NULL DEFAULT 100,
+  active boolean NOT NULL DEFAULT true,
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  CONSTRAINT band_roles_system_band_scope CHECK ((is_system AND band_id IS NULL) OR (NOT is_system AND band_id IS NOT NULL)),
+  CONSTRAINT band_roles_name_not_blank CHECK (length(trim(name)) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS band_roles_system_role_type_uidx ON public.band_roles (role_type) WHERE is_system AND deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS band_roles_band_name_uidx ON public.band_roles (band_id, lower(name)) WHERE band_id IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS band_roles_band_active_idx ON public.band_roles (band_id, active, sort_order) WHERE deleted_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.band_role_permissions (
+  role_id uuid NOT NULL REFERENCES public.band_roles(id) ON DELETE CASCADE,
+  permission_key text NOT NULL REFERENCES public.band_permission_catalogue(permission_key) ON DELETE RESTRICT,
+  granted_at timestamptz NOT NULL DEFAULT now(),
+  granted_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  PRIMARY KEY (role_id, permission_key)
+);
+CREATE INDEX IF NOT EXISTS band_role_permissions_lookup_idx ON public.band_role_permissions (permission_key, role_id);
+
+CREATE TABLE IF NOT EXISTS public.band_member_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  member_id uuid NOT NULL REFERENCES public.band_members(id) ON DELETE CASCADE,
+  role_id uuid NOT NULL REFERENCES public.band_roles(id) ON DELETE RESTRICT,
+  assigned_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  starts_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  removed_at timestamptz,
+  removal_reason text,
+  CONSTRAINT band_member_roles_expiry_check CHECK (expires_at IS NULL OR expires_at > starts_at)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS band_member_roles_active_uidx ON public.band_member_roles (member_id, role_id) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS band_member_roles_member_active_idx ON public.band_member_roles (band_id, member_id, starts_at, expires_at) WHERE removed_at IS NULL;
+CREATE INDEX IF NOT EXISTS band_member_roles_expiring_idx ON public.band_member_roles (expires_at) WHERE removed_at IS NULL AND expires_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.band_member_permission_overrides (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  member_id uuid NOT NULL REFERENCES public.band_members(id) ON DELETE CASCADE,
+  permission_key text NOT NULL REFERENCES public.band_permission_catalogue(permission_key) ON DELETE RESTRICT,
+  effect text NOT NULL CHECK (effect IN ('allow','deny')),
+  reason text,
+  assigned_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  revoked_at timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS band_member_permission_overrides_active_uidx ON public.band_member_permission_overrides (member_id, permission_key) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS band_member_permission_overrides_resolution_idx ON public.band_member_permission_overrides (band_id, member_id, permission_key, effect) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS band_member_permission_overrides_expiring_idx ON public.band_member_permission_overrides (expires_at) WHERE revoked_at IS NULL AND expires_at IS NOT NULL;
+
+ALTER TABLE public.band_members
+  ADD COLUMN IF NOT EXISTS leadership_role text,
+  ADD COLUMN IF NOT EXISTS trial_status text CHECK (trial_status IS NULL OR trial_status IN ('active','passed','extended','failed','withdrawn')),
+  ADD COLUMN IF NOT EXISTS trial_start timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_end timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_review_date timestamptz,
+  ADD COLUMN IF NOT EXISTS trial_sponsor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS trial_notes text;
+
+CREATE TABLE IF NOT EXISTS public.band_approval_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  action_type text NOT NULL,
+  action_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  requested_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected','cancelled','expired','executed','failed')),
+  required_policy text NOT NULL CHECK (required_policy IN ('single_authorised','leader_approval','owner_approval','two_authorised','majority','unanimous')),
+  required_approvals integer NOT NULL DEFAULT 1 CHECK (required_approvals > 0),
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS band_approval_requests_band_status_idx ON public.band_approval_requests (band_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.band_approval_responses (
+  approval_request_id uuid NOT NULL REFERENCES public.band_approval_requests(id) ON DELETE CASCADE,
+  member_id uuid NOT NULL REFERENCES public.band_members(id) ON DELETE CASCADE,
+  response text NOT NULL CHECK (response IN ('approve','reject')),
+  comment text,
+  responded_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (approval_request_id, member_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.band_governance_settings (
+  band_id uuid PRIMARY KEY REFERENCES public.bands(id) ON DELETE CASCADE,
+  assign_standard_roles_policy text NOT NULL DEFAULT 'leader_approval',
+  assign_sensitive_roles_policy text NOT NULL DEFAULT 'owner_approval',
+  finance_actions_need_approval boolean NOT NULL DEFAULT true,
+  new_members_start_on_trial boolean NOT NULL DEFAULT false,
+  default_trial_length_days integer NOT NULL DEFAULT 14 CHECK (default_trial_length_days BETWEEN 1 AND 180),
+  internal_roles_publicly_visible boolean NOT NULL DEFAULT false,
+  members_can_view_audit_history boolean NOT NULL DEFAULT false,
+  leader_approval_required_for_recruitment boolean NOT NULL DEFAULT true,
+  two_person_approval_large_spending boolean NOT NULL DEFAULT true,
+  role_expiry_notifications_enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.band_role_audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  target_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  target_member_id uuid REFERENCES public.band_members(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  before_state jsonb,
+  after_state jsonb,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS band_role_audit_log_band_created_idx ON public.band_role_audit_log (band_id, created_at DESC);
+
+INSERT INTO public.band_permission_catalogue(permission_key, category, label, risk_level) VALUES
+('membership.view_roster','membership','View full member roster','low'),('membership.invite_player','membership','Invite player','standard'),('membership.review_applications','membership','Review applications','standard'),('membership.send_offer','membership','Send membership offer','standard'),('membership.remove_member','membership','Remove member','sensitive'),('membership.approve_departure','membership','Approve member departure','sensitive'),('membership.manage_trials','membership','Manage trial members','standard'),('membership.change_positions','membership','Change musical positions','standard'),('membership.assign_responsibilities','membership','Assign responsibilities','sensitive'),
+('scheduling.create_rehearsal','scheduling','Create rehearsal','standard'),('scheduling.edit_rehearsal','scheduling','Edit rehearsal','standard'),('scheduling.cancel_rehearsal','scheduling','Cancel rehearsal','sensitive'),('scheduling.create_jam','scheduling','Create jam session','standard'),('scheduling.schedule_activity','scheduling','Schedule band activity','standard'),('scheduling.manage_attendance','scheduling','Manage attendance','standard'),('scheduling.view_private','scheduling','View private band schedule','low'),
+('gigs.apply','gigs_tours','Apply for gig','standard'),('gigs.accept','gigs_tours','Accept gig','sensitive'),('gigs.decline','gigs_tours','Decline gig','sensitive'),('gigs.prepare','gigs_tours','Create gig preparation','standard'),('gigs.edit_setlist','gigs_tours','Edit setlist','standard'),('tours.schedule','gigs_tours','Schedule tour','sensitive'),('tours.edit','gigs_tours','Edit tour','standard'),('tours.cancel','gigs_tours','Cancel tour','critical'),('tours.book_transport','gigs_tours','Book transport','sensitive'),('tours.book_accommodation','gigs_tours','Book accommodation','sensitive'),
+('creative.propose_song','creative','Propose song','low'),('creative.approve_song','creative','Approve band song','sensitive'),('creative.manage_songwriting','creative','Manage songwriting session','standard'),('creative.assign_contributors','creative','Assign song contributors','standard'),('creative.approve_recording','creative','Approve recording','sensitive'),('creative.select_studio','creative','Select recording studio','standard'),('creative.approve_release','creative','Approve release','sensitive'),('creative.manage_credits','creative','Manage credits','sensitive'),('creative.manage_repertoire','creative','Manage repertoire','standard'),
+('finance.view_summary','finance','View summary finances','standard'),('finance.view_transactions','finance','View full transaction history','sensitive'),('finance.approve_expense','finance','Approve expense','sensitive'),('finance.make_payment','finance','Make payment','critical'),('finance.set_spending_limits','finance','Set spending limits','critical'),('finance.manage_revenue_splits','finance','Manage revenue splits','critical'),('finance.manage_budget','finance','Manage band budget','sensitive'),('finance.purchase_equipment','finance','Purchase equipment','sensitive'),('finance.sell_assets','finance','Sell band assets','sensitive'),
+('publicity.edit_profile','publicity','Edit band profile','low'),('publicity.post_updates','publicity','Post band updates','standard'),('publicity.manage_twaater','publicity','Manage Twaater account','standard'),('publicity.manage_campaigns','publicity','Manage publicity campaigns','standard'),('publicity.update_recruitment','publicity','Update recruitment status','standard'),('publicity.manage_fans','publicity','Manage fan communications','standard'),
+('merch.create','merch','Create merchandise','standard'),('merch.set_prices','merch','Set prices','sensitive'),('merch.order_stock','merch','Order stock','sensitive'),('merch.manage_inventory','merch','Manage inventory','standard'),('merch.view_finances','merch','View merch finances','sensitive'),
+('admin.manage_roles','administration','Manage roles','sensitive'),('admin.manage_permissions','administration','Manage permissions','critical'),('admin.transfer_ownership','administration','Transfer ownership','critical'),('admin.change_settings','administration','Change band settings','sensitive'),('admin.disband','administration','Disband band','critical'),('admin.view_audit','administration','View audit history','sensitive')
+ON CONFLICT (permission_key) DO UPDATE SET label = EXCLUDED.label, category = EXCLUDED.category, risk_level = EXCLUDED.risk_level;
+
+
+
+INSERT INTO public.band_roles(name, description, role_type, is_system, is_protected, is_primary_leadership, risk_level, sort_order) VALUES
+('Founder','Historical creator marker; not permanently authoritative by itself.','founder',true,true,false,'low',10),
+('Band leader','Broad active operational control without ownership-transfer powers.','band_leader',true,true,true,'sensitive',20),
+('Co-leader','Shared leadership for sensitive operations and day-to-day control.','co_leader',true,false,true,'sensitive',30),
+('Manager','Recruitment, scheduling, gigs, tours and publicity without ownership or unrestricted finance.','manager',true,false,false,'sensitive',40),
+('Musical director','Repertoire, setlists, song approvals, rehearsal planning and recording preparation.','musical_director',true,false,false,'sensitive',50),
+('Recruitment manager','Vacancies, applications, invitations and trial-member management.','recruitment_manager',true,false,false,'standard',60),
+('Booking manager','Gig applications, offer responses, venue communication and tour scheduling.','booking_manager',true,false,false,'sensitive',70),
+('Tour manager','Tour planning, logistics, transport, accommodation and attendance coordination.','tour_manager',true,false,false,'sensitive',80),
+('Finance manager','Reports, budgets, expense approval and limited payments; no ownership control.','finance_manager',true,false,false,'sensitive',90),
+('Recording manager','Recording approvals, studios, sessions and release preparation.','recording_manager',true,false,false,'sensitive',100),
+('Songwriting coordinator','Song pipeline, collaboration sessions and contributor assignments.','songwriting_coordinator',true,false,false,'standard',110),
+('Publicity manager','Public profile, social posts, campaigns and fan announcements.','publicity_manager',true,false,false,'standard',120),
+('Merch manager','Products, sale prices, stock orders, inventory and merch performance.','merch_manager',true,false,false,'sensitive',130),
+('Member','Ordinary member access to roster, private schedule and creative proposals.','member',true,false,false,'low',140),
+('Trial member','Limited rehearsal and internal access while under review.','trial_member',true,false,false,'low',150)
+ON CONFLICT (role_type) WHERE is_system AND deleted_at IS NULL DO UPDATE SET name=EXCLUDED.name, description=EXCLUDED.description, risk_level=EXCLUDED.risk_level, sort_order=EXCLUDED.sort_order;
+
+INSERT INTO public.band_role_permissions(role_id, permission_key)
+SELECT br.id, pc.permission_key
+FROM public.band_roles br
+JOIN public.band_permission_catalogue pc ON (
+  (br.role_type = 'band_leader' AND pc.risk_level <> 'critical') OR
+  (br.role_type = 'co_leader' AND pc.risk_level <> 'critical' AND pc.permission_key <> 'finance.view_transactions') OR
+  (br.role_type = 'member' AND pc.permission_key IN ('membership.view_roster','scheduling.view_private','creative.propose_song')) OR
+  (br.role_type = 'trial_member' AND pc.permission_key IN ('scheduling.view_private','creative.propose_song')) OR
+  (br.role_type = 'recruitment_manager' AND pc.permission_key IN ('membership.invite_player','membership.review_applications','membership.send_offer','membership.manage_trials','publicity.update_recruitment')) OR
+  (br.role_type = 'booking_manager' AND pc.permission_key IN ('gigs.apply','gigs.accept','gigs.decline','gigs.prepare','tours.schedule','tours.edit')) OR
+  (br.role_type = 'tour_manager' AND pc.permission_key IN ('tours.schedule','tours.edit','tours.book_transport','tours.book_accommodation','scheduling.manage_attendance')) OR
+  (br.role_type = 'finance_manager' AND pc.permission_key IN ('finance.view_summary','finance.view_transactions','finance.approve_expense','finance.manage_budget','finance.purchase_equipment')) OR
+  (br.role_type = 'musical_director' AND pc.permission_key IN ('creative.approve_song','creative.manage_songwriting','creative.assign_contributors','creative.select_studio','creative.manage_repertoire','gigs.edit_setlist','scheduling.create_rehearsal','scheduling.edit_rehearsal')) OR
+  (br.role_type = 'recording_manager' AND pc.permission_key IN ('creative.approve_recording','creative.select_studio','creative.approve_release','creative.manage_credits')) OR
+  (br.role_type = 'songwriting_coordinator' AND pc.permission_key IN ('creative.propose_song','creative.manage_songwriting','creative.assign_contributors')) OR
+  (br.role_type = 'publicity_manager' AND pc.permission_key IN ('publicity.edit_profile','publicity.post_updates','publicity.manage_twaater','publicity.manage_campaigns','publicity.update_recruitment','publicity.manage_fans')) OR
+  (br.role_type = 'merch_manager' AND pc.permission_key IN ('merch.create','merch.set_prices','merch.order_stock','merch.manage_inventory','merch.view_finances'))
+)
+WHERE br.is_system
+ON CONFLICT DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.is_band_owner(p_band_id uuid, p_user_id uuid DEFAULT auth.uid()) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.bands b WHERE b.id = p_band_id AND b.leader_id = p_user_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_active_band_member(p_band_id uuid, p_user_id uuid DEFAULT auth.uid()) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (SELECT 1 FROM public.band_members bm WHERE bm.band_id = p_band_id AND bm.user_id = p_user_id AND COALESCE(bm.member_status, 'active') = 'active');
+$$;
+
+CREATE OR REPLACE FUNCTION public.member_has_band_permission(p_band_id uuid, p_user_id uuid, p_permission_key text) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  WITH member_row AS (
+    SELECT bm.id FROM public.band_members bm WHERE bm.band_id = p_band_id AND bm.user_id = p_user_id AND COALESCE(bm.member_status, 'active') = 'active' LIMIT 1
+  ), denied AS (
+    SELECT 1 FROM member_row mr JOIN public.band_member_permission_overrides o ON o.member_id = mr.id WHERE o.permission_key = p_permission_key AND o.effect = 'deny' AND o.revoked_at IS NULL AND (o.expires_at IS NULL OR o.expires_at > now())
+  )
+  SELECT public.is_band_owner(p_band_id, p_user_id)
+    OR (EXISTS (SELECT 1 FROM member_row) AND NOT EXISTS (SELECT 1 FROM denied) AND (
+      EXISTS (SELECT 1 FROM member_row mr JOIN public.band_member_permission_overrides o ON o.member_id = mr.id WHERE o.permission_key = p_permission_key AND o.effect = 'allow' AND o.revoked_at IS NULL AND (o.expires_at IS NULL OR o.expires_at > now()))
+      OR EXISTS (SELECT 1 FROM member_row mr JOIN public.band_member_roles bmr ON bmr.member_id = mr.id JOIN public.band_role_permissions brp ON brp.role_id = bmr.role_id JOIN public.band_roles br ON br.id = bmr.role_id WHERE brp.permission_key = p_permission_key AND br.active AND br.deleted_at IS NULL AND bmr.removed_at IS NULL AND bmr.starts_at <= now() AND (bmr.expires_at IS NULL OR bmr.expires_at > now()))
+    ));
+$$;
+
+ALTER TABLE public.band_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_role_permissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_member_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_member_permission_overrides ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_approval_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_approval_responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_governance_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_role_audit_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_permission_catalogue ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "permission catalogue is authenticated readable" ON public.band_permission_catalogue FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "band members can view roles" ON public.band_roles FOR SELECT USING (band_id IS NULL OR public.is_active_band_member(band_id, auth.uid()));
+CREATE POLICY "role managers can manage roles" ON public.band_roles FOR ALL USING (band_id IS NOT NULL AND public.member_has_band_permission(band_id, auth.uid(), 'admin.manage_roles')) WITH CHECK (band_id IS NOT NULL AND public.member_has_band_permission(band_id, auth.uid(), 'admin.manage_roles'));
+CREATE POLICY "band members can view role permissions" ON public.band_role_permissions FOR SELECT USING (EXISTS (SELECT 1 FROM public.band_roles br WHERE br.id = role_id AND (br.band_id IS NULL OR public.is_active_band_member(br.band_id, auth.uid()))));
+CREATE POLICY "permission managers can manage role permissions" ON public.band_role_permissions FOR ALL USING (EXISTS (SELECT 1 FROM public.band_roles br WHERE br.id = role_id AND br.band_id IS NOT NULL AND public.member_has_band_permission(br.band_id, auth.uid(), 'admin.manage_permissions'))) WITH CHECK (EXISTS (SELECT 1 FROM public.band_roles br WHERE br.id = role_id AND br.band_id IS NOT NULL AND public.member_has_band_permission(br.band_id, auth.uid(), 'admin.manage_permissions')));
+CREATE POLICY "band members can view member roles" ON public.band_member_roles FOR SELECT USING (public.is_active_band_member(band_id, auth.uid()));
+CREATE POLICY "responsibility managers can manage assignments" ON public.band_member_roles FOR ALL USING (public.member_has_band_permission(band_id, auth.uid(), 'membership.assign_responsibilities')) WITH CHECK (public.member_has_band_permission(band_id, auth.uid(), 'membership.assign_responsibilities'));
+CREATE POLICY "permission managers can view overrides" ON public.band_member_permission_overrides FOR SELECT USING (public.member_has_band_permission(band_id, auth.uid(), 'admin.manage_permissions'));
+CREATE POLICY "permission managers can manage overrides" ON public.band_member_permission_overrides FOR ALL USING (public.member_has_band_permission(band_id, auth.uid(), 'admin.manage_permissions')) WITH CHECK (public.member_has_band_permission(band_id, auth.uid(), 'admin.manage_permissions'));
+CREATE POLICY "band members can view approvals" ON public.band_approval_requests FOR SELECT USING (public.is_active_band_member(band_id, auth.uid()));
+CREATE POLICY "authorised members can create approvals" ON public.band_approval_requests FOR INSERT WITH CHECK (public.is_active_band_member(band_id, auth.uid()));
+CREATE POLICY "band members can view approval responses" ON public.band_approval_responses FOR SELECT USING (EXISTS (SELECT 1 FROM public.band_approval_requests r WHERE r.id = approval_request_id AND public.is_active_band_member(r.band_id, auth.uid())));
+CREATE POLICY "band members can respond to approvals" ON public.band_approval_responses FOR INSERT WITH CHECK (EXISTS (SELECT 1 FROM public.band_approval_requests r JOIN public.band_members bm ON bm.band_id = r.band_id WHERE r.id = approval_request_id AND bm.id = member_id AND bm.user_id = auth.uid() AND r.status = 'pending'));
+CREATE POLICY "band members can view governance settings" ON public.band_governance_settings FOR SELECT USING (public.is_active_band_member(band_id, auth.uid()));
+CREATE POLICY "settings managers can update governance settings" ON public.band_governance_settings FOR ALL USING (public.member_has_band_permission(band_id, auth.uid(), 'admin.change_settings')) WITH CHECK (public.member_has_band_permission(band_id, auth.uid(), 'admin.change_settings'));
+CREATE POLICY "audit viewers can view band role audit" ON public.band_role_audit_log FOR SELECT USING (public.member_has_band_permission(band_id, auth.uid(), 'admin.view_audit'));


### PR DESCRIPTION
### Motivation

- Provide a central, auditable permission foundation so bands can delegate leadership, recruitment, scheduling, finance, creative and operational responsibilities without relying on a single leader.
- Preserve and extend the existing authority model: `bands.leader_id` remains the active owner/controller, `band_members.role` remains legacy membership metadata, and musical positions remain separate; migration comments document this inspection and approach.
- Support future governance features (approvals, voting, spending limits, audits, temporary delegations) while keeping sensitive actions protected server-side.

### Description

- Add a Supabase migration `supabase/migrations/20260713193000_band_roles_permissions_responsibilities.sql` that creates `band_permission_catalogue`, `band_roles`, `band_role_permissions`, `band_member_roles`, `band_member_permission_overrides`, `band_approval_requests`, `band_approval_responses`, `band_governance_settings`, `band_role_audit_log`, augments `band_members` with trial fields, seeds the permission catalogue and default system roles, and installs RLS policies and helper functions (`is_band_owner`, `is_active_band_member`, `member_has_band_permission`).
- Add a TypeScript central permission catalogue and resolver in `src/lib/band-permissions.ts` exposing `BAND_PERMISSION_CATALOGUE`, `DEFAULT_BAND_ROLE_TEMPLATES`, and `BandPermissionService` with effective-permission resolution (owner grants, role grants, temporary delegations with expiry, direct allow/deny overrides with deny precedence), and risk-based `canGrant` checks.
- Add a management UI tab component `src/components/bands/BandRolesTab.tsx` and wire it into the band management page and route (`/bands/:bandId/manage/roles`) so teams can inspect role templates, permission keys and risk levels in the frontend.
- Add unit test coverage for the permission resolver in `src/lib/__tests__/band-permissions.test.ts` validating permission uniqueness, role templates, delegation expiry and deny precedence.
- Keep the implementation backwards-compatible by extending authority checks rather than replacing them; migration comments explicitly document the approach and constraints.

### Testing

- `tsc --noEmit` (`npm run typecheck`) completed successfully.
- Unit tests (`npm run test:unit` / `vitest`) could not be executed in this environment because `vitest` is not available, so the new tests were added but not run here; they are included at `src/lib/__tests__/band-permissions.test.ts`.
- Linting (`npm run lint`) could not be executed in this environment due to a missing ESLint package resolution (`@eslint/js`), so style checks should be run in CI or locally where dev dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552a1b947c83258f2a8bb8c9a7408a)