### PR TITLE
feat(festivals): introduce canonical festival editions and lifecycle model

### DIFF
--- a/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
+++ b/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -75,3 +75,17 @@ This ADR does not create the schema. It records the proposed direction for follo
 4. `feat(festivals): move performance settlement server-side`
 5. `refactor(festivals): migrate owner and admin tools to festival editions`
 6. `chore(festivals): stop and remove legacy festival writes after verification`
+
+## Accepted foundation implementation
+
+This PR establishes the first additive canonical schema layer:
+
+- `festival_editions` owns dated occurrence state, city, venue, capacity, ticket-price cents, budget allocation and lifecycle timestamps.
+- `festival_edition_status` is a PostgreSQL enum with: `concept`, `planning`, `applications_open`, `booking`, `announced`, `on_sale`, `setup`, `live`, `settling`, `completed`, `postponed`, `cancelled`, and `abandoned`.
+- `festival_edition_lifecycle_events` records immutable server-side lifecycle history with idempotency keys.
+- `festival_legacy_mappings` bridges canonical editions to `dedicated_festival_row`, conservatively matched `game_event`, and `festival_lineup_source` identifiers.
+- Owners derive edition-management rights from `festivals.owner_profile_id`; admins continue to use `public.has_role(auth.uid(), 'admin')`.
+- Direct browser writes are denied for edition, lifecycle and mapping tables. Mutations go through `create_festival_edition`, `update_festival_edition_planning`, and `transition_festival_edition`.
+- Compatibility remains explicit: owner tools may display canonical edition lifecycle, but brand-scoped staff, permits, insurance, marketplace and legacy event-backed player flows remain unchanged until later migrations.
+
+Unresolved migration items remain canonical applications, contracts, setlists, performances, stage/slot re-keying, tickets, attendance, settlement, reward ledgers, audience/incident/vendor/staff-shift systems, and final legacy withdrawal.

--- a/docs/festivals/CURRENT_STATE_AUDIT.md
+++ b/docs/festivals/CURRENT_STATE_AUDIT.md
@@ -309,3 +309,9 @@ Flagged issues: browser score calculation, direct `bands.band_balance` and `band
 4. Which route should be canonical for discovery after migration: `/festivals` as browser, `/festivals/directory` as brand directory, or a tabbed shell combining both?
 5. Should `game_events` projection rows be one-to-one with `festival_editions`, and should existing event IDs remain stable for deep links?
 6. Are marketplace sale prices denominated in cents intended to affect player/band/company balances, or are they currently out-of-economy ownership transfers?
+
+## Implementation progress — canonical editions foundation
+
+The canonical edition foundation PR introduces `festival_editions` as the dated occurrence model beneath permanent `festivals` brand rows. It adds a server-validated edition lifecycle RPC, immutable lifecycle history, dedicated-festival backfill into first editions, and explicit legacy mappings for dedicated festival rows plus conservatively matched festival `game_events`.
+
+Legacy event/player flows remain active during this migration. Stage, slot, ticket, attendance, application, contract, setlist, performance and settlement tables are not re-keyed in this step and remain outstanding for later PRs.

--- a/docs/festivals/EDITION_MIGRATION_NOTES.md
+++ b/docs/festivals/EDITION_MIGRATION_NOTES.md
@@ -1,0 +1,34 @@
+# Festival edition migration notes
+
+## Backfill rules
+
+Every existing `festivals` row receives an initial `festival_editions` row when one does not already exist for the same brand and edition number. The migration preserves brand dates, city, venue, expected attendance, description, treasury and metadata. Existing `ticket_price_low` and `ticket_price_high` are decimal currency units, while the new edition ticket fields are cents, so the backfill multiplies those prices by 100 and records the compatibility decision in `legacy_metadata`.
+
+## Status mapping
+
+Dedicated festival statuses verified in repository code and migrations are mapped conservatively:
+
+- `draft`, `upcoming` → `planning`
+- `confirmed` → `booking`
+- `published`, `announced` → `announced`
+- `live` → `live`
+- `completed` → `completed`
+- `postponed` → `postponed`
+- `cancelled` → `cancelled`
+- unknown values → `planning` with the original status retained in `legacy_metadata`
+
+## Legacy event handling
+
+The migration creates explicit `dedicated_festival_row` mappings for all backfilled editions. Legacy `game_events` rows are mapped only when the match is deterministic: festival event type, exact/normalised title match, compatible venue when present, and overlapping dates. Unmatched legacy festival events are left unmapped for the later data-migration PR rather than creating placeholder brands.
+
+## Compatibility rules
+
+`festivals` remains the permanent brand and marketplace asset. Brand-level staff, permits, insurance and ledger screens continue to operate until later edition re-keying. Current player festival routes backed by `game_events` and `festival_participants` remain active.
+
+## Rollback strategy
+
+This change is additive. Rollback can drop the three new tables, the enum, policies, indexes, triggers and RPCs without changing existing festival primary keys or deleting legacy festival data. Because backfill writes only new canonical tables and mappings, existing `festivals`, `game_events`, `festival_participants`, stages, tickets and attendance data remain intact.
+
+## Next migration PR
+
+Recommended next PR: `feat(festivals): add canonical applications contracts setlists and performances`.

--- a/docs/festivals/festival-domain-inventory.json
+++ b/docs/festivals/festival-domain-inventory.json
@@ -281,7 +281,10 @@
     }
   ],
   "utilities": [
-    { "path": "src/data/festivals.ts", "classification": "mock/static data" },
+    {
+      "path": "src/data/festivals.ts",
+      "classification": "mock/static data"
+    },
     {
       "path": "src/utils/festivalCareerImpact.ts",
       "classification": "client-side reward impact utility"
@@ -292,31 +295,70 @@
     }
   ],
   "tables": [
-    { "name": "game_events", "classification": "legacy event authority" },
+    {
+      "name": "game_events",
+      "classification": "legacy event authority"
+    },
     {
       "name": "festival_participants",
       "classification": "legacy participation"
     },
-    { "name": "festival_revenue_streams", "classification": "legacy finance" },
-    { "name": "festival_stages", "classification": "hybrid event-backed" },
-    { "name": "festival_stage_slots", "classification": "hybrid event-backed" },
-    { "name": "festival_tickets", "classification": "hybrid event-backed" },
-    { "name": "festival_attendance", "classification": "hybrid event-backed" },
+    {
+      "name": "festival_revenue_streams",
+      "classification": "legacy finance"
+    },
+    {
+      "name": "festival_stages",
+      "classification": "hybrid event-backed"
+    },
+    {
+      "name": "festival_stage_slots",
+      "classification": "hybrid event-backed"
+    },
+    {
+      "name": "festival_tickets",
+      "classification": "hybrid event-backed"
+    },
+    {
+      "name": "festival_attendance",
+      "classification": "hybrid event-backed"
+    },
     {
       "name": "festival_watch_rewards",
       "classification": "hybrid event-backed"
     },
-    { "name": "festival_finances", "classification": "hybrid summary finance" },
-    { "name": "festival_quality_ratings", "classification": "hybrid quality" },
+    {
+      "name": "festival_finances",
+      "classification": "hybrid summary finance"
+    },
+    {
+      "name": "festival_quality_ratings",
+      "classification": "hybrid quality"
+    },
     {
       "name": "festival_performance_history",
       "classification": "hybrid performance history"
     },
-    { "name": "festival_sponsorships", "classification": "hybrid sponsorship" },
-    { "name": "festival_rivalries", "classification": "hybrid rivalry" },
-    { "name": "festival_reviews", "classification": "hybrid reviews" },
-    { "name": "festival_merch_sales", "classification": "hybrid merch" },
-    { "name": "festival_slot_offers", "classification": "hybrid offers" },
+    {
+      "name": "festival_sponsorships",
+      "classification": "hybrid sponsorship"
+    },
+    {
+      "name": "festival_rivalries",
+      "classification": "hybrid rivalry"
+    },
+    {
+      "name": "festival_reviews",
+      "classification": "hybrid reviews"
+    },
+    {
+      "name": "festival_merch_sales",
+      "classification": "hybrid merch"
+    },
+    {
+      "name": "festival_slot_offers",
+      "classification": "hybrid offers"
+    },
     {
       "name": "festival_offer_negotiations",
       "classification": "hybrid negotiations"
@@ -325,8 +367,14 @@
       "name": "festival_backstage_events",
       "classification": "hybrid incidents"
     },
-    { "name": "festivals", "classification": "canonical brand candidate" },
-    { "name": "festival_lineups", "classification": "dedicated but uncertain" },
+    {
+      "name": "festivals",
+      "classification": "canonical brand candidate"
+    },
+    {
+      "name": "festival_lineups",
+      "classification": "dedicated but uncertain"
+    },
     {
       "name": "festival_sale_listings",
       "classification": "canonical brand marketplace"
@@ -373,27 +421,78 @@
   ],
   "edge_functions": [],
   "statuses": [
-    { "name": "pending", "classification": "overloaded" },
-    { "name": "invited", "classification": "legacy participant" },
+    {
+      "name": "pending",
+      "classification": "overloaded"
+    },
+    {
+      "name": "invited",
+      "classification": "legacy participant"
+    },
     {
       "name": "confirmed",
       "classification": "overloaded participant/festival"
     },
-    { "name": "performed", "classification": "legacy terminal participant" },
-    { "name": "withdrawn", "classification": "legacy participant" },
-    { "name": "rejected", "classification": "application/offer" },
-    { "name": "accepted", "classification": "application/offer/negotiation" },
-    { "name": "declined", "classification": "legacy participant constraint" },
-    { "name": "cancelled", "classification": "overloaded terminal" },
-    { "name": "postponed", "classification": "festival lifecycle" },
-    { "name": "draft", "classification": "festival lifecycle" },
-    { "name": "published", "classification": "festival lifecycle" },
-    { "name": "announced", "classification": "festival lifecycle" },
-    { "name": "live", "classification": "festival lifecycle" },
-    { "name": "completed", "classification": "activity/edition target" },
-    { "name": "booked", "classification": "stage slot" },
-    { "name": "approved", "classification": "permit" },
-    { "name": "upcoming", "classification": "dedicated festival seed" }
+    {
+      "name": "performed",
+      "classification": "legacy terminal participant"
+    },
+    {
+      "name": "withdrawn",
+      "classification": "legacy participant"
+    },
+    {
+      "name": "rejected",
+      "classification": "application/offer"
+    },
+    {
+      "name": "accepted",
+      "classification": "application/offer/negotiation"
+    },
+    {
+      "name": "declined",
+      "classification": "legacy participant constraint"
+    },
+    {
+      "name": "cancelled",
+      "classification": "overloaded terminal"
+    },
+    {
+      "name": "postponed",
+      "classification": "festival lifecycle"
+    },
+    {
+      "name": "draft",
+      "classification": "festival lifecycle"
+    },
+    {
+      "name": "published",
+      "classification": "festival lifecycle"
+    },
+    {
+      "name": "announced",
+      "classification": "festival lifecycle"
+    },
+    {
+      "name": "live",
+      "classification": "festival lifecycle"
+    },
+    {
+      "name": "completed",
+      "classification": "activity/edition target"
+    },
+    {
+      "name": "booked",
+      "classification": "stage slot"
+    },
+    {
+      "name": "approved",
+      "classification": "permit"
+    },
+    {
+      "name": "upcoming",
+      "classification": "dedicated festival seed"
+    }
   ],
   "mutations": [
     {
@@ -522,5 +621,39 @@
       "path": "src/pages/admin/FestivalsAdmin.tsx",
       "classification": "merge after admin migration"
     }
-  ]
+  ],
+  "canonical_foundation": {
+    "tables": [
+      "festival_editions",
+      "festival_edition_lifecycle_events",
+      "festival_legacy_mappings"
+    ],
+    "rpcs": [
+      "create_festival_edition",
+      "update_festival_edition_planning",
+      "transition_festival_edition"
+    ],
+    "frontend_services": [
+      "src/features/festivals/types.ts",
+      "src/features/festivals/service.ts",
+      "src/features/festivals/lifecycle.ts",
+      "src/features/festivals/legacyResolver.ts"
+    ],
+    "statuses": [
+      "concept",
+      "planning",
+      "applications_open",
+      "booking",
+      "announced",
+      "on_sale",
+      "setup",
+      "live",
+      "settling",
+      "completed",
+      "postponed",
+      "cancelled",
+      "abandoned"
+    ],
+    "compatibility": "Existing festivals rows are permanent brands; existing game_events festival player flows remain active and can be mapped through festival_legacy_mappings."
+  }
 }

--- a/src/features/festivals/__tests__/lifecycle.test.ts
+++ b/src/features/festivals/__tests__/lifecycle.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  canShowFestivalEditionTransition,
+  getFestivalEditionStatusLabel,
+  isFestivalEditionPubliclyVisible,
+  isFestivalEditionTerminal,
+} from "../lifecycle";
+
+describe("festival edition lifecycle UI helper", () => {
+  it("returns labels for statuses", () => {
+    expect(getFestivalEditionStatusLabel("applications_open")).toBe(
+      "Applications open",
+    );
+    expect(getFestivalEditionStatusLabel("on_sale")).toBe("On sale");
+  });
+
+  it("marks public states as visible", () => {
+    expect(isFestivalEditionPubliclyVisible("concept")).toBe(false);
+    expect(isFestivalEditionPubliclyVisible("planning")).toBe(false);
+    expect(isFestivalEditionPubliclyVisible("announced")).toBe(true);
+    expect(isFestivalEditionPubliclyVisible("completed")).toBe(true);
+  });
+
+  it("detects terminal states", () => {
+    expect(isFestivalEditionTerminal("completed")).toBe(true);
+    expect(isFestivalEditionTerminal("cancelled")).toBe(true);
+    expect(isFestivalEditionTerminal("abandoned")).toBe(true);
+    expect(isFestivalEditionTerminal("live")).toBe(false);
+  });
+
+  it("shows valid advisory transitions", () => {
+    expect(canShowFestivalEditionTransition("concept", "planning")).toBe(true);
+    expect(
+      canShowFestivalEditionTransition("planning", "applications_open"),
+    ).toBe(true);
+    expect(canShowFestivalEditionTransition("booking", "announced")).toBe(true);
+    expect(canShowFestivalEditionTransition("setup", "live")).toBe(true);
+  });
+
+  it("rejects invalid advisory transitions while leaving server RPC authoritative", () => {
+    expect(canShowFestivalEditionTransition("concept", "live")).toBe(false);
+    expect(canShowFestivalEditionTransition("live", "planning")).toBe(false);
+    expect(canShowFestivalEditionTransition("completed", "live")).toBe(false);
+  });
+
+  it("allows postponed recovery only to planning or announced in the UI", () => {
+    expect(canShowFestivalEditionTransition("postponed", "planning")).toBe(
+      true,
+    );
+    expect(canShowFestivalEditionTransition("postponed", "announced")).toBe(
+      true,
+    );
+    expect(canShowFestivalEditionTransition("postponed", "live")).toBe(false);
+  });
+
+  it("keeps cancelled and completed terminal in the UI", () => {
+    expect(canShowFestivalEditionTransition("cancelled", "planning")).toBe(
+      false,
+    );
+    expect(canShowFestivalEditionTransition("completed", "live")).toBe(false);
+  });
+});

--- a/src/features/festivals/legacyResolver.ts
+++ b/src/features/festivals/legacyResolver.ts
@@ -1,0 +1,42 @@
+import {
+  getFestivalEdition,
+  resolveEditionFromLegacyIdentifier,
+} from "./service";
+import type { FestivalEdition, FestivalLegacySource } from "./types";
+
+export type LegacyEditionResolution = {
+  editionId: string;
+  festivalId: string;
+  legacySource: FestivalLegacySource;
+  legacyId: string;
+  isLegacyRoute: boolean;
+  edition: FestivalEdition | null;
+};
+
+export async function resolveLegacyFestivalEdition(params: {
+  legacyId: string;
+  legacySource?: FestivalLegacySource;
+}): Promise<LegacyEditionResolution | null> {
+  const source = params.legacySource ?? "dedicated_festival_row";
+  const mapping = await resolveEditionFromLegacyIdentifier(
+    source,
+    params.legacyId,
+  );
+  if (!mapping) return null;
+
+  const edition = await getFestivalEdition(mapping.edition_id);
+  return {
+    editionId: mapping.edition_id,
+    festivalId:
+      mapping.legacy_festival_id ?? edition?.festival_id ?? params.legacyId,
+    legacySource: mapping.legacy_source,
+    legacyId: mapping.legacy_id,
+    isLegacyRoute: true,
+    edition,
+  };
+}
+
+export const legacyFestivalEditionQueryKey = (
+  legacySource: FestivalLegacySource,
+  legacyId: string,
+) => ["festival-edition-resolution", legacySource, legacyId] as const;

--- a/src/features/festivals/lifecycle.ts
+++ b/src/features/festivals/lifecycle.ts
@@ -1,0 +1,104 @@
+export const FESTIVAL_EDITION_STATUSES = [
+  "concept",
+  "planning",
+  "applications_open",
+  "booking",
+  "announced",
+  "on_sale",
+  "setup",
+  "live",
+  "settling",
+  "completed",
+  "postponed",
+  "cancelled",
+  "abandoned",
+] as const;
+
+export type FestivalEditionStatus = (typeof FESTIVAL_EDITION_STATUSES)[number];
+
+export const FESTIVAL_EDITION_STATUS_LABELS: Record<
+  FestivalEditionStatus,
+  string
+> = {
+  concept: "Concept",
+  planning: "Planning",
+  applications_open: "Applications open",
+  booking: "Booking",
+  announced: "Announced",
+  on_sale: "On sale",
+  setup: "Setup",
+  live: "Live",
+  settling: "Settling",
+  completed: "Completed",
+  postponed: "Postponed",
+  cancelled: "Cancelled",
+  abandoned: "Abandoned",
+};
+
+const PUBLIC_STATUSES = new Set<FestivalEditionStatus>([
+  "applications_open",
+  "booking",
+  "announced",
+  "on_sale",
+  "setup",
+  "live",
+  "settling",
+  "completed",
+]);
+
+const TERMINAL_STATUSES = new Set<FestivalEditionStatus>([
+  "completed",
+  "cancelled",
+  "abandoned",
+]);
+
+const TRANSITIONS: Partial<
+  Record<FestivalEditionStatus, FestivalEditionStatus[]>
+> = {
+  concept: ["planning", "cancelled", "abandoned"],
+  planning: [
+    "applications_open",
+    "booking",
+    "postponed",
+    "cancelled",
+    "abandoned",
+  ],
+  applications_open: ["booking", "postponed", "cancelled", "abandoned"],
+  booking: ["announced", "postponed", "cancelled", "abandoned"],
+  announced: ["on_sale", "setup", "postponed", "cancelled", "abandoned"],
+  on_sale: ["setup", "postponed", "cancelled", "abandoned"],
+  setup: ["live", "cancelled", "abandoned"],
+  live: ["settling"],
+  settling: ["completed"],
+  postponed: ["planning", "announced", "cancelled", "abandoned"],
+};
+
+export function getFestivalEditionStatusLabel(
+  status: FestivalEditionStatus,
+): string {
+  return FESTIVAL_EDITION_STATUS_LABELS[status];
+}
+
+export function isFestivalEditionTerminal(
+  status: FestivalEditionStatus,
+): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export function isFestivalEditionPubliclyVisible(
+  status: FestivalEditionStatus,
+): boolean {
+  return PUBLIC_STATUSES.has(status);
+}
+
+/**
+ * UI-only advisory transition check. The transition_festival_edition RPC is the
+ * authoritative validator and also enforces permission, readiness and idempotency.
+ */
+export function canShowFestivalEditionTransition(
+  from: FestivalEditionStatus,
+  to: FestivalEditionStatus,
+): boolean {
+  if (from === to) return true;
+  return TRANSITIONS[from]?.includes(to) ?? false;
+}

--- a/src/features/festivals/service.ts
+++ b/src/features/festivals/service.ts
@@ -1,0 +1,131 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Json } from "@/integrations/supabase/types";
+import type {
+  FestivalEdition,
+  FestivalEditionStatus,
+  FestivalLegacyMapping,
+  FestivalLegacySource,
+} from "./types";
+
+const editionsTable = () => supabase.from("festival_editions");
+const mappingsTable = () => supabase.from("festival_legacy_mappings");
+
+export async function listFestivalEditions(
+  festivalId: string,
+): Promise<FestivalEdition[]> {
+  const { data, error } = await editionsTable()
+    .select("*")
+    .eq("festival_id", festivalId)
+    .order("edition_number", { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as unknown as FestivalEdition[];
+}
+
+export async function getFestivalEdition(
+  editionId: string,
+): Promise<FestivalEdition | null> {
+  const { data, error } = await editionsTable()
+    .select("*")
+    .eq("id", editionId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as unknown as FestivalEdition | null;
+}
+
+export async function createFestivalEdition(input: {
+  festivalId: string;
+  title?: string | null;
+  startAt?: string | null;
+  endAt?: string | null;
+  cityId?: string | null;
+  venueId?: string | null;
+  expectedAttendance?: number | null;
+  capacity?: number | null;
+  minimumTicketPriceCents?: number | null;
+  maximumTicketPriceCents?: number | null;
+  publicMetadata?: Json;
+}): Promise<FestivalEdition> {
+  const { data, error } = await supabase.rpc("create_festival_edition", {
+    p_festival_id: input.festivalId,
+    p_title: input.title ?? null,
+    p_start_at: input.startAt ?? null,
+    p_end_at: input.endAt ?? null,
+    p_city_id: input.cityId ?? null,
+    p_venue_id: input.venueId ?? null,
+    p_expected_attendance: input.expectedAttendance ?? null,
+    p_capacity: input.capacity ?? null,
+    p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
+    p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
+    p_public_metadata: input.publicMetadata ?? {},
+  });
+  if (error) throw error;
+  return data as unknown as FestivalEdition;
+}
+
+export async function updateFestivalEditionPlanning(
+  editionId: string,
+  input: Partial<{
+    title: string | null;
+    description: string | null;
+    startAt: string | null;
+    endAt: string | null;
+    cityId: string | null;
+    venueId: string | null;
+    expectedAttendance: number | null;
+    capacity: number | null;
+    minimumTicketPriceCents: number | null;
+    maximumTicketPriceCents: number | null;
+    publicMetadata: Json;
+  }>,
+): Promise<FestivalEdition> {
+  const { data, error } = await supabase.rpc(
+    "update_festival_edition_planning",
+    {
+      p_edition_id: editionId,
+      p_title: input.title ?? null,
+      p_description: input.description ?? null,
+      p_start_at: input.startAt ?? null,
+      p_end_at: input.endAt ?? null,
+      p_city_id: input.cityId ?? null,
+      p_venue_id: input.venueId ?? null,
+      p_expected_attendance: input.expectedAttendance ?? null,
+      p_capacity: input.capacity ?? null,
+      p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
+      p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
+      p_public_metadata: input.publicMetadata ?? null,
+    },
+  );
+  if (error) throw error;
+  return data as unknown as FestivalEdition;
+}
+
+export async function transitionFestivalEdition(input: {
+  editionId: string;
+  targetStatus: FestivalEditionStatus;
+  reason?: string | null;
+  metadata?: Json;
+  idempotencyKey?: string | null;
+}): Promise<FestivalEdition> {
+  const { data, error } = await supabase.rpc("transition_festival_edition", {
+    p_edition_id: input.editionId,
+    p_target_status: input.targetStatus,
+    p_reason: input.reason ?? null,
+    p_metadata: input.metadata ?? {},
+    p_idempotency_key: input.idempotencyKey ?? null,
+  });
+  if (error) throw error;
+  return data as unknown as FestivalEdition;
+}
+
+export async function resolveEditionFromLegacyIdentifier(
+  legacySource: FestivalLegacySource,
+  legacyId: string,
+): Promise<FestivalLegacyMapping | null> {
+  const { data, error } = await mappingsTable()
+    .select("*")
+    .eq("legacy_source", legacySource)
+    .eq("legacy_id", legacyId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as unknown as FestivalLegacyMapping | null;
+}

--- a/src/features/festivals/types.ts
+++ b/src/features/festivals/types.ts
@@ -1,0 +1,57 @@
+import type { Database } from "@/integrations/supabase/types";
+import type { FestivalEditionStatus } from "./lifecycle";
+export type { FestivalEditionStatus };
+
+export type FestivalBrand = Database["public"]["Tables"]["festivals"]["Row"];
+
+export type FestivalEdition = Database["public"]["Tables"] extends {
+  festival_editions: { Row: infer Row };
+}
+  ? Row
+  : {
+      id: string;
+      festival_id: string;
+      edition_number: number;
+      edition_year: number | null;
+      title: string | null;
+      status: FestivalEditionStatus;
+      start_at: string | null;
+      end_at: string | null;
+      city_id: string | null;
+      venue_id: string | null;
+      expected_attendance: number | null;
+      capacity: number | null;
+    };
+
+export type FestivalEditionLifecycleEvent =
+  Database["public"]["Tables"] extends {
+    festival_edition_lifecycle_events: { Row: infer Row };
+  }
+    ? Row
+    : {
+        id: string;
+        edition_id: string;
+        from_status: FestivalEditionStatus | null;
+        to_status: FestivalEditionStatus;
+        actor_profile_id: string | null;
+        reason: string | null;
+        created_at: string;
+      };
+
+export type FestivalLegacyMapping = Database["public"]["Tables"] extends {
+  festival_legacy_mappings: { Row: infer Row };
+}
+  ? Row
+  : {
+      id: string;
+      edition_id: string;
+      legacy_source:
+        | "game_event"
+        | "dedicated_festival_row"
+        | "festival_lineup_source";
+      legacy_id: string;
+      legacy_festival_id: string | null;
+      created_at: string;
+    };
+
+export type FestivalLegacySource = FestivalLegacyMapping["legacy_source"];

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10398,6 +10398,76 @@ export type Database = {
           },
         ]
       }
+      festival_editions: {
+        Row: {
+          id: string
+          festival_id: string
+          edition_number: number
+          edition_year: number | null
+          title: string | null
+          slug: string | null
+          description: string | null
+          city_id: string | null
+          venue_id: string | null
+          start_at: string | null
+          end_at: string | null
+          timezone: string
+          doors_open_at: string | null
+          curfew_at: string | null
+          expected_attendance: number | null
+          capacity: number | null
+          minimum_ticket_price_cents: number | null
+          maximum_ticket_price_cents: number | null
+          currency_code: string
+          budget_cents: number | null
+          treasury_allocation_cents: number | null
+          status: Database["public"]["Enums"]["festival_edition_status"]
+          lifecycle_metadata: Json
+          public_metadata: Json
+          legacy_metadata: Json
+          created_by: string | null
+          created_at: string
+          updated_at: string
+          announced_at: string | null
+          on_sale_at: string | null
+          live_at: string | null
+          completed_at: string | null
+          cancelled_at: string | null
+        }
+        Insert: Partial<Database["public"]["Tables"]["festival_editions"]["Row"]> & { festival_id: string; edition_number: number }
+        Update: Partial<Database["public"]["Tables"]["festival_editions"]["Row"]>
+        Relationships: []
+      }
+      festival_edition_lifecycle_events: {
+        Row: {
+          id: string
+          edition_id: string
+          from_status: Database["public"]["Enums"]["festival_edition_status"] | null
+          to_status: Database["public"]["Enums"]["festival_edition_status"]
+          actor_profile_id: string | null
+          reason: string | null
+          metadata: Json
+          idempotency_key: string | null
+          created_at: string
+        }
+        Insert: Partial<Database["public"]["Tables"]["festival_edition_lifecycle_events"]["Row"]> & { edition_id: string; to_status: Database["public"]["Enums"]["festival_edition_status"] }
+        Update: Partial<Database["public"]["Tables"]["festival_edition_lifecycle_events"]["Row"]>
+        Relationships: []
+      }
+      festival_legacy_mappings: {
+        Row: {
+          id: string
+          edition_id: string
+          legacy_source: "game_event" | "dedicated_festival_row" | "festival_lineup_source"
+          legacy_id: string
+          legacy_festival_id: string | null
+          created_at: string
+          metadata: Json
+        }
+        Insert: Partial<Database["public"]["Tables"]["festival_legacy_mappings"]["Row"]> & { edition_id: string; legacy_source: "game_event" | "dedicated_festival_row" | "festival_lineup_source"; legacy_id: string }
+        Update: Partial<Database["public"]["Tables"]["festival_legacy_mappings"]["Row"]>
+        Relationships: []
+      }
       festival_finances: {
         Row: {
           artist_bonuses_cents: number
@@ -37337,6 +37407,49 @@ export type Database = {
       }
     }
     Functions: {
+      create_festival_edition: {
+        Args: {
+          p_festival_id: string
+          p_title?: string | null
+          p_start_at?: string | null
+          p_end_at?: string | null
+          p_city_id?: string | null
+          p_venue_id?: string | null
+          p_expected_attendance?: number | null
+          p_capacity?: number | null
+          p_minimum_ticket_price_cents?: number | null
+          p_maximum_ticket_price_cents?: number | null
+          p_public_metadata?: Json
+        }
+        Returns: Database["public"]["Tables"]["festival_editions"]["Row"]
+      }
+      transition_festival_edition: {
+        Args: {
+          p_edition_id: string
+          p_target_status: Database["public"]["Enums"]["festival_edition_status"]
+          p_reason?: string | null
+          p_metadata?: Json
+          p_idempotency_key?: string | null
+        }
+        Returns: Database["public"]["Tables"]["festival_editions"]["Row"]
+      }
+      update_festival_edition_planning: {
+        Args: {
+          p_edition_id: string
+          p_title?: string | null
+          p_description?: string | null
+          p_start_at?: string | null
+          p_end_at?: string | null
+          p_city_id?: string | null
+          p_venue_id?: string | null
+          p_expected_attendance?: number | null
+          p_capacity?: number | null
+          p_minimum_ticket_price_cents?: number | null
+          p_maximum_ticket_price_cents?: number | null
+          p_public_metadata?: Json | null
+        }
+        Returns: Database["public"]["Tables"]["festival_editions"]["Row"]
+      }
       add_band_country_fame:
         | {
             Args: {
@@ -38268,6 +38381,20 @@ export type Database = {
       }
     }
     Enums: {
+      festival_edition_status:
+        | "concept"
+        | "planning"
+        | "applications_open"
+        | "booking"
+        | "announced"
+        | "on_sale"
+        | "setup"
+        | "live"
+        | "settling"
+        | "completed"
+        | "postponed"
+        | "cancelled"
+        | "abandoned"
       app_role: "admin" | "moderator" | "user"
       band_status: "active" | "on_hiatus" | "disbanded"
       book_reading_status: "reading" | "completed" | "abandoned"

--- a/src/pages/FestivalOwnerConsole.tsx
+++ b/src/pages/FestivalOwnerConsole.tsx
@@ -4,16 +4,42 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { ArrowLeft, Loader2, DollarSign, ShieldCheck, Users, FileText, TrendingUp, Ticket, Megaphone, Trophy, Store } from "lucide-react";
+import {
+  ArrowLeft,
+  Loader2,
+  DollarSign,
+  ShieldCheck,
+  Users,
+  FileText,
+  TrendingUp,
+  Ticket,
+  Megaphone,
+  Trophy,
+  Store,
+} from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { listFestivalEditions } from "@/features/festivals/service";
+import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
 
 const money = (cents: number | null | undefined) => {
   const c = Number(cents ?? 0);
@@ -51,12 +77,24 @@ export default function FestivalOwnerConsole() {
     enabled: !!festivalId,
   });
 
-  const isOwner = festival && profileId && festival.owner_profile_id === profileId;
+  const isOwner =
+    festival && profileId && festival.owner_profile_id === profileId;
+
+  const { data: editions = [] } = useQuery({
+    queryKey: ["festival-editions", festivalId],
+    queryFn: () => listFestivalEditions(festivalId!),
+    enabled: !!festivalId,
+  });
+  const currentEdition = editions[0];
 
   const { data: staff = [] } = useQuery({
     queryKey: ["festival-staff", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_staff").select("*").eq("festival_id", festivalId).is("terminated_at", null);
+      const { data } = await (supabase as any)
+        .from("festival_staff")
+        .select("*")
+        .eq("festival_id", festivalId)
+        .is("terminated_at", null);
       return data || [];
     },
     enabled: !!festivalId,
@@ -65,7 +103,10 @@ export default function FestivalOwnerConsole() {
   const { data: permits = [] } = useQuery({
     queryKey: ["festival-permits", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_permits").select("*").eq("festival_id", festivalId);
+      const { data } = await (supabase as any)
+        .from("festival_permits")
+        .select("*")
+        .eq("festival_id", festivalId);
       return data || [];
     },
     enabled: !!festivalId,
@@ -74,7 +115,11 @@ export default function FestivalOwnerConsole() {
   const { data: insurance = [] } = useQuery({
     queryKey: ["festival-insurance", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_insurance_policies").select("*").eq("festival_id", festivalId).eq("active", true);
+      const { data } = await (supabase as any)
+        .from("festival_insurance_policies")
+        .select("*")
+        .eq("festival_id", festivalId)
+        .eq("active", true);
       return data || [];
     },
     enabled: !!festivalId,
@@ -83,7 +128,12 @@ export default function FestivalOwnerConsole() {
   const { data: ledger = [] } = useQuery({
     queryKey: ["festival-ledger", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_expense_ledger").select("*").eq("festival_id", festivalId).order("posted_at", { ascending: false }).limit(100);
+      const { data } = await (supabase as any)
+        .from("festival_expense_ledger")
+        .select("*")
+        .eq("festival_id", festivalId)
+        .order("posted_at", { ascending: false })
+        .limit(100);
       return data || [];
     },
     enabled: !!festivalId,
@@ -92,7 +142,12 @@ export default function FestivalOwnerConsole() {
   const { data: stages = [] } = useQuery({
     queryKey: ["festival-stages", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_stages").select("*, slots:festival_stage_slots(id, day_number, slot_number, band_id, status, payout_amount)").eq("festival_id", festivalId);
+      const { data } = await (supabase as any)
+        .from("festival_stages")
+        .select(
+          "*, slots:festival_stage_slots(id, day_number, slot_number, band_id, status, payout_amount)",
+        )
+        .eq("festival_id", festivalId);
       return data || [];
     },
     enabled: !!festivalId,
@@ -100,7 +155,7 @@ export default function FestivalOwnerConsole() {
 
   const hireStaff = useMutation({
     mutationFn: async (role: string) => {
-      const cfg = STAFF_ROLES.find(r => r.value === role)!;
+      const cfg = STAFF_ROLES.find((r) => r.value === role)!;
       const { error } = await (supabase as any).from("festival_staff").insert({
         festival_id: festivalId,
         role,
@@ -119,7 +174,10 @@ export default function FestivalOwnerConsole() {
 
   const fireStaff = useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await (supabase as any).from("festival_staff").update({ terminated_at: new Date().toISOString() }).eq("id", id);
+      const { error } = await (supabase as any)
+        .from("festival_staff")
+        .update({ terminated_at: new Date().toISOString() })
+        .eq("id", id);
       if (error) throw error;
     },
     onSuccess: () => {
@@ -130,15 +188,27 @@ export default function FestivalOwnerConsole() {
 
   const buyInsurance = useMutation({
     mutationFn: async (coverage: string) => {
-      const premiums: Record<string, number> = { basic: 500000, standard: 1200000, premium: 3000000, all_risk: 6000000 };
-      const ceilings: Record<string, number> = { basic: 2000000, standard: 8000000, premium: 25000000, all_risk: 100000000 };
-      const { error } = await (supabase as any).from("festival_insurance_policies").insert({
-        festival_id: festivalId,
-        coverage_type: coverage,
-        premium_cents: premiums[coverage],
-        payout_ceiling_cents: ceilings[coverage],
-        weather_rider: coverage === "premium" || coverage === "all_risk",
-      });
+      const premiums: Record<string, number> = {
+        basic: 500000,
+        standard: 1200000,
+        premium: 3000000,
+        all_risk: 6000000,
+      };
+      const ceilings: Record<string, number> = {
+        basic: 2000000,
+        standard: 8000000,
+        premium: 25000000,
+        all_risk: 100000000,
+      };
+      const { error } = await (supabase as any)
+        .from("festival_insurance_policies")
+        .insert({
+          festival_id: festivalId,
+          coverage_type: coverage,
+          premium_cents: premiums[coverage],
+          payout_ceiling_cents: ceilings[coverage],
+          weather_rider: coverage === "premium" || coverage === "all_risk",
+        });
       if (error) throw error;
     },
     onSuccess: () => {
@@ -150,14 +220,21 @@ export default function FestivalOwnerConsole() {
 
   const applyPermit = useMutation({
     mutationFn: async (permit_type: string) => {
-      const fees: Record<string, number> = { event: 150000, noise: 40000, alcohol: 90000, safety: 60000 };
-      const { error } = await (supabase as any).from("festival_permits").insert({
-        festival_id: festivalId,
-        city_id: festival?.city_id,
-        permit_type,
-        permit_fee_cents: fees[permit_type],
-        status: "pending",
-      });
+      const fees: Record<string, number> = {
+        event: 150000,
+        noise: 40000,
+        alcohol: 90000,
+        safety: 60000,
+      };
+      const { error } = await (supabase as any)
+        .from("festival_permits")
+        .insert({
+          festival_id: festivalId,
+          city_id: festival?.city_id,
+          permit_type,
+          permit_fee_cents: fees[permit_type],
+          status: "pending",
+        });
       if (error) throw error;
     },
     onSuccess: () => {
@@ -173,58 +250,153 @@ export default function FestivalOwnerConsole() {
     mutationFn: async () => {
       const cents = Math.round(parseFloat(listPrice || "0") * 100);
       if (cents <= 0) throw new Error("Enter a valid price");
-      const { error } = await (supabase as any).rpc("list_festival_for_sale", { p_festival_id: festivalId, p_price_cents: cents, p_notes: listNotes });
+      const { error } = await (supabase as any).rpc("list_festival_for_sale", {
+        p_festival_id: festivalId,
+        p_price_cents: cents,
+        p_notes: listNotes,
+      });
       if (error) throw error;
     },
     onSuccess: () => {
       toast.success("Festival listed for sale");
-      setListPrice(""); setListNotes("");
+      setListPrice("");
+      setListNotes("");
       qc.invalidateQueries({ queryKey: ["festival-owner", festivalId] });
     },
     onError: (e: any) => toast.error(e.message),
   });
 
   if (isLoading) {
-    return <div className="flex items-center justify-center h-96"><Loader2 className="h-8 w-8 animate-spin" /></div>;
+    return (
+      <div className="flex items-center justify-center h-96">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
   }
 
   if (!festival) {
-    return <div className="p-8 text-center">Festival not found. <Button variant="link" onClick={() => navigate("/festivals")}>Back to browser</Button></div>;
+    return (
+      <div className="p-8 text-center">
+        Festival not found.{" "}
+        <Button variant="link" onClick={() => navigate("/festivals")}>
+          Back to browser
+        </Button>
+      </div>
+    );
   }
 
   if (!isOwner) {
     return (
       <FMPageScaffold title={festival.name} subtitle="Owner-only console">
-        <Card><CardContent className="pt-6 text-center space-y-4">
-          <p>You are not the owner of this festival. Only the owner (or an admin) can manage operations.</p>
-          <Button asChild variant="outline"><Link to={`/festivals/${festivalId}`}>View public page</Link></Button>
-        </CardContent></Card>
+        <Card>
+          <CardContent className="pt-6 text-center space-y-4">
+            <p>
+              You are not the owner of this festival. Only the owner (or an
+              admin) can manage operations.
+            </p>
+            <Button asChild variant="outline">
+              <Link to={`/festivals/${festivalId}`}>View public page</Link>
+            </Button>
+          </CardContent>
+        </Card>
       </FMPageScaffold>
     );
   }
 
-  const totalIncome = ledger.filter((l: any) => l.direction === "income").reduce((s: number, l: any) => s + Number(l.amount_cents), 0);
-  const totalExpense = ledger.filter((l: any) => l.direction === "expense").reduce((s: number, l: any) => s + Number(l.amount_cents), 0);
+  const totalIncome = ledger
+    .filter((l: any) => l.direction === "income")
+    .reduce((s: number, l: any) => s + Number(l.amount_cents), 0);
+  const totalExpense = ledger
+    .filter((l: any) => l.direction === "expense")
+    .reduce((s: number, l: any) => s + Number(l.amount_cents), 0);
   const netEdition = totalIncome - totalExpense;
-  const totalStaffWages = staff.reduce((s: number, m: any) => s + Number(m.weekly_wage_cents || 0), 0);
+  const totalStaffWages = staff.reduce(
+    (s: number, m: any) => s + Number(m.weekly_wage_cents || 0),
+    0,
+  );
   const activeInsurance = insurance[0];
-  const approvedPermits = permits.filter((p: any) => p.status === "approved").length;
+  const approvedPermits = permits.filter(
+    (p: any) => p.status === "approved",
+  ).length;
 
   return (
     <FMPageScaffold
       title={festival.name}
-      subtitle={`${festival.city?.name ?? ""} · Prestige ${festival.prestige_tier}/5 · Edition #${festival.edition_number}`}
+      subtitle={`${festival.city?.name ?? ""} · Prestige ${festival.prestige_tier}/5 · Brand edition seed #${festival.edition_number}`}
       headerActions={
-        <Button variant="ghost" size="sm" onClick={() => navigate(`/festivals/${festivalId}`)}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate(`/festivals/${festivalId}`)}
+        >
           <ArrowLeft className="h-4 w-4 mr-1" /> Public page
         </Button>
       }
     >
+      <Card className="mb-4 border-primary/30">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Canonical edition</CardTitle>
+          <CardDescription>
+            Lifecycle is edition-scoped; marketplace ownership remains attached
+            to the festival brand.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap items-center gap-3 text-sm">
+          {currentEdition ? (
+            <>
+              <Badge variant="outline">
+                Edition #{currentEdition.edition_number}
+              </Badge>
+              <span>{currentEdition.title ?? festival.name}</span>
+              <Badge>
+                {getFestivalEditionStatusLabel(currentEdition.status)}
+              </Badge>
+              {currentEdition.start_at && (
+                <span className="text-muted-foreground">
+                  Starts{" "}
+                  {new Date(currentEdition.start_at).toLocaleDateString()}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <span className="text-amber-500">
+                No canonical edition found for this brand yet.
+              </span>
+              <Button size="sm" variant="outline" asChild>
+                <Link to={`/festivals/${festivalId}/run`}>
+                  Create or resolve edition
+                </Link>
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
-        <StatCard icon={<DollarSign className="h-4 w-4" />} label="Treasury" value={money(festival.treasury_cents)} />
-        <StatCard icon={<TrendingUp className="h-4 w-4" />} label="Edition Net" value={money(netEdition)} tone={netEdition >= 0 ? "positive" : "negative"} />
-        <StatCard icon={<Users className="h-4 w-4" />} label="Staff" value={String(staff.length)} sub={`${money(totalStaffWages)}/wk`} />
-        <StatCard icon={<ShieldCheck className="h-4 w-4" />} label="Coverage" value={activeInsurance?.coverage_type ?? "None"} sub={`${approvedPermits} permits`} />
+        <StatCard
+          icon={<DollarSign className="h-4 w-4" />}
+          label="Treasury"
+          value={money(festival.treasury_cents)}
+        />
+        <StatCard
+          icon={<TrendingUp className="h-4 w-4" />}
+          label="Edition Net"
+          value={money(netEdition)}
+          tone={netEdition >= 0 ? "positive" : "negative"}
+        />
+        <StatCard
+          icon={<Users className="h-4 w-4" />}
+          label="Staff"
+          value={String(staff.length)}
+          sub={`${money(totalStaffWages)}/wk`}
+        />
+        <StatCard
+          icon={<ShieldCheck className="h-4 w-4" />}
+          label="Coverage"
+          value={activeInsurance?.coverage_type ?? "None"}
+          sub={`${approvedPermits} permits`}
+        />
       </div>
 
       <Tabs value={tab} onValueChange={setTab}>
@@ -242,81 +414,183 @@ export default function FestivalOwnerConsole() {
         </TabsList>
 
         <TabsContent value="overview">
-          <Card><CardHeader><CardTitle>Edition Checklist</CardTitle><CardDescription>Steps before opening gates</CardDescription></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Edition Checklist</CardTitle>
+              <CardDescription>
+                Temporary compatibility checks still read brand-level staff,
+                permits and insurance until those tables are re-keyed to
+                editions.
+              </CardDescription>
+            </CardHeader>
             <CardContent className="space-y-2 text-sm">
-              <ChecklistRow ok={approvedPermits > 0} label="At least one approved permit" />
-              <ChecklistRow ok={!!activeInsurance} label="Active insurance policy" />
-              <ChecklistRow ok={staff.length >= 3} label="Minimum 3 crew hired" />
-              <ChecklistRow ok={stages.length > 0} label="At least one stage configured" />
-              <ChecklistRow ok={stages.some((s: any) => (s.slots || []).some((sl: any) => sl.band_id))} label="At least one band booked" />
+              <ChecklistRow
+                ok={approvedPermits > 0}
+                label="At least one approved permit"
+              />
+              <ChecklistRow
+                ok={!!activeInsurance}
+                label="Active insurance policy"
+              />
+              <ChecklistRow
+                ok={staff.length >= 3}
+                label="Minimum 3 crew hired"
+              />
+              <ChecklistRow
+                ok={stages.length > 0}
+                label="At least one stage configured"
+              />
+              <ChecklistRow
+                ok={stages.some((s: any) =>
+                  (s.slots || []).some((sl: any) => sl.band_id),
+                )}
+                label="At least one band booked"
+              />
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="booking">
-          <Card><CardHeader><CardTitle>Slot Bookings</CardTitle><CardDescription>Manage stage slots and offers</CardDescription></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Slot Bookings</CardTitle>
+              <CardDescription>Manage stage slots and offers</CardDescription>
+            </CardHeader>
             <CardContent className="text-sm text-muted-foreground">
-              {stages.length === 0 ? "Configure a stage first, then invite bands or open slots to applications." :
-                stages.map((s: any) => (
-                  <div key={s.id} className="mb-3 p-3 border rounded">
-                    <div className="font-semibold">{s.stage_name}</div>
-                    <div className="text-xs">{(s.slots || []).length} slots · {(s.slots || []).filter((sl: any) => sl.band_id).length} booked</div>
-                  </div>
-                ))}
+              {stages.length === 0
+                ? "Configure a stage first, then invite bands or open slots to applications."
+                : stages.map((s: any) => (
+                    <div key={s.id} className="mb-3 p-3 border rounded">
+                      <div className="font-semibold">{s.stage_name}</div>
+                      <div className="text-xs">
+                        {(s.slots || []).length} slots ·{" "}
+                        {(s.slots || []).filter((sl: any) => sl.band_id).length}{" "}
+                        booked
+                      </div>
+                    </div>
+                  ))}
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="stages">
-          <Card><CardHeader><CardTitle>Stages & Production</CardTitle></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Stages & Production</CardTitle>
+            </CardHeader>
             <CardContent className="text-sm">
-              {stages.length === 0 ? <p className="text-muted-foreground">No stages yet. Add one from the admin panel.</p> :
-                <ul className="space-y-2">{stages.map((s: any) => <li key={s.id} className="flex justify-between border-b pb-1"><span>{s.stage_name}</span><span className="text-muted-foreground">Cap {s.capacity} · {s.genre_focus ?? "mixed"}</span></li>)}</ul>}
+              {stages.length === 0 ? (
+                <p className="text-muted-foreground">
+                  No stages yet. Add one from the admin panel.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {stages.map((s: any) => (
+                    <li
+                      key={s.id}
+                      className="flex justify-between border-b pb-1"
+                    >
+                      <span>{s.stage_name}</span>
+                      <span className="text-muted-foreground">
+                        Cap {s.capacity} · {s.genre_focus ?? "mixed"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="tickets">
-          <Card><CardHeader><CardTitle>Ticket Pricing</CardTitle></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Ticket Pricing</CardTitle>
+            </CardHeader>
             <CardContent className="grid grid-cols-2 gap-3 text-sm">
-              <div><Label>Low tier</Label><div>${festival.ticket_price_low}</div></div>
-              <div><Label>High tier / VIP</Label><div>${festival.ticket_price_high}</div></div>
-              <div><Label>Expected attendance</Label><div>{festival.expected_attendance?.toLocaleString()}</div></div>
-              <div><Label>Runs</Label><div>{festival.start_date} → {festival.end_date}</div></div>
+              <div>
+                <Label>Low tier</Label>
+                <div>${festival.ticket_price_low}</div>
+              </div>
+              <div>
+                <Label>High tier / VIP</Label>
+                <div>${festival.ticket_price_high}</div>
+              </div>
+              <div>
+                <Label>Expected attendance</Label>
+                <div>{festival.expected_attendance?.toLocaleString()}</div>
+              </div>
+              <div>
+                <Label>Runs</Label>
+                <div>
+                  {festival.start_date} → {festival.end_date}
+                </div>
+              </div>
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="sponsors">
-          <Card><CardHeader><CardTitle>Sponsorship Deals</CardTitle></CardHeader>
-            <CardContent className="text-sm text-muted-foreground">Solicit sponsor offers from brand partners. Approach the sponsorship marketplace to send RFPs and negotiate placement tiers.</CardContent>
+          <Card>
+            <CardHeader>
+              <CardTitle>Sponsorship Deals</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground">
+              Solicit sponsor offers from brand partners. Approach the
+              sponsorship marketplace to send RFPs and negotiate placement
+              tiers.
+            </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="staff">
-          <Card><CardHeader><CardTitle>Crew Roster</CardTitle></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Crew Roster</CardTitle>
+            </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2 mb-3">
-                {STAFF_ROLES.map(r => (
-                  <Button key={r.value} size="sm" variant="outline" disabled={hireStaff.isPending} onClick={() => hireStaff.mutate(r.value)}>
+                {STAFF_ROLES.map((r) => (
+                  <Button
+                    key={r.value}
+                    size="sm"
+                    variant="outline"
+                    disabled={hireStaff.isPending}
+                    onClick={() => hireStaff.mutate(r.value)}
+                  >
                     + {r.label} ({money(r.wage)}/wk)
                   </Button>
                 ))}
               </div>
               <ul className="text-sm divide-y">
                 {staff.map((m: any) => (
-                  <li key={m.id} className="py-2 flex justify-between items-center">
+                  <li
+                    key={m.id}
+                    className="py-2 flex justify-between items-center"
+                  >
                     <div>
                       <div className="font-semibold">{m.name}</div>
-                      <div className="text-xs text-muted-foreground">{m.role} · skill {m.skill_level} · morale {m.morale}%</div>
+                      <div className="text-xs text-muted-foreground">
+                        {m.role} · skill {m.skill_level} · morale {m.morale}%
+                      </div>
                     </div>
                     <div className="flex items-center gap-2">
                       <span>{money(m.weekly_wage_cents)}/wk</span>
-                      <Button size="sm" variant="ghost" onClick={() => fireStaff.mutate(m.id)}>Fire</Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => fireStaff.mutate(m.id)}
+                      >
+                        Fire
+                      </Button>
                     </div>
                   </li>
                 ))}
-                {staff.length === 0 && <li className="py-4 text-muted-foreground text-center">No staff hired yet.</li>}
+                {staff.length === 0 && (
+                  <li className="py-4 text-muted-foreground text-center">
+                    No staff hired yet.
+                  </li>
+                )}
               </ul>
             </CardContent>
           </Card>
@@ -324,73 +598,170 @@ export default function FestivalOwnerConsole() {
 
         <TabsContent value="insurance">
           <div className="grid md:grid-cols-2 gap-4">
-            <Card><CardHeader><CardTitle>Insurance</CardTitle></CardHeader>
+            <Card>
+              <CardHeader>
+                <CardTitle>Insurance</CardTitle>
+              </CardHeader>
               <CardContent>
                 {activeInsurance ? (
                   <div className="text-sm space-y-1">
                     <Badge>{activeInsurance.coverage_type}</Badge>
                     <div>Premium: {money(activeInsurance.premium_cents)}</div>
-                    <div>Ceiling: {money(activeInsurance.payout_ceiling_cents)}</div>
-                    <div>Weather rider: {activeInsurance.weather_rider ? "Yes" : "No"}</div>
+                    <div>
+                      Ceiling: {money(activeInsurance.payout_ceiling_cents)}
+                    </div>
+                    <div>
+                      Weather rider:{" "}
+                      {activeInsurance.weather_rider ? "Yes" : "No"}
+                    </div>
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    {["basic","standard","premium","all_risk"].map(c =>
-                      <Button key={c} variant="outline" size="sm" className="mr-2" onClick={() => buyInsurance.mutate(c)}>Buy {c}</Button>
-                    )}
+                    {["basic", "standard", "premium", "all_risk"].map((c) => (
+                      <Button
+                        key={c}
+                        variant="outline"
+                        size="sm"
+                        className="mr-2"
+                        onClick={() => buyInsurance.mutate(c)}
+                      >
+                        Buy {c}
+                      </Button>
+                    ))}
                   </div>
                 )}
               </CardContent>
             </Card>
-            <Card><CardHeader><CardTitle>Permits</CardTitle></CardHeader>
+            <Card>
+              <CardHeader>
+                <CardTitle>Permits</CardTitle>
+              </CardHeader>
               <CardContent>
                 <div className="flex flex-wrap gap-2 mb-3">
-                  {["event","noise","alcohol","safety"].map(t =>
-                    <Button key={t} size="sm" variant="outline" onClick={() => applyPermit.mutate(t)}>Apply {t}</Button>
-                  )}
+                  {["event", "noise", "alcohol", "safety"].map((t) => (
+                    <Button
+                      key={t}
+                      size="sm"
+                      variant="outline"
+                      onClick={() => applyPermit.mutate(t)}
+                    >
+                      Apply {t}
+                    </Button>
+                  ))}
                 </div>
-                <ul className="text-sm">{permits.map((p: any) =>
-                  <li key={p.id} className="flex justify-between py-1"><span>{p.permit_type}</span><Badge variant={p.status === "approved" ? "default" : "secondary"}>{p.status}</Badge></li>
-                )}</ul>
+                <ul className="text-sm">
+                  {permits.map((p: any) => (
+                    <li key={p.id} className="flex justify-between py-1">
+                      <span>{p.permit_type}</span>
+                      <Badge
+                        variant={
+                          p.status === "approved" ? "default" : "secondary"
+                        }
+                      >
+                        {p.status}
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
               </CardContent>
             </Card>
           </div>
         </TabsContent>
 
         <TabsContent value="finances">
-          <Card><CardHeader><CardTitle>Ledger — Edition #{festival.edition_number}</CardTitle>
-            <CardDescription>Income {money(totalIncome)} · Expense {money(totalExpense)} · Net {money(netEdition)}</CardDescription>
-          </CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Ledger —{" "}
+                {currentEdition
+                  ? `Canonical edition #${currentEdition.edition_number}`
+                  : `Legacy edition #${festival.edition_number}`}
+              </CardTitle>
+              <CardDescription>
+                Income {money(totalIncome)} · Expense {money(totalExpense)} ·
+                Net {money(netEdition)}
+              </CardDescription>
+            </CardHeader>
             <CardContent>
               <div className="max-h-96 overflow-y-auto text-xs divide-y">
                 {ledger.map((l: any) => (
                   <div key={l.id} className="py-1.5 flex justify-between">
-                    <div><span className="text-muted-foreground mr-2">{new Date(l.posted_at).toLocaleDateString()}</span>{l.category}{l.description ? ` — ${l.description}` : ""}</div>
-                    <div className={l.direction === "income" ? "text-emerald-500" : "text-red-500"}>{l.direction === "income" ? "+" : "-"}{money(l.amount_cents)}</div>
+                    <div>
+                      <span className="text-muted-foreground mr-2">
+                        {new Date(l.posted_at).toLocaleDateString()}
+                      </span>
+                      {l.category}
+                      {l.description ? ` — ${l.description}` : ""}
+                    </div>
+                    <div
+                      className={
+                        l.direction === "income"
+                          ? "text-emerald-500"
+                          : "text-red-500"
+                      }
+                    >
+                      {l.direction === "income" ? "+" : "-"}
+                      {money(l.amount_cents)}
+                    </div>
                   </div>
                 ))}
-                {ledger.length === 0 && <div className="py-4 text-center text-muted-foreground">No entries yet.</div>}
+                {ledger.length === 0 && (
+                  <div className="py-4 text-center text-muted-foreground">
+                    No entries yet.
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="marketing">
-          <Card><CardHeader><CardTitle>Marketing Campaigns</CardTitle></CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>Marketing Campaigns</CardTitle>
+            </CardHeader>
             <CardContent className="text-sm text-muted-foreground">
-              Buy radio, press and social campaigns to raise attendance forecasts. Head over to <Link to="/media/pr" className="underline">PR Hub</Link> to launch a festival-tagged campaign.
+              Buy radio, press and social campaigns to raise attendance
+              forecasts. Head over to{" "}
+              <Link to="/media/pr" className="underline">
+                PR Hub
+              </Link>{" "}
+              to launch a festival-tagged campaign.
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="sell">
-          <Card><CardHeader><CardTitle>List Festival For Sale</CardTitle>
-            <CardDescription>Cash out to another player. Current status: <Badge>{festival.sale_status}</Badge></CardDescription>
-          </CardHeader>
+          <Card>
+            <CardHeader>
+              <CardTitle>List Festival For Sale</CardTitle>
+              <CardDescription>
+                Cash out to another player. Current status:{" "}
+                <Badge>{festival.sale_status}</Badge>
+              </CardDescription>
+            </CardHeader>
             <CardContent className="space-y-3 max-w-md">
-              <div><Label>Asking price ($)</Label><Input type="number" value={listPrice} onChange={e => setListPrice(e.target.value)} /></div>
-              <div><Label>Notes</Label><Textarea value={listNotes} onChange={e => setListNotes(e.target.value)} /></div>
-              <Button onClick={() => listForSale.mutate()} disabled={listForSale.isPending}>List for sale</Button>
+              <div>
+                <Label>Asking price ($)</Label>
+                <Input
+                  type="number"
+                  value={listPrice}
+                  onChange={(e) => setListPrice(e.target.value)}
+                />
+              </div>
+              <div>
+                <Label>Notes</Label>
+                <Textarea
+                  value={listNotes}
+                  onChange={(e) => setListNotes(e.target.value)}
+                />
+              </div>
+              <Button
+                onClick={() => listForSale.mutate()}
+                disabled={listForSale.isPending}
+              >
+                List for sale
+              </Button>
             </CardContent>
           </Card>
         </TabsContent>
@@ -399,12 +770,31 @@ export default function FestivalOwnerConsole() {
   );
 }
 
-function StatCard({ icon, label, value, sub, tone }: { icon: React.ReactNode; label: string; value: string; sub?: string; tone?: "positive" | "negative" }) {
+function StatCard({
+  icon,
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "positive" | "negative";
+}) {
   return (
     <Card>
       <CardContent className="p-3">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">{icon}<span>{label}</span></div>
-        <div className={`text-lg font-bold ${tone === "positive" ? "text-emerald-500" : tone === "negative" ? "text-red-500" : ""}`}>{value}</div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {icon}
+          <span>{label}</span>
+        </div>
+        <div
+          className={`text-lg font-bold ${tone === "positive" ? "text-emerald-500" : tone === "negative" ? "text-red-500" : ""}`}
+        >
+          {value}
+        </div>
         {sub && <div className="text-xs text-muted-foreground">{sub}</div>}
       </CardContent>
     </Card>
@@ -413,7 +803,9 @@ function StatCard({ icon, label, value, sub, tone }: { icon: React.ReactNode; la
 
 function ChecklistRow({ ok, label }: { ok: boolean; label: string }) {
   return (
-    <div className={`flex items-center gap-2 ${ok ? "text-emerald-500" : "text-amber-500"}`}>
+    <div
+      className={`flex items-center gap-2 ${ok ? "text-emerald-500" : "text-amber-500"}`}
+    >
       <span>{ok ? "✓" : "○"}</span>
       <span className="text-foreground">{label}</span>
     </div>

--- a/src/pages/FestivalRunWizard.tsx
+++ b/src/pages/FestivalRunWizard.tsx
@@ -4,16 +4,43 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { toast } from "sonner";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
-import { CheckCircle2, XCircle, AlertTriangle, Loader2, Rocket, FileText, ShieldCheck, Music, Calendar as CalendarIcon, Ticket, ArrowRight, ArrowLeft } from "lucide-react";
+import {
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Loader2,
+  Rocket,
+  FileText,
+  ShieldCheck,
+  Music,
+  Calendar as CalendarIcon,
+  Ticket,
+  ArrowRight,
+  ArrowLeft,
+} from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { useFestivalStages, useFestivalStageSlots } from "@/hooks/useFestivalStages";
+import {
+  useFestivalStages,
+  useFestivalStageSlots,
+} from "@/hooks/useFestivalStages";
+import {
+  listFestivalEditions,
+  transitionFestivalEdition,
+} from "@/features/festivals/service";
+import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
 import { format } from "date-fns";
 
 type StepKey = "draft" | "booking" | "compliance" | "launch";
@@ -45,13 +72,23 @@ export default function FestivalRunWizard() {
     enabled: !!festivalId,
   });
 
+  const { data: editions = [] } = useQuery({
+    queryKey: ["festival-editions", festivalId],
+    queryFn: () => listFestivalEditions(festivalId!),
+    enabled: !!festivalId,
+  });
+  const currentEdition = editions[0];
+
   const { data: stages = [] } = useFestivalStages(festivalId);
   const { data: slots = [] } = useFestivalStageSlots(festivalId);
 
   const { data: permits = [] } = useQuery({
     queryKey: ["run-wizard-permits", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_permits").select("*").eq("festival_id", festivalId);
+      const { data } = await (supabase as any)
+        .from("festival_permits")
+        .select("*")
+        .eq("festival_id", festivalId);
       return data || [];
     },
     enabled: !!festivalId,
@@ -60,20 +97,30 @@ export default function FestivalRunWizard() {
   const { data: insurance = [] } = useQuery({
     queryKey: ["run-wizard-insurance", festivalId],
     queryFn: async () => {
-      const { data } = await (supabase as any).from("festival_insurance_policies").select("*").eq("festival_id", festivalId).eq("active", true);
+      const { data } = await (supabase as any)
+        .from("festival_insurance_policies")
+        .select("*")
+        .eq("festival_id", festivalId)
+        .eq("active", true);
       return data || [];
     },
     enabled: !!festivalId,
   });
 
-  const isOwner = !!festival && !!profileId && festival.owner_profile_id === profileId;
+  const isOwner =
+    !!festival && !!profileId && festival.owner_profile_id === profileId;
 
   // Draft edits
   const [draftName, setDraftName] = useState<string>("");
   const [draftAttendance, setDraftAttendance] = useState<string>("");
   const [draftLow, setDraftLow] = useState<string>("");
   const [draftHigh, setDraftHigh] = useState<string>("");
-  const [originalDraft, setOriginalDraft] = useState<{ name: string; attendance: string; low: string; high: string } | null>(null);
+  const [originalDraft, setOriginalDraft] = useState<{
+    name: string;
+    attendance: string;
+    low: string;
+    high: string;
+  } | null>(null);
 
   // Initialize once
   useMemo(() => {
@@ -96,8 +143,10 @@ export default function FestivalRunWizard() {
       const low = Number(draftLow);
       const high = Number(draftHigh);
       if (!draftName.trim()) throw new Error("Name is required");
-      if (!Number.isFinite(attendance) || attendance <= 0) throw new Error("Attendance must be positive");
-      if (!Number.isFinite(low) || !Number.isFinite(high) || high < low) throw new Error("Ticket range invalid");
+      if (!Number.isFinite(attendance) || attendance <= 0)
+        throw new Error("Attendance must be positive");
+      if (!Number.isFinite(low) || !Number.isFinite(high) || high < low)
+        throw new Error("Ticket range invalid");
       const { error } = await (supabase as any)
         .from("festivals")
         .update({
@@ -113,6 +162,7 @@ export default function FestivalRunWizard() {
     onSuccess: () => {
       toast.success("Draft saved");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
+      qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
     },
     onError: (e: Error) => toast.error(e.message),
   });
@@ -121,98 +171,187 @@ export default function FestivalRunWizard() {
   const approvedPermits = permits.filter((p: any) => p.status === "approved");
   const requiredPermitTypes = ["event", "safety", "noise"]; // baseline required
   const missingPermitTypes = requiredPermitTypes.filter(
-    (t) => !approvedPermits.some((p: any) => (p.permit_type || "").toLowerCase().includes(t))
+    (t) =>
+      !approvedPermits.some((p: any) =>
+        (p.permit_type || "").toLowerCase().includes(t),
+      ),
   );
   const hasInsurance = insurance.length > 0;
 
   // Booking checks
   const confirmedSlots = slots.filter((s: any) => s.band_id || s.is_npc_dj);
-  const stagesWithBookings = new Set(confirmedSlots.map((s: any) => s.stage_id));
-  const stagesMissing = stages.filter(st => !stagesWithBookings.has(st.id));
-  const headliners = confirmedSlots.filter((s: any) => s.slot_type === "headliner");
+  const stagesWithBookings = new Set(
+    confirmedSlots.map((s: any) => s.stage_id),
+  );
+  const stagesMissing = stages.filter((st) => !stagesWithBookings.has(st.id));
+  const headliners = confirmedSlots.filter(
+    (s: any) => s.slot_type === "headliner",
+  );
 
   const checks: Record<StepKey, { ok: boolean; label: string }[]> = {
     draft: [
       { ok: !!festival?.name, label: "Festival has a name" },
-      { ok: (festival?.expected_attendance ?? 0) > 0, label: "Expected attendance set" },
-      { ok: (Number(festival?.ticket_price_low) || 0) > 0 && Number(festival?.ticket_price_high) >= Number(festival?.ticket_price_low), label: "Ticket price range valid" },
-      { ok: !!festival?.start_date && !!festival?.end_date, label: "Run dates confirmed" },
-      { ok: !!festival?.city_id && !!festival?.venue_id, label: "City & venue selected" },
+      {
+        ok: (festival?.expected_attendance ?? 0) > 0,
+        label: "Expected attendance set",
+      },
+      {
+        ok:
+          (Number(festival?.ticket_price_low) || 0) > 0 &&
+          Number(festival?.ticket_price_high) >=
+            Number(festival?.ticket_price_low),
+        label: "Ticket price range valid",
+      },
+      {
+        ok: !!festival?.start_date && !!festival?.end_date,
+        label: "Run dates confirmed",
+      },
+      {
+        ok: !!festival?.city_id && !!festival?.venue_id,
+        label: "City & venue selected",
+      },
     ],
     booking: [
       { ok: stages.length > 0, label: "At least one stage created" },
-      { ok: stagesMissing.length === 0 && stages.length > 0, label: "All stages have at least one booking" },
+      {
+        ok: stagesMissing.length === 0 && stages.length > 0,
+        label: "All stages have at least one booking",
+      },
       { ok: headliners.length > 0, label: "Headline act confirmed" },
-      { ok: confirmedSlots.length >= Math.max(3, stages.length * 2), label: `Minimum performers booked (${confirmedSlots.length}/${Math.max(3, stages.length * 2)})` },
-      { ok: confirmedSlots.every((s: any) => s.start_time && s.end_time), label: "All confirmed slots have set times" },
+      {
+        ok: confirmedSlots.length >= Math.max(3, stages.length * 2),
+        label: `Minimum performers booked (${confirmedSlots.length}/${Math.max(3, stages.length * 2)})`,
+      },
+      {
+        ok: confirmedSlots.every((s: any) => s.start_time && s.end_time),
+        label: "All confirmed slots have set times",
+      },
     ],
     compliance: [
-      { ok: missingPermitTypes.length === 0, label: `Required permits approved (missing: ${missingPermitTypes.join(", ") || "none"})` },
+      {
+        ok: missingPermitTypes.length === 0,
+        label: `Required permits approved (missing: ${missingPermitTypes.join(", ") || "none"})`,
+      },
       { ok: hasInsurance, label: "Active insurance policy on file" },
-      { ok: insurance.some((i: any) => i.weather_rider), label: "Weather cover rider (recommended)" },
+      {
+        ok: insurance.some((i: any) => i.weather_rider),
+        label: "Weather cover rider (recommended)",
+      },
     ],
     launch: [
-      { ok: festival?.status === "confirmed" || festival?.status === "live" || festival?.status === "announced", label: "Festival status ready for launch" },
+      {
+        ok: currentEdition
+          ? ["booking", "announced", "on_sale", "setup", "live"].includes(
+              currentEdition.status as string,
+            )
+          : festival?.status === "confirmed" ||
+            festival?.status === "live" ||
+            festival?.status === "announced",
+        label: currentEdition
+          ? "Canonical edition lifecycle ready for launch"
+          : "Legacy festival status ready (compatibility only)",
+      },
     ],
   };
 
-  const stepReady = (k: StepKey) => checks[k].every(c => c.ok);
-  const canLaunch = stepReady("draft") && stepReady("booking") && stepReady("compliance");
+  const stepReady = (k: StepKey) => checks[k].every((c) => c.ok);
+  const canLaunch =
+    stepReady("draft") && stepReady("booking") && stepReady("compliance");
 
   const launchMutation = useMutation({
     mutationFn: async () => {
-      const { error } = await (supabase as any)
-        .from("festivals")
-        .update({ status: "announced", updated_at: new Date().toISOString() })
-        .eq("id", festivalId);
-      if (error) throw error;
+      if (currentEdition) {
+        await transitionFestivalEdition({
+          editionId: currentEdition.id,
+          targetStatus: "announced",
+          metadata: { source: "FestivalRunWizard" },
+          idempotencyKey: `run-wizard-announce-${currentEdition.id}`,
+        });
+        return;
+      }
+      throw new Error(
+        "No canonical edition is available yet; legacy brand status was not changed.",
+      );
     },
     onSuccess: () => {
       toast.success("Festival is live! Announcement pushed.");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
+      qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
       setStepIdx(STEPS.length - 1);
     },
     onError: (e: Error) => toast.error(e.message),
   });
 
   const progressPct = Math.round(
-    (STEPS.slice(0, stepIdx + 1).filter(s => stepReady(s.key)).length / STEPS.length) * 100
+    (STEPS.slice(0, stepIdx + 1).filter((s) => stepReady(s.key)).length /
+      STEPS.length) *
+      100,
   );
 
   const step = STEPS[stepIdx];
 
   if (isLoading) {
     return (
-      <FMPageScaffold title="Run Festival" icon={Rocket} backTo={`/festivals/${festivalId}`}>
-        <div className="animate-pulse space-y-4"><div className="h-8 bg-muted rounded w-1/3" /><div className="h-64 bg-muted rounded" /></div>
+      <FMPageScaffold
+        title="Run Festival"
+        icon={Rocket}
+        backTo={`/festivals/${festivalId}`}
+      >
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-muted rounded w-1/3" />
+          <div className="h-64 bg-muted rounded" />
+        </div>
       </FMPageScaffold>
     );
   }
   if (!festival) {
     return (
       <FMPageScaffold title="Run Festival" icon={Rocket} backTo="/festivals">
-        <p className="p-8 text-center text-muted-foreground">Festival not found.</p>
+        <p className="p-8 text-center text-muted-foreground">
+          Festival not found.
+        </p>
       </FMPageScaffold>
     );
   }
   if (!isOwner) {
     return (
-      <FMPageScaffold title="Run Festival" icon={Rocket} backTo={`/festivals/${festivalId}`}>
-        <Card><CardContent className="p-6 text-center">
-          <AlertTriangle className="h-10 w-10 mx-auto mb-2 text-yellow-500" />
-          <p className="font-medium mb-1">Owner access required</p>
-          <p className="text-sm text-muted-foreground mb-4">Only the festival owner can run the go-live wizard.</p>
-          <Button variant="outline" onClick={() => navigate(`/festivals/${festivalId}`)}>Back to festival</Button>
-        </CardContent></Card>
+      <FMPageScaffold
+        title="Run Festival"
+        icon={Rocket}
+        backTo={`/festivals/${festivalId}`}
+      >
+        <Card>
+          <CardContent className="p-6 text-center">
+            <AlertTriangle className="h-10 w-10 mx-auto mb-2 text-yellow-500" />
+            <p className="font-medium mb-1">Owner access required</p>
+            <p className="text-sm text-muted-foreground mb-4">
+              Only the festival owner can run the go-live wizard.
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => navigate(`/festivals/${festivalId}`)}
+            >
+              Back to festival
+            </Button>
+          </CardContent>
+        </Card>
       </FMPageScaffold>
     );
   }
 
-  const CheckList = ({ items }: { items: { ok: boolean; label: string }[] }) => (
+  const CheckList = ({
+    items,
+  }: {
+    items: { ok: boolean; label: string }[];
+  }) => (
     <ul className="space-y-2">
       {items.map((c, i) => (
         <li key={i} className="flex items-start gap-2 text-sm">
-          {c.ok ? <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5" /> : <XCircle className="h-4 w-4 text-destructive mt-0.5" />}
+          {c.ok ? (
+            <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5" />
+          ) : (
+            <XCircle className="h-4 w-4 text-destructive mt-0.5" />
+          )}
           <span className={c.ok ? "" : "text-muted-foreground"}>{c.label}</span>
         </li>
       ))}
@@ -239,12 +378,20 @@ export default function FestivalRunWizard() {
                   key={s.key}
                   onClick={() => setStepIdx(i)}
                   className={`flex items-center gap-2 px-3 py-2 rounded-md border text-sm transition ${
-                    active ? "border-primary bg-primary/10" : "border-border/50 hover:bg-muted/50"
+                    active
+                      ? "border-primary bg-primary/10"
+                      : "border-border/50 hover:bg-muted/50"
                   }`}
                 >
-                  <span className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ${
-                    done ? "bg-green-500/20 text-green-500" : active ? "bg-primary/20 text-primary" : "bg-muted text-muted-foreground"
-                  }`}>
+                  <span
+                    className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ${
+                      done
+                        ? "bg-green-500/20 text-green-500"
+                        : active
+                          ? "bg-primary/20 text-primary"
+                          : "bg-muted text-muted-foreground"
+                    }`}
+                  >
                     {done ? <CheckCircle2 className="h-3.5 w-3.5" /> : i + 1}
                   </span>
                   <Icon className="h-4 w-4" />
@@ -254,7 +401,22 @@ export default function FestivalRunWizard() {
             })}
           </div>
           <Progress value={progressPct} />
-          <p className="text-xs text-muted-foreground">Overall readiness: {progressPct}%</p>
+          <p className="text-xs text-muted-foreground">
+            Overall readiness: {progressPct}%
+          </p>
+          {currentEdition ? (
+            <p className="text-xs text-muted-foreground">
+              Canonical edition #{currentEdition.edition_number} lifecycle:{" "}
+              <Badge variant="outline">
+                {getFestivalEditionStatusLabel(currentEdition.status)}
+              </Badge>
+            </p>
+          ) : (
+            <p className="text-xs text-amber-500">
+              Canonical edition not resolved. The wizard will not mutate the
+              permanent festival brand lifecycle.
+            </p>
+          )}
         </CardContent>
       </Card>
 
@@ -266,10 +428,14 @@ export default function FestivalRunWizard() {
             {step.label}
           </CardTitle>
           <CardDescription>
-            {step.key === "draft" && "Confirm the festival's core details before promotion."}
-            {step.key === "booking" && "Verify stages, lineup, and set times are locked in."}
-            {step.key === "compliance" && "Approve permits and confirm active insurance before doors."}
-            {step.key === "launch" && "Push the announcement and open ticket sales."}
+            {step.key === "draft" &&
+              "Confirm the festival's core details before promotion."}
+            {step.key === "booking" &&
+              "Verify stages, lineup, and set times are locked in."}
+            {step.key === "compliance" &&
+              "Approve permits and confirm active insurance before doors."}
+            {step.key === "launch" &&
+              "Push the announcement and open ticket sales."}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -277,23 +443,49 @@ export default function FestivalRunWizard() {
             <div className="grid gap-4 md:grid-cols-2">
               <div>
                 <Label>Name</Label>
-                <Input value={draftName} onChange={e => setDraftName(e.target.value)} />
+                <Input
+                  value={draftName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                />
               </div>
               <div>
                 <Label>Expected Attendance</Label>
-                <Input type="number" min={0} value={draftAttendance} onChange={e => setDraftAttendance(e.target.value)} />
+                <Input
+                  type="number"
+                  min={0}
+                  value={draftAttendance}
+                  onChange={(e) => setDraftAttendance(e.target.value)}
+                />
               </div>
               <div>
                 <Label>Ticket Price — Low</Label>
-                <Input type="number" min={0} step="0.01" value={draftLow} onChange={e => setDraftLow(e.target.value)} />
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={draftLow}
+                  onChange={(e) => setDraftLow(e.target.value)}
+                />
               </div>
               <div>
                 <Label>Ticket Price — High</Label>
-                <Input type="number" min={0} step="0.01" value={draftHigh} onChange={e => setDraftHigh(e.target.value)} />
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={draftHigh}
+                  onChange={(e) => setDraftHigh(e.target.value)}
+                />
               </div>
               <div className="md:col-span-2 flex justify-end">
-                <Button size="sm" onClick={() => saveDraft.mutate()} disabled={saveDraft.isPending}>
-                  {saveDraft.isPending ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
+                <Button
+                  size="sm"
+                  onClick={() => saveDraft.mutate()}
+                  disabled={saveDraft.isPending}
+                >
+                  {saveDraft.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                  ) : null}
                   Save Draft
                 </Button>
               </div>
@@ -312,7 +504,9 @@ export default function FestivalRunWizard() {
                   <p className="text-xl font-bold">{stages.length}</p>
                 </div>
                 <div className="rounded-md border p-3">
-                  <p className="text-xs text-muted-foreground">Confirmed slots</p>
+                  <p className="text-xs text-muted-foreground">
+                    Confirmed slots
+                  </p>
                   <p className="text-xl font-bold">{confirmedSlots.length}</p>
                 </div>
                 <div className="rounded-md border p-3">
@@ -322,18 +516,34 @@ export default function FestivalRunWizard() {
               </div>
               {stagesMissing.length > 0 && (
                 <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm">
-                  <p className="font-medium mb-1 flex items-center gap-1"><AlertTriangle className="h-4 w-4 text-yellow-500" /> Stages without bookings</p>
+                  <p className="font-medium mb-1 flex items-center gap-1">
+                    <AlertTriangle className="h-4 w-4 text-yellow-500" /> Stages
+                    without bookings
+                  </p>
                   <div className="flex flex-wrap gap-1">
-                    {stagesMissing.map(s => <Badge key={s.id} variant="outline">{s.stage_name}</Badge>)}
+                    {stagesMissing.map((s) => (
+                      <Badge key={s.id} variant="outline">
+                        {s.stage_name}
+                      </Badge>
+                    ))}
                   </div>
                 </div>
               )}
               <CheckList items={checks.booking} />
               <div className="flex flex-wrap gap-2">
-                <Button size="sm" variant="outline" onClick={() => navigate(`/festivals/${festivalId}/calendar`)}>
-                  <CalendarIcon className="h-4 w-4 mr-1" /> Open Booking Calendar
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate(`/festivals/${festivalId}/calendar`)}
+                >
+                  <CalendarIcon className="h-4 w-4 mr-1" /> Open Booking
+                  Calendar
                 </Button>
-                <Button size="sm" variant="outline" onClick={() => navigate(`/festivals/${festivalId}/manage`)}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate(`/festivals/${festivalId}/manage`)}
+                >
                   Manage Lineup
                 </Button>
               </div>
@@ -344,37 +554,66 @@ export default function FestivalRunWizard() {
             <div className="space-y-4">
               <div className="grid gap-3 md:grid-cols-2">
                 <Card className="border-border/60">
-                  <CardHeader className="pb-2"><CardTitle className="text-base flex items-center gap-2"><FileText className="h-4 w-4" /> Permits</CardTitle></CardHeader>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      <FileText className="h-4 w-4" /> Permits
+                    </CardTitle>
+                  </CardHeader>
                   <CardContent className="text-sm">
                     {permits.length === 0 ? (
                       <p className="text-muted-foreground">No permits filed.</p>
                     ) : (
                       <ul className="space-y-1">
                         {permits.map((p: any) => (
-                          <li key={p.id} className="flex items-center justify-between">
+                          <li
+                            key={p.id}
+                            className="flex items-center justify-between"
+                          >
                             <span className="capitalize">{p.permit_type}</span>
-                            <Badge variant={p.status === "approved" ? "default" : "outline"} className="capitalize">{p.status}</Badge>
+                            <Badge
+                              variant={
+                                p.status === "approved" ? "default" : "outline"
+                              }
+                              className="capitalize"
+                            >
+                              {p.status}
+                            </Badge>
                           </li>
                         ))}
                       </ul>
                     )}
                     {missingPermitTypes.length > 0 && (
-                      <p className="text-xs text-yellow-500 mt-2">Missing approvals: {missingPermitTypes.join(", ")}</p>
+                      <p className="text-xs text-yellow-500 mt-2">
+                        Missing approvals: {missingPermitTypes.join(", ")}
+                      </p>
                     )}
                   </CardContent>
                 </Card>
                 <Card className="border-border/60">
-                  <CardHeader className="pb-2"><CardTitle className="text-base flex items-center gap-2"><ShieldCheck className="h-4 w-4" /> Insurance</CardTitle></CardHeader>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base flex items-center gap-2">
+                      <ShieldCheck className="h-4 w-4" /> Insurance
+                    </CardTitle>
+                  </CardHeader>
                   <CardContent className="text-sm">
                     {!hasInsurance ? (
                       <p className="text-muted-foreground">No active policy.</p>
                     ) : (
                       <ul className="space-y-1">
                         {insurance.map((i: any) => (
-                          <li key={i.id} className="flex items-center justify-between">
-                            <span className="capitalize">{i.coverage_type}{i.weather_rider ? " + weather" : ""}</span>
+                          <li
+                            key={i.id}
+                            className="flex items-center justify-between"
+                          >
+                            <span className="capitalize">
+                              {i.coverage_type}
+                              {i.weather_rider ? " + weather" : ""}
+                            </span>
                             <span className="text-xs text-muted-foreground">
-                              cap ${((i.payout_ceiling_cents ?? 0) / 100).toLocaleString()}
+                              cap $
+                              {(
+                                (i.payout_ceiling_cents ?? 0) / 100
+                              ).toLocaleString()}
                             </span>
                           </li>
                         ))}
@@ -385,186 +624,310 @@ export default function FestivalRunWizard() {
               </div>
               <CheckList items={checks.compliance} />
               <div className="flex gap-2">
-                <Button size="sm" variant="outline" onClick={() => navigate(`/festivals/${festivalId}/manage?tab=compliance`)}>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    navigate(`/festivals/${festivalId}/manage?tab=compliance`)
+                  }
+                >
                   Manage Permits & Insurance
                 </Button>
               </div>
             </div>
           )}
 
-          {step.key === "launch" && (() => {
-            // Build run order across all stages, sorted by day + start_time
-            const runOrder = [...confirmedSlots].sort((a: any, b: any) => {
-              if (a.day_number !== b.day_number) return a.day_number - b.day_number;
-              const at = a.start_time || "";
-              const bt = b.start_time || "";
-              return at.localeCompare(bt);
-            });
-            const bookedByStage = stages
-              .map(st => ({
-                stage: st,
-                slots: confirmedSlots
-                  .filter((s: any) => s.stage_id === st.id)
-                  .sort((a: any, b: any) => (a.day_number - b.day_number) || String(a.start_time || "").localeCompare(String(b.start_time || ""))),
-              }))
-              .filter(g => g.slots.length > 0);
+          {step.key === "launch" &&
+            (() => {
+              // Build run order across all stages, sorted by day + start_time
+              const runOrder = [...confirmedSlots].sort((a: any, b: any) => {
+                if (a.day_number !== b.day_number)
+                  return a.day_number - b.day_number;
+                const at = a.start_time || "";
+                const bt = b.start_time || "";
+                return at.localeCompare(bt);
+              });
+              const bookedByStage = stages
+                .map((st) => ({
+                  stage: st,
+                  slots: confirmedSlots
+                    .filter((s: any) => s.stage_id === st.id)
+                    .sort(
+                      (a: any, b: any) =>
+                        a.day_number - b.day_number ||
+                        String(a.start_time || "").localeCompare(
+                          String(b.start_time || ""),
+                        ),
+                    ),
+                }))
+                .filter((g) => g.slots.length > 0);
 
-            const slotLabel = (s: any) => s.band?.name || s.npc_dj_name || (s.is_npc_dj ? "NPC DJ" : "Unassigned");
-            const fmtTime = (t: string | null) => t ? String(t).slice(0, 5) : "TBA";
+              const slotLabel = (s: any) =>
+                s.band?.name ||
+                s.npc_dj_name ||
+                (s.is_npc_dj ? "NPC DJ" : "Unassigned");
+              const fmtTime = (t: string | null) =>
+                t ? String(t).slice(0, 5) : "TBA";
 
-            const edits: { label: string; before: string; after: string }[] = originalDraft ? [
-              { label: "Name", before: originalDraft.name || "—", after: draftName || "—" },
-              { label: "Expected attendance", before: originalDraft.attendance || "—", after: draftAttendance || "—" },
-              { label: "Ticket low", before: `$${originalDraft.low || "0"}`, after: `$${draftLow || "0"}` },
-              { label: "Ticket high", before: `$${originalDraft.high || "0"}`, after: `$${draftHigh || "0"}` },
-            ].filter(e => e.before !== e.after) : [];
+              const edits: { label: string; before: string; after: string }[] =
+                originalDraft
+                  ? [
+                      {
+                        label: "Name",
+                        before: originalDraft.name || "—",
+                        after: draftName || "—",
+                      },
+                      {
+                        label: "Expected attendance",
+                        before: originalDraft.attendance || "—",
+                        after: draftAttendance || "—",
+                      },
+                      {
+                        label: "Ticket low",
+                        before: `$${originalDraft.low || "0"}`,
+                        after: `$${draftLow || "0"}`,
+                      },
+                      {
+                        label: "Ticket high",
+                        before: `$${originalDraft.high || "0"}`,
+                        after: `$${draftHigh || "0"}`,
+                      },
+                    ].filter((e) => e.before !== e.after)
+                  : [];
 
-            return (
-            <div className="space-y-4">
-              <div className="rounded-md border p-4 space-y-2">
-                <div className="flex items-center gap-2 text-sm">
-                  <Ticket className="h-4 w-4 text-primary" />
-                  <span>Ticket range: ${festival.ticket_price_low} – ${festival.ticket_price_high}</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm">
-                  <CalendarIcon className="h-4 w-4 text-primary" />
-                  <span>{format(new Date(festival.start_date), "MMM d")} – {format(new Date(festival.end_date), "MMM d, yyyy")}</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm">
-                  <Music className="h-4 w-4 text-primary" />
-                  <span>{stages.length} stages • {confirmedSlots.length} confirmed acts</span>
-                </div>
-                <div className="flex items-center gap-2 text-sm">
-                  <ShieldCheck className="h-4 w-4 text-primary" />
-                  <span>{approvedPermits.length} approved permits • {insurance.length} active policies</span>
-                </div>
-              </div>
+              return (
+                <div className="space-y-4">
+                  <div className="rounded-md border p-4 space-y-2">
+                    <div className="flex items-center gap-2 text-sm">
+                      <Ticket className="h-4 w-4 text-primary" />
+                      <span>
+                        Ticket range: ${festival.ticket_price_low} – $
+                        {festival.ticket_price_high}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <CalendarIcon className="h-4 w-4 text-primary" />
+                      <span>
+                        {format(new Date(festival.start_date), "MMM d")} –{" "}
+                        {format(new Date(festival.end_date), "MMM d, yyyy")}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <Music className="h-4 w-4 text-primary" />
+                      <span>
+                        {stages.length} stages • {confirmedSlots.length}{" "}
+                        confirmed acts
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-sm">
+                      <ShieldCheck className="h-4 w-4 text-primary" />
+                      <span>
+                        {approvedPermits.length} approved permits •{" "}
+                        {insurance.length} active policies
+                      </span>
+                    </div>
+                  </div>
 
-              {/* Wizard edits diff */}
-              {edits.length > 0 && (
-                <Card className="border-primary/40 bg-primary/5">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-base flex items-center gap-2">
-                      <FileText className="h-4 w-4" /> Edits made in this wizard
-                    </CardTitle>
-                    <CardDescription>Review changes before going live.</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <ul className="space-y-1.5 text-sm">
-                      {edits.map((e, i) => (
-                        <li key={i} className="flex items-center justify-between gap-2 flex-wrap">
-                          <span className="text-muted-foreground">{e.label}</span>
-                          <span className="font-mono text-xs">
-                            <span className="line-through text-muted-foreground">{e.before}</span>
-                            <ArrowRight className="inline h-3 w-3 mx-1" />
-                            <span className="text-primary">{e.after}</span>
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                </Card>
-              )}
-
-              {/* Side-by-side: Run Order vs Booked Stages */}
-              <div className="grid gap-3 md:grid-cols-2">
-                <Card className="border-border/60">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-base flex items-center gap-2">
-                      <CalendarIcon className="h-4 w-4" /> Run Order
-                    </CardTitle>
-                    <CardDescription>Chronological across all stages ({runOrder.length} acts)</CardDescription>
-                  </CardHeader>
-                  <CardContent className="text-sm">
-                    {runOrder.length === 0 ? (
-                      <p className="text-muted-foreground">No confirmed acts yet.</p>
-                    ) : (
-                      <ol className="space-y-1.5 max-h-80 overflow-auto pr-1">
-                        {runOrder.map((s: any, idx: number) => {
-                          const stageName = stages.find(st => st.id === s.stage_id)?.stage_name || "Stage";
-                          return (
-                            <li key={s.id} className="flex items-center justify-between gap-2 border-b border-border/40 pb-1 last:border-0">
-                              <div className="flex items-center gap-2 min-w-0">
-                                <span className="text-[10px] font-mono text-muted-foreground w-6">#{idx + 1}</span>
-                                <div className="min-w-0">
-                                  <div className="font-medium truncate">{slotLabel(s)}</div>
-                                  <div className="text-[11px] text-muted-foreground truncate">
-                                    Day {s.day_number} • {fmtTime(s.start_time)}–{fmtTime(s.end_time)} • {stageName}
-                                  </div>
-                                </div>
-                              </div>
-                              <Badge variant="outline" className="capitalize text-[10px]">{String(s.slot_type).replace("_", " ")}</Badge>
+                  {/* Wizard edits diff */}
+                  {edits.length > 0 && (
+                    <Card className="border-primary/40 bg-primary/5">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center gap-2">
+                          <FileText className="h-4 w-4" /> Edits made in this
+                          wizard
+                        </CardTitle>
+                        <CardDescription>
+                          Review changes before going live.
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <ul className="space-y-1.5 text-sm">
+                          {edits.map((e, i) => (
+                            <li
+                              key={i}
+                              className="flex items-center justify-between gap-2 flex-wrap"
+                            >
+                              <span className="text-muted-foreground">
+                                {e.label}
+                              </span>
+                              <span className="font-mono text-xs">
+                                <span className="line-through text-muted-foreground">
+                                  {e.before}
+                                </span>
+                                <ArrowRight className="inline h-3 w-3 mx-1" />
+                                <span className="text-primary">{e.after}</span>
+                              </span>
                             </li>
-                          );
-                        })}
-                      </ol>
-                    )}
-                  </CardContent>
-                </Card>
+                          ))}
+                        </ul>
+                      </CardContent>
+                    </Card>
+                  )}
 
-                <Card className="border-border/60">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-base flex items-center gap-2">
-                      <Music className="h-4 w-4" /> Booked Stages
-                    </CardTitle>
-                    <CardDescription>Grouped by stage ({bookedByStage.length}/{stages.length})</CardDescription>
-                  </CardHeader>
-                  <CardContent className="text-sm">
-                    {bookedByStage.length === 0 ? (
-                      <p className="text-muted-foreground">No stages have bookings yet.</p>
-                    ) : (
-                      <div className="space-y-3 max-h-80 overflow-auto pr-1">
-                        {bookedByStage.map(({ stage, slots: stageSlots }) => (
-                          <div key={stage.id}>
-                            <div className="flex items-center justify-between mb-1">
-                              <div className="font-medium">{stage.stage_name}</div>
-                              <Badge variant="secondary" className="text-[10px]">{stageSlots.length} act{stageSlots.length !== 1 ? "s" : ""}</Badge>
-                            </div>
-                            <ul className="space-y-1 pl-2 border-l border-border/60">
-                              {stageSlots.map((s: any) => (
-                                <li key={s.id} className="flex items-center justify-between text-[12px]">
-                                  <span className="truncate">{slotLabel(s)}</span>
-                                  <span className="text-muted-foreground font-mono text-[10px] ml-2">
-                                    D{s.day_number} {fmtTime(s.start_time)}
-                                  </span>
+                  {/* Side-by-side: Run Order vs Booked Stages */}
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Card className="border-border/60">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center gap-2">
+                          <CalendarIcon className="h-4 w-4" /> Run Order
+                        </CardTitle>
+                        <CardDescription>
+                          Chronological across all stages ({runOrder.length}{" "}
+                          acts)
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="text-sm">
+                        {runOrder.length === 0 ? (
+                          <p className="text-muted-foreground">
+                            No confirmed acts yet.
+                          </p>
+                        ) : (
+                          <ol className="space-y-1.5 max-h-80 overflow-auto pr-1">
+                            {runOrder.map((s: any, idx: number) => {
+                              const stageName =
+                                stages.find((st) => st.id === s.stage_id)
+                                  ?.stage_name || "Stage";
+                              return (
+                                <li
+                                  key={s.id}
+                                  className="flex items-center justify-between gap-2 border-b border-border/40 pb-1 last:border-0"
+                                >
+                                  <div className="flex items-center gap-2 min-w-0">
+                                    <span className="text-[10px] font-mono text-muted-foreground w-6">
+                                      #{idx + 1}
+                                    </span>
+                                    <div className="min-w-0">
+                                      <div className="font-medium truncate">
+                                        {slotLabel(s)}
+                                      </div>
+                                      <div className="text-[11px] text-muted-foreground truncate">
+                                        Day {s.day_number} •{" "}
+                                        {fmtTime(s.start_time)}–
+                                        {fmtTime(s.end_time)} • {stageName}
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <Badge
+                                    variant="outline"
+                                    className="capitalize text-[10px]"
+                                  >
+                                    {String(s.slot_type).replace("_", " ")}
+                                  </Badge>
                                 </li>
-                              ))}
-                            </ul>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
-              </div>
+                              );
+                            })}
+                          </ol>
+                        )}
+                      </CardContent>
+                    </Card>
 
-              {!canLaunch && (
-                <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm flex items-start gap-2">
-                  <AlertTriangle className="h-4 w-4 text-destructive mt-0.5" />
-                  <span>Complete all previous steps before going live.</span>
+                    <Card className="border-border/60">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-center gap-2">
+                          <Music className="h-4 w-4" /> Booked Stages
+                        </CardTitle>
+                        <CardDescription>
+                          Grouped by stage ({bookedByStage.length}/
+                          {stages.length})
+                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="text-sm">
+                        {bookedByStage.length === 0 ? (
+                          <p className="text-muted-foreground">
+                            No stages have bookings yet.
+                          </p>
+                        ) : (
+                          <div className="space-y-3 max-h-80 overflow-auto pr-1">
+                            {bookedByStage.map(
+                              ({ stage, slots: stageSlots }) => (
+                                <div key={stage.id}>
+                                  <div className="flex items-center justify-between mb-1">
+                                    <div className="font-medium">
+                                      {stage.stage_name}
+                                    </div>
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-[10px]"
+                                    >
+                                      {stageSlots.length} act
+                                      {stageSlots.length !== 1 ? "s" : ""}
+                                    </Badge>
+                                  </div>
+                                  <ul className="space-y-1 pl-2 border-l border-border/60">
+                                    {stageSlots.map((s: any) => (
+                                      <li
+                                        key={s.id}
+                                        className="flex items-center justify-between text-[12px]"
+                                      >
+                                        <span className="truncate">
+                                          {slotLabel(s)}
+                                        </span>
+                                        <span className="text-muted-foreground font-mono text-[10px] ml-2">
+                                          D{s.day_number}{" "}
+                                          {fmtTime(s.start_time)}
+                                        </span>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              ),
+                            )}
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  </div>
+
+                  {!canLaunch && (
+                    <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm flex items-start gap-2">
+                      <AlertTriangle className="h-4 w-4 text-destructive mt-0.5" />
+                      <span>
+                        Complete all previous steps before going live.
+                      </span>
+                    </div>
+                  )}
+                  <Button
+                    size="lg"
+                    className="w-full"
+                    disabled={
+                      !canLaunch ||
+                      launchMutation.isPending ||
+                      festival.status === "announced" ||
+                      festival.status === "live"
+                    }
+                    onClick={() => launchMutation.mutate()}
+                  >
+                    {launchMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    ) : (
+                      <Rocket className="h-4 w-4 mr-2" />
+                    )}
+                    {festival.status === "announced" ||
+                    festival.status === "live"
+                      ? "Festival is Live"
+                      : "Go Live & Announce"}
+                  </Button>
                 </div>
-              )}
-              <Button
-                size="lg"
-                className="w-full"
-                disabled={!canLaunch || launchMutation.isPending || festival.status === "announced" || festival.status === "live"}
-                onClick={() => launchMutation.mutate()}
-              >
-                {launchMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Rocket className="h-4 w-4 mr-2" />}
-                {festival.status === "announced" || festival.status === "live" ? "Festival is Live" : "Go Live & Announce"}
-              </Button>
-            </div>
-            );
-          })()}
+              );
+            })()}
         </CardContent>
       </Card>
 
       {/* Nav */}
       <div className="flex justify-between">
-        <Button variant="outline" size="sm" onClick={() => setStepIdx(Math.max(0, stepIdx - 1))} disabled={stepIdx === 0}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setStepIdx(Math.max(0, stepIdx - 1))}
+          disabled={stepIdx === 0}
+        >
           <ArrowLeft className="h-4 w-4 mr-1" /> Back
         </Button>
-        <Button size="sm" onClick={() => setStepIdx(Math.min(STEPS.length - 1, stepIdx + 1))} disabled={stepIdx >= STEPS.length - 1}>
+        <Button
+          size="sm"
+          onClick={() => setStepIdx(Math.min(STEPS.length - 1, stepIdx + 1))}
+          disabled={stepIdx >= STEPS.length - 1}
+        >
           Next <ArrowRight className="h-4 w-4 ml-1" />
         </Button>
       </div>

--- a/supabase/migrations/20291204090000_create_festival_editions.sql
+++ b/supabase/migrations/20291204090000_create_festival_editions.sql
@@ -1,0 +1,316 @@
+-- Canonical festival editions foundation.
+-- Dedicated `festivals` rows remain permanent brands. This migration introduces dated editions
+-- and maps legacy brand/game_event identifiers without deleting or re-keying legacy tables.
+
+DO $$ BEGIN
+  CREATE TYPE public.festival_edition_status AS ENUM (
+    'concept','planning','applications_open','booking','announced','on_sale','setup','live','settling','completed','postponed','cancelled','abandoned'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.festival_editions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  festival_id uuid NOT NULL REFERENCES public.festivals(id) ON DELETE CASCADE,
+  edition_number integer NOT NULL,
+  edition_year integer,
+  title text,
+  slug text,
+  description text,
+  city_id uuid REFERENCES public.cities(id) ON DELETE RESTRICT,
+  venue_id uuid REFERENCES public.venues(id) ON DELETE SET NULL,
+  start_at timestamptz,
+  end_at timestamptz,
+  timezone text NOT NULL DEFAULT 'UTC',
+  doors_open_at timestamptz,
+  curfew_at timestamptz,
+  expected_attendance integer,
+  capacity integer,
+  minimum_ticket_price_cents bigint,
+  maximum_ticket_price_cents bigint,
+  currency_code text NOT NULL DEFAULT 'USD',
+  budget_cents bigint,
+  treasury_allocation_cents bigint,
+  status public.festival_edition_status NOT NULL DEFAULT 'planning',
+  lifecycle_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  public_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  legacy_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  announced_at timestamptz,
+  on_sale_at timestamptz,
+  live_at timestamptz,
+  completed_at timestamptz,
+  cancelled_at timestamptz,
+  CONSTRAINT festival_editions_festival_number_key UNIQUE (festival_id, edition_number),
+  CONSTRAINT festival_editions_edition_number_positive CHECK (edition_number > 0),
+  CONSTRAINT festival_editions_year_reasonable CHECK (edition_year IS NULL OR edition_year BETWEEN 1900 AND 2200),
+  CONSTRAINT festival_editions_dates_order CHECK (start_at IS NULL OR end_at IS NULL OR end_at > start_at),
+  CONSTRAINT festival_editions_doors_before_end CHECK (doors_open_at IS NULL OR end_at IS NULL OR doors_open_at <= end_at),
+  CONSTRAINT festival_editions_curfew_after_start CHECK (curfew_at IS NULL OR start_at IS NULL OR curfew_at >= start_at),
+  CONSTRAINT festival_editions_nonnegative_attendance CHECK (expected_attendance IS NULL OR expected_attendance >= 0),
+  CONSTRAINT festival_editions_nonnegative_capacity CHECK (capacity IS NULL OR capacity >= 0),
+  CONSTRAINT festival_editions_nonnegative_money CHECK (
+    (minimum_ticket_price_cents IS NULL OR minimum_ticket_price_cents >= 0)
+    AND (maximum_ticket_price_cents IS NULL OR maximum_ticket_price_cents >= 0)
+    AND (budget_cents IS NULL OR budget_cents >= 0)
+    AND (treasury_allocation_cents IS NULL OR treasury_allocation_cents >= 0)
+  ),
+  CONSTRAINT festival_editions_ticket_range CHECK (
+    minimum_ticket_price_cents IS NULL OR maximum_ticket_price_cents IS NULL OR maximum_ticket_price_cents >= minimum_ticket_price_cents
+  ),
+  CONSTRAINT festival_editions_currency_code_format CHECK (currency_code ~ '^[A-Z]{3}$')
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_edition_lifecycle_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
+  from_status public.festival_edition_status,
+  to_status public.festival_edition_status NOT NULL,
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  reason text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  idempotency_key text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_lifecycle_reason_required CHECK (to_status NOT IN ('cancelled','postponed','abandoned') OR length(trim(coalesce(reason,''))) > 0),
+  CONSTRAINT festival_lifecycle_idempotency_key_not_blank CHECK (idempotency_key IS NULL OR length(trim(idempotency_key)) > 0),
+  CONSTRAINT festival_lifecycle_idempotency_unique UNIQUE (edition_id, idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_legacy_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
+  legacy_source text NOT NULL CHECK (legacy_source IN ('game_event','dedicated_festival_row','festival_lineup_source')),
+  legacy_id uuid NOT NULL,
+  legacy_festival_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT festival_legacy_mappings_source_id_key UNIQUE (legacy_source, legacy_id),
+  CONSTRAINT festival_legacy_mappings_edition_source_id_key UNIQUE (edition_id, legacy_source, legacy_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_festival_editions_status_start ON public.festival_editions(status, start_at);
+CREATE INDEX IF NOT EXISTS idx_festival_editions_city_start ON public.festival_editions(city_id, start_at) WHERE city_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_festival_editions_venue_start ON public.festival_editions(venue_id, start_at) WHERE venue_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_festival_editions_visible_upcoming ON public.festival_editions(start_at, status) WHERE status IN ('applications_open','booking','announced','on_sale','setup','live','settling','completed');
+CREATE INDEX IF NOT EXISTS idx_festival_editions_processing ON public.festival_editions(status, start_at, end_at) WHERE status IN ('setup','live','settling');
+CREATE INDEX IF NOT EXISTS idx_festival_lifecycle_edition_created ON public.festival_edition_lifecycle_events(edition_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_festival_legacy_source_id ON public.festival_legacy_mappings(legacy_source, legacy_id);
+CREATE INDEX IF NOT EXISTS idx_festival_legacy_edition ON public.festival_legacy_mappings(edition_id);
+
+CREATE OR REPLACE VIEW public.public_festival_editions AS
+SELECT
+  id, festival_id, edition_number, edition_year, title, slug, description, city_id, venue_id,
+  start_at, end_at, timezone, doors_open_at, curfew_at, expected_attendance, capacity,
+  minimum_ticket_price_cents, maximum_ticket_price_cents, currency_code, status, public_metadata,
+  announced_at, on_sale_at, live_at, completed_at, cancelled_at, created_at, updated_at
+FROM public.festival_editions
+WHERE public.is_public_festival_edition_status(status);
+GRANT SELECT ON public.public_festival_editions TO anon, authenticated;
+
+
+DROP TRIGGER IF EXISTS tg_festival_editions_touch ON public.festival_editions;
+CREATE TRIGGER tg_festival_editions_touch BEFORE UPDATE ON public.festival_editions FOR EACH ROW EXECUTE FUNCTION public.tg_touch_updated_at();
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_brand(p_festival_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path=public AS $$
+  SELECT coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false)
+    OR EXISTS (SELECT 1 FROM public.festivals f WHERE f.id = p_festival_id AND f.owner_profile_id = public.current_profile_id())
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_public_festival_edition_status(p_status public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT p_status IN ('applications_open','booking','announced','on_sale','setup','live','settling','completed')
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_festival_edition_transition(p_from public.festival_edition_status, p_to public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT CASE
+    WHEN p_from = p_to THEN true
+    WHEN p_from IN ('completed','cancelled','abandoned') THEN false
+    WHEN p_to IN ('cancelled','abandoned') THEN p_from NOT IN ('completed','cancelled','abandoned')
+    WHEN p_to = 'postponed' THEN p_from NOT IN ('live','settling','completed','cancelled','abandoned')
+    WHEN p_from = 'postponed' THEN p_to IN ('planning','announced')
+    WHEN p_from = 'concept' THEN p_to = 'planning'
+    WHEN p_from = 'planning' THEN p_to IN ('applications_open','booking')
+    WHEN p_from = 'applications_open' THEN p_to = 'booking'
+    WHEN p_from = 'booking' THEN p_to = 'announced'
+    WHEN p_from = 'announced' THEN p_to IN ('on_sale','setup')
+    WHEN p_from = 'on_sale' THEN p_to = 'setup'
+    WHEN p_from = 'setup' THEN p_to = 'live'
+    WHEN p_from = 'live' THEN p_to = 'settling'
+    WHEN p_from = 'settling' THEN p_to = 'completed'
+    ELSE false
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION public.transition_festival_edition(
+  p_edition_id uuid,
+  p_target_status public.festival_edition_status,
+  p_reason text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_edition public.festival_editions%ROWTYPE; v_existing public.festival_edition_lifecycle_events%ROWTYPE; v_actor uuid; v_now timestamptz := now(); v_is_admin boolean; v_from public.festival_edition_status;
+BEGIN
+  v_actor := public.current_profile_id();
+  v_is_admin := coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false);
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_existing FROM public.festival_edition_lifecycle_events WHERE edition_id=p_edition_id AND idempotency_key=p_idempotency_key;
+    IF FOUND THEN SELECT * INTO v_edition FROM public.festival_editions WHERE id=p_edition_id; RETURN v_edition; END IF;
+  END IF;
+  SELECT * INTO v_edition FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v_edition.festival_id) THEN RAISE EXCEPTION 'Not authorised to manage this festival edition'; END IF;
+  v_from := v_edition.status;
+  IF p_target_status IN ('cancelled','postponed','abandoned') AND length(trim(coalesce(p_reason,''))) = 0 THEN RAISE EXCEPTION 'A reason is required for % transitions', p_target_status; END IF;
+  IF NOT public.validate_festival_edition_transition(v_edition.status, p_target_status) THEN RAISE EXCEPTION 'Invalid festival edition transition from % to %', v_edition.status, p_target_status; END IF;
+  IF p_target_status = 'announced' AND (v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR v_edition.city_id IS NULL OR v_edition.venue_id IS NULL OR coalesce(v_edition.capacity, v_edition.expected_attendance, 0) <= 0) THEN
+    RAISE EXCEPTION 'Festival edition requires dates, city, venue and positive capacity or attendance before announcement';
+  END IF;
+  IF p_target_status = 'on_sale' AND (v_edition.status <> 'announced' OR v_edition.minimum_ticket_price_cents IS NULL OR v_edition.maximum_ticket_price_cents IS NULL OR v_edition.maximum_ticket_price_cents < v_edition.minimum_ticket_price_cents) THEN
+    RAISE EXCEPTION 'Festival edition requires announced state and valid ticket price range before on-sale';
+  END IF;
+  IF p_target_status = 'live' AND NOT v_is_admin AND (v_now < v_edition.start_at - interval '24 hours' OR v_now > v_edition.end_at + interval '24 hours') THEN
+    RAISE EXCEPTION 'Festival edition cannot go live outside the launch window without admin override';
+  END IF;
+  IF v_edition.status = 'postponed' AND p_target_status IN ('planning','announced') AND (v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR v_edition.start_at <= v_now) THEN
+    RAISE EXCEPTION 'Postponed festival edition requires new future dates before recovery';
+  END IF;
+
+  UPDATE public.festival_editions SET
+    status=p_target_status,
+    lifecycle_metadata = lifecycle_metadata || coalesce(p_metadata,'{}'::jsonb),
+    announced_at = CASE WHEN p_target_status='announced' AND announced_at IS NULL THEN v_now ELSE announced_at END,
+    on_sale_at = CASE WHEN p_target_status='on_sale' AND on_sale_at IS NULL THEN v_now ELSE on_sale_at END,
+    live_at = CASE WHEN p_target_status='live' AND live_at IS NULL THEN v_now ELSE live_at END,
+    completed_at = CASE WHEN p_target_status='completed' AND completed_at IS NULL THEN v_now ELSE completed_at END,
+    cancelled_at = CASE WHEN p_target_status IN ('cancelled','abandoned') AND cancelled_at IS NULL THEN v_now ELSE cancelled_at END
+  WHERE id=p_edition_id RETURNING * INTO v_edition;
+
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key)
+  VALUES (p_edition_id, v_from, p_target_status, v_actor, p_reason, coalesce(p_metadata,'{}'::jsonb), p_idempotency_key)
+  ON CONFLICT (edition_id, idempotency_key) DO NOTHING;
+  RETURN v_edition;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.create_festival_edition(
+  p_festival_id uuid,
+  p_title text DEFAULT NULL,
+  p_start_at timestamptz DEFAULT NULL,
+  p_end_at timestamptz DEFAULT NULL,
+  p_city_id uuid DEFAULT NULL,
+  p_venue_id uuid DEFAULT NULL,
+  p_expected_attendance integer DEFAULT NULL,
+  p_capacity integer DEFAULT NULL,
+  p_minimum_ticket_price_cents bigint DEFAULT NULL,
+  p_maximum_ticket_price_cents bigint DEFAULT NULL,
+  p_public_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_festival public.festivals%ROWTYPE; v_edition public.festival_editions%ROWTYPE; v_next integer; v_actor uuid;
+BEGIN
+  v_actor := public.current_profile_id();
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival not found'; END IF;
+  IF NOT public.can_manage_festival_brand(p_festival_id) THEN RAISE EXCEPTION 'Not authorised to create festival editions'; END IF;
+  IF p_start_at IS NOT NULL AND p_end_at IS NOT NULL AND p_end_at <= p_start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  SELECT coalesce(max(edition_number),0)+1 INTO v_next FROM public.festival_editions WHERE festival_id=p_festival_id;
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, treasury_allocation_cents, public_metadata, created_by, legacy_metadata)
+  VALUES (p_festival_id, v_next, extract(year from coalesce(p_start_at, v_festival.start_date::timestamptz))::int, coalesce(p_title, v_festival.name || ' #' || v_next), v_festival.description, coalesce(p_city_id, v_festival.city_id), coalesce(p_venue_id, v_festival.venue_id), coalesce(p_start_at, v_festival.start_date::timestamptz), coalesce(p_end_at, (v_festival.end_date + 1)::timestamptz), coalesce(p_expected_attendance, v_festival.expected_attendance), coalesce(p_capacity, v_festival.expected_attendance), p_minimum_ticket_price_cents, p_maximum_ticket_price_cents, v_festival.treasury_cents, coalesce(p_public_metadata,'{}'::jsonb), v_actor, jsonb_build_object('created_from_rpc', true))
+  RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata)
+  VALUES (v_edition.id, NULL, v_edition.status, v_actor, 'edition_created', jsonb_build_object('source','create_festival_edition'));
+  RETURN v_edition;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.update_festival_edition_planning(
+  p_edition_id uuid,
+  p_title text DEFAULT NULL,
+  p_description text DEFAULT NULL,
+  p_start_at timestamptz DEFAULT NULL,
+  p_end_at timestamptz DEFAULT NULL,
+  p_city_id uuid DEFAULT NULL,
+  p_venue_id uuid DEFAULT NULL,
+  p_expected_attendance integer DEFAULT NULL,
+  p_capacity integer DEFAULT NULL,
+  p_minimum_ticket_price_cents bigint DEFAULT NULL,
+  p_maximum_ticket_price_cents bigint DEFAULT NULL,
+  p_public_metadata jsonb DEFAULT NULL
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_edition public.festival_editions%ROWTYPE;
+BEGIN
+  SELECT * INTO v_edition FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v_edition.festival_id) THEN RAISE EXCEPTION 'Not authorised to update festival edition'; END IF;
+  IF v_edition.status NOT IN ('concept','planning','applications_open','booking') THEN RAISE EXCEPTION 'Festival edition planning fields are locked after announcement'; END IF;
+  IF p_start_at IS NOT NULL AND p_end_at IS NOT NULL AND p_end_at <= p_start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  UPDATE public.festival_editions SET
+    title=coalesce(p_title,title), description=coalesce(p_description,description), start_at=coalesce(p_start_at,start_at), end_at=coalesce(p_end_at,end_at), city_id=coalesce(p_city_id,city_id), venue_id=coalesce(p_venue_id,venue_id), expected_attendance=coalesce(p_expected_attendance,expected_attendance), capacity=coalesce(p_capacity,capacity), minimum_ticket_price_cents=coalesce(p_minimum_ticket_price_cents,minimum_ticket_price_cents), maximum_ticket_price_cents=coalesce(p_maximum_ticket_price_cents,maximum_ticket_price_cents), public_metadata=coalesce(p_public_metadata,public_metadata)
+  WHERE id=p_edition_id RETURNING * INTO v_edition;
+  RETURN v_edition;
+END; $$;
+
+GRANT SELECT ON public.festival_editions TO authenticated;
+GRANT SELECT ON public.festival_edition_lifecycle_events TO authenticated;
+GRANT SELECT ON public.festival_legacy_mappings TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transition_festival_edition(uuid, public.festival_edition_status, text, jsonb, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_festival_edition(uuid, text, timestamptz, timestamptz, uuid, uuid, integer, integer, bigint, bigint, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_festival_edition_planning(uuid, text, text, timestamptz, timestamptz, uuid, uuid, integer, integer, bigint, bigint, jsonb) TO authenticated;
+
+ALTER TABLE public.festival_editions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_edition_lifecycle_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_legacy_mappings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "festival_editions_owner_admin_read" ON public.festival_editions FOR SELECT TO authenticated USING (public.can_manage_festival_brand(festival_id));
+CREATE POLICY "festival_lifecycle_owner_admin_read" ON public.festival_edition_lifecycle_events FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.id=edition_id AND public.can_manage_festival_brand(e.festival_id)));
+CREATE POLICY "festival_legacy_mappings_owner_admin_read" ON public.festival_legacy_mappings FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.id=edition_id AND public.can_manage_festival_brand(e.festival_id)));
+
+-- Backfill dedicated festival rows as their first canonical edition. Existing numeric ticket prices are dollars,
+-- while newer marketplace finance fields are cents, so ticket values are multiplied by 100 and preserved in legacy_metadata.
+WITH source_festivals AS (
+  SELECT f.*,
+    CASE
+      WHEN f.status = 'live' THEN 'live'::public.festival_edition_status
+      WHEN f.status = 'completed' THEN 'completed'::public.festival_edition_status
+      WHEN f.status = 'postponed' THEN 'postponed'::public.festival_edition_status
+      WHEN f.status = 'cancelled' THEN 'cancelled'::public.festival_edition_status
+      WHEN f.status IN ('published','announced') THEN 'announced'::public.festival_edition_status
+      WHEN f.status = 'confirmed' THEN 'booking'::public.festival_edition_status
+      WHEN f.status IN ('upcoming','draft') THEN 'planning'::public.festival_edition_status
+      ELSE 'planning'::public.festival_edition_status
+    END AS mapped_status
+  FROM public.festivals f
+), inserted AS (
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, currency_code, treasury_allocation_cents, status, public_metadata, legacy_metadata, created_at, updated_at, announced_at, live_at, completed_at, cancelled_at)
+  SELECT sf.id, greatest(coalesce(sf.edition_number,1),1), extract(year from sf.start_date)::int, sf.name || ' ' || extract(year from sf.start_date)::int, sf.description, sf.city_id, sf.venue_id, sf.start_date::timestamptz, (sf.end_date + 1)::timestamptz, sf.expected_attendance, sf.expected_attendance, CASE WHEN sf.ticket_price_low IS NULL THEN NULL ELSE round(sf.ticket_price_low * 100)::bigint END, CASE WHEN sf.ticket_price_high IS NULL THEN NULL ELSE round(sf.ticket_price_high * 100)::bigint END, 'USD', sf.treasury_cents, sf.mapped_status, jsonb_build_object('legacy_brand_public_metadata', sf.metadata), jsonb_build_object('source','dedicated_festival_backfill','original_status',sf.status,'ticket_price_unit','dollars','brand_edition_number',sf.edition_number,'brand_next_edition_start',sf.next_edition_start,'brand_cancellation_reason',sf.cancellation_reason), sf.created_at, sf.updated_at, CASE WHEN sf.mapped_status IN ('announced','on_sale','setup','live','settling','completed') THEN sf.updated_at ELSE NULL END, CASE WHEN sf.mapped_status='live' THEN sf.updated_at ELSE NULL END, CASE WHEN sf.mapped_status='completed' THEN sf.updated_at ELSE NULL END, CASE WHEN sf.mapped_status IN ('cancelled','abandoned') THEN sf.updated_at ELSE NULL END
+  FROM source_festivals sf
+  WHERE NOT EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.festival_id=sf.id AND e.edition_number=greatest(coalesce(sf.edition_number,1),1))
+  RETURNING *
+)
+INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, reason, metadata)
+SELECT id, NULL, status, 'dedicated_festival_backfill', jsonb_build_object('source','migration') FROM inserted;
+
+INSERT INTO public.festival_legacy_mappings(edition_id, legacy_source, legacy_id, legacy_festival_id, metadata)
+SELECT e.id, 'dedicated_festival_row', e.festival_id, e.festival_id, jsonb_build_object('source','migration')
+FROM public.festival_editions e
+ON CONFLICT (legacy_source, legacy_id) DO NOTHING;
+
+-- Conservative game_event linkage: exact title/name, same venue when present, and overlapping date ranges.
+INSERT INTO public.festival_legacy_mappings(edition_id, legacy_source, legacy_id, legacy_festival_id, metadata)
+SELECT e.id, 'game_event', ge.id, e.festival_id, jsonb_build_object('source','migration','match','exact_title_venue_date_overlap')
+FROM public.game_events ge
+JOIN public.festival_editions e ON lower(trim(e.title)) = lower(trim(ge.title)) OR lower(trim(split_part(e.title, ' ' || coalesce(e.edition_year::text,''), 1))) = lower(trim(ge.title))
+WHERE ge.event_type = 'festival'
+  AND (ge.venue_id IS NULL OR e.venue_id IS NULL OR ge.venue_id = e.venue_id)
+  AND ge.start_date <= e.end_at::date AND ge.end_date >= e.start_at::date
+ON CONFLICT (legacy_source, legacy_id) DO NOTHING;
+
+INSERT INTO public.festival_legacy_mappings(edition_id, legacy_source, legacy_id, legacy_festival_id, metadata)
+SELECT e.id, 'festival_lineup_source', fl.id, e.festival_id, jsonb_build_object('source','migration')
+FROM public.festival_lineups fl
+JOIN public.festival_editions e ON e.festival_id = fl.festival_id
+ON CONFLICT (legacy_source, legacy_id) DO NOTHING;

--- a/supabase/tests/festival_editions_harness.sql
+++ b/supabase/tests/festival_editions_harness.sql
@@ -1,0 +1,20 @@
+-- Festival editions release-gate harness. Intended for psql after migrations are applied.
+DO $$
+DECLARE
+  v_count integer;
+BEGIN
+  IF to_regclass('public.festival_editions') IS NULL THEN RAISE EXCEPTION 'festival_editions missing'; END IF;
+  IF to_regclass('public.festival_edition_lifecycle_events') IS NULL THEN RAISE EXCEPTION 'lifecycle events missing'; END IF;
+  IF to_regclass('public.festival_legacy_mappings') IS NULL THEN RAISE EXCEPTION 'legacy mappings missing'; END IF;
+  IF to_regtype('public.festival_edition_status') IS NULL THEN RAISE EXCEPTION 'festival_edition_status enum missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='transition_festival_edition') THEN RAISE EXCEPTION 'transition RPC missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='create_festival_edition') THEN RAISE EXCEPTION 'create RPC missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='update_festival_edition_planning') THEN RAISE EXCEPTION 'planning update RPC missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='festival_editions_festival_number_key') THEN RAISE EXCEPTION 'edition uniqueness missing'; END IF;
+  SELECT count(*) INTO v_count FROM public.festivals f WHERE NOT EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.festival_id=f.id);
+  IF v_count <> 0 THEN RAISE EXCEPTION 'backfilled dedicated festivals missing editions: %', v_count; END IF;
+  SELECT count(*) INTO v_count FROM (SELECT legacy_source, legacy_id FROM public.festival_legacy_mappings GROUP BY 1,2 HAVING count(*) > 1) dupes;
+  IF v_count <> 0 THEN RAISE EXCEPTION 'duplicate legacy mappings found'; END IF;
+  IF EXISTS (SELECT 1 FROM pg_policies WHERE tablename='festival_editions' AND cmd IN ('INSERT','UPDATE','DELETE')) THEN RAISE EXCEPTION 'direct client edition writes should not have policies'; END IF;
+  RAISE NOTICE 'festival edition schema harness passed';
+END $$;


### PR DESCRIPTION
### Motivation

- Establish a single additive canonical layer that separates permanent festival brands (`festivals`) from dated occurrences, introducing `festival_editions` to own dates, venue, capacity and lifecycle state.
- Provide server-authoritative edition lifecycle with immutable history and idempotent transitions so owner/run-wizard actions and future application/contract migrations are consistent and auditable.
- Bridge legacy systems (`game_events`, `festival_lineups`, `festival_participants`) with an explicit compatibility mapping to allow incremental migration without breaking current player flows.

### Description

- Database: add migration `supabase/migrations/20291204090000_create_festival_editions.sql` that creates enum `festival_edition_status`, tables `festival_editions`, `festival_edition_lifecycle_events`, `festival_legacy_mappings`, indexes, a public-safe view `public.public_festival_editions`, triggers using existing `tg_touch_updated_at()`, RLS and owner/admin select policies, and constraints/checks for dates, edition numbers and money fields.
- RPCs / functions: implement `create_festival_edition`, `update_festival_edition_planning`, and `transition_festival_edition` with security-definer logic, permission checks, readiness validation, lifecycle timestamp updates and lifecycle-event insertion with idempotency keys; add helper functions `can_manage_festival_brand`, `is_public_festival_edition_status`, and `validate_festival_edition_transition`.
- Backfill & mappings: add an idempotent backfill that inserts an initial edition per existing `festivals` row, converts legacy decimal ticket prices to cents (documented in `legacy_metadata`), conservatively maps known `festivals` statuses to edition statuses, and creates deterministic `game_event` and `festival_lineup` legacy mappings when safe.
- Frontend & types: add typed edition service and helpers under `src/features/festivals/` (`types.ts`, `service.ts`, `lifecycle.ts`, `legacyResolver.ts`) and update generated Supabase types to include new tables, enum and RPCs; minimally update `FestivalRunWizard.tsx` and `FestivalOwnerConsole.tsx` to resolve/display canonical editions and call `transition_festival_edition` instead of mutating brand status when a canonical edition exists.

### Testing

- Ran TypeScript type check with `npm run typecheck` which succeeded (no type errors).
- Formatted and validated code with Prettier via `npx prettier --check` (passed) and applied `npx prettier --write` for files created/modified.
- Validated JSON inventory with `python -m json.tool docs/festivals/festival-domain-inventory.json` (passed) and ran `git diff --check` (no problems reported).
- Added a SQL release-gate harness `supabase/tests/festival_editions_harness.sql` and a TypeScript unit test `src/features/festivals/__tests__/lifecycle.test.ts` for the pure lifecycle helper; the unit test file was added but running `vitest` in this environment failed due to unavailable registry/local dependencies (test runner install failure), so the TS unit test was not executed here.
- Database-level tests (`supabase db reset` and running the SQL harness via `psql`) could not be executed in this environment because the Supabase CLI / `psql` were not available; those checks are noted as outstanding and should be run in the CI or a developer environment with DB tooling available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bab5f0208325a95f61a66b5ea220)