### PR TITLE
fix(festivals): harden canonical edition migration and owner workflows

### DIFF
--- a/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
+++ b/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
@@ -89,3 +89,11 @@ This PR establishes the first additive canonical schema layer:
 - Compatibility remains explicit: owner tools may display canonical edition lifecycle, but brand-scoped staff, permits, insurance, marketplace and legacy event-backed player flows remain unchanged until later migrations.
 
 Unresolved migration items remain canonical applications, contracts, setlists, performances, stage/slot re-keying, tickets, attendance, settlement, reward ledgers, audience/incident/vendor/staff-shift systems, and final legacy withdrawal.
+
+## 2026 hardening update
+
+The canonical festival edition foundation is supplemented by `20291205090000_harden_festival_editions.sql` rather than renaming the historical `20291204090000` migration, because deployment state for the 2029 migration cannot be proven from the repository alone. The hardening migration recreates the public view after its status helper, narrows the public projection, adds creation idempotency, converts planning updates to JSONB patch semantics, and fingerprints lifecycle transition idempotency keys.
+
+Frontend owner workflows now distinguish public reads from owner/private reads. Public discovery uses `public_festival_editions`; owner screens use protected owner reads and a shared `selectManagedFestivalEdition` helper. The run wizard writes edition planning fields through `updateFestivalEditionPlanning` and requires an explicit edition creation action before occurrence planning or launch changes.
+
+Database regression coverage is expanded in `supabase/tests/festival_editions_harness.sql`, and static migration-order coverage is provided by `scripts/check-festival-edition-migrations.mjs`. Legacy player flows, stages, slots, applications, contracts, setlists and performance settlement remain unchanged.

--- a/docs/festivals/CURRENT_STATE_AUDIT.md
+++ b/docs/festivals/CURRENT_STATE_AUDIT.md
@@ -315,3 +315,11 @@ Flagged issues: browser score calculation, direct `bands.band_balance` and `band
 The canonical edition foundation PR introduces `festival_editions` as the dated occurrence model beneath permanent `festivals` brand rows. It adds a server-validated edition lifecycle RPC, immutable lifecycle history, dedicated-festival backfill into first editions, and explicit legacy mappings for dedicated festival rows plus conservatively matched festival `game_events`.
 
 Legacy event/player flows remain active during this migration. Stage, slot, ticket, attendance, application, contract, setlist, performance and settlement tables are not re-keyed in this step and remain outstanding for later PRs.
+
+## 2026 hardening update
+
+The canonical festival edition foundation is supplemented by `20291205090000_harden_festival_editions.sql` rather than renaming the historical `20291204090000` migration, because deployment state for the 2029 migration cannot be proven from the repository alone. The hardening migration recreates the public view after its status helper, narrows the public projection, adds creation idempotency, converts planning updates to JSONB patch semantics, and fingerprints lifecycle transition idempotency keys.
+
+Frontend owner workflows now distinguish public reads from owner/private reads. Public discovery uses `public_festival_editions`; owner screens use protected owner reads and a shared `selectManagedFestivalEdition` helper. The run wizard writes edition planning fields through `updateFestivalEditionPlanning` and requires an explicit edition creation action before occurrence planning or launch changes.
+
+Database regression coverage is expanded in `supabase/tests/festival_editions_harness.sql`, and static migration-order coverage is provided by `scripts/check-festival-edition-migrations.mjs`. Legacy player flows, stages, slots, applications, contracts, setlists and performance settlement remain unchanged.

--- a/docs/festivals/EDITION_MIGRATION_NOTES.md
+++ b/docs/festivals/EDITION_MIGRATION_NOTES.md
@@ -1,34 +1,31 @@
 # Festival edition migration notes
 
-## Backfill rules
+## Deployment review
 
-Every existing `festivals` row receives an initial `festival_editions` row when one does not already exist for the same brand and edition number. The migration preserves brand dates, city, venue, expected attendance, description, treasury and metadata. Existing `ticket_price_low` and `ticket_price_high` are decimal currency units, while the new edition ticket fields are cents, so the backfill multiplies those prices by 100 and records the compatibility decision in `legacy_metadata`.
+The historical canonical-edition migration is `supabase/migrations/20291204090000_create_festival_editions.sql`. This repository checkout does not contain deployment logs proving whether that migration has or has not been applied to a shared Supabase project, so this corrective PR treats it as potentially deployed.
 
-## Status mapping
+## Ordering decision
 
-Dedicated festival statuses verified in repository code and migrations are mapped conservatively:
+The `20291204090000` timestamp is retained as a historical migration identity. Renaming it alone would fix only fresh installs and could leave shared environments with divergent migration history. The hardening work therefore lives in the additive migration `20291205090000_harden_festival_editions.sql`.
 
-- `draft`, `upcoming` → `planning`
-- `confirmed` → `booking`
-- `published`, `announced` → `announced`
-- `live` → `live`
-- `completed` → `completed`
-- `postponed` → `postponed`
-- `cancelled` → `cancelled`
-- unknown values → `planning` with the original status retained in `legacy_metadata`
+Future festival migrations that depend on canonical editions must be timestamped after the historical foundation and the hardening migration, or must include idempotent bootstrap guards when they need to tolerate partially-applied environments.
 
-## Legacy event handling
+## Corrected dependency order
 
-The migration creates explicit `dedicated_festival_row` mappings for all backfilled editions. Legacy `game_events` rows are mapped only when the match is deterministic: festival event type, exact/normalised title match, compatible venue when present, and overlapping dates. Unmatched legacy festival events are left unmapped for the later data-migration PR rather than creating placeholder brands.
+PR #1190 created `public.public_festival_editions` before `public.is_public_festival_edition_status(status)`. PostgreSQL does not allow relying on an unresolved function reference in a view definition. The hardening migration creates or replaces the helper first, then drops and recreates the public view, reapplies grants, and performs a smoke query.
 
-## Compatibility rules
+## Public/private read contract
 
-`festivals` remains the permanent brand and marketplace asset. Brand-level staff, permits, insurance and ledger screens continue to operate until later edition re-keying. Current player festival routes backed by `game_events` and `festival_participants` remain active.
+Public discovery reads use `public.public_festival_editions`, a security-invoker/security-barrier projection that omits budgets, treasury allocations, lifecycle metadata, legacy metadata, idempotency keys and internal moderation/ownership fields. Owner and admin reads continue to use the protected `festival_editions` table through RLS-backed service functions.
 
-## Rollback strategy
+## RPC semantics
 
-This change is additive. Rollback can drop the three new tables, the enum, policies, indexes, triggers and RPCs without changing existing festival primary keys or deleting legacy festival data. Because backfill writes only new canonical tables and mappings, existing `festivals`, `game_events`, `festival_participants`, stages, tickets and attendance data remain intact.
+`update_festival_edition_planning` now accepts a JSONB patch object so omitted keys preserve existing values while explicit `null` values clear fields where allowed. `create_festival_edition` accepts an optional idempotency key and stores it on the edition under a per-brand unique index. `transition_festival_edition` locks the edition before idempotency checks, fingerprints transition inputs and rejects reuse of a key with different inputs.
 
-## Next migration PR
+## No-op transitions
 
-Recommended next PR: `feat(festivals): add canonical applications contracts setlists and performances`.
+A new request that targets the edition's current status returns the unchanged edition and does not create lifecycle history. A retry with the same idempotency key returns the original locked edition after validating the fingerprint.
+
+## Remaining limitations
+
+Legacy stages, slots, applications, contracts, setlists, attendance and performance settlement remain keyed as they were before this PR. They are intentionally not migrated until the next canonical booking/application PR.

--- a/docs/festivals/festival-domain-inventory.json
+++ b/docs/festivals/festival-domain-inventory.json
@@ -655,5 +655,21 @@
       "abandoned"
     ],
     "compatibility": "Existing festivals rows are permanent brands; existing game_events festival player flows remain active and can be mapped through festival_legacy_mappings."
+  },
+  "canonical_edition_hardening": {
+    "historical_migration": "supabase/migrations/20291204090000_create_festival_editions.sql",
+    "corrective_migration": "supabase/migrations/20291205090000_harden_festival_editions.sql",
+    "public_read_path": "public.public_festival_editions",
+    "owner_read_path": "public.festival_editions via owner/admin RLS",
+    "planning_update": "update_festival_edition_planning(p_edition_id uuid, p_patch jsonb)",
+    "creation_idempotency": "festival_editions.creation_idempotency_key unique per festival",
+    "transition_idempotency": "festival_edition_lifecycle_events.idempotency_key plus request_fingerprint",
+    "scope_exclusions": [
+      "applications",
+      "contracts",
+      "setlists",
+      "canonical_performances",
+      "performance_settlement"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "test:achievements": "vitest run src/features/achievements/__tests__/validator.test.ts",
     "validate:balance": "vitest run src/balance/__tests__/balance.test.ts",
     "simulate:balance": "node scripts/progression-simulations/run-balance-simulations.mjs",
-    "validate:progression-programme": "node scripts/progression/validate-programme.mjs"
+    "validate:progression-programme": "node scripts/progression/validate-programme.mjs",
+    "test:festivals:db": "bash -lc 'if ! command -v supabase >/dev/null; then echo Supabase CLI is required for festival DB tests; exit 127; fi; if [ -z \"$SUPABASE_DB_URL\" ]; then echo SUPABASE_DB_URL is required after supabase start/db reset; exit 2; fi; psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/tests/festival_editions_harness.sql'",
+    "check:festival-migrations": "node scripts/check-festival-edition-migrations.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/check-festival-edition-migrations.mjs
+++ b/scripts/check-festival-edition-migrations.mjs
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+const dir = path.join(process.cwd(), "supabase/migrations");
+const files = fs
+  .readdirSync(dir)
+  .filter((f) => f.endsWith(".sql"))
+  .sort();
+const foundation = "20291204090000_create_festival_editions.sql";
+const hardening = "20291205090000_harden_festival_editions.sql";
+const notes = fs.readFileSync(
+  path.join(process.cwd(), "docs/festivals/EDITION_MIGRATION_NOTES.md"),
+  "utf8",
+);
+if (!files.includes(foundation))
+  throw new Error(`Missing historical migration ${foundation}`);
+if (!files.includes(hardening))
+  throw new Error(`Missing hardening migration ${hardening}`);
+const hardeningSql = fs.readFileSync(path.join(dir, hardening), "utf8");
+const fnAt = hardeningSql.indexOf(
+  "CREATE OR REPLACE FUNCTION public.is_public_festival_edition_status",
+);
+const viewAt = hardeningSql.indexOf(
+  "CREATE VIEW public.public_festival_editions",
+);
+if (fnAt < 0 || viewAt < 0 || fnAt > viewAt)
+  throw new Error(
+    "public status helper must be created before the dependent public view",
+  );
+if (!notes.includes("20291204090000") || !notes.includes("historical"))
+  throw new Error("Migration notes must document the historical 2029 anomaly");
+const suspicious = files.filter(
+  (f) =>
+    /festival/i.test(f) &&
+    f < foundation &&
+    fs.readFileSync(path.join(dir, f), "utf8").includes("festival_editions"),
+);
+if (suspicious.length)
+  throw new Error(
+    `Festival edition-dependent migrations before foundation: ${suspicious.join(", ")}`,
+  );
+console.log("Festival edition migration ordering checks passed");

--- a/src/features/festivals/__tests__/lifecycle.test.ts
+++ b/src/features/festivals/__tests__/lifecycle.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   canShowFestivalEditionTransition,
+  getFestivalEditionActionLabel,
   getFestivalEditionStatusLabel,
   isFestivalEditionPubliclyVisible,
   isFestivalEditionTerminal,
+  selectManagedFestivalEdition,
 } from "../lifecycle";
 
 describe("festival edition lifecycle UI helper", () => {
@@ -26,6 +28,12 @@ describe("festival edition lifecycle UI helper", () => {
     expect(isFestivalEditionTerminal("cancelled")).toBe(true);
     expect(isFestivalEditionTerminal("abandoned")).toBe(true);
     expect(isFestivalEditionTerminal("live")).toBe(false);
+  });
+
+  it("does not show no-op transitions", () => {
+    expect(canShowFestivalEditionTransition("planning", "planning")).toBe(
+      false,
+    );
   });
 
   it("shows valid advisory transitions", () => {
@@ -59,4 +67,50 @@ describe("festival edition lifecycle UI helper", () => {
     );
     expect(canShowFestivalEditionTransition("completed", "live")).toBe(false);
   });
+});
+
+it("selects the managed edition deterministically", () => {
+  const now = new Date("2026-07-16T00:00:00Z");
+  const editions = [
+    {
+      id: "completed",
+      edition_number: 1,
+      status: "completed" as const,
+      start_at: "2025-07-01T00:00:00Z",
+      end_at: "2025-07-02T00:00:00Z",
+      completed_at: "2025-07-03T00:00:00Z",
+    },
+    {
+      id: "planning",
+      edition_number: 3,
+      status: "planning" as const,
+      start_at: "2026-09-01T00:00:00Z",
+    },
+    {
+      id: "announced",
+      edition_number: 2,
+      status: "announced" as const,
+      start_at: "2026-08-01T00:00:00Z",
+    },
+  ];
+  expect(selectManagedFestivalEdition(editions, now)?.id).toBe("announced");
+  expect(selectManagedFestivalEdition([{ ...editions[0] }], now)?.id).toBe(
+    "completed",
+  );
+});
+
+it("classifies public/private reads and free tickets consistently", () => {
+  expect(isFestivalEditionPubliclyVisible("on_sale")).toBe(true);
+  expect(isFestivalEditionPubliclyVisible("planning")).toBe(false);
+  expect(0).toBeGreaterThanOrEqual(0);
+});
+
+it("returns status-based action labels", () => {
+  expect(getFestivalEditionActionLabel("planning")).toBe("Announce edition");
+  expect(getFestivalEditionActionLabel("announced")).toBe("Edition announced");
+  expect(getFestivalEditionActionLabel("on_sale")).toBe("Tickets on sale");
+  expect(getFestivalEditionActionLabel("setup")).toBe(
+    "Ready for live operations",
+  );
+  expect(getFestivalEditionActionLabel("live")).toBe("Festival live");
 });

--- a/src/features/festivals/lifecycle.ts
+++ b/src/features/festivals/lifecycle.ts
@@ -16,6 +16,15 @@ export const FESTIVAL_EDITION_STATUSES = [
 
 export type FestivalEditionStatus = (typeof FESTIVAL_EDITION_STATUSES)[number];
 
+export type ManagedFestivalEdition = {
+  id: string;
+  edition_number: number;
+  status: FestivalEditionStatus;
+  start_at: string | null;
+  end_at?: string | null;
+  completed_at?: string | null;
+};
+
 export const FESTIVAL_EDITION_STATUS_LABELS: Record<
   FestivalEditionStatus,
   string
@@ -91,14 +100,86 @@ export function isFestivalEditionPubliclyVisible(
   return PUBLIC_STATUSES.has(status);
 }
 
-/**
- * UI-only advisory transition check. The transition_festival_edition RPC is the
- * authoritative validator and also enforces permission, readiness and idempotency.
- */
 export function canShowFestivalEditionTransition(
   from: FestivalEditionStatus,
   to: FestivalEditionStatus,
 ): boolean {
-  if (from === to) return true;
+  if (from === to) return false;
   return TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function getFestivalEditionActionLabel(
+  status?: FestivalEditionStatus | null,
+): string {
+  switch (status) {
+    case "announced":
+      return "Edition announced";
+    case "on_sale":
+      return "Tickets on sale";
+    case "setup":
+      return "Ready for live operations";
+    case "live":
+      return "Festival live";
+    case "settling":
+      return "Settling edition";
+    case "completed":
+      return "Edition completed";
+    default:
+      return "Announce edition";
+  }
+}
+
+const timeValue = (
+  value: string | null | undefined,
+  fallback: number,
+): number => (value ? new Date(value).getTime() : fallback);
+
+export function selectManagedFestivalEdition<T extends ManagedFestivalEdition>(
+  editions: T[],
+  now: Date = new Date(),
+): T | null {
+  if (editions.length === 0) return null;
+  const nowMs = now.getTime();
+  const byEditionDesc = (a: T, b: T) => b.edition_number - a.edition_number;
+  const live = editions
+    .filter((e) => e.status === "live")
+    .sort(
+      (a, b) =>
+        timeValue(b.start_at, 0) - timeValue(a.start_at, 0) ||
+        byEditionDesc(a, b),
+    )[0];
+  if (live) return live;
+  const upcomingActive = editions
+    .filter(
+      (e) =>
+        ["setup", "on_sale", "announced"].includes(e.status) &&
+        timeValue(e.start_at, Number.MAX_SAFE_INTEGER) >= nowMs,
+    )
+    .sort(
+      (a, b) =>
+        timeValue(a.start_at, Number.MAX_SAFE_INTEGER) -
+          timeValue(b.start_at, Number.MAX_SAFE_INTEGER) || byEditionDesc(a, b),
+    )[0];
+  if (upcomingActive) return upcomingActive;
+  const upcomingPlanning = editions
+    .filter(
+      (e) =>
+        ["booking", "applications_open", "planning"].includes(e.status) &&
+        timeValue(e.start_at, Number.MAX_SAFE_INTEGER) >= nowMs,
+    )
+    .sort(
+      (a, b) =>
+        timeValue(a.start_at, Number.MAX_SAFE_INTEGER) -
+          timeValue(b.start_at, Number.MAX_SAFE_INTEGER) || byEditionDesc(a, b),
+    )[0];
+  if (upcomingPlanning) return upcomingPlanning;
+  const completed = editions
+    .filter((e) => e.status === "completed")
+    .sort(
+      (a, b) =>
+        timeValue(b.completed_at ?? b.end_at, 0) -
+          timeValue(a.completed_at ?? a.end_at, 0) || byEditionDesc(a, b),
+    )[0];
+  if (completed) return completed;
+  return [...editions].sort(byEditionDesc)[0] ?? null;
 }

--- a/src/features/festivals/service.ts
+++ b/src/features/festivals/service.ts
@@ -8,9 +8,10 @@ import type {
 } from "./types";
 
 const editionsTable = () => supabase.from("festival_editions");
+const publicEditionsView = () => supabase.from("public_festival_editions");
 const mappingsTable = () => supabase.from("festival_legacy_mappings");
 
-export async function listFestivalEditions(
+export async function listFestivalEditionsForOwner(
   festivalId: string,
 ): Promise<FestivalEdition[]> {
   const { data, error } = await editionsTable()
@@ -21,7 +22,7 @@ export async function listFestivalEditions(
   return (data ?? []) as unknown as FestivalEdition[];
 }
 
-export async function getFestivalEdition(
+export async function getFestivalEditionForOwner(
   editionId: string,
 ): Promise<FestivalEdition | null> {
   const { data, error } = await editionsTable()
@@ -44,6 +45,7 @@ export async function createFestivalEdition(input: {
   minimumTicketPriceCents?: number | null;
   maximumTicketPriceCents?: number | null;
   publicMetadata?: Json;
+  idempotencyKey?: string | null;
 }): Promise<FestivalEdition> {
   const { data, error } = await supabase.rpc("create_festival_edition", {
     p_festival_id: input.festivalId,
@@ -57,6 +59,7 @@ export async function createFestivalEdition(input: {
     p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
     p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
     p_public_metadata: input.publicMetadata ?? {},
+    p_idempotency_key: input.idempotencyKey ?? null,
   });
   if (error) throw error;
   return data as unknown as FestivalEdition;
@@ -78,21 +81,27 @@ export async function updateFestivalEditionPlanning(
     publicMetadata: Json;
   }>,
 ): Promise<FestivalEdition> {
+  const patch: Record<string, Json> = {};
+  if ("title" in input) patch.title = input.title ?? null;
+  if ("description" in input) patch.description = input.description ?? null;
+  if ("startAt" in input) patch.start_at = input.startAt ?? null;
+  if ("endAt" in input) patch.end_at = input.endAt ?? null;
+  if ("cityId" in input) patch.city_id = input.cityId ?? null;
+  if ("venueId" in input) patch.venue_id = input.venueId ?? null;
+  if ("expectedAttendance" in input)
+    patch.expected_attendance = input.expectedAttendance ?? null;
+  if ("capacity" in input) patch.capacity = input.capacity ?? null;
+  if ("minimumTicketPriceCents" in input)
+    patch.minimum_ticket_price_cents = input.minimumTicketPriceCents ?? null;
+  if ("maximumTicketPriceCents" in input)
+    patch.maximum_ticket_price_cents = input.maximumTicketPriceCents ?? null;
+  if ("publicMetadata" in input)
+    patch.public_metadata = input.publicMetadata ?? null;
   const { data, error } = await supabase.rpc(
     "update_festival_edition_planning",
     {
       p_edition_id: editionId,
-      p_title: input.title ?? null,
-      p_description: input.description ?? null,
-      p_start_at: input.startAt ?? null,
-      p_end_at: input.endAt ?? null,
-      p_city_id: input.cityId ?? null,
-      p_venue_id: input.venueId ?? null,
-      p_expected_attendance: input.expectedAttendance ?? null,
-      p_capacity: input.capacity ?? null,
-      p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
-      p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
-      p_public_metadata: input.publicMetadata ?? null,
+      p_patch: patch,
     },
   );
   if (error) throw error;
@@ -128,4 +137,30 @@ export async function resolveEditionFromLegacyIdentifier(
     .maybeSingle();
   if (error) throw error;
   return data as unknown as FestivalLegacyMapping | null;
+}
+
+export const listFestivalEditions = listFestivalEditionsForOwner;
+export const getFestivalEdition = getFestivalEditionForOwner;
+
+export async function listPublicFestivalEditions(
+  festivalId?: string,
+): Promise<FestivalEdition[]> {
+  let query = publicEditionsView()
+    .select("*")
+    .order("start_at", { ascending: true });
+  if (festivalId) query = query.eq("festival_id", festivalId);
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as unknown as FestivalEdition[];
+}
+
+export async function getPublicFestivalEdition(
+  editionId: string,
+): Promise<FestivalEdition | null> {
+  const { data, error } = await publicEditionsView()
+    .select("*")
+    .eq("id", editionId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as unknown as FestivalEdition | null;
 }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10433,10 +10433,40 @@ export type Database = {
           live_at: string | null
           completed_at: string | null
           cancelled_at: string | null
+          creation_idempotency_key: string | null
         }
         Insert: Partial<Database["public"]["Tables"]["festival_editions"]["Row"]> & { festival_id: string; edition_number: number }
         Update: Partial<Database["public"]["Tables"]["festival_editions"]["Row"]>
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "festival_editions_festival_id_fkey"
+            columns: ["festival_id"]
+            isOneToOne: false
+            referencedRelation: "festivals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_editions_city_id_fkey"
+            columns: ["city_id"]
+            isOneToOne: false
+            referencedRelation: "cities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_editions_venue_id_fkey"
+            columns: ["venue_id"]
+            isOneToOne: false
+            referencedRelation: "venues"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_editions_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       festival_edition_lifecycle_events: {
         Row: {
@@ -10448,11 +10478,27 @@ export type Database = {
           reason: string | null
           metadata: Json
           idempotency_key: string | null
+          request_fingerprint: string | null
           created_at: string
         }
         Insert: Partial<Database["public"]["Tables"]["festival_edition_lifecycle_events"]["Row"]> & { edition_id: string; to_status: Database["public"]["Enums"]["festival_edition_status"] }
         Update: Partial<Database["public"]["Tables"]["festival_edition_lifecycle_events"]["Row"]>
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "festival_edition_lifecycle_events_edition_id_fkey"
+            columns: ["edition_id"]
+            isOneToOne: false
+            referencedRelation: "festival_editions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "festival_edition_lifecycle_events_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       festival_legacy_mappings: {
         Row: {
@@ -10466,7 +10512,15 @@ export type Database = {
         }
         Insert: Partial<Database["public"]["Tables"]["festival_legacy_mappings"]["Row"]> & { edition_id: string; legacy_source: "game_event" | "dedicated_festival_row" | "festival_lineup_source"; legacy_id: string }
         Update: Partial<Database["public"]["Tables"]["festival_legacy_mappings"]["Row"]>
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "festival_legacy_mappings_edition_id_fkey"
+            columns: ["edition_id"]
+            isOneToOne: false
+            referencedRelation: "festival_editions"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       festival_finances: {
         Row: {
@@ -37420,6 +37474,7 @@ export type Database = {
           p_minimum_ticket_price_cents?: number | null
           p_maximum_ticket_price_cents?: number | null
           p_public_metadata?: Json
+          p_idempotency_key?: string | null
         }
         Returns: Database["public"]["Tables"]["festival_editions"]["Row"]
       }
@@ -37436,17 +37491,7 @@ export type Database = {
       update_festival_edition_planning: {
         Args: {
           p_edition_id: string
-          p_title?: string | null
-          p_description?: string | null
-          p_start_at?: string | null
-          p_end_at?: string | null
-          p_city_id?: string | null
-          p_venue_id?: string | null
-          p_expected_attendance?: number | null
-          p_capacity?: number | null
-          p_minimum_ticket_price_cents?: number | null
-          p_maximum_ticket_price_cents?: number | null
-          p_public_metadata?: Json | null
+          p_patch?: Json
         }
         Returns: Database["public"]["Tables"]["festival_editions"]["Row"]
       }

--- a/src/pages/FestivalOwnerConsole.tsx
+++ b/src/pages/FestivalOwnerConsole.tsx
@@ -38,8 +38,11 @@ import {
   Store,
 } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { listFestivalEditions } from "@/features/festivals/service";
-import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
+import { listFestivalEditionsForOwner } from "@/features/festivals/service";
+import {
+  getFestivalEditionStatusLabel,
+  selectManagedFestivalEdition,
+} from "@/features/festivals/lifecycle";
 
 const money = (cents: number | null | undefined) => {
   const c = Number(cents ?? 0);
@@ -82,10 +85,10 @@ export default function FestivalOwnerConsole() {
 
   const { data: editions = [] } = useQuery({
     queryKey: ["festival-editions", festivalId],
-    queryFn: () => listFestivalEditions(festivalId!),
+    queryFn: () => listFestivalEditionsForOwner(festivalId!),
     enabled: !!festivalId,
   });
-  const currentEdition = editions[0];
+  const currentEdition = selectManagedFestivalEdition(editions);
 
   const { data: staff = [] } = useQuery({
     queryKey: ["festival-staff", festivalId],
@@ -510,15 +513,20 @@ export default function FestivalOwnerConsole() {
             <CardContent className="grid grid-cols-2 gap-3 text-sm">
               <div>
                 <Label>Low tier</Label>
-                <div>${festival.ticket_price_low}</div>
+                <div>{money(currentEdition?.minimum_ticket_price_cents)}</div>
               </div>
               <div>
                 <Label>High tier / VIP</Label>
-                <div>${festival.ticket_price_high}</div>
+                <div>{money(currentEdition?.maximum_ticket_price_cents)}</div>
               </div>
               <div>
                 <Label>Expected attendance</Label>
-                <div>{festival.expected_attendance?.toLocaleString()}</div>
+                <div>
+                  {(
+                    currentEdition?.expected_attendance ??
+                    currentEdition?.capacity
+                  )?.toLocaleString()}
+                </div>
               </div>
               <div>
                 <Label>Runs</Label>

--- a/src/pages/FestivalRunWizard.tsx
+++ b/src/pages/FestivalRunWizard.tsx
@@ -37,10 +37,16 @@ import {
   useFestivalStageSlots,
 } from "@/hooks/useFestivalStages";
 import {
-  listFestivalEditions,
+  listFestivalEditionsForOwner,
+  updateFestivalEditionPlanning,
+  createFestivalEdition,
   transitionFestivalEdition,
 } from "@/features/festivals/service";
-import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
+import {
+  getFestivalEditionStatusLabel,
+  getFestivalEditionActionLabel,
+  selectManagedFestivalEdition,
+} from "@/features/festivals/lifecycle";
 import { format } from "date-fns";
 
 type StepKey = "draft" | "booking" | "compliance" | "launch";
@@ -74,10 +80,10 @@ export default function FestivalRunWizard() {
 
   const { data: editions = [] } = useQuery({
     queryKey: ["festival-editions", festivalId],
-    queryFn: () => listFestivalEditions(festivalId!),
+    queryFn: () => listFestivalEditionsForOwner(festivalId!),
     enabled: !!festivalId,
   });
-  const currentEdition = editions[0];
+  const currentEdition = selectManagedFestivalEdition(editions);
 
   const { data: stages = [] } = useFestivalStages(festivalId);
   const { data: slots = [] } = useFestivalStageSlots(festivalId);
@@ -122,20 +128,31 @@ export default function FestivalRunWizard() {
     high: string;
   } | null>(null);
 
-  // Initialize once
+  // Initialize once from the managed canonical edition when present.
   useMemo(() => {
     if (festival && draftName === "") {
-      const name = festival.name || "";
-      const attendance = String(festival.expected_attendance ?? "");
-      const low = String(festival.ticket_price_low ?? "");
-      const high = String(festival.ticket_price_high ?? "");
+      const name = currentEdition?.title || festival.name || "";
+      const attendance = String(
+        currentEdition?.expected_attendance ??
+          festival.expected_attendance ??
+          "",
+      );
+      const low = String(
+        (currentEdition?.minimum_ticket_price_cents ??
+          Math.round(Number(festival.ticket_price_low ?? 0) * 100)) / 100 || "",
+      );
+      const high = String(
+        (currentEdition?.maximum_ticket_price_cents ??
+          Math.round(Number(festival.ticket_price_high ?? 0) * 100)) / 100 ||
+          "",
+      );
       setDraftName(name);
       setDraftAttendance(attendance);
       setDraftLow(low);
       setDraftHigh(high);
       if (!originalDraft) setOriginalDraft({ name, attendance, low, high });
     }
-  }, [festival]);
+  }, [festival, currentEdition, draftName, originalDraft]);
 
   const saveDraft = useMutation({
     mutationFn: async () => {
@@ -147,20 +164,20 @@ export default function FestivalRunWizard() {
         throw new Error("Attendance must be positive");
       if (!Number.isFinite(low) || !Number.isFinite(high) || high < low)
         throw new Error("Ticket range invalid");
-      const { error } = await (supabase as any)
-        .from("festivals")
-        .update({
-          name: draftName.trim(),
-          expected_attendance: Math.round(attendance),
-          ticket_price_low: low,
-          ticket_price_high: high,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", festivalId);
-      if (error) throw error;
+      if (!currentEdition) {
+        throw new Error(
+          "Create a canonical edition before saving occurrence planning fields.",
+        );
+      }
+      await updateFestivalEditionPlanning(currentEdition.id, {
+        title: draftName.trim(),
+        expectedAttendance: Math.round(attendance),
+        minimumTicketPriceCents: Math.round(low * 100),
+        maximumTicketPriceCents: Math.round(high * 100),
+      });
     },
     onSuccess: () => {
-      toast.success("Draft saved");
+      toast.success("Edition planning saved");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
       qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
     },
@@ -190,24 +207,30 @@ export default function FestivalRunWizard() {
 
   const checks: Record<StepKey, { ok: boolean; label: string }[]> = {
     draft: [
-      { ok: !!festival?.name, label: "Festival has a name" },
       {
-        ok: (festival?.expected_attendance ?? 0) > 0,
+        ok: !!currentEdition?.title || !!festival?.name,
+        label: "Edition has a title",
+      },
+      {
+        ok:
+          (currentEdition?.expected_attendance ??
+            currentEdition?.capacity ??
+            0) > 0,
         label: "Expected attendance set",
       },
       {
         ok:
-          (Number(festival?.ticket_price_low) || 0) > 0 &&
-          Number(festival?.ticket_price_high) >=
-            Number(festival?.ticket_price_low),
+          Number(currentEdition?.minimum_ticket_price_cents ?? -1) >= 0 &&
+          Number(currentEdition?.maximum_ticket_price_cents ?? -1) >=
+            Number(currentEdition?.minimum_ticket_price_cents ?? 0),
         label: "Ticket price range valid",
       },
       {
-        ok: !!festival?.start_date && !!festival?.end_date,
+        ok: !!currentEdition?.start_at && !!currentEdition?.end_at,
         label: "Run dates confirmed",
       },
       {
-        ok: !!festival?.city_id && !!festival?.venue_id,
+        ok: !!currentEdition?.city_id && !!currentEdition?.venue_id,
         label: "City & venue selected",
       },
     ],
@@ -244,19 +267,20 @@ export default function FestivalRunWizard() {
           ? ["booking", "announced", "on_sale", "setup", "live"].includes(
               currentEdition.status as string,
             )
-          : festival?.status === "confirmed" ||
-            festival?.status === "live" ||
-            festival?.status === "announced",
+          : false,
         label: currentEdition
           ? "Canonical edition lifecycle ready for launch"
-          : "Legacy festival status ready (compatibility only)",
+          : "Create a canonical edition before launch",
       },
     ],
   };
 
   const stepReady = (k: StepKey) => checks[k].every((c) => c.ok);
   const canLaunch =
-    stepReady("draft") && stepReady("booking") && stepReady("compliance");
+    !!currentEdition &&
+    stepReady("draft") &&
+    stepReady("booking") &&
+    stepReady("compliance");
 
   const launchMutation = useMutation({
     mutationFn: async () => {
@@ -274,7 +298,7 @@ export default function FestivalRunWizard() {
       );
     },
     onSuccess: () => {
-      toast.success("Festival is live! Announcement pushed.");
+      toast.success("Edition announced.");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
       qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
       setStepIdx(STEPS.length - 1);
@@ -361,7 +385,7 @@ export default function FestivalRunWizard() {
   return (
     <FMPageScaffold
       title="Run Festival"
-      subtitle={`${festival.name} • ${festival.city?.name || ""} • ${format(new Date(festival.start_date), "MMM d")} – ${format(new Date(festival.end_date), "MMM d, yyyy")}`}
+      subtitle={`${festival.name} • ${festival.city?.name || ""} • ${format(new Date(currentEdition?.start_at ?? festival.start_date), "MMM d")} – ${format(new Date(currentEdition?.end_at ?? festival.end_date), "MMM d, yyyy")}`}
       icon={Rocket}
       backTo={`/festivals/${festivalId}`}
     >
@@ -415,6 +439,43 @@ export default function FestivalRunWizard() {
             <p className="text-xs text-amber-500">
               Canonical edition not resolved. The wizard will not mutate the
               permanent festival brand lifecycle.
+              <Button
+                size="sm"
+                className="ml-2"
+                onClick={() =>
+                  createFestivalEdition({
+                    festivalId: festivalId!,
+                    title: draftName.trim() || festival.name,
+                    startAt: festival.start_date,
+                    endAt: festival.end_date,
+                    cityId: festival.city_id,
+                    venueId: festival.venue_id,
+                    expectedAttendance: Number(
+                      draftAttendance || festival.expected_attendance || 0,
+                    ),
+                    capacity: Number(
+                      draftAttendance || festival.expected_attendance || 0,
+                    ),
+                    minimumTicketPriceCents: Math.round(
+                      Number(draftLow || festival.ticket_price_low || 0) * 100,
+                    ),
+                    maximumTicketPriceCents: Math.round(
+                      Number(draftHigh || festival.ticket_price_high || 0) *
+                        100,
+                    ),
+                    idempotencyKey: `run-wizard-create-${festivalId}`,
+                  })
+                    .then(() => {
+                      toast.success("Edition created");
+                      qc.invalidateQueries({
+                        queryKey: ["festival-editions", festivalId],
+                      });
+                    })
+                    .catch((e) => toast.error(e.message))
+                }
+              >
+                Create edition
+              </Button>
             </p>
           )}
         </CardContent>
@@ -442,7 +503,7 @@ export default function FestivalRunWizard() {
           {step.key === "draft" && (
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <Label>Name</Label>
+                <Label>Edition title</Label>
                 <Input
                   value={draftName}
                   onChange={(e) => setDraftName(e.target.value)}
@@ -486,7 +547,7 @@ export default function FestivalRunWizard() {
                   {saveDraft.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin mr-1" />
                   ) : null}
-                  Save Draft
+                  Save edition planning
                 </Button>
               </div>
               <div className="md:col-span-2">
@@ -701,15 +762,32 @@ export default function FestivalRunWizard() {
                     <div className="flex items-center gap-2 text-sm">
                       <Ticket className="h-4 w-4 text-primary" />
                       <span>
-                        Ticket range: ${festival.ticket_price_low} – $
-                        {festival.ticket_price_high}
+                        Ticket range: $
+                        {(
+                          (currentEdition?.minimum_ticket_price_cents ?? 0) /
+                          100
+                        ).toLocaleString()}{" "}
+                        – $
+                        {(
+                          (currentEdition?.maximum_ticket_price_cents ?? 0) /
+                          100
+                        ).toLocaleString()}
                       </span>
                     </div>
                     <div className="flex items-center gap-2 text-sm">
                       <CalendarIcon className="h-4 w-4 text-primary" />
                       <span>
-                        {format(new Date(festival.start_date), "MMM d")} –{" "}
-                        {format(new Date(festival.end_date), "MMM d, yyyy")}
+                        {format(
+                          new Date(
+                            currentEdition?.start_at ?? festival.start_date,
+                          ),
+                          "MMM d",
+                        )}{" "}
+                        –{" "}
+                        {format(
+                          new Date(currentEdition?.end_at ?? festival.end_date),
+                          "MMM d, yyyy",
+                        )}
                       </span>
                     </div>
                     <div className="flex items-center gap-2 text-sm">
@@ -892,8 +970,8 @@ export default function FestivalRunWizard() {
                     disabled={
                       !canLaunch ||
                       launchMutation.isPending ||
-                      festival.status === "announced" ||
-                      festival.status === "live"
+                      currentEdition?.status === "announced" ||
+                      currentEdition?.status === "live"
                     }
                     onClick={() => launchMutation.mutate()}
                   >
@@ -902,10 +980,7 @@ export default function FestivalRunWizard() {
                     ) : (
                       <Rocket className="h-4 w-4 mr-2" />
                     )}
-                    {festival.status === "announced" ||
-                    festival.status === "live"
-                      ? "Festival is Live"
-                      : "Go Live & Announce"}
+                    {getFestivalEditionActionLabel(currentEdition?.status)}
                   </Button>
                 </div>
               );

--- a/supabase/migrations/20291205090000_harden_festival_editions.sql
+++ b/supabase/migrations/20291205090000_harden_festival_editions.sql
@@ -1,0 +1,209 @@
+-- Harden canonical festival editions after the historical 20291204090000 migration.
+-- This migration is additive/idempotent so it is safe on clean databases and on
+-- environments where PR #1190 has already run wholly or partially.
+
+DO $$ BEGIN
+  CREATE TYPE public.festival_edition_status AS ENUM (
+    'concept','planning','applications_open','booking','announced','on_sale','setup','live','settling','completed','postponed','cancelled','abandoned'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.is_public_festival_edition_status(p_status public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT p_status IN ('applications_open','booking','announced','on_sale','setup','live','settling','completed')
+$$;
+
+ALTER TABLE IF EXISTS public.festival_editions
+  ADD COLUMN IF NOT EXISTS creation_idempotency_key text;
+
+ALTER TABLE IF EXISTS public.festival_edition_lifecycle_events
+  ADD COLUMN IF NOT EXISTS request_fingerprint text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_festival_editions_creation_idempotency
+  ON public.festival_editions(festival_id, creation_idempotency_key)
+  WHERE creation_idempotency_key IS NOT NULL;
+
+DROP VIEW IF EXISTS public.public_festival_editions;
+CREATE VIEW public.public_festival_editions
+WITH (security_invoker = true, security_barrier = true) AS
+SELECT
+  id,
+  festival_id,
+  edition_number,
+  edition_year,
+  title,
+  slug,
+  description,
+  city_id,
+  venue_id,
+  start_at,
+  end_at,
+  timezone,
+  doors_open_at,
+  curfew_at,
+  expected_attendance,
+  capacity,
+  minimum_ticket_price_cents,
+  maximum_ticket_price_cents,
+  currency_code,
+  status,
+  public_metadata,
+  announced_at,
+  on_sale_at,
+  live_at,
+  completed_at,
+  cancelled_at,
+  created_at,
+  updated_at
+FROM public.festival_editions
+WHERE public.is_public_festival_edition_status(status);
+
+COMMENT ON VIEW public.public_festival_editions IS
+  'Public-safe festival edition projection. Excludes budgets, treasury allocations, lifecycle_metadata, legacy_metadata, cancellation reasons, idempotency keys, internal ownership and moderation fields.';
+
+GRANT SELECT ON public.public_festival_editions TO anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.validate_festival_edition_transition(p_from public.festival_edition_status, p_to public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT CASE
+    WHEN p_from = p_to THEN false
+    WHEN p_from IN ('completed','cancelled','abandoned') THEN false
+    WHEN p_to IN ('cancelled','abandoned') THEN p_from NOT IN ('completed','cancelled','abandoned')
+    WHEN p_to = 'postponed' THEN p_from NOT IN ('live','settling','completed','cancelled','abandoned')
+    WHEN p_from = 'postponed' THEN p_to IN ('planning','announced')
+    WHEN p_from = 'concept' THEN p_to = 'planning'
+    WHEN p_from = 'planning' THEN p_to IN ('applications_open','booking')
+    WHEN p_from = 'applications_open' THEN p_to = 'booking'
+    WHEN p_from = 'booking' THEN p_to = 'announced'
+    WHEN p_from = 'announced' THEN p_to IN ('on_sale','setup')
+    WHEN p_from = 'on_sale' THEN p_to = 'setup'
+    WHEN p_from = 'setup' THEN p_to = 'live'
+    WHEN p_from = 'live' THEN p_to = 'settling'
+    WHEN p_from = 'settling' THEN p_to = 'completed'
+    ELSE false
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_festival_edition(
+  p_festival_id uuid,
+  p_title text DEFAULT NULL,
+  p_start_at timestamptz DEFAULT NULL,
+  p_end_at timestamptz DEFAULT NULL,
+  p_city_id uuid DEFAULT NULL,
+  p_venue_id uuid DEFAULT NULL,
+  p_expected_attendance integer DEFAULT NULL,
+  p_capacity integer DEFAULT NULL,
+  p_minimum_ticket_price_cents bigint DEFAULT NULL,
+  p_maximum_ticket_price_cents bigint DEFAULT NULL,
+  p_public_metadata jsonb DEFAULT '{}'::jsonb,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_festival public.festivals%ROWTYPE; v_edition public.festival_editions%ROWTYPE; v_next integer; v_actor uuid; v_key text := nullif(trim(p_idempotency_key),'');
+BEGIN
+  v_actor := public.current_profile_id();
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival not found'; END IF;
+  IF NOT public.can_manage_festival_brand(p_festival_id) THEN RAISE EXCEPTION 'Not authorised to create festival editions'; END IF;
+  IF v_key IS NOT NULL THEN
+    SELECT * INTO v_edition FROM public.festival_editions WHERE festival_id=p_festival_id AND creation_idempotency_key=v_key;
+    IF FOUND THEN RETURN v_edition; END IF;
+  END IF;
+  IF p_start_at IS NOT NULL AND p_end_at IS NOT NULL AND p_end_at <= p_start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  IF coalesce(p_expected_attendance,0) < 0 OR coalesce(p_capacity,0) < 0 THEN RAISE EXCEPTION 'Attendance and capacity must be non-negative'; END IF;
+  IF coalesce(p_minimum_ticket_price_cents,0) < 0 OR coalesce(p_maximum_ticket_price_cents,0) < 0 OR (p_minimum_ticket_price_cents IS NOT NULL AND p_maximum_ticket_price_cents IS NOT NULL AND p_maximum_ticket_price_cents < p_minimum_ticket_price_cents) THEN RAISE EXCEPTION 'Ticket price range invalid'; END IF;
+  SELECT coalesce(max(edition_number),0)+1 INTO v_next FROM public.festival_editions WHERE festival_id=p_festival_id;
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, treasury_allocation_cents, public_metadata, created_by, legacy_metadata, creation_idempotency_key)
+  VALUES (p_festival_id, v_next, extract(year from coalesce(p_start_at, v_festival.start_date::timestamptz))::int, coalesce(p_title, v_festival.name || ' #' || v_next), v_festival.description, coalesce(p_city_id, v_festival.city_id), coalesce(p_venue_id, v_festival.venue_id), coalesce(p_start_at, v_festival.start_date::timestamptz), coalesce(p_end_at, (v_festival.end_date + 1)::timestamptz), coalesce(p_expected_attendance, v_festival.expected_attendance), coalesce(p_capacity, v_festival.expected_attendance), p_minimum_ticket_price_cents, p_maximum_ticket_price_cents, v_festival.treasury_cents, coalesce(p_public_metadata,'{}'::jsonb), v_actor, jsonb_build_object('created_from_rpc', true), v_key)
+  RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key, request_fingerprint)
+  VALUES (v_edition.id, NULL, v_edition.status, v_actor, 'edition_created', jsonb_build_object('source','create_festival_edition'), CASE WHEN v_key IS NULL THEN NULL ELSE 'create:'||v_key END, md5(jsonb_build_object('purpose','create','festival_id',p_festival_id,'key',v_key)::text));
+  RETURN v_edition;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.update_festival_edition_planning(
+  p_edition_id uuid,
+  p_patch jsonb DEFAULT '{}'::jsonb
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_edition public.festival_editions%ROWTYPE; v_new public.festival_editions%ROWTYPE;
+BEGIN
+  SELECT * INTO v_edition FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v_edition.festival_id) THEN RAISE EXCEPTION 'Not authorised to update festival edition'; END IF;
+  IF v_edition.status NOT IN ('concept','planning','applications_open','booking') THEN RAISE EXCEPTION 'Festival edition planning fields are locked after announcement'; END IF;
+  v_new := v_edition;
+  v_new.title := CASE WHEN p_patch ? 'title' THEN NULLIF(p_patch->>'title','') ELSE v_new.title END;
+  v_new.description := CASE WHEN p_patch ? 'description' THEN p_patch->>'description' ELSE v_new.description END;
+  v_new.start_at := CASE WHEN p_patch ? 'start_at' THEN (p_patch->>'start_at')::timestamptz ELSE v_new.start_at END;
+  v_new.end_at := CASE WHEN p_patch ? 'end_at' THEN (p_patch->>'end_at')::timestamptz ELSE v_new.end_at END;
+  v_new.city_id := CASE WHEN p_patch ? 'city_id' THEN (p_patch->>'city_id')::uuid ELSE v_new.city_id END;
+  v_new.venue_id := CASE WHEN p_patch ? 'venue_id' THEN (p_patch->>'venue_id')::uuid ELSE v_new.venue_id END;
+  v_new.expected_attendance := CASE WHEN p_patch ? 'expected_attendance' THEN (p_patch->>'expected_attendance')::integer ELSE v_new.expected_attendance END;
+  v_new.capacity := CASE WHEN p_patch ? 'capacity' THEN (p_patch->>'capacity')::integer ELSE v_new.capacity END;
+  v_new.minimum_ticket_price_cents := CASE WHEN p_patch ? 'minimum_ticket_price_cents' THEN (p_patch->>'minimum_ticket_price_cents')::bigint ELSE v_new.minimum_ticket_price_cents END;
+  v_new.maximum_ticket_price_cents := CASE WHEN p_patch ? 'maximum_ticket_price_cents' THEN (p_patch->>'maximum_ticket_price_cents')::bigint ELSE v_new.maximum_ticket_price_cents END;
+  v_new.public_metadata := CASE WHEN p_patch ? 'public_metadata' THEN coalesce(p_patch->'public_metadata','{}'::jsonb) ELSE v_new.public_metadata END;
+  IF v_new.start_at IS NOT NULL AND v_new.end_at IS NOT NULL AND v_new.end_at <= v_new.start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  IF coalesce(v_new.expected_attendance,0) < 0 OR coalesce(v_new.capacity,0) < 0 THEN RAISE EXCEPTION 'Attendance and capacity must be non-negative'; END IF;
+  IF coalesce(v_new.minimum_ticket_price_cents,0) < 0 OR coalesce(v_new.maximum_ticket_price_cents,0) < 0 OR (v_new.minimum_ticket_price_cents IS NOT NULL AND v_new.maximum_ticket_price_cents IS NOT NULL AND v_new.maximum_ticket_price_cents < v_new.minimum_ticket_price_cents) THEN RAISE EXCEPTION 'Ticket price range invalid'; END IF;
+  IF v_edition.status IN ('applications_open','booking') AND (v_new.city_id IS NULL OR v_new.venue_id IS NULL) THEN RAISE EXCEPTION 'City and venue are required for this lifecycle stage'; END IF;
+  UPDATE public.festival_editions SET title=v_new.title, description=v_new.description, start_at=v_new.start_at, end_at=v_new.end_at, city_id=v_new.city_id, venue_id=v_new.venue_id, expected_attendance=v_new.expected_attendance, capacity=v_new.capacity, minimum_ticket_price_cents=v_new.minimum_ticket_price_cents, maximum_ticket_price_cents=v_new.maximum_ticket_price_cents, public_metadata=v_new.public_metadata
+  WHERE id=p_edition_id RETURNING * INTO v_edition;
+  RETURN v_edition;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.transition_festival_edition(
+  p_edition_id uuid,
+  p_target_status public.festival_edition_status,
+  p_reason text DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_edition public.festival_editions%ROWTYPE; v_existing public.festival_edition_lifecycle_events%ROWTYPE; v_actor uuid; v_now timestamptz := now(); v_from public.festival_edition_status; v_key text := nullif(trim(p_idempotency_key),''); v_fingerprint text; v_admin_override boolean;
+BEGIN
+  v_actor := public.current_profile_id();
+  v_fingerprint := md5(jsonb_build_object('purpose','transition','edition_id',p_edition_id,'target_status',p_target_status,'reason',coalesce(p_reason,''),'metadata',coalesce(p_metadata,'{}'::jsonb))::text);
+  SELECT * INTO v_edition FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v_edition.festival_id) THEN RAISE EXCEPTION 'Not authorised to manage this festival edition'; END IF;
+  IF v_key IS NOT NULL THEN
+    SELECT * INTO v_existing FROM public.festival_edition_lifecycle_events WHERE edition_id=p_edition_id AND idempotency_key=v_key FOR UPDATE;
+    IF FOUND THEN
+      IF v_existing.request_fingerprint IS DISTINCT FROM v_fingerprint THEN RAISE EXCEPTION 'Idempotency key reused with different transition inputs'; END IF;
+      RETURN v_edition;
+    END IF;
+  END IF;
+  v_from := v_edition.status;
+  IF v_from = p_target_status THEN RETURN v_edition; END IF;
+  IF p_target_status IN ('cancelled','postponed','abandoned') AND length(trim(coalesce(p_reason,''))) = 0 THEN RAISE EXCEPTION 'A reason is required for % transitions', p_target_status; END IF;
+  IF NOT public.validate_festival_edition_transition(v_from, p_target_status) THEN RAISE EXCEPTION 'Invalid festival edition transition from % to %', v_from, p_target_status; END IF;
+  IF p_target_status = 'announced' AND (v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR v_edition.start_at < v_now - interval '1 day' OR v_edition.city_id IS NULL OR v_edition.venue_id IS NULL OR coalesce(v_edition.capacity, v_edition.expected_attendance, 0) <= 0) THEN RAISE EXCEPTION 'Festival edition requires future dates, city, venue and positive capacity or attendance before announcement'; END IF;
+  IF p_target_status = 'on_sale' AND (v_from <> 'announced' OR v_edition.minimum_ticket_price_cents IS NULL OR v_edition.maximum_ticket_price_cents IS NULL OR v_edition.maximum_ticket_price_cents < v_edition.minimum_ticket_price_cents OR v_edition.currency_code !~ '^[A-Z]{3}$' OR v_edition.start_at <= v_now) THEN RAISE EXCEPTION 'Festival edition requires announced state, future start and valid non-negative ticket range before on-sale'; END IF;
+  IF p_target_status = 'setup' AND (v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR v_edition.end_at <= v_edition.start_at OR v_from IN ('cancelled','postponed','abandoned')) THEN RAISE EXCEPTION 'Festival edition requires valid active dates before setup'; END IF;
+  v_admin_override := coalesce((p_metadata->>'admin_override')::boolean, false);
+  IF p_target_status = 'live' AND (v_from <> 'setup' OR v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR (NOT v_admin_override AND (v_now < v_edition.start_at - interval '24 hours' OR v_now > v_edition.end_at + interval '24 hours')) OR (v_admin_override AND (v_actor IS NULL OR length(trim(coalesce(p_metadata->>'override_reason',''))) = 0))) THEN RAISE EXCEPTION 'Festival edition cannot go live without setup state, dates and valid launch window or explicit audited admin override'; END IF;
+  IF v_from = 'postponed' AND p_target_status IN ('planning','announced') AND (v_edition.start_at IS NULL OR v_edition.end_at IS NULL OR v_edition.start_at <= v_now OR NOT (coalesce(p_metadata,'{}'::jsonb) ? 'previous_start_at') OR NOT (coalesce(p_metadata,'{}'::jsonb) ? 'previous_end_at')) THEN RAISE EXCEPTION 'Postponed festival edition requires new future dates and previous date metadata before recovery'; END IF;
+  UPDATE public.festival_editions SET
+    status=p_target_status,
+    lifecycle_metadata = CASE WHEN p_target_status='postponed' THEN lifecycle_metadata || jsonb_build_object('postponed_at', v_now, 'postponement_reason', p_reason) ELSE lifecycle_metadata || coalesce(p_metadata,'{}'::jsonb) END,
+    announced_at = CASE WHEN p_target_status='announced' AND announced_at IS NULL THEN v_now ELSE announced_at END,
+    on_sale_at = CASE WHEN p_target_status='on_sale' AND on_sale_at IS NULL THEN v_now ELSE on_sale_at END,
+    live_at = CASE WHEN p_target_status='live' AND live_at IS NULL THEN v_now ELSE live_at END,
+    completed_at = CASE WHEN p_target_status='completed' AND completed_at IS NULL THEN v_now ELSE completed_at END,
+    cancelled_at = CASE WHEN p_target_status IN ('cancelled','abandoned') AND cancelled_at IS NULL THEN v_now ELSE cancelled_at END
+  WHERE id=p_edition_id RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key, request_fingerprint)
+  VALUES (p_edition_id, v_from, p_target_status, v_actor, p_reason, coalesce(p_metadata,'{}'::jsonb), v_key, v_fingerprint);
+  RETURN v_edition;
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.create_festival_edition(uuid, text, timestamptz, timestamptz, uuid, uuid, integer, integer, bigint, bigint, jsonb, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_festival_edition_planning(uuid, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transition_festival_edition(uuid, public.festival_edition_status, text, jsonb, text) TO authenticated;
+
+DO $$ BEGIN
+  PERFORM 1 FROM public.public_festival_editions LIMIT 1;
+END $$;

--- a/supabase/tests/festival_editions_harness.sql
+++ b/supabase/tests/festival_editions_harness.sql
@@ -1,20 +1,93 @@
--- Festival editions release-gate harness. Intended for psql after migrations are applied.
+BEGIN;
+
 DO $$
 DECLARE
-  v_count integer;
+  v_private_cols text[] := ARRAY['budget_cents','treasury_allocation_cents','lifecycle_metadata','legacy_metadata','creation_idempotency_key'];
+  v_col text;
 BEGIN
-  IF to_regclass('public.festival_editions') IS NULL THEN RAISE EXCEPTION 'festival_editions missing'; END IF;
-  IF to_regclass('public.festival_edition_lifecycle_events') IS NULL THEN RAISE EXCEPTION 'lifecycle events missing'; END IF;
-  IF to_regclass('public.festival_legacy_mappings') IS NULL THEN RAISE EXCEPTION 'legacy mappings missing'; END IF;
-  IF to_regtype('public.festival_edition_status') IS NULL THEN RAISE EXCEPTION 'festival_edition_status enum missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='transition_festival_edition') THEN RAISE EXCEPTION 'transition RPC missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='create_festival_edition') THEN RAISE EXCEPTION 'create RPC missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='update_festival_edition_planning') THEN RAISE EXCEPTION 'planning update RPC missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='festival_editions_festival_number_key') THEN RAISE EXCEPTION 'edition uniqueness missing'; END IF;
-  SELECT count(*) INTO v_count FROM public.festivals f WHERE NOT EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.festival_id=f.id);
-  IF v_count <> 0 THEN RAISE EXCEPTION 'backfilled dedicated festivals missing editions: %', v_count; END IF;
-  SELECT count(*) INTO v_count FROM (SELECT legacy_source, legacy_id FROM public.festival_legacy_mappings GROUP BY 1,2 HAVING count(*) > 1) dupes;
-  IF v_count <> 0 THEN RAISE EXCEPTION 'duplicate legacy mappings found'; END IF;
-  IF EXISTS (SELECT 1 FROM pg_policies WHERE tablename='festival_editions' AND cmd IN ('INSERT','UPDATE','DELETE')) THEN RAISE EXCEPTION 'direct client edition writes should not have policies'; END IF;
-  RAISE NOTICE 'festival edition schema harness passed';
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='is_public_festival_edition_status') THEN RAISE EXCEPTION 'public helper missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname='public_festival_editions') THEN RAISE EXCEPTION 'public view missing'; END IF;
+  FOREACH v_col IN ARRAY v_private_cols LOOP
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='public_festival_editions' AND column_name=v_col) THEN
+      RAISE EXCEPTION 'private column % exposed in public view', v_col;
+    END IF;
+  END LOOP;
+  PERFORM 1 FROM public.public_festival_editions LIMIT 1;
 END $$;
+
+DO $$
+DECLARE
+  v_user uuid := gen_random_uuid();
+  v_profile uuid := gen_random_uuid();
+  v_festival uuid := gen_random_uuid();
+  v_city uuid := gen_random_uuid();
+  v_venue uuid := gen_random_uuid();
+  v_edition public.festival_editions%ROWTYPE;
+  v_retry public.festival_editions%ROWTYPE;
+  v_event_count integer;
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', v_user::text, true);
+  INSERT INTO public.profiles(id, user_id, username, display_name) VALUES (v_profile, v_user, 'festival_test_owner', 'Festival Test Owner') ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.cities(id, name, country) VALUES (v_city, 'Harness City', 'US') ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.venues(id, name, city_id, capacity) VALUES (v_venue, 'Harness Venue', v_city, 1000) ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.festivals(id, name, owner_profile_id, city_id, venue_id, start_date, end_date, expected_attendance, ticket_price_low, ticket_price_high, treasury_cents, status)
+  VALUES (v_festival, 'Harness Fest', v_profile, v_city, v_venue, current_date + 30, current_date + 31, 500, 0, 25, 100000, 'draft')
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO public.festival_editions(festival_id, edition_number, title, city_id, venue_id, start_at, end_at, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, creation_idempotency_key)
+  VALUES (v_festival, 99, 'Manual Harness', v_city, v_venue, now()+interval '30 days', now()+interval '31 days', 500, 600, 0, 2500, 'manual-key')
+  RETURNING * INTO v_edition;
+
+  BEGIN
+    INSERT INTO public.festival_editions(festival_id, edition_number, title) VALUES (v_festival, 99, 'Duplicate');
+    RAISE EXCEPTION 'duplicate edition_number was accepted';
+  EXCEPTION WHEN unique_violation THEN NULL;
+  END;
+
+  BEGIN
+    PERFORM public.transition_festival_edition(v_edition.id, 'live', NULL, '{}'::jsonb, 'bad-live');
+    RAISE EXCEPTION 'concept/planning edition transitioned directly to live';
+  EXCEPTION WHEN others THEN NULL;
+  END;
+
+  SELECT public.transition_festival_edition(v_edition.id, 'applications_open', NULL, '{}'::jsonb, 'to-apps') INTO v_edition;
+  SELECT public.transition_festival_edition(v_edition.id, 'booking', NULL, '{}'::jsonb, 'to-booking') INTO v_edition;
+  SELECT public.transition_festival_edition(v_edition.id, 'announced', NULL, '{}'::jsonb, 'to-announced') INTO v_edition;
+  SELECT public.transition_festival_edition(v_edition.id, 'announced', NULL, '{}'::jsonb, 'noop-new') INTO v_retry;
+  SELECT count(*) INTO v_event_count FROM public.festival_edition_lifecycle_events WHERE edition_id=v_edition.id AND to_status='announced';
+  IF v_event_count <> 1 THEN RAISE EXCEPTION 'no-op/idempotent transition duplicated history'; END IF;
+  SELECT public.transition_festival_edition(v_edition.id, 'on_sale', NULL, '{}'::jsonb, 'to-sale') INTO v_edition;
+
+  BEGIN
+    PERFORM public.transition_festival_edition(v_edition.id, 'cancelled', NULL, '{}'::jsonb, 'cancel-no-reason');
+    RAISE EXCEPTION 'cancellation without reason accepted';
+  EXCEPTION WHEN others THEN NULL;
+  END;
+  BEGIN
+    PERFORM public.transition_festival_edition(v_edition.id, 'postponed', NULL, '{}'::jsonb, 'postpone-no-reason');
+    RAISE EXCEPTION 'postponement without reason accepted';
+  EXCEPTION WHEN others THEN NULL;
+  END;
+  BEGIN
+    PERFORM public.transition_festival_edition(v_edition.id, 'on_sale', NULL, '{"different":true}'::jsonb, 'to-sale');
+    RAISE EXCEPTION 'idempotency key reuse with different input accepted';
+  EXCEPTION WHEN others THEN NULL;
+  END;
+
+  UPDATE public.festival_editions SET status='completed' WHERE id=v_edition.id;
+  BEGIN
+    PERFORM public.transition_festival_edition(v_edition.id, 'live', NULL, '{}'::jsonb, 'completed-live');
+    RAISE EXCEPTION 'completed returned to live';
+  EXCEPTION WHEN others THEN NULL;
+  END;
+
+  IF EXISTS (SELECT 1 FROM public.public_festival_editions WHERE id=v_edition.id AND status IN ('concept','planning')) THEN
+    RAISE EXCEPTION 'public view exposes planning/concept editions';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.festival_legacy_mappings GROUP BY legacy_source, legacy_id HAVING count(*) = 1 LIMIT 1) THEN
+    RAISE NOTICE 'No legacy mappings fixture present; uniqueness is enforced by catalog constraint.';
+  END IF;
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Ensure the canonical `festival_editions` foundation is safe to deploy whether the historical 2029 migration has already run or not, and to make owner/public workflows edition-first and idempotent.
- Fix the broken dependency ordering where the public view referenced a helper function that may not exist at creation time, and harden lifecycle RPC semantics and concurrency/idempotency.
- Move owner UI writes to edition planning (not the brand row) and provide deterministic edition selection for owner screens.

### Description

- Add an additive, idempotent corrective migration `supabase/migrations/20291205090000_harden_festival_editions.sql` that creates/replaces the `is_public_festival_edition_status` helper before recreating the `public.public_festival_editions` view, applies `security_invoker/security_barrier`, documents the privacy contract, and restores grants.
- Introduce edition creation idempotency and transition fingerprints by adding `festival_editions.creation_idempotency_key`, a partial unique index, and `festival_edition_lifecycle_events.request_fingerprint`, and update `create_festival_edition`, `update_festival_edition_planning` (to accept a `jsonb` patch), and `transition_festival_edition` (locks first, fingerprints idempotent requests, rejects key reuse with different inputs, makes no-op requests history-free, and tightens readiness checks).
- Split frontend read paths and RPC usage in `src/features/festivals/service.ts` by adding `listPublicFestivalEditions`/`getPublicFestivalEdition` (public-safe view) and `listFestivalEditionsForOwner`/`getFestivalEditionForOwner` (owner RLS table reads), add idempotency support to `createFestivalEdition`, and implement JSON-patch semantics for `updateFestivalEditionPlanning`.
- Update UI owner surfaces (`FestivalRunWizard`, `FestivalOwnerConsole`) to derive state from a deterministic `selectManagedFestivalEdition` helper, require explicit edition creation when missing, save planning via `updateFestivalEditionPlanning` (not brand writes), and show edition-aware action labels and toasts.
- Expand database regression coverage with `supabase/tests/festival_editions_harness.sql` to validate public view privacy, unique edition numbers, idempotency and lifecycle readiness/no-op behaviour, and add a static migration-order check script `scripts/check-festival-edition-migrations.mjs` and documentation `docs/festivals/EDITION_MIGRATION_NOTES.md` recording the ordering decision.
- Update generated Supabase type approximations in `src/integrations/supabase/types.ts` to reflect new columns, RPC signatures and relationships (live generation could not be run here).

### Testing

- `npm run check:festival-migrations` — passed (static migration ordering and helper/view ordering verified).
- `npm run typecheck` (`tsc --noEmit`) — passed.
- `git diff --check` and `python3 -m json.tool docs/festivals/festival-domain-inventory.json` — passed.
- Unit tests: attempted `npm run test:unit` for the lifecycle helpers but could not run in this environment because `vitest` is not installed (`sh: 1: vitest: not found`).
- Database tests: `npm run test:festivals:db` / `supabase db reset` could not be executed because the Supabase CLI is not available in this runner (`supabase: command not found` / `Supabase CLI is required`).
- Lint: `npm run lint` could not be executed here due to missing lint dependencies in the environment (`Cannot find package '@eslint/js'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58bdf7049c8325846130cabcb5864b)