### PR TITLE
Consolidate mobile shell routing and add mobile route registry

### DIFF
--- a/docs/mobile/mobile-consolidation-audit.md
+++ b/docs/mobile/mobile-consolidation-audit.md
@@ -1,0 +1,91 @@
+# RockMundo Mobile UI Phase 9 Consolidation Audit
+
+## Executive summary
+
+This audit covers the player-facing route table in `src/App.tsx`, the dedicated mobile shell in `src/mobile/shell`, and the current mobile pages in `src/mobile/pages`. Phase 9 consolidates mobile routing around a single route registry and a single shell decision so mobile players no longer receive the desktop FM shell, breadcrumbs, desktop-only gate, or desktop loading frame while authenticated routes resolve.
+
+## Route inventory
+
+### Public / unauthenticated routes
+
+| Route | Mobile behaviour | Notes |
+| --- | --- | --- |
+| `/` | Public responsive landing | Outside authenticated mobile shell. |
+| `/auth` | Public responsive auth | Outside authenticated mobile shell. |
+| `/about` | Public responsive content | Outside authenticated mobile shell. |
+| `/song/:songId` | Public song detail | Outside authenticated mobile shell. |
+
+### Authenticated dedicated mobile routes
+
+| Route pattern | Section | Component | Bottom nav owner | Shell |
+| --- | --- | --- | --- | --- |
+| `/mobile` | Home | `MobileHome` | Home | Mobile shell |
+| `/mobile/career`, `/mobile/career/:section`, `/mobile/career/:section/:id` | Career | `MobileCareerRoutes` | Career | Mobile shell |
+| `/mobile/social`, `/mobile/social/:section`, `/mobile/social/:section/:id` | Social | `MobileSocial` | Social | Mobile shell |
+| `/mobile/world`, `/mobile/world/:section`, `/mobile/world/:section/:id` | World | `MobileWorldPhase5` | World | Mobile shell |
+| `/mobile/me`, `/mobile/me/:section`, `/mobile/me/:section/:id` | Me | `MobileMe` | Me | Mobile shell |
+
+### Authenticated contained fallback groups
+
+All remaining authenticated player routes continue to use their existing page components, but on mobile they now mount inside `MobileShell` instead of `FMShell`. The fallback groups are tracked in `src/mobile/routeRegistry.ts` and are intentionally owned by a bottom navigation destination:
+
+| Group | Representative route patterns | Bottom nav owner | Fallback status |
+| --- | --- | --- | --- |
+| Home | `/home`, `/dashboard` | Home | Dedicated or redirect |
+| Career/music/live | `/career/*`, `/band/*`, `/gigs/*`, `/songwriting`, `/stage-practice`, `/recording-studio`, `/release-manager`, `/streaming-platforms`, `/music/*`, `/festivals/*`, `/skills`, `/education`, `/jobs` | Career | Contained desktop fallback where no dedicated route exists |
+| Social | `/social/*`, `/twaater/*`, `/inbox`, `/community/*`, `/player/*`, `/players/*`, `/gettit`, `/dikcok` | Social | Contained desktop fallback where no dedicated route exists |
+| World/business/market | `/world/*`, `/cities/*`, `/venues`, `/world-companies`, `/company/*`, `/gear-shop`, `/housing`, `/casino/*`, `/business/*`, `/labels/*` | World | Contained desktop fallback where no dedicated route exists |
+| Me/account/identity | `/character/*`, `/wellness`, `/inventory`, `/achievements`, `/my-character/*`, `/characters/*`, `/legacy`, `/journal`, `/premium-store`, `/blind-boxes/*` | Me | Contained desktop fallback where no dedicated route exists |
+
+Admin routes are deliberately excluded from player-facing mobile coverage; they remain desktop-managed.
+
+## Findings against the required audit checklist
+
+1. Authenticated player routes are enumerated by the central registry groups above.
+2. Unauthenticated routes are listed above and remain outside the authenticated shell.
+3. Dedicated mobile implementations exist for the five permanent destinations and their nested mobile route families.
+4. Remaining desktop components on mobile are documented as `wrapped-desktop` fallback routes and are contained in `MobileShell`.
+5. Mixed patterns remain primarily in high-complexity management/detail pages; they are tracked as fallbacks rather than silently leaking desktop shell chrome.
+6. Authenticated player mobile routes no longer bypass the mobile shell through `Layout`.
+7. The authenticated loading state now uses the mobile background and dynamic viewport height when mobile is active, preventing desktop shell flashes.
+8. Direct refresh is supported by route metadata ownership and `Outlet` rendering inside `MobileShell`.
+9. Nested route bottom-navigation ownership now comes from registry metadata instead of ad hoc path prefix checks.
+10. Browser-back behaviour is unchanged for page routes; transient sheet history remains a follow-up for domain sheets that do not route-link state.
+11. Known sheet/dialog history entries are limited to Radix/Vaul UI state and are not intentionally pushed to browser history.
+12. The authenticated `Layout` no longer mounts both `FMShell` and `MobileShell` for mobile routes.
+13. Hidden desktop tree duplicate requests are reduced by not mounting the desktop shell tree on mobile.
+14. Mobile breakpoint detection remains centralized in `useIsMobileDevice`; route ownership is centralized in `routeRegistry`.
+15. Horizontal overflow risk remains in contained fallback components and should be tested route-by-route with the smoke journey.
+16. Mobile shell content padding accounts for bottom nav, activity bar, and safe-area variables.
+17. Keyboard-sensitive composers remain covered by sticky composer classes in dedicated social routes; contained fallback forms need targeted follow-up.
+18. Dedicated mobile controls use labelled buttons where audited; fallback controls inherit existing accessibility state.
+19. Dedicated mobile pages use shared skeleton/empty/card primitives; fallback pages remain documented.
+20. Duplicate real-time subscription risk is reduced by preventing hidden desktop subscriptions from mounting beside mobile pages.
+21. Layout shift risk is reduced in shell loading; chart-heavy and media-heavy fallback routes remain follow-up candidates.
+22. Shared primitives are already present in `src/mobile/components`; this pass standardizes route and action ownership rather than creating another component set.
+23. Visual patterns are documented below for future route work.
+24. Common daily actions are centralized in `FabMenu`, ordered by registry section.
+25. Development-only fallback warnings now identify contained desktop fallback routes during mobile inspection.
+
+## Mobile page patterns
+
+- **Dashboard pages:** section header, current-status card, summary widgets, quick actions, grouped content, independent loading boundaries.
+- **List pages:** compact header, optional search/filter, mobile cards or compact rows, incremental loading, empty state, retry state.
+- **Detail pages:** entity header, status, primary information, expandable secondary sections, sticky actions where useful.
+- **Step flows:** title, progress, large selectable cards, inline validation, review, server revalidation, safe cancellation.
+- **Conversation pages:** compact header, incremental history, keyboard-safe composer, connection state, stable scroll-to-latest behaviour.
+
+## Navigation and shell decisions
+
+- `useIsMobileDevice` remains the only viewport/flag decision hook for the authenticated app.
+- `mobileRouteRegistry` owns destination, shell, activity-bar, FAB, fallback, and auth metadata.
+- `BottomNav` resolves active state from registry metadata, so nested routes such as `/twaater/notifications`, `/cities/:cityId`, `/release/:id`, and `/character/profile/edit` keep the correct primary destination.
+- `FabMenu` orders quick actions by registry destination instead of duplicating section string checks.
+
+## Remaining fallbacks and reasons
+
+High-complexity management, media, business, festival, company, casino, governance, and performance pages still use desktop page components. They are retained because replacing them safely would require domain-specific mobile redesign and fixture-heavy testing beyond this consolidation PR. They are now safely contained inside the mobile shell and produce development warnings when visited on mobile.
+
+## Follow-up recommendations
+
+The next mobile PR should focus on onboarding and returning-player guidance: mobile tutorials, contextual help, returning-player summary, notification-centre improvements, installable PWA behaviour, and mobile engagement polish rather than migrating more core route families.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,6 +30,7 @@ import MobileCareer from "@/mobile/pages/MobileCareer";
 import MobileSocial from "@/mobile/pages/MobileSocial";
 import MobileWorld from "@/mobile/pages/MobileWorld";
 import MobileMe from "@/mobile/pages/MobileMe";
+import { getMobileRouteMeta } from "@/mobile/routeRegistry";
 import { DesktopOnlyGate } from "@/components/DesktopOnlyGate";
 import { useGameCalendar } from "@/hooks/useGameCalendar";
 import { useAutoRecordingCompletion } from "@/hooks/useAutoRecordingCompletion";
@@ -95,9 +96,9 @@ const Layout = () => {
 
   if (authLoading || (dataLoading && user)) {
     return (
-      <div className="flex h-screen items-center justify-center bg-gradient-stage" role="status" aria-live="polite" aria-busy="true">
+      <div className={isMobile ? "rm-mobile flex min-h-[100dvh] items-center justify-center bg-background" : "flex h-screen items-center justify-center bg-gradient-stage"} role="status" aria-live="polite" aria-busy="true">
         <div className="text-center">
-          <div className="mx-auto mb-4 h-32 w-32 animate-spin rounded-full border-b-2 border-primary" aria-hidden="true"></div>
+          <div className={isMobile ? "mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-b-2 border-primary" : "mx-auto mb-4 h-32 w-32 animate-spin rounded-full border-b-2 border-primary"} aria-hidden="true"></div>
           <p className="text-lg font-oswald">Loading Rockmundo...</p>
         </div>
       </div>
@@ -108,13 +109,15 @@ const Layout = () => {
     return null;
   }
 
-  // Mobile users get redirected to the dedicated /mobile shell only from the
-  // primary landing routes. Deep-links to feature pages (from mobile quick
-  // actions, FAB, etc.) must render inline so buttons actually work — otherwise
-  // every tap bounces back to /mobile.
   if (isMobile) {
-    const path = typeof window !== "undefined" ? window.location.pathname : "";
-    const mobileSection = (() => {
+    const path = typeof window !== "undefined" ? window.location.pathname : "/";
+    const routeMeta = getMobileRouteMeta(path);
+
+    if (import.meta.env.DEV && routeMeta?.fallbackStatus === "wrapped-desktop") {
+      console.warn(`[RockMundo mobile] Contained desktop fallback rendered in MobileShell: ${path}`);
+    }
+
+    const dedicatedEntry = (() => {
       if (path === "/" || path === "/home" || path === "/index") return <MobileHome />;
       if (path === "/career" || path === "/career/overview") return <MobileCareer />;
       if (path === "/social" || path === "/social/overview") return <MobileSocial />;
@@ -123,14 +126,15 @@ const Layout = () => {
       return null;
     })();
 
-    if (mobileSection) {
-      return (
-        <MobileShell>
-          <CharacterGate>{mobileSection}</CharacterGate>
-        </MobileShell>
-      );
-    }
+    return (
+      <MobileShell>
+        <CharacterGate>
+          {dedicatedEntry ?? <Outlet />}
+        </CharacterGate>
+      </MobileShell>
+    );
   }
+
 
 
 

--- a/src/mobile/routeRegistry.test.ts
+++ b/src/mobile/routeRegistry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getMobileDestination, getMobileRouteMeta, mobileRouteAuditSummary, mobileRouteRegistry } from "./routeRegistry";
+
+describe("mobile route registry", () => {
+  it("tracks required dedicated mobile destinations", () => {
+    expect(getMobileRouteMeta("/mobile")?.fallbackStatus).toBe("dedicated");
+    expect(getMobileRouteMeta("/mobile/career/songs")?.bottomNav).toBe("career");
+    expect(getMobileRouteMeta("/mobile/social/messages/123")?.bottomNav).toBe("social");
+    expect(getMobileRouteMeta("/mobile/world/cities")?.bottomNav).toBe("world");
+    expect(getMobileRouteMeta("/mobile/me/settings")?.bottomNav).toBe("me");
+  });
+
+  it("maps nested desktop fallback routes to stable bottom-navigation owners", () => {
+    expect(getMobileDestination("/twaater/notifications")).toBe("social");
+    expect(getMobileDestination("/cities/berlin")).toBe("world");
+    expect(getMobileDestination("/release/abc123")).toBe("career");
+    expect(getMobileDestination("/character/profile/edit")).toBe("me");
+  });
+
+  it("keeps fallback routes inside the mobile shell metadata", () => {
+    const fallbacks = mobileRouteRegistry.filter((route) => route.fallbackStatus === "wrapped-desktop");
+    expect(fallbacks.length).toBeGreaterThan(20);
+    expect(fallbacks.every((route) => route.shell === "mobile")).toBe(true);
+    expect(fallbacks.every((route) => route.bottomNav)).toBe(true);
+  });
+
+  it("exposes an audit summary for docs and PR descriptions", () => {
+    expect(mobileRouteAuditSummary.authenticatedRoutesAudited).toBeGreaterThan(50);
+    expect(mobileRouteAuditSummary.unauthenticatedRoutesAudited).toBe(4);
+    expect(mobileRouteAuditSummary.dedicatedMobilePatterns).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/src/mobile/routeRegistry.ts
+++ b/src/mobile/routeRegistry.ts
@@ -1,0 +1,60 @@
+import { matchPath } from "react-router-dom";
+
+export type MobileDestination = "home" | "career" | "social" | "world" | "me";
+export type MobileFallbackStatus = "dedicated" | "wrapped-desktop" | "redirect" | "public";
+
+export interface MobileRouteMeta {
+  pattern: string;
+  section: MobileDestination;
+  bottomNav: MobileDestination;
+  auth: "public" | "player";
+  shell: "mobile" | "none";
+  component: string;
+  showActivityBar: boolean;
+  showFab: boolean;
+  fullscreenAllowed: boolean;
+  fallbackStatus: MobileFallbackStatus;
+  notes?: string;
+}
+
+const career = [
+  "/career/*", "/band/*", "/bands/*", "/gigs/*", "/jams", "/jam-sessions", "/rehearsals", "/setlists", "/tour-manager", "/travel", "/song-manager", "/songwriting", "/stage-practice", "/recording-studio", "/release-manager", "/streaming-platforms", "/streaming/*", "/music/*", "/music", "/music/charts", "/competitive-charts", "/country-charts", "/festivals/*", "/festivals", "/awards", "/jobs", "/employment", "/education", "/booking/*", "/skills", "/teaching", "/stage-setup", "/stage-equipment", "/band-crew", "/performance/*", "/open-mic/*", "/major-events/*", "/busking", "/pr", "/public-relations", "/offers-dashboard", "/statistics", "/progression", "/song-market", "/song-rankings", "/release/*"
+];
+const social = [
+  "/social/*", "/social", "/twaater/*", "/twaater", "/inbox", "/relationships", "/community/*", "/player/*", "/players/*", "/bands/finder", "/bands/browse", "/bands/search", "/band-rankings", "/band-fame-map", "/band/:bandId", "/gettit", "/dikcok"
+];
+const world = [
+  "/world/*", "/world", "/cities/*", "/cities", "/venues", "/world-companies", "/companies/*", "/company/*", "/landmarks", "/world-map", "/world-pulse", "/nightclubs", "/nightclub/*", "/marketplace", "/gear-shop", "/gear", "/clothing-shop", "/tattoo-parlour", "/housing", "/personal-vehicles", "/casino/*", "/casino", "/lottery", "/political-party/*", "/political-party", "/world-parliament", "/politics-career", "/business/*", "/business", "/my-companies", "/labels/*", "/labels", "/record-label", "/security-firm/*", "/merch-factory/*", "/logistics-company/*", "/venue-business/*", "/rehearsal-studio-business/*", "/recording-studio-business/*"
+];
+const me = [
+  "/me/*", "/me", "/character/*", "/character", "/wellness", "/inventory", "/avatar-designer", "/skin-store", "/clothing-designer", "/achievements", "/my-character/*", "/my-character", "/characters/*", "/characters", "/buy-character-slot", "/slot-purchase-success", "/underworld", "/legacy", "/family/*", "/journal", "/version-history", "/vip-*", "/premium-store", "/blind-boxes/*", "/blind-boxes", "/hall-of-immortals"
+];
+
+function meta(pattern: string, section: MobileDestination, fallbackStatus: MobileFallbackStatus = "wrapped-desktop"): MobileRouteMeta {
+  const dedicated = pattern.startsWith("/mobile") || fallbackStatus === "dedicated";
+  return { pattern, section, bottomNav: section, auth: "player", shell: "mobile", component: dedicated ? `Mobile${section}` : "Desktop route wrapped by MobileShell", showActivityBar: true, showFab: true, fullscreenAllowed: pattern.includes("perform") || pattern.includes("compose"), fallbackStatus, notes: dedicated ? "Dedicated mobile implementation." : "Contained fallback: desktop navigation, breadcrumbs and DesktopOnlyGate are not mounted on mobile." };
+}
+
+export const mobileRouteRegistry: MobileRouteMeta[] = [
+  meta("/mobile", "home", "dedicated"), meta("/mobile/career/*", "career", "dedicated"), meta("/mobile/social/*", "social", "dedicated"), meta("/mobile/world/*", "world", "dedicated"), meta("/mobile/me/*", "me", "dedicated"),
+  meta("/", "home", "public"), meta("/home", "home", "dedicated"), meta("/dashboard", "home", "redirect"),
+  ...career.map((p) => meta(p, "career")), ...social.map((p) => meta(p, "social")), ...world.map((p) => meta(p, "world")), ...me.map((p) => meta(p, "me")),
+  { pattern: "/auth", section: "home", bottomNav: "home", auth: "public", shell: "none", component: "Auth", showActivityBar: false, showFab: false, fullscreenAllowed: true, fallbackStatus: "public" },
+  { pattern: "/about", section: "home", bottomNav: "home", auth: "public", shell: "none", component: "About", showActivityBar: false, showFab: false, fullscreenAllowed: true, fallbackStatus: "public" },
+  { pattern: "/song/:songId", section: "career", bottomNav: "career", auth: "public", shell: "none", component: "PublicSong", showActivityBar: false, showFab: false, fullscreenAllowed: true, fallbackStatus: "public" },
+];
+
+export function getMobileRouteMeta(pathname: string): MobileRouteMeta | undefined {
+  return mobileRouteRegistry.find((route) => matchPath({ path: route.pattern, end: route.pattern === "/" || !route.pattern.endsWith("/*") }, pathname));
+}
+
+export function getMobileDestination(pathname: string): MobileDestination {
+  return getMobileRouteMeta(pathname)?.bottomNav ?? "home";
+}
+
+export const mobileRouteAuditSummary = {
+  authenticatedRoutesAudited: mobileRouteRegistry.filter((r) => r.auth === "player").length,
+  unauthenticatedRoutesAudited: mobileRouteRegistry.filter((r) => r.auth === "public").length,
+  dedicatedMobilePatterns: mobileRouteRegistry.filter((r) => r.fallbackStatus === "dedicated").length,
+  containedFallbackPatterns: mobileRouteRegistry.filter((r) => r.fallbackStatus === "wrapped-desktop").length,
+};

--- a/src/mobile/shell/BottomNav.tsx
+++ b/src/mobile/shell/BottomNav.tsx
@@ -1,6 +1,7 @@
 import { NavLink, useLocation } from "react-router-dom";
 import { Home, Guitar, Users, Globe2, User } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getMobileDestination } from "@/mobile/routeRegistry";
 
 export const mobilePrimaryNavItems = [
   { to: "/mobile", label: "Home", icon: Home, exact: true },
@@ -12,6 +13,7 @@ export const mobilePrimaryNavItems = [
 
 export const BottomNav = () => {
   const location = useLocation();
+  const activeDestination = getMobileDestination(location.pathname);
   return (
     <nav
       className="fixed bottom-0 inset-x-0 z-30 bg-background/95 backdrop-blur border-t border-border"
@@ -25,9 +27,8 @@ export const BottomNav = () => {
               to={to}
               end={exact}
               className={({ isActive }) => {
-                const primaryPath = to.replace("/mobile", "") || "/home";
-                const primaryActive = exact ? ["/mobile", "/home", "/"].includes(location.pathname) : location.pathname.startsWith(primaryPath);
-                const active = isActive || primaryActive;
+                const destination = (to.replace("/mobile/", "") || "home") as ReturnType<typeof getMobileDestination>;
+                const active = isActive || activeDestination === destination;
                 return cn("h-full w-full flex flex-col items-center justify-center gap-0.5 text-[10px] font-medium", active ? "text-primary" : "text-muted-foreground");
               }}
             >

--- a/src/mobile/shell/FabMenu.tsx
+++ b/src/mobile/shell/FabMenu.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { Plus, X, Music4, Plane, PenLine, Zap, MessageSquare, Mic2, CalendarClock, Twitter, Moon, Utensils, ShoppingBag, Backpack, Shirt, Trophy, GraduationCap } from "lucide-react";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { getMobileDestination } from "@/mobile/routeRegistry";
 
 type Action = {
   key: string;
@@ -14,13 +15,14 @@ type Action = {
 
 // Context-aware ordering: put likely actions first for the current section.
 function orderFor(pathname: string, base: Action[]): Action[] {
+  const destination = getMobileDestination(pathname);
   const bucket = (keys: string[]) => {
     const set = new Set(keys);
     return [...base.filter((a) => set.has(a.key)), ...base.filter((a) => !set.has(a.key))];
   };
-  if (pathname.startsWith("/mobile/career") || pathname.startsWith("/career")) return bucket(["practice", "write", "book-studio", "book-rehearsal", "jam"]);
-  if (pathname.startsWith("/mobile/social") || pathname.startsWith("/social")) return bucket(["message", "twaater", "jam"]);
-  if (pathname.startsWith("/mobile/world") || pathname.startsWith("/world")) return bucket(["travel", "shop", "book-studio"]);
+  if (destination === "career") return bucket(["practice", "write", "book-studio", "book-rehearsal", "jam"]);
+  if (destination === "social") return bucket(["message", "twaater", "jam"]);
+  if (destination === "world") return bucket(["travel", "shop", "book-studio"]);
   if (pathname.startsWith("/mobile/me/wellness")) return bucket(["eat", "sleep", "rest", "recovery-item"]);
   if (pathname.startsWith("/mobile/me/inventory")) return bucket(["use-item", "equip-item", "shop"]);
   if (pathname.startsWith("/mobile/me/wardrobe")) return bucket(["change-outfit", "shop"]);


### PR DESCRIPTION
### Motivation
- Finish Phase 9 consolidation by removing remaining desktop leakage on mobile and making every mobile route render in a single, consistent mobile shell with stable bottom-navigation ownership and quick-action behaviour.
- Centralise mobile detection and route ownership so nested routes, deep links and refresh/back behaviour map to the correct mobile destination and avoid double-rendering desktop components.
- Provide a concise audit and registry to make mobile coverage visible and to document remaining high-complexity fallbacks for tracked follow-ups.

### Description
- Added a central route registry at `src/mobile/routeRegistry.ts` that records route pattern, mobile section, bottom-nav ownership, shell/fallback status, FAB/activity-bar visibility and audit summary numbers.
- Updated authenticated layout in `src/components/Layout.tsx` to render the `MobileShell` for mobile devices (with a `dedicatedEntry` for the five top-level mobile experiences) and to use a mobile-friendly loading treatment and a development warning when a contained desktop fallback is rendered on mobile.
- Switched mobile navigation and quick-action logic to use the registry by updating `src/mobile/shell/BottomNav.tsx` and `src/mobile/shell/FabMenu.tsx` so bottom-nav active state and FAB ordering are driven by `getMobileDestination` from the registry.
- Added a documentation audit at `docs/mobile/mobile-consolidation-audit.md` summarising the route inventory, dedicated mobile coverage, contained fallbacks, page patterns and follow-up recommendations.
- Added a small regression test `src/mobile/routeRegistry.test.ts` that validates registry mappings and exposes an audit summary for use in further automation.

### Testing
- Ran project type checks with `tsc --noEmit` and the typecheck passed successfully.
- Added unit tests (`src/mobile/routeRegistry.test.ts`) but running `npm run test:unit` in this environment failed because `vitest` is not available (`sh: 1: vitest: not found`), so tests were added but could not be executed here.
- Attempted to run `npm run lint` but linting could not complete in this environment because ESLint dev-dependencies are not installed (`Cannot find package '@eslint/js'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59151ce6f08325b7bb8baa9fefb996)