### PR TITLE
fix(festivals): harden canonical edition migration and owner workflows

### DIFF
--- a/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
+++ b/docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md
@@ -89,3 +89,11 @@ This PR establishes the first additive canonical schema layer:
 - Compatibility remains explicit: owner tools may display canonical edition lifecycle, but brand-scoped staff, permits, insurance, marketplace and legacy event-backed player flows remain unchanged until later migrations.
 
 Unresolved migration items remain canonical applications, contracts, setlists, performances, stage/slot re-keying, tickets, attendance, settlement, reward ledgers, audience/incident/vendor/staff-shift systems, and final legacy withdrawal.
+
+## Correction: deployable edition foundation
+
+The edition foundation is hardened by additive migration rather than by renaming the historical `20291204090000` migration. This preserves compatibility with any environment that may already have recorded that migration while allowing clean databases to apply a deterministic follow-up correction.
+
+The public edition projection is explicitly privacy-scoped and rebuilt after its helper function. Creation and transition RPCs now persist idempotency request records and reject mismatched idempotency reuse. Planning writes use JSONB patch semantics so clients can distinguish omitted values from intentional clears. Owner UI flows derive managed state from a shared edition selector and save occurrence planning to editions rather than permanent festival brands.
+
+Remaining canonicalisation work is intentionally deferred: applications, contracts, setlists, performance settlement, stage re-keying, ticket/attendance re-keying and reward/fame settlement are not included in this correction.

--- a/docs/festivals/CURRENT_STATE_AUDIT.md
+++ b/docs/festivals/CURRENT_STATE_AUDIT.md
@@ -315,3 +315,9 @@ Flagged issues: browser score calculation, direct `bands.band_balance` and `band
 The canonical edition foundation PR introduces `festival_editions` as the dated occurrence model beneath permanent `festivals` brand rows. It adds a server-validated edition lifecycle RPC, immutable lifecycle history, dedicated-festival backfill into first editions, and explicit legacy mappings for dedicated festival rows plus conservatively matched festival `game_events`.
 
 Legacy event/player flows remain active during this migration. Stage, slot, ticket, attendance, application, contract, setlist, performance and settlement tables are not re-keyed in this step and remain outstanding for later PRs.
+
+## Canonical edition hardening update
+
+The corrective edition hardening PR retains the historical `20291204090000_create_festival_editions.sql` migration because this checkout cannot prove it has not been applied in a shared Supabase environment. A follow-up additive migration, `20291205090000_harden_festival_editions.sql`, fixes the public-view dependency ordering, recreates the public-safe view, adds creation/transition idempotency request records, changes planning updates to JSONB patch semantics, and strengthens lifecycle validation.
+
+Public festival discovery must read `public_festival_editions`; owner/admin tools use protected `festival_editions` reads. Owner workflow edits to attendance, ticket range, dates and title now target canonical editions when present, while permanent festival brand edits remain separate. Legacy player flows, stages, slots, applications, contracts, setlists and performances remain unchanged pending later canonical migration PRs.

--- a/docs/festivals/EDITION_MIGRATION_NOTES.md
+++ b/docs/festivals/EDITION_MIGRATION_NOTES.md
@@ -1,34 +1,32 @@
 # Festival edition migration notes
 
-## Backfill rules
+## 2029 timestamp anomaly
 
-Every existing `festivals` row receives an initial `festival_editions` row when one does not already exist for the same brand and edition number. The migration preserves brand dates, city, venue, expected attendance, description, treasury and metadata. Existing `ticket_price_low` and `ticket_price_high` are decimal currency units, while the new edition ticket fields are cents, so the backfill multiplies those prices by 100 and records the compatibility decision in `legacy_metadata`.
+`supabase/migrations/20291204090000_create_festival_editions.sql` is retained under its historical identity. This workspace cannot confirm whether the merged migration has already run in a shared or production Supabase environment, so renaming it would only repair clean installs and could strand deployed databases that already recorded the 20291204090000 version.
 
-## Status mapping
+The corrective migration is therefore additive: `supabase/migrations/20291205090000_harden_festival_editions.sql`. Future festival migrations that depend on canonical editions must be timestamped after `20291205090000` or include explicit idempotent guards if they are ever backported.
 
-Dedicated festival statuses verified in repository code and migrations are mapped conservatively:
+## Dependency correction
 
-- `draft`, `upcoming` → `planning`
-- `confirmed` → `booking`
-- `published`, `announced` → `announced`
-- `live` → `live`
-- `completed` → `completed`
-- `postponed` → `postponed`
-- `cancelled` → `cancelled`
-- unknown values → `planning` with the original status retained in `legacy_metadata`
+PR #1190 created `public_festival_editions` before `is_public_festival_edition_status`. PostgreSQL cannot create a view with an unresolved function reference, so the corrective migration creates/replaces the helper first, then drops and recreates the public-safe view and reapplies grants.
 
-## Legacy event handling
+## Public/private read contract
 
-The migration creates explicit `dedicated_festival_row` mappings for all backfilled editions. Legacy `game_events` rows are mapped only when the match is deterministic: festival event type, exact/normalised title match, compatible venue when present, and overlapping dates. Unmatched legacy festival events are left unmapped for the later data-migration PR rather than creating placeholder brands.
+Public discovery reads use `public.public_festival_editions`, which exposes only edition identity, brand ID, title/description, city, venue, dates, public capacity/attendance, ticket price range, currency, public lifecycle status, public metadata and public lifecycle timestamps. It deliberately excludes budgets, treasury allocation, lifecycle metadata, legacy metadata, reasons, idempotency data, ownership and moderation fields.
 
-## Compatibility rules
+Owner/admin reads continue to use protected `festival_editions` access behind RLS and owner/admin checks.
 
-`festivals` remains the permanent brand and marketplace asset. Brand-level staff, permits, insurance and ledger screens continue to operate until later edition re-keying. Current player festival routes backed by `game_events` and `festival_participants` remain active.
+## RPC hardening
 
-## Rollback strategy
+- `create_festival_edition` accepts an optional idempotency key and records request hashes in `festival_edition_creation_requests` so retries return the original edition and mismatched reuse is rejected.
+- `update_festival_edition_planning` now accepts a JSONB patch, making omitted keys distinct from keys explicitly set to null.
+- `transition_festival_edition` locks the edition before checking transition idempotency, records transition request hashes, rejects mismatched idempotency reuse and returns unchanged rows for no-op requests without lifecycle events.
+- Lifecycle validation keeps free ticket ranges valid (`0..0` is allowed) while enforcing non-negative prices, date ordering, readiness and explicit admin override metadata for live launch exceptions.
 
-This change is additive. Rollback can drop the three new tables, the enum, policies, indexes, triggers and RPCs without changing existing festival primary keys or deleting legacy festival data. Because backfill writes only new canonical tables and mappings, existing `festivals`, `game_events`, `festival_participants`, stages, tickets and attendance data remain intact.
+## Owner workflow correction
 
-## Next migration PR
+Owner screens now share deterministic managed-edition selection. The run wizard saves occurrence planning values to the current edition instead of mutating permanent festival brand occurrence fields. When no edition exists, owner workflows present an explicit create-edition action rather than silently falling back to legacy lifecycle writes.
 
-Recommended next PR: `feat(festivals): add canonical applications contracts setlists and performances`.
+## Validation
+
+`supabase/tests/festival_editions_harness.sql` now checks schema contracts, view privacy, idempotency objects, transition graph invariants and legacy mapping uniqueness inside a rollback-only transaction. `scripts/festivals/check-edition-migration-order.mjs` statically verifies helper-before-view ordering and documents the 2029 anomaly.

--- a/docs/festivals/festival-domain-inventory.json
+++ b/docs/festivals/festival-domain-inventory.json
@@ -655,5 +655,20 @@
       "abandoned"
     ],
     "compatibility": "Existing festivals rows are permanent brands; existing game_events festival player flows remain active and can be mapped through festival_legacy_mappings."
+  },
+  "canonical_edition_hardening": {
+    "migration_ordering": "historical 20291204090000 retained; additive 20291205090000 hardening migration added",
+    "public_reads": "public_festival_editions privacy view",
+    "owner_reads": "festival_editions protected by owner/admin RLS",
+    "creation_idempotency": "festival_edition_creation_requests",
+    "transition_idempotency": "festival_edition_transition_requests",
+    "owner_workflow": "run wizard writes edition planning fields when a canonical edition exists",
+    "deferred": [
+      "applications",
+      "contracts",
+      "setlists",
+      "canonical_performances",
+      "settlement"
+    ]
   }
 }

--- a/scripts/festivals/check-edition-migration-order.mjs
+++ b/scripts/festivals/check-edition-migration-order.mjs
@@ -1,0 +1,27 @@
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migrationsDir = 'supabase/migrations';
+const files = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).sort();
+const foundation = '20291204090000_create_festival_editions.sql';
+const corrective = '20291205090000_harden_festival_editions.sql';
+if (!files.includes(foundation)) throw new Error('Historical 2029 festival edition foundation migration is missing');
+if (!files.includes(corrective)) throw new Error('Corrective festival edition hardening migration is missing');
+const correctiveSql = readFileSync(join(migrationsDir, corrective), 'utf8');
+const helperIndex = correctiveSql.indexOf('CREATE OR REPLACE FUNCTION public.is_public_festival_edition_status');
+const viewIndex = correctiveSql.indexOf('CREATE VIEW public.public_festival_editions');
+if (helperIndex < 0 || viewIndex < 0 || helperIndex > viewIndex) {
+  throw new Error('Public status helper must be created before public_festival_editions view');
+}
+const dependentBeforeFoundation = files.filter((file) =>
+  file < foundation && /festival.*edition|edition.*festival/i.test(file) &&
+  file !== foundation
+);
+if (dependentBeforeFoundation.length > 0) {
+  throw new Error(`Festival edition dependent migrations before foundation: ${dependentBeforeFoundation.join(', ')}`);
+}
+const notes = 'docs/festivals/EDITION_MIGRATION_NOTES.md';
+if (!existsSync(notes) || !/20291204090000/.test(readFileSync(notes, 'utf8'))) {
+  throw new Error('Migration notes must document the 20291204090000 anomaly');
+}
+console.log('festival edition migration order check passed');

--- a/src/features/festivals/__tests__/lifecycle.test.ts
+++ b/src/features/festivals/__tests__/lifecycle.test.ts
@@ -29,6 +29,7 @@ describe("festival edition lifecycle UI helper", () => {
   });
 
   it("shows valid advisory transitions", () => {
+    expect(canShowFestivalEditionTransition("announced", "announced")).toBe(false);
     expect(canShowFestivalEditionTransition("concept", "planning")).toBe(true);
     expect(
       canShowFestivalEditionTransition("planning", "applications_open"),

--- a/src/features/festivals/__tests__/managedEdition.test.ts
+++ b/src/features/festivals/__tests__/managedEdition.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  canShowFestivalEditionTransition,
+  getFestivalEditionActionLabel,
+  isFestivalEditionPubliclyVisible,
+  selectManagedFestivalEdition,
+} from "../lifecycle";
+
+const edition = (id: string, status: any, edition_number: number, start_at: string | null, completed_at: string | null = null) => ({
+  id,
+  status,
+  edition_number,
+  start_at,
+  end_at: start_at,
+  completed_at,
+});
+
+describe("managed festival edition selection", () => {
+  const now = new Date("2030-01-01T00:00:00Z");
+
+  it("prefers live before upcoming and completed editions", () => {
+    const selected = selectManagedFestivalEdition([
+      edition("future", "announced", 4, "2030-06-01T00:00:00Z"),
+      edition("live", "live", 2, "2029-12-30T00:00:00Z"),
+      edition("done", "completed", 3, "2029-01-01T00:00:00Z", "2029-01-03T00:00:00Z"),
+    ], now);
+    expect(selected?.id).toBe("live");
+  });
+
+  it("selects next active upcoming before planning upcoming", () => {
+    const selected = selectManagedFestivalEdition([
+      edition("planning", "planning", 8, "2030-03-01T00:00:00Z"),
+      edition("announced", "announced", 7, "2030-04-01T00:00:00Z"),
+    ], now);
+    expect(selected?.id).toBe("announced");
+  });
+
+  it("falls back to most recent completed then latest edition number", () => {
+    expect(selectManagedFestivalEdition([
+      edition("old", "completed", 1, "2027-01-01T00:00:00Z", "2027-01-02T00:00:00Z"),
+      edition("new", "completed", 2, "2028-01-01T00:00:00Z", "2028-01-02T00:00:00Z"),
+    ], now)?.id).toBe("new");
+    expect(selectManagedFestivalEdition([
+      edition("cancelled", "cancelled", 3, null),
+      edition("abandoned", "abandoned", 4, null),
+    ], now)?.id).toBe("abandoned");
+  });
+});
+
+describe("festival edition UI classifications", () => {
+  it("does not present no-op transitions as actionable", () => {
+    expect(canShowFestivalEditionTransition("announced", "announced")).toBe(false);
+  });
+
+  it("keeps terminal states closed", () => {
+    expect(canShowFestivalEditionTransition("completed", "live")).toBe(false);
+    expect(canShowFestivalEditionTransition("cancelled", "planning")).toBe(false);
+  });
+
+  it("classifies public/private read statuses", () => {
+    expect(isFestivalEditionPubliclyVisible("planning")).toBe(false);
+    expect(isFestivalEditionPubliclyVisible("on_sale")).toBe(true);
+  });
+
+  it("labels owner action states", () => {
+    expect(getFestivalEditionActionLabel("planning")).toBe("Announce edition");
+    expect(getFestivalEditionActionLabel("announced")).toBe("Edition announced");
+    expect(getFestivalEditionActionLabel("on_sale")).toBe("Tickets on sale");
+    expect(getFestivalEditionActionLabel("setup")).toBe("Ready for live operations");
+    expect(getFestivalEditionActionLabel("live")).toBe("Festival live");
+  });
+});

--- a/src/features/festivals/lifecycle.ts
+++ b/src/features/festivals/lifecycle.ts
@@ -99,6 +99,89 @@ export function canShowFestivalEditionTransition(
   from: FestivalEditionStatus,
   to: FestivalEditionStatus,
 ): boolean {
-  if (from === to) return true;
+  if (from === to) return false;
   return TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export type ManagedFestivalEditionLike = {
+  id: string;
+  status: FestivalEditionStatus;
+  edition_number: number | null;
+  start_at: string | null;
+  end_at: string | null;
+  completed_at?: string | null;
+};
+
+const UPCOMING_ACTIVE = new Set<FestivalEditionStatus>([
+  "setup",
+  "on_sale",
+  "announced",
+]);
+const UPCOMING_PLANNING = new Set<FestivalEditionStatus>([
+  "booking",
+  "applications_open",
+  "planning",
+]);
+
+const timeOrInfinity = (value: string | null | undefined) =>
+  value ? new Date(value).getTime() : Number.POSITIVE_INFINITY;
+const timeOrZero = (value: string | null | undefined) =>
+  value ? new Date(value).getTime() : 0;
+
+export function selectManagedFestivalEdition<T extends ManagedFestivalEditionLike>(
+  editions: readonly T[],
+  now: Date = new Date(),
+): T | null {
+  if (editions.length === 0) return null;
+  const currentTime = now.getTime();
+  const byStartAsc = (a: T, b: T) =>
+    timeOrInfinity(a.start_at) - timeOrInfinity(b.start_at) ||
+    Number(b.edition_number ?? 0) - Number(a.edition_number ?? 0);
+  const byRecent = (a: T, b: T) =>
+    timeOrZero(b.completed_at ?? b.end_at) - timeOrZero(a.completed_at ?? a.end_at) ||
+    Number(b.edition_number ?? 0) - Number(a.edition_number ?? 0);
+  const live = editions
+    .filter((edition) => edition.status === "live")
+    .sort(byStartAsc)[0];
+  if (live) return live;
+  const upcomingActive = editions
+    .filter(
+      (edition) =>
+        UPCOMING_ACTIVE.has(edition.status) &&
+        timeOrInfinity(edition.start_at) >= currentTime,
+    )
+    .sort(byStartAsc)[0];
+  if (upcomingActive) return upcomingActive;
+  const upcomingPlanning = editions
+    .filter(
+      (edition) =>
+        UPCOMING_PLANNING.has(edition.status) &&
+        timeOrInfinity(edition.start_at) >= currentTime,
+    )
+    .sort(byStartAsc)[0];
+  if (upcomingPlanning) return upcomingPlanning;
+  const completed = editions
+    .filter((edition) => edition.status === "completed")
+    .sort(byRecent)[0];
+  if (completed) return completed;
+  return [...editions].sort(
+    (a, b) => Number(b.edition_number ?? 0) - Number(a.edition_number ?? 0),
+  )[0];
+}
+
+export function getFestivalEditionActionLabel(
+  status: FestivalEditionStatus | null | undefined,
+): string {
+  switch (status) {
+    case "announced":
+      return "Edition announced";
+    case "on_sale":
+      return "Tickets on sale";
+    case "setup":
+      return "Ready for live operations";
+    case "live":
+      return "Festival live";
+    default:
+      return "Announce edition";
+  }
 }

--- a/src/features/festivals/service.ts
+++ b/src/features/festivals/service.ts
@@ -8,13 +8,14 @@ import type {
 } from "./types";
 
 const selectAll = "*" as string;
-const editionsTable = () => (supabase as any).from("festival_editions");
+const ownerEditionsTable = () => (supabase as any).from("festival_editions");
+const publicEditionsTable = () => (supabase as any).from("public_festival_editions");
 const mappingsTable = () => (supabase as any).from("festival_legacy_mappings");
 
-export async function listFestivalEditions(
+export async function listFestivalEditionsForOwner(
   festivalId: string,
 ): Promise<FestivalEdition[]> {
-  const { data, error } = await editionsTable()
+  const { data, error } = await ownerEditionsTable()
     .select(selectAll)
     .eq("festival_id", festivalId)
     .order("edition_number", { ascending: false });
@@ -22,10 +23,10 @@ export async function listFestivalEditions(
   return (data ?? []) as unknown as FestivalEdition[];
 }
 
-export async function getFestivalEdition(
+export async function getFestivalEditionForOwner(
   editionId: string,
 ): Promise<FestivalEdition | null> {
-  const { data, error } = await editionsTable()
+  const { data, error } = await ownerEditionsTable()
     .select(selectAll)
     .eq("id", editionId)
     .maybeSingle();
@@ -45,6 +46,7 @@ export async function createFestivalEdition(input: {
   minimumTicketPriceCents?: number | null;
   maximumTicketPriceCents?: number | null;
   publicMetadata?: Json;
+  idempotencyKey?: string | null;
 }): Promise<FestivalEdition> {
   const { data, error } = await (supabase as any).rpc("create_festival_edition", {
     p_festival_id: input.festivalId,
@@ -58,6 +60,7 @@ export async function createFestivalEdition(input: {
     p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
     p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
     p_public_metadata: input.publicMetadata ?? {},
+    p_idempotency_key: input.idempotencyKey ?? null,
   });
   if (error) throw error;
   return data as unknown as FestivalEdition;
@@ -83,17 +86,19 @@ export async function updateFestivalEditionPlanning(
     "update_festival_edition_planning",
     {
       p_edition_id: editionId,
-      p_title: input.title ?? null,
-      p_description: input.description ?? null,
-      p_start_at: input.startAt ?? null,
-      p_end_at: input.endAt ?? null,
-      p_city_id: input.cityId ?? null,
-      p_venue_id: input.venueId ?? null,
-      p_expected_attendance: input.expectedAttendance ?? null,
-      p_capacity: input.capacity ?? null,
-      p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
-      p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
-      p_public_metadata: input.publicMetadata ?? null,
+      p_patch: {
+        ...(Object.prototype.hasOwnProperty.call(input, "title") ? { title: input.title } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "description") ? { description: input.description } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "startAt") ? { start_at: input.startAt } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "endAt") ? { end_at: input.endAt } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "cityId") ? { city_id: input.cityId } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "venueId") ? { venue_id: input.venueId } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "expectedAttendance") ? { expected_attendance: input.expectedAttendance } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "capacity") ? { capacity: input.capacity } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "minimumTicketPriceCents") ? { minimum_ticket_price_cents: input.minimumTicketPriceCents } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "maximumTicketPriceCents") ? { maximum_ticket_price_cents: input.maximumTicketPriceCents } : {}),
+        ...(Object.prototype.hasOwnProperty.call(input, "publicMetadata") ? { public_metadata: input.publicMetadata } : {}),
+      },
     },
   );
   if (error) throw error;
@@ -129,4 +134,27 @@ export async function resolveEditionFromLegacyIdentifier(
     .maybeSingle();
   if (error) throw error;
   return data as unknown as FestivalLegacyMapping | null;
+}
+
+
+export const listFestivalEditions = listFestivalEditionsForOwner;
+export const getFestivalEdition = getFestivalEditionForOwner;
+
+export async function listPublicFestivalEditions(): Promise<FestivalEdition[]> {
+  const { data, error } = await publicEditionsTable()
+    .select(selectAll)
+    .order("start_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as unknown as FestivalEdition[];
+}
+
+export async function getPublicFestivalEdition(
+  editionId: string,
+): Promise<FestivalEdition | null> {
+  const { data, error } = await publicEditionsTable()
+    .select(selectAll)
+    .eq("id", editionId)
+    .maybeSingle();
+  if (error) throw error;
+  return data as unknown as FestivalEdition | null;
 }

--- a/src/pages/FestivalOwnerConsole.tsx
+++ b/src/pages/FestivalOwnerConsole.tsx
@@ -38,8 +38,14 @@ import {
   Store,
 } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { listFestivalEditions } from "@/features/festivals/service";
-import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
+import {
+  createFestivalEdition,
+  listFestivalEditionsForOwner,
+} from "@/features/festivals/service";
+import {
+  getFestivalEditionStatusLabel,
+  selectManagedFestivalEdition,
+} from "@/features/festivals/lifecycle";
 
 const money = (cents: number | null | undefined) => {
   const c = Number(cents ?? 0);
@@ -82,10 +88,44 @@ export default function FestivalOwnerConsole() {
 
   const { data: editions = [] } = useQuery({
     queryKey: ["festival-editions", festivalId],
-    queryFn: () => listFestivalEditions(festivalId!),
+    queryFn: () => listFestivalEditionsForOwner(festivalId!),
     enabled: !!festivalId,
   });
-  const currentEdition = editions[0];
+  const currentEdition = selectManagedFestivalEdition(editions);
+
+  const createEdition = useMutation({
+    mutationFn: async () => {
+      if (!festivalId || !festival) throw new Error("Festival is unavailable");
+      return createFestivalEdition({
+        festivalId,
+        title: `${festival.name} ${new Date(
+          festival.start_date,
+        ).getFullYear()}`,
+        startAt: festival.start_date
+          ? new Date(festival.start_date).toISOString()
+          : null,
+        endAt: festival.end_date
+          ? new Date(festival.end_date).toISOString()
+          : null,
+        cityId: festival.city_id,
+        venueId: festival.venue_id,
+        expectedAttendance: festival.expected_attendance,
+        capacity: festival.expected_attendance,
+        minimumTicketPriceCents: Math.round(
+          Number(festival.ticket_price_low ?? 0) * 100,
+        ),
+        maximumTicketPriceCents: Math.round(
+          Number(festival.ticket_price_high ?? 0) * 100,
+        ),
+        idempotencyKey: `owner-console-create-${festivalId}`,
+      });
+    },
+    onSuccess: () => {
+      toast.success("Canonical edition created");
+      qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
+    },
+    onError: (e: any) => toast.error(e.message),
+  });
 
   const { data: staff = [] } = useQuery({
     queryKey: ["festival-staff", festivalId],
@@ -365,8 +405,15 @@ export default function FestivalOwnerConsole() {
               </span>
               <Button size="sm" variant="outline" asChild>
                 <Link to={`/festivals/${festivalId}/run`}>
-                  Create or resolve edition
+                  Open run wizard
                 </Link>
+              </Button>
+              <Button
+                size="sm"
+                disabled={createEdition.isPending}
+                onClick={() => createEdition.mutate()}
+              >
+                {createEdition.isPending ? "Creating…" : "Create edition"}
               </Button>
             </>
           )}

--- a/src/pages/FestivalRunWizard.tsx
+++ b/src/pages/FestivalRunWizard.tsx
@@ -37,10 +37,15 @@ import {
   useFestivalStageSlots,
 } from "@/hooks/useFestivalStages";
 import {
-  listFestivalEditions,
+  listFestivalEditionsForOwner,
   transitionFestivalEdition,
+  updateFestivalEditionPlanning,
 } from "@/features/festivals/service";
-import { getFestivalEditionStatusLabel } from "@/features/festivals/lifecycle";
+import {
+  getFestivalEditionActionLabel,
+  getFestivalEditionStatusLabel,
+  selectManagedFestivalEdition,
+} from "@/features/festivals/lifecycle";
 import { format } from "date-fns";
 
 type StepKey = "draft" | "booking" | "compliance" | "launch";
@@ -74,10 +79,10 @@ export default function FestivalRunWizard() {
 
   const { data: editions = [] } = useQuery({
     queryKey: ["festival-editions", festivalId],
-    queryFn: () => listFestivalEditions(festivalId!),
+    queryFn: () => listFestivalEditionsForOwner(festivalId!),
     enabled: !!festivalId,
   });
-  const currentEdition = editions[0];
+  const currentEdition = selectManagedFestivalEdition(editions);
 
   const { data: stages = [] } = useFestivalStages(festivalId);
   const { data: slots = [] } = useFestivalStageSlots(festivalId);
@@ -125,17 +130,27 @@ export default function FestivalRunWizard() {
   // Initialize once
   useMemo(() => {
     if (festival && draftName === "") {
-      const name = festival.name || "";
-      const attendance = String(festival.expected_attendance ?? "");
-      const low = String(festival.ticket_price_low ?? "");
-      const high = String(festival.ticket_price_high ?? "");
+      const name = currentEdition?.title || festival.name || "";
+      const attendance = String(
+        currentEdition?.expected_attendance ?? festival.expected_attendance ?? "",
+      );
+      const low = String(
+        currentEdition?.minimum_ticket_price_cents != null
+          ? currentEdition.minimum_ticket_price_cents / 100
+          : festival.ticket_price_low ?? "",
+      );
+      const high = String(
+        currentEdition?.maximum_ticket_price_cents != null
+          ? currentEdition.maximum_ticket_price_cents / 100
+          : festival.ticket_price_high ?? "",
+      );
       setDraftName(name);
       setDraftAttendance(attendance);
       setDraftLow(low);
       setDraftHigh(high);
       if (!originalDraft) setOriginalDraft({ name, attendance, low, high });
     }
-  }, [festival]);
+  }, [festival, currentEdition, draftName, originalDraft]);
 
   const saveDraft = useMutation({
     mutationFn: async () => {
@@ -147,20 +162,21 @@ export default function FestivalRunWizard() {
         throw new Error("Attendance must be positive");
       if (!Number.isFinite(low) || !Number.isFinite(high) || high < low)
         throw new Error("Ticket range invalid");
-      const { error } = await (supabase as any)
-        .from("festivals")
-        .update({
-          name: draftName.trim(),
-          expected_attendance: Math.round(attendance),
-          ticket_price_low: low,
-          ticket_price_high: high,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", festivalId);
-      if (error) throw error;
+      if (currentEdition) {
+        await updateFestivalEditionPlanning(currentEdition.id, {
+          title: draftName.trim(),
+          expectedAttendance: Math.round(attendance),
+          minimumTicketPriceCents: Math.round(low * 100),
+          maximumTicketPriceCents: Math.round(high * 100),
+        });
+        return;
+      }
+      throw new Error(
+        "Create a canonical edition before saving occurrence planning fields.",
+      );
     },
     onSuccess: () => {
-      toast.success("Draft saved");
+      toast.success(currentEdition ? "Edition planning saved" : "Draft saved");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
       qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
     },
@@ -248,7 +264,7 @@ export default function FestivalRunWizard() {
             festival?.status === "live" ||
             festival?.status === "announced",
         label: currentEdition
-          ? "Canonical edition lifecycle ready for launch"
+          ? "Canonical edition lifecycle ready"
           : "Legacy festival status ready (compatibility only)",
       },
     ],
@@ -274,7 +290,7 @@ export default function FestivalRunWizard() {
       );
     },
     onSuccess: () => {
-      toast.success("Festival is live! Announcement pushed.");
+      toast.success("Edition announced.");
       qc.invalidateQueries({ queryKey: ["run-wizard-festival", festivalId] });
       qc.invalidateQueries({ queryKey: ["festival-editions", festivalId] });
       setStepIdx(STEPS.length - 1);
@@ -413,8 +429,8 @@ export default function FestivalRunWizard() {
             </p>
           ) : (
             <p className="text-xs text-amber-500">
-              Canonical edition not resolved. The wizard will not mutate the
-              permanent festival brand lifecycle.
+              Canonical edition not resolved. Create one before editing
+              occurrence planning.
             </p>
           )}
         </CardContent>
@@ -481,12 +497,14 @@ export default function FestivalRunWizard() {
                 <Button
                   size="sm"
                   onClick={() => saveDraft.mutate()}
-                  disabled={saveDraft.isPending}
+                  disabled={saveDraft.isPending || !currentEdition}
                 >
                   {saveDraft.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin mr-1" />
                   ) : null}
-                  Save Draft
+                  {currentEdition
+                    ? "Save edition planning"
+                    : "Create edition first"}
                 </Button>
               </div>
               <div className="md:col-span-2">
@@ -701,15 +719,30 @@ export default function FestivalRunWizard() {
                     <div className="flex items-center gap-2 text-sm">
                       <Ticket className="h-4 w-4 text-primary" />
                       <span>
-                        Ticket range: ${festival.ticket_price_low} – $
-                        {festival.ticket_price_high}
+                        Ticket range: $
+                        {(
+                          (currentEdition?.minimum_ticket_price_cents ??
+                            Math.round(Number(festival.ticket_price_low ?? 0) * 100)) /
+                          100
+                        ).toLocaleString()} – $
+                        {(
+                          (currentEdition?.maximum_ticket_price_cents ??
+                            Math.round(Number(festival.ticket_price_high ?? 0) * 100)) /
+                          100
+                        ).toLocaleString()}
                       </span>
                     </div>
                     <div className="flex items-center gap-2 text-sm">
                       <CalendarIcon className="h-4 w-4 text-primary" />
                       <span>
-                        {format(new Date(festival.start_date), "MMM d")} –{" "}
-                        {format(new Date(festival.end_date), "MMM d, yyyy")}
+                        {format(
+                          new Date(currentEdition?.start_at ?? festival.start_date),
+                          "MMM d",
+                        )} –{" "}
+                        {format(
+                          new Date(currentEdition?.end_at ?? festival.end_date),
+                          "MMM d, yyyy",
+                        )}
                       </span>
                     </div>
                     <div className="flex items-center gap-2 text-sm">
@@ -891,9 +924,11 @@ export default function FestivalRunWizard() {
                     className="w-full"
                     disabled={
                       !canLaunch ||
+                      !currentEdition ||
                       launchMutation.isPending ||
-                      festival.status === "announced" ||
-                      festival.status === "live"
+                      ["announced", "on_sale", "setup", "live"].includes(
+                        currentEdition.status,
+                      )
                     }
                     onClick={() => launchMutation.mutate()}
                   >
@@ -902,10 +937,7 @@ export default function FestivalRunWizard() {
                     ) : (
                       <Rocket className="h-4 w-4 mr-2" />
                     )}
-                    {festival.status === "announced" ||
-                    festival.status === "live"
-                      ? "Festival is Live"
-                      : "Go Live & Announce"}
+                    {getFestivalEditionActionLabel(currentEdition?.status)}
                   </Button>
                 </div>
               );

--- a/supabase/migrations/20291205090000_harden_festival_editions.sql
+++ b/supabase/migrations/20291205090000_harden_festival_editions.sql
@@ -1,0 +1,174 @@
+-- Harden canonical festival editions after PR #1190 without renaming the historical 20291204090000 migration.
+
+CREATE OR REPLACE FUNCTION public.is_public_festival_edition_status(p_status public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT p_status IN ('applications_open','booking','announced','on_sale','setup','live','settling','completed')
+$$;
+
+DROP VIEW IF EXISTS public.public_festival_editions;
+CREATE VIEW public.public_festival_editions
+WITH (security_invoker = true, security_barrier = true) AS
+SELECT
+  id, festival_id, edition_number, edition_year, title, slug, description,
+  city_id, venue_id, start_at, end_at, timezone, doors_open_at, curfew_at,
+  expected_attendance, capacity, minimum_ticket_price_cents,
+  maximum_ticket_price_cents, currency_code, status, public_metadata,
+  announced_at, on_sale_at, live_at, completed_at, cancelled_at, created_at, updated_at
+FROM public.festival_editions
+WHERE public.is_public_festival_edition_status(status);
+COMMENT ON VIEW public.public_festival_editions IS 'Public-safe festival edition projection. Excludes budget, treasury allocation, lifecycle/legacy metadata, private reasons, idempotency details, ownership and moderation fields.';
+GRANT SELECT ON public.public_festival_editions TO anon, authenticated;
+
+CREATE TABLE IF NOT EXISTS public.festival_edition_creation_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  festival_id uuid NOT NULL REFERENCES public.festivals(id) ON DELETE CASCADE,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_creation_request_key_unique UNIQUE (festival_id, idempotency_key),
+  CONSTRAINT festival_creation_request_key_not_blank CHECK (length(trim(idempotency_key)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_edition_transition_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  target_status public.festival_edition_status NOT NULL,
+  reason text,
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  lifecycle_event_id uuid REFERENCES public.festival_edition_lifecycle_events(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_transition_request_key_unique UNIQUE (edition_id, idempotency_key),
+  CONSTRAINT festival_transition_request_key_not_blank CHECK (length(trim(idempotency_key)) > 0)
+);
+
+ALTER TABLE public.festival_edition_creation_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_edition_transition_requests ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "festival_creation_requests_owner_admin_read" ON public.festival_edition_creation_requests;
+CREATE POLICY "festival_creation_requests_owner_admin_read" ON public.festival_edition_creation_requests FOR SELECT TO authenticated USING (public.can_manage_festival_brand(festival_id));
+DROP POLICY IF EXISTS "festival_transition_requests_owner_admin_read" ON public.festival_edition_transition_requests;
+CREATE POLICY "festival_transition_requests_owner_admin_read" ON public.festival_edition_transition_requests FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.id=edition_id AND public.can_manage_festival_brand(e.festival_id)));
+
+CREATE OR REPLACE FUNCTION public.validate_festival_edition_transition(p_from public.festival_edition_status, p_to public.festival_edition_status)
+RETURNS boolean LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT CASE
+    WHEN p_from = p_to THEN false
+    WHEN p_from IN ('completed','cancelled','abandoned') THEN false
+    WHEN p_to IN ('cancelled','abandoned') THEN p_from NOT IN ('completed','cancelled','abandoned')
+    WHEN p_to = 'postponed' THEN p_from NOT IN ('live','settling','completed','cancelled','abandoned')
+    WHEN p_from = 'postponed' THEN p_to IN ('planning','announced')
+    WHEN p_from = 'concept' THEN p_to = 'planning'
+    WHEN p_from = 'planning' THEN p_to IN ('applications_open','booking')
+    WHEN p_from = 'applications_open' THEN p_to = 'booking'
+    WHEN p_from = 'booking' THEN p_to = 'announced'
+    WHEN p_from = 'announced' THEN p_to IN ('on_sale','setup')
+    WHEN p_from = 'on_sale' THEN p_to = 'setup'
+    WHEN p_from = 'setup' THEN p_to = 'live'
+    WHEN p_from = 'live' THEN p_to = 'settling'
+    WHEN p_from = 'settling' THEN p_to = 'completed'
+    ELSE false END
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_festival_edition(
+  p_festival_id uuid, p_title text DEFAULT NULL, p_start_at timestamptz DEFAULT NULL,
+  p_end_at timestamptz DEFAULT NULL, p_city_id uuid DEFAULT NULL, p_venue_id uuid DEFAULT NULL,
+  p_expected_attendance integer DEFAULT NULL, p_capacity integer DEFAULT NULL,
+  p_minimum_ticket_price_cents bigint DEFAULT NULL, p_maximum_ticket_price_cents bigint DEFAULT NULL,
+  p_public_metadata jsonb DEFAULT '{}'::jsonb, p_idempotency_key text DEFAULT NULL
+) RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_festival public.festivals%ROWTYPE; v_edition public.festival_editions%ROWTYPE; v_next integer; v_actor uuid; v_hash text; v_req public.festival_edition_creation_requests%ROWTYPE;
+BEGIN
+  v_actor := public.current_profile_id();
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival not found'; END IF;
+  IF NOT public.can_manage_festival_brand(p_festival_id) THEN RAISE EXCEPTION 'Not authorised to create festival editions'; END IF;
+  IF p_start_at IS NOT NULL AND p_end_at IS NOT NULL AND p_end_at <= p_start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  IF coalesce(p_expected_attendance,0) < 0 OR coalesce(p_capacity,0) < 0 THEN RAISE EXCEPTION 'Attendance and capacity must be non-negative'; END IF;
+  IF p_minimum_ticket_price_cents IS NOT NULL AND p_minimum_ticket_price_cents < 0 OR p_maximum_ticket_price_cents IS NOT NULL AND p_maximum_ticket_price_cents < 0 OR (p_minimum_ticket_price_cents IS NOT NULL AND p_maximum_ticket_price_cents IS NOT NULL AND p_maximum_ticket_price_cents < p_minimum_ticket_price_cents) THEN RAISE EXCEPTION 'Ticket price range invalid'; END IF;
+  v_hash := md5(jsonb_build_object('festival_id',p_festival_id,'title',p_title,'start_at',p_start_at,'end_at',p_end_at,'city_id',p_city_id,'venue_id',p_venue_id,'expected_attendance',p_expected_attendance,'capacity',p_capacity,'min',p_minimum_ticket_price_cents,'max',p_maximum_ticket_price_cents,'public_metadata',coalesce(p_public_metadata,'{}'::jsonb))::text);
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_req FROM public.festival_edition_creation_requests WHERE festival_id=p_festival_id AND idempotency_key=p_idempotency_key FOR UPDATE;
+    IF FOUND THEN
+      IF v_req.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different creation input'; END IF;
+      SELECT * INTO v_edition FROM public.festival_editions WHERE id=v_req.edition_id; RETURN v_edition;
+    END IF;
+  END IF;
+  SELECT coalesce(max(edition_number),0)+1 INTO v_next FROM public.festival_editions WHERE festival_id=p_festival_id;
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, treasury_allocation_cents, public_metadata, created_by, legacy_metadata)
+  VALUES (p_festival_id, v_next, extract(year from coalesce(p_start_at, v_festival.start_date::timestamptz))::int, coalesce(p_title, v_festival.name || ' #' || v_next), v_festival.description, coalesce(p_city_id, v_festival.city_id), coalesce(p_venue_id, v_festival.venue_id), coalesce(p_start_at, v_festival.start_date::timestamptz), coalesce(p_end_at, (v_festival.end_date + 1)::timestamptz), coalesce(p_expected_attendance, v_festival.expected_attendance), coalesce(p_capacity, v_festival.expected_attendance), p_minimum_ticket_price_cents, p_maximum_ticket_price_cents, v_festival.treasury_cents, coalesce(p_public_metadata,'{}'::jsonb), v_actor, jsonb_build_object('created_from_rpc', true)) RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata) VALUES (v_edition.id, NULL, v_edition.status, v_actor, 'edition_created', jsonb_build_object('source','create_festival_edition'));
+  IF p_idempotency_key IS NOT NULL THEN INSERT INTO public.festival_edition_creation_requests(festival_id,idempotency_key,request_hash,edition_id,actor_profile_id) VALUES (p_festival_id,p_idempotency_key,v_hash,v_edition.id,v_actor); END IF;
+  RETURN v_edition;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.update_festival_edition_planning(p_edition_id uuid, p_patch jsonb DEFAULT '{}'::jsonb)
+RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v public.festival_editions%ROWTYPE; n public.festival_editions%ROWTYPE; j jsonb := coalesce(p_patch,'{}'::jsonb);
+BEGIN
+  SELECT * INTO v FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v.festival_id) THEN RAISE EXCEPTION 'Not authorised to update festival edition'; END IF;
+  n := v;
+  IF j ? 'title' THEN n.title := j->>'title'; END IF;
+  IF j ? 'description' THEN n.description := j->>'description'; END IF;
+  IF j ? 'start_at' THEN n.start_at := NULLIF(j->>'start_at','')::timestamptz; END IF;
+  IF j ? 'end_at' THEN n.end_at := NULLIF(j->>'end_at','')::timestamptz; END IF;
+  IF j ? 'city_id' THEN n.city_id := NULLIF(j->>'city_id','')::uuid; END IF;
+  IF j ? 'venue_id' THEN n.venue_id := NULLIF(j->>'venue_id','')::uuid; END IF;
+  IF j ? 'expected_attendance' THEN n.expected_attendance := NULLIF(j->>'expected_attendance','')::integer; END IF;
+  IF j ? 'capacity' THEN n.capacity := NULLIF(j->>'capacity','')::integer; END IF;
+  IF j ? 'minimum_ticket_price_cents' THEN n.minimum_ticket_price_cents := NULLIF(j->>'minimum_ticket_price_cents','')::bigint; END IF;
+  IF j ? 'maximum_ticket_price_cents' THEN n.maximum_ticket_price_cents := NULLIF(j->>'maximum_ticket_price_cents','')::bigint; END IF;
+  IF j ? 'public_metadata' THEN n.public_metadata := coalesce(j->'public_metadata','{}'::jsonb); END IF;
+  IF v.status NOT IN ('concept','planning','applications_open','booking') AND (n.start_at IS DISTINCT FROM v.start_at OR n.end_at IS DISTINCT FROM v.end_at OR n.city_id IS DISTINCT FROM v.city_id OR n.venue_id IS DISTINCT FROM v.venue_id OR n.expected_attendance IS DISTINCT FROM v.expected_attendance OR n.capacity IS DISTINCT FROM v.capacity OR n.minimum_ticket_price_cents IS DISTINCT FROM v.minimum_ticket_price_cents OR n.maximum_ticket_price_cents IS DISTINCT FROM v.maximum_ticket_price_cents) THEN RAISE EXCEPTION 'Festival edition planning fields are locked after announcement'; END IF;
+  IF n.start_at IS NOT NULL AND n.end_at IS NOT NULL AND n.end_at <= n.start_at THEN RAISE EXCEPTION 'Edition end must be after start'; END IF;
+  IF coalesce(n.expected_attendance,0) < 0 OR coalesce(n.capacity,0) < 0 THEN RAISE EXCEPTION 'Attendance and capacity must be non-negative'; END IF;
+  IF n.minimum_ticket_price_cents IS NOT NULL AND n.minimum_ticket_price_cents < 0 OR n.maximum_ticket_price_cents IS NOT NULL AND n.maximum_ticket_price_cents < 0 OR (n.minimum_ticket_price_cents IS NOT NULL AND n.maximum_ticket_price_cents IS NOT NULL AND n.maximum_ticket_price_cents < n.minimum_ticket_price_cents) THEN RAISE EXCEPTION 'Ticket price range invalid'; END IF;
+  IF v.status IN ('announced','on_sale','setup','live','settling','completed') AND (n.city_id IS NULL OR n.venue_id IS NULL OR coalesce(n.capacity,n.expected_attendance,0) <= 0) THEN RAISE EXCEPTION 'Published editions require city, venue and positive capacity or attendance'; END IF;
+  UPDATE public.festival_editions SET title=n.title, description=n.description, start_at=n.start_at, end_at=n.end_at, city_id=n.city_id, venue_id=n.venue_id, expected_attendance=n.expected_attendance, capacity=n.capacity, minimum_ticket_price_cents=n.minimum_ticket_price_cents, maximum_ticket_price_cents=n.maximum_ticket_price_cents, public_metadata=n.public_metadata WHERE id=p_edition_id RETURNING * INTO n;
+  RETURN n;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.transition_festival_edition(p_edition_id uuid, p_target_status public.festival_edition_status, p_reason text DEFAULT NULL, p_metadata jsonb DEFAULT '{}'::jsonb, p_idempotency_key text DEFAULT NULL)
+RETURNS public.festival_editions
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v public.festival_editions%ROWTYPE; v_actor uuid; v_now timestamptz := now(); v_is_admin boolean; v_from public.festival_edition_status; v_hash text; v_req public.festival_edition_transition_requests%ROWTYPE; v_event uuid; v_override boolean;
+BEGIN
+  v_actor := public.current_profile_id(); v_is_admin := coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false); v_override := coalesce((p_metadata->>'admin_override')::boolean,false);
+  SELECT * INTO v FROM public.festival_editions WHERE id=p_edition_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Festival edition not found'; END IF;
+  IF NOT public.can_manage_festival_brand(v.festival_id) THEN RAISE EXCEPTION 'Not authorised to manage this festival edition'; END IF;
+  v_hash := md5(jsonb_build_object('edition_id',p_edition_id,'target_status',p_target_status,'reason',p_reason,'metadata',coalesce(p_metadata,'{}'::jsonb))::text);
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT * INTO v_req FROM public.festival_edition_transition_requests WHERE edition_id=p_edition_id AND idempotency_key=p_idempotency_key FOR UPDATE;
+    IF FOUND THEN IF v_req.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different transition input'; END IF; RETURN v; END IF;
+    IF EXISTS (SELECT 1 FROM public.festival_edition_lifecycle_events le WHERE le.edition_id=p_edition_id AND le.idempotency_key=p_idempotency_key) THEN
+      IF EXISTS (SELECT 1 FROM public.festival_edition_lifecycle_events le WHERE le.edition_id=p_edition_id AND le.idempotency_key=p_idempotency_key AND le.to_status=p_target_status AND le.reason IS NOT DISTINCT FROM p_reason) THEN RETURN v; END IF;
+      RAISE EXCEPTION 'Idempotency key reused with different transition input';
+    END IF;
+  END IF;
+  IF v.status = p_target_status THEN RETURN v; END IF;
+  v_from := v.status;
+  IF p_target_status IN ('cancelled','postponed','abandoned') AND length(trim(coalesce(p_reason,''))) = 0 THEN RAISE EXCEPTION 'A reason is required for % transitions', p_target_status; END IF;
+  IF NOT public.validate_festival_edition_transition(v.status, p_target_status) THEN RAISE EXCEPTION 'Invalid festival edition transition from % to %', v.status, p_target_status; END IF;
+  IF p_target_status = 'announced' AND (v.start_at IS NULL OR v.end_at IS NULL OR v.start_at <= v_now OR v.city_id IS NULL OR v.venue_id IS NULL OR coalesce(v.capacity, v.expected_attendance, 0) <= 0) THEN RAISE EXCEPTION 'Festival edition requires future dates, city, venue and positive capacity or attendance before announcement'; END IF;
+  IF p_target_status = 'on_sale' AND (v.status <> 'announced' OR v.start_at IS NULL OR v.start_at <= v_now OR v.minimum_ticket_price_cents IS NULL OR v.maximum_ticket_price_cents IS NULL OR v.maximum_ticket_price_cents < v.minimum_ticket_price_cents OR v.currency_code !~ '^[A-Z]{3}$') THEN RAISE EXCEPTION 'Festival edition requires announced state, future start and valid ticket price range before on-sale'; END IF;
+  IF p_target_status = 'setup' AND (v.start_at IS NULL OR v.end_at IS NULL OR v.end_at <= v.start_at OR v.status IN ('cancelled','postponed')) THEN RAISE EXCEPTION 'Festival edition requires valid active dates before setup'; END IF;
+  IF p_target_status = 'live' AND (v.status <> 'setup' OR v.start_at IS NULL OR v.end_at IS NULL OR (NOT (v_is_admin AND v_override) AND (v_now < v.start_at - interval '24 hours' OR v_now > v.end_at + interval '24 hours'))) THEN RAISE EXCEPTION 'Festival edition cannot go live outside the launch window without explicit admin override'; END IF;
+  IF v.status = 'postponed' AND p_target_status IN ('planning','announced') AND (v.start_at IS NULL OR v.end_at IS NULL OR v.start_at <= v_now) THEN RAISE EXCEPTION 'Postponed festival edition requires new future dates before recovery'; END IF;
+  UPDATE public.festival_editions SET status=p_target_status, lifecycle_metadata = lifecycle_metadata || coalesce(p_metadata,'{}'::jsonb), announced_at = CASE WHEN p_target_status='announced' AND announced_at IS NULL THEN v_now ELSE announced_at END, on_sale_at = CASE WHEN p_target_status='on_sale' AND on_sale_at IS NULL THEN v_now ELSE on_sale_at END, live_at = CASE WHEN p_target_status='live' AND live_at IS NULL THEN v_now ELSE live_at END, completed_at = CASE WHEN p_target_status='completed' AND completed_at IS NULL THEN v_now ELSE completed_at END, cancelled_at = CASE WHEN p_target_status IN ('cancelled','abandoned') AND cancelled_at IS NULL THEN v_now ELSE cancelled_at END WHERE id=p_edition_id RETURNING * INTO v;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key) VALUES (p_edition_id, v_from, p_target_status, v_actor, p_reason, coalesce(p_metadata,'{}'::jsonb), p_idempotency_key) RETURNING id INTO v_event;
+  IF p_idempotency_key IS NOT NULL THEN INSERT INTO public.festival_edition_transition_requests(edition_id,idempotency_key,request_hash,target_status,reason,actor_profile_id,lifecycle_event_id) VALUES (p_edition_id,p_idempotency_key,v_hash,p_target_status,p_reason,v_actor,v_event); END IF;
+  RETURN v;
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.create_festival_edition(uuid, text, timestamptz, timestamptz, uuid, uuid, integer, integer, bigint, bigint, jsonb, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_festival_edition_planning(uuid, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.transition_festival_edition(uuid, public.festival_edition_status, text, jsonb, text) TO authenticated;
+
+DO $$ BEGIN PERFORM 1 FROM public.public_festival_editions LIMIT 1; END $$;

--- a/supabase/tests/festival_editions_harness.sql
+++ b/supabase/tests/festival_editions_harness.sql
@@ -1,20 +1,39 @@
--- Festival editions release-gate harness. Intended for psql after migrations are applied.
+BEGIN;
 DO $$
 DECLARE
   v_count integer;
+  v_private_cols text[] := ARRAY['budget_cents','treasury_allocation_cents','lifecycle_metadata','legacy_metadata','created_by'];
 BEGIN
   IF to_regclass('public.festival_editions') IS NULL THEN RAISE EXCEPTION 'festival_editions missing'; END IF;
   IF to_regclass('public.festival_edition_lifecycle_events') IS NULL THEN RAISE EXCEPTION 'lifecycle events missing'; END IF;
   IF to_regclass('public.festival_legacy_mappings') IS NULL THEN RAISE EXCEPTION 'legacy mappings missing'; END IF;
+  IF to_regclass('public.festival_edition_creation_requests') IS NULL THEN RAISE EXCEPTION 'creation idempotency table missing'; END IF;
+  IF to_regclass('public.festival_edition_transition_requests') IS NULL THEN RAISE EXCEPTION 'transition idempotency table missing'; END IF;
   IF to_regtype('public.festival_edition_status') IS NULL THEN RAISE EXCEPTION 'festival_edition_status enum missing'; END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='transition_festival_edition') THEN RAISE EXCEPTION 'transition RPC missing'; END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='create_festival_edition') THEN RAISE EXCEPTION 'create RPC missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='update_festival_edition_planning') THEN RAISE EXCEPTION 'planning update RPC missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='update_festival_edition_planning' AND oid::regprocedure::text LIKE '%jsonb%') THEN RAISE EXCEPTION 'planning patch RPC missing'; END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='festival_editions_festival_number_key') THEN RAISE EXCEPTION 'edition uniqueness missing'; END IF;
-  SELECT count(*) INTO v_count FROM public.festivals f WHERE NOT EXISTS (SELECT 1 FROM public.festival_editions e WHERE e.festival_id=f.id);
-  IF v_count <> 0 THEN RAISE EXCEPTION 'backfilled dedicated festivals missing editions: %', v_count; END IF;
-  SELECT count(*) INTO v_count FROM (SELECT legacy_source, legacy_id FROM public.festival_legacy_mappings GROUP BY 1,2 HAVING count(*) > 1) dupes;
-  IF v_count <> 0 THEN RAISE EXCEPTION 'duplicate legacy mappings found'; END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='public_festival_editions' AND column_name = ANY(v_private_cols)) THEN RAISE EXCEPTION 'public view exposes private columns'; END IF;
   IF EXISTS (SELECT 1 FROM pg_policies WHERE tablename='festival_editions' AND cmd IN ('INSERT','UPDATE','DELETE')) THEN RAISE EXCEPTION 'direct client edition writes should not have policies'; END IF;
-  RAISE NOTICE 'festival edition schema harness passed';
+  SELECT count(*) INTO v_count FROM (SELECT legacy_source, legacy_id FROM public.festival_legacy_mappings GROUP BY 1,2 HAVING count(*) > 1) dupes;
+  IF v_count <> 0 THEN RAISE EXCEPTION 'duplicate legacy source mappings found'; END IF;
 END $$;
+
+-- Fixture behaviour checks use existing schema functions/constraints without keeping data.
+DO $$
+DECLARE
+  v_festival uuid;
+  v_edition uuid;
+BEGIN
+  SELECT id INTO v_festival FROM public.festivals LIMIT 1;
+  IF v_festival IS NULL THEN RAISE NOTICE 'No festival fixtures are present; behavioural RPC checks skipped after catalogue assertions'; RETURN; END IF;
+  SELECT id INTO v_edition FROM public.festival_editions WHERE festival_id=v_festival ORDER BY edition_number DESC LIMIT 1;
+  IF v_edition IS NULL THEN RAISE EXCEPTION 'festival brand lacks a canonical edition'; END IF;
+  PERFORM public.validate_festival_edition_transition('concept','live');
+  IF public.validate_festival_edition_transition('concept','live') THEN RAISE EXCEPTION 'concept must not transition directly to live'; END IF;
+  IF public.validate_festival_edition_transition('completed','live') THEN RAISE EXCEPTION 'completed must not return to live'; END IF;
+  IF public.validate_festival_edition_transition('announced','announced') THEN RAISE EXCEPTION 'no-op transitions must not be lifecycle-valid'; END IF;
+  IF NOT public.validate_festival_edition_transition('announced','on_sale') THEN RAISE EXCEPTION 'announced should transition to on_sale'; END IF;
+END $$;
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Ensure the canonical `festival_editions` foundation is deployable and safe in databases that may already have applied the historical 2029 migration, and prevent view/function ordering, idempotency and owner-workflow regressions before further canonical migrations.
- Make public discovery reads and owner/admin reads strictly separate and prevent accidental exposure or mutation of private edition fields.
- Make edition planning updates and lifecycle transitions explicit, idempotent and concurrency-safe so retries and concurrent calls cannot corrupt history or produce duplicate events.
- Move owner UI writes and selection logic to target canonical editions so the run wizard no longer mutates legacy brand occurrence fields.

### Description

- Retain the historical `20291204090000_create_festival_editions.sql` and add an additive corrective migration `supabase/migrations/20291205090000_harden_festival_editions.sql` that recreates `is_public_festival_edition_status`, rebuilds `public.public_festival_editions` with `security_invoker`/`security_barrier` and a privacy comment, and re-applies grants.
- Add idempotency request tables and RLS policies: `festival_edition_creation_requests` and `festival_edition_transition_requests`, and harden `create_festival_edition` and `transition_festival_edition` to record request hashes and reject mismatched reuse.
- Replace `update_festival_edition_planning` `COALESCE` semantics with a JSONB patch RPC that distinguishes omitted keys from explicit `null`, performs final-row validation, and enforces planning locks for published states.
- Harden lifecycle validation (no-op transitions rejected at validation level, explicit admin override required for live outside window, timestamp-setting rules preserved) and ensure transition idempotency checks run with the edition locked and validated.
- Split frontend services into owner and public paths (`listFestivalEditionsForOwner` / `getFestivalEditionForOwner` vs `listPublicFestivalEditions` / `getPublicFestivalEdition`) and wire RPC idempotency/patch changes into `src/features/festivals/service.ts`.
- Add deterministic edition selection and UI helpers in `src/features/festivals/lifecycle.ts` (`selectManagedFestivalEdition`, `getFestivalEditionActionLabel`) and update owner screens (`FestivalRunWizard.tsx`, `FestivalOwnerConsole.tsx`) to: select the managed edition, save planning to the edition via the patched RPC, show canonical labels, and provide an explicit minimal `createFestivalEdition` action with an idempotency key when no edition exists.
- Add SQL harness `supabase/tests/festival_editions_harness.sql`, a static migration-order check script `scripts/festivals/check-edition-migration-order.mjs`, TypeScript unit tests `src/features/festivals/__tests__/managedEdition.test.ts` and small lifecycle test adjustments, and update documentation (`docs/festivals/EDITION_MIGRATION_NOTES.md`, `docs/festivals/CURRENT_STATE_AUDIT.md`, `docs/architecture/ADR-FESTIVAL-DOMAIN-CANONICALISATION.md`, `docs/festivals/festival-domain-inventory.json`).

### Testing

- `npm run typecheck` — succeeded (TypeScript `tsc --noEmit` passed).
- Migration ordering and static checks — `node scripts/festivals/check-edition-migration-order.mjs` succeeded and the new `supabase/migrations/20291205090000_harden_festival_editions.sql` was created to avoid renaming the 2029 migration.
- Repository JSON validation and quick static checks — `node -e "JSON.parse(...)"` and `git diff --check` passed.
- Database integration and SQL harness (`supabase db reset` and `psql "$SUPABASE_DB_URL" -f supabase/tests/festival_editions_harness.sql`) — not executed because the environment lacks the `supabase` CLI and `psql` binary.
- Unit tests and runtime checks (`vitest`, `eslint`, `vite`/build) — test runner or local dev dependencies were unavailable in this environment (`vitest: not found`, `@eslint/js` missing, `vite: not found`) so those steps were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58d1fc1fd4832598b26b1eaa404644)