### PR TITLE
fix(festivals): consolidate and stabilise festival administration

### DIFF
--- a/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
+++ b/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
@@ -1,0 +1,61 @@
+# Festival Admin Recovery Plan
+
+## Why the admin interface is being simplified
+
+Festival administration had drifted into multiple competing admin pages, duplicate catalogue tabs, manual database UUID entry, and technical support tooling shown as normal admin workflow. Phase 0 stabilises the current canonical implementation without restoring legacy `game_events` writes or rebuilding festival creation.
+
+## Canonical page and routes
+
+`src/pages/admin/FestivalsAdmin.tsx` is now the canonical festival administration page. The single primary destination is:
+
+- `/admin/festivals`
+
+Legacy or duplicate routes redirect to `/admin/festivals`:
+
+- `/admin/city-festivals`
+- `/admin/festival`
+- `/admin/festival-admin`
+
+Admin navigation should link directly to `/admin/festivals`.
+
+## New tab structure
+
+The visible top-level tabs are:
+
+1. **Overview** - festival catalogue, selected festival summary, selected edition summary, lifecycle status, dates, city, stage count, confirmed-band count, and system-check warnings.
+2. **Applications** - pending and reviewed application queues with accept/reject actions, offered payment, admin notes, and existing review functionality.
+3. **Operations** - edition-specific stages, staff, permits, insurance, and live-event tools behind secondary navigation.
+4. **Results** - outcomes and settlement for the selected edition.
+5. **Advanced** - legacy records, system checks, and audit logs with a warning that these are technical support tools.
+
+## Festival and edition selection
+
+Administrators select a festival from the canonical catalogue. Once a festival is selected, its editions are loaded through existing authorised festival management services. The page automatically selects the most relevant available edition in this order:
+
+1. Live edition.
+2. Upcoming/planning edition.
+3. Most recently completed edition.
+4. First available edition.
+
+Administrators no longer paste a festival edition UUID. When a festival has no edition, the UI displays `No edition has been created for this festival.` and a disabled `Create first edition` action. First-edition creation is deliberately deferred.
+
+## Retained functionality
+
+- Canonical festival catalogue and management links.
+- Application review queue, history, accept/reject actions, offered payment, and admin notes.
+- Edition-scoped operational tools for stages, staff, permits, insurance, live operation, outcomes, and settlement.
+- Legacy records, system checks, and audit log access in Advanced.
+
+## Deferred functionality
+
+- New festival creation.
+- New first-edition creation.
+- Full festival creation wizard.
+- Major schema replacement or legacy `game_events` restoration.
+
+## Planned next phases
+
+- **Phase 1:** Restore festival creation and first-edition setup.
+- **Phase 2:** Unified stage, slot, lineup and application management.
+- **Phase 3:** Commercial, staffing and operating decisions.
+- **Phase 4:** Live festival execution and outcomes.

--- a/docs/festivals/FESTIVAL_ADMIN_UI_GUIDE.md
+++ b/docs/festivals/FESTIVAL_ADMIN_UI_GUIDE.md
@@ -1,5 +1,14 @@
-# Festival admin UI guide
+# Festival Admin UI Guide
 
-Open `/admin/festivals`. Catalogue, brands, editions and lifecycle use the canonical catalogue workspace. Edition-specific operations require an edition id in the admin edition selector.
+Open `/admin/festivals` for festival administration. This is the only primary admin workspace for festivals; older festival admin routes redirect here.
 
-Admin-only screens include Data Health, Legacy Records and Audit. Data-health repairs use classified actions only; there is no generic SQL action. Legacy migration preview/apply failures are rendered in the card that launched the operation.
+The page flow is:
+
+1. View the Festivals catalogue.
+2. Select a festival.
+3. Select an available festival edition, or allow the page to select the most relevant edition automatically.
+4. Use Overview, Applications, Operations, Results, or Advanced.
+
+Administrators should not paste database UUIDs. If a festival has no edition, the page shows `No edition has been created for this festival.` and a disabled `Create first edition` placeholder until Phase 1 restores creation.
+
+Technical support tools such as legacy records, system checks, and audit logs are available from Advanced and are not required for normal festival management.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -301,7 +301,6 @@ const OpenMicNights = lazyWithRetry(() => import("./pages/OpenMicNights"));
 const PerformOpenMic = lazyWithRetry(() => import("./pages/PerformOpenMic"));
 const MajorEvents = lazyWithRetry(() => import("./pages/MajorEvents"));
 const PerformMajorEvent = lazyWithRetry(() => import("./pages/PerformMajorEvent"));
-const FestivalAdmin = lazyWithRetry(() => import("./pages/admin/FestivalAdmin"));
 const Education = lazyWithRetry(() => import("./pages/Education"));
 const RecordingStudio = lazyWithRetry(() => import("./pages/RecordingStudio"));
 const ReleaseManager = lazyWithRetry(() => import("./pages/ReleaseManager"));
@@ -836,6 +835,8 @@ function App() {
                     <Route path="admin/song-gifts" element={<AdminSongGifts />} />
                     <Route path="admin/music-videos" element={<MusicVideosAdmin />} />
                     <Route path="admin/festivals" element={<FestivalsAdminPage />} />
+                    <Route path="admin/festival" element={<Navigate to="/admin/festivals" replace />} />
+                    <Route path="admin/festival-admin" element={<Navigate to="/admin/festivals" replace />} />
                     <Route path="admin/city-festivals" element={<Navigate to="/admin/festivals" replace />} />
                     <Route path="admin/system-status" element={<SystemStatusAdminPage />} />
                     <Route path="admin/eurovision" element={<EurovisionAdminPage />} />

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -85,7 +85,6 @@ export const adminCategories: AdminCategory[] = [
     icon: Trophy,
     items: [
       { path: "/admin/festivals", label: "Festivals", description: "Festival system" },
-      { path: "/admin/city-festivals", label: "City Festival Editor", description: "Adjust capacity, ticket range, and run dates per city" },
       { path: "/admin/eurovision", label: "Eurovision", description: "Eurovision management" },
       { path: "/admin/awards", label: "Awards", description: "Award shows" },
       { path: "/admin/random-events", label: "Random Events", description: "In-game random events" },

--- a/src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts
+++ b/src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { formatFestivalMoney, mapCatalogueRow, mapOwnerEdition } from "../mappers";
 import { projectFestivalPermissions } from "../permissions";
+import { selectPreferredFestivalEdition } from "@/pages/admin/FestivalsAdmin";
 
 describe("canonical festival admin management", () => {
   it("keeps brand and edition fields separated in catalogue mapping", () => {
@@ -24,5 +25,16 @@ describe("canonical festival admin management", () => {
 
   it("formats currencies without assuming USD", () => {
     expect(formatFestivalMoney(12345, "EUR")).toContain("123");
+  });
+});
+
+describe("festival admin edition selection", () => {
+  const edition = (id: string, status: any, endAt = `2027-01-0${id}`) => ({ id, festivalId: "festival-1", title: id, editionNumber: Number(id), status, startAt: null, endAt, cityName: null, currencyCode: "USD" });
+
+  it("selects live, then upcoming, then most recently completed, then first available edition", () => {
+    expect(selectPreferredFestivalEdition([edition("1", "completed"), edition("2", "live")])?.id).toBe("2");
+    expect(selectPreferredFestivalEdition([edition("1", "completed"), edition("2", "planning")])?.id).toBe("2");
+    expect(selectPreferredFestivalEdition([edition("1", "completed", "2027-01-01"), edition("2", "completed", "2027-02-01")])?.id).toBe("2");
+    expect(selectPreferredFestivalEdition([edition("1", "cancelled")])?.id).toBe("1");
   });
 });

--- a/src/features/festivals/admin/components/AdminFestivalCatalogue.tsx
+++ b/src/features/festivals/admin/components/AdminFestivalCatalogue.tsx
@@ -13,28 +13,28 @@ export function AdminFestivalCatalogue() {
   const [filter, setFilter] = useState("");
   const rows = useMemo(() => (data ?? []).filter((row) => [row.brandName, row.cityName, row.lifecycleState].join(" ").toLowerCase().includes(filter.toLowerCase())), [data, filter]);
 
-  if (isLoading) return <Card><CardContent className="p-6">Loading canonical festival catalogue…</CardContent></Card>;
-  if (error) return <Card><CardContent className="p-6 text-destructive">Failed to load catalogue: {(error as Error).message}</CardContent></Card>;
+  if (isLoading) return <Card><CardContent className="p-6">Loading festivals…</CardContent></Card>;
+  if (error) return <Card><CardContent className="p-6 text-destructive">Festivals could not be loaded.</CardContent></Card>;
 
   const warnings = (data ?? []).reduce((sum, row) => sum + row.dataHealthWarnings.length, 0);
   return <div className="space-y-4">
     <div className="grid gap-3 md:grid-cols-4">
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Active brands</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.length ?? 0}</CardContent></Card>
+      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Festivals</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.length ?? 0}</CardContent></Card>
       <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Upcoming editions</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.filter((r) => r.nextEditionId).length ?? 0}</CardContent></Card>
       <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Live / settling</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.filter((r) => r.lifecycleState === "live" || r.lifecycleState === "settling").length ?? 0}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Data-health warnings</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{warnings}</CardContent></Card>
+      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">System check warnings</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{warnings}</CardContent></Card>
     </div>
-    <Input placeholder="Filter by brand, city or lifecycle…" value={filter} onChange={(event) => setFilter(event.target.value)} />
+    <Input placeholder="Filter by festival, city or lifecycle…" value={filter} onChange={(event) => setFilter(event.target.value)} />
     <div className="grid gap-3">
       {rows.map((row) => <Card key={row.festivalId}>
         <CardHeader><CardTitle className="flex flex-wrap items-center gap-2"><CalendarDays className="h-5 w-5" />{row.brandName}<Badge>{row.lifecycleState ?? "no edition"}</Badge>{row.dataHealthWarnings.length > 0 && <Badge variant="destructive"><AlertTriangle className="mr-1 h-3 w-3" />{row.dataHealthWarnings.length}</Badge>}</CardTitle></CardHeader>
         <CardContent className="grid gap-3 md:grid-cols-6">
           <div><p className="text-xs text-muted-foreground">City</p><p>{row.cityName ?? "—"}</p></div>
-          <div><p className="text-xs text-muted-foreground">Selected edition</p><p>{row.currentEditionTitle ?? row.currentEditionId ?? "Create edition"}</p></div>
+          <div><p className="text-xs text-muted-foreground">Festival edition</p><p>{row.currentEditionTitle ?? row.currentEditionId ?? "No edition"}</p></div>
           <div><p className="text-xs text-muted-foreground">Stages / contracts</p><p>{row.stageCount} / {row.activeContractCount}</p></div>
           <div><p className="text-xs text-muted-foreground">Sessions / outcomes</p><p>{row.performanceSessionCount} / {row.outcomeCount}</p></div>
           <div><p className="text-xs text-muted-foreground">Forecast</p><p>{formatFestivalMoney(row.projectedFinanceCents, row.currencyCode)}</p></div>
-          <div className="flex flex-wrap items-end gap-2"><Button asChild variant="outline" size="sm"><Link to={`/festivals/${row.festivalId}/manage/editions/${row.currentEditionId ?? row.nextEditionId ?? row.completedEditionId}`}><HeartPulse className="mr-2 h-4 w-4" />Open management</Link></Button><Button asChild variant="ghost" size="sm"><Link to={`/festivals/${row.festivalId}`}><ExternalLink className="mr-2 h-4 w-4" />View public page</Link></Button><Button asChild variant="ghost" size="sm"><Link to="/admin/festivals#health">View data health</Link></Button></div>
+          <div className="flex flex-wrap items-end gap-2">{(() => { const editionId = row.currentEditionId || row.nextEditionId || row.completedEditionId; return editionId ? <Button asChild variant="outline" size="sm"><Link to={`/festivals/${row.festivalId}/manage/editions/${editionId}`}><HeartPulse className="mr-2 h-4 w-4" />Open management</Link></Button> : <Button variant="outline" size="sm" disabled>Create first edition</Button>; })()}<Button asChild variant="ghost" size="sm"><Link to={`/festivals/${row.festivalId}`}><ExternalLink className="mr-2 h-4 w-4" />View public page</Link></Button><Button asChild variant="ghost" size="sm"><Link to="/admin/festivals#system-checks">View system checks</Link></Button></div>
           {row.dataHealthWarnings.length > 0 && <div className="md:col-span-6 text-sm text-muted-foreground">{row.dataHealthWarnings.map((issue) => issue.message).join(" · ")}</div>}
         </CardContent>
       </Card>)}

--- a/src/pages/admin/FestivalsAdmin.tsx
+++ b/src/pages/admin/FestivalsAdmin.tsx
@@ -1,18 +1,81 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { CheckCircle, ExternalLink, XCircle } from "lucide-react";
 import { AdminFestivalCatalogue } from "@/features/festivals/admin/components/AdminFestivalCatalogue";
 import { FestivalStageManagement } from "@/features/festivals/admin/components/FestivalStageManagement";
 import { FestivalStaffManagement } from "@/features/festivals/admin/components/FestivalStaffManagement";
 import { FestivalPermitManagement } from "@/features/festivals/admin/components/FestivalPermitManagement";
 import { FestivalInsuranceManagement } from "@/features/festivals/admin/components/FestivalInsuranceManagement";
-import { FestivalFinanceManagement } from "@/features/festivals/admin/components/FestivalFinanceManagement";
 import { FestivalOutcomesManagement } from "@/features/festivals/admin/components/FestivalOutcomesManagement";
 import { FestivalSettlementManagement } from "@/features/festivals/admin/components/FestivalSettlementManagement";
 import { FestivalDataHealthManagement } from "@/features/festivals/admin/components/FestivalDataHealthManagement";
 import { FestivalLegacyRecordsManagement } from "@/features/festivals/admin/components/FestivalLegacyRecordsManagement";
 import { FestivalAuditLog } from "@/features/festivals/admin/components/FestivalAuditLog";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAdminFestivalCatalogue, useOwnerFestivalEditions } from "@/features/festivals/admin/hooks";
+import type { AdminFestivalCatalogueRow, OwnerEditionOption } from "@/features/festivals/admin/types";
+import { useFestivalSlotApplications } from "@/hooks/useFestivalSlotApplications";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
 
-function EditionRequired({ editionId, children }: { editionId: string; children: React.ReactNode }) { return editionId ? <>{children}</> : <Card><CardHeader><CardTitle>Select an edition</CardTitle></CardHeader><CardContent className="text-sm text-muted-foreground">This admin section is edition-specific. Paste or select a canonical edition id before loading data.</CardContent></Card>; }
-export default function FestivalsAdminPage() { const [editionId,setEditionId]=useState(""); return <div className="space-y-6"><div><h1 className="text-3xl font-oswald">Festivals Administration</h1><p className="text-muted-foreground">Canonical brand, edition, operation, migration and audit management.</p></div><Card><CardHeader><CardTitle>Admin edition selection</CardTitle></CardHeader><CardContent><Input aria-label="Admin edition id" placeholder="Festival edition id for operational tabs" value={editionId} onChange={e=>setEditionId(e.target.value)} /></CardContent></Card><Tabs defaultValue="catalogue" className="space-y-4"><TabsList className="flex h-auto flex-wrap">{["catalogue","brands","editions","lifecycle","stages","staff","permits","insurance","live","outcomes","settlement","legacy","data-health","audit"].map(t=><TabsTrigger key={t} value={t}>{t.replace("data-health","Data Health").replace("legacy","Legacy Records")}</TabsTrigger>)}</TabsList><TabsContent value="catalogue"><AdminFestivalCatalogue /></TabsContent><TabsContent value="brands"><AdminFestivalCatalogue /></TabsContent><TabsContent value="editions"><AdminFestivalCatalogue /></TabsContent><TabsContent value="lifecycle"><AdminFestivalCatalogue /></TabsContent><TabsContent value="stages"><EditionRequired editionId={editionId}><FestivalStageManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="staff"><EditionRequired editionId={editionId}><FestivalStaffManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="permits"><EditionRequired editionId={editionId}><FestivalPermitManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="insurance"><EditionRequired editionId={editionId}><FestivalInsuranceManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="live"><EditionRequired editionId={editionId}><FestivalOutcomesManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="outcomes"><EditionRequired editionId={editionId}><FestivalOutcomesManagement editionId={editionId} scope="admin" /></EditionRequired></TabsContent><TabsContent value="settlement"><EditionRequired editionId={editionId}><FestivalSettlementManagement editionId={editionId} /></EditionRequired></TabsContent><TabsContent value="legacy"><FestivalLegacyRecordsManagement /></TabsContent><TabsContent value="data-health"><FestivalDataHealthManagement /></TabsContent><TabsContent value="audit"><FestivalAuditLog /></TabsContent></Tabs></div> }
+export function selectPreferredFestivalEdition(editions: OwnerEditionOption[]) {
+  const ranked = [
+    (e: OwnerEditionOption) => e.status === "live",
+    (e: OwnerEditionOption) => ["applications_open", "booking", "announced", "on_sale", "setup", "planning", "concept"].includes(e.status),
+    (e: OwnerEditionOption) => e.status === "completed",
+    () => true,
+  ];
+  for (const match of ranked) {
+    const candidates = editions.filter(match).sort((a, b) => String(b.endAt ?? b.startAt ?? "").localeCompare(String(a.endAt ?? a.startAt ?? "")));
+    if (candidates[0]) return candidates[0];
+  }
+  return undefined;
+}
+
+function EditionRequired({ editionId, children }: { editionId?: string; children: React.ReactNode }) {
+  if (editionId) return <>{children}</>;
+  return <Card><CardHeader><CardTitle>Festival operations are unavailable until an edition is selected.</CardTitle></CardHeader><CardContent className="space-y-3 text-sm text-muted-foreground"><p>Select a festival edition above before loading edition-specific tools.</p><Button disabled>Create first edition</Button></CardContent></Card>;
+}
+
+function FestivalEditionSelector({ rows, selectedFestivalId, setSelectedFestivalId, selectedEditionId, setSelectedEditionId }: { rows: AdminFestivalCatalogueRow[]; selectedFestivalId?: string; setSelectedFestivalId: (id: string) => void; selectedEditionId?: string; setSelectedEditionId: (id: string) => void }) {
+  const editionsQuery = useOwnerFestivalEditions(selectedFestivalId);
+  const editions = editionsQuery.data ?? [];
+  useEffect(() => {
+    if (!selectedFestivalId && rows[0]) setSelectedFestivalId(rows[0].festivalId);
+  }, [rows, selectedFestivalId, setSelectedFestivalId]);
+  useEffect(() => {
+    if (!selectedFestivalId) return;
+    if (editions.length === 0) { setSelectedEditionId(""); return; }
+    if (!editions.some((edition) => edition.id === selectedEditionId)) setSelectedEditionId(selectPreferredFestivalEdition(editions)?.id ?? "");
+  }, [editions, selectedFestivalId, selectedEditionId, setSelectedEditionId]);
+
+  return <Card><CardHeader><CardTitle>Festival and edition selection</CardTitle><CardDescription>Choose the festival workspace. The most relevant edition is selected automatically when possible.</CardDescription></CardHeader><CardContent className="grid gap-4 md:grid-cols-2"><div><Label>Festival</Label><Select value={selectedFestivalId} onValueChange={setSelectedFestivalId}><SelectTrigger><SelectValue placeholder="Select a festival" /></SelectTrigger><SelectContent>{rows.map((row) => <SelectItem key={row.festivalId} value={row.festivalId}>{row.brandName}</SelectItem>)}</SelectContent></Select></div><div><Label>Festival edition</Label><Select value={selectedEditionId} onValueChange={setSelectedEditionId} disabled={editionsQuery.isLoading || editions.length === 0}><SelectTrigger><SelectValue placeholder={editions.length ? "Select an edition" : "No edition available"} /></SelectTrigger><SelectContent>{editions.map((edition) => <SelectItem key={edition.id} value={edition.id}>{edition.title} · {edition.status}</SelectItem>)}</SelectContent></Select>{editionsQuery.isLoading && <p className="mt-2 text-sm text-muted-foreground">Loading festival editions…</p>}{editionsQuery.error && <p className="mt-2 text-sm text-destructive">Festival editions could not be loaded.</p>}{!editionsQuery.isLoading && editions.length === 0 && <p className="mt-2 text-sm text-muted-foreground">No edition has been created for this festival.</p>}</div></CardContent></Card>;
+}
+
+function Overview({ selectedFestival, selectedEdition }: { selectedFestival?: AdminFestivalCatalogueRow; selectedEdition?: OwnerEditionOption }) {
+  if (!selectedFestival) return <Card><CardContent className="p-6 text-muted-foreground">No festivals have been created yet.</CardContent></Card>;
+  return <div className="space-y-4"><AdminFestivalCatalogue /><Card><CardHeader><CardTitle>Selected festival summary</CardTitle><CardDescription>Lifecycle controls are shown after a valid festival edition is selected.</CardDescription></CardHeader><CardContent className="grid gap-3 md:grid-cols-4"><p><span className="text-muted-foreground">Festival</span><br /><b>{selectedFestival.brandName}</b></p><p><span className="text-muted-foreground">City</span><br /><b>{selectedFestival.cityName ?? "Not set"}</b></p><p><span className="text-muted-foreground">Lifecycle</span><br /><b>{selectedEdition?.status ?? selectedFestival.lifecycleState ?? "No edition"}</b></p><p><span className="text-muted-foreground">Dates</span><br /><b>{selectedEdition?.startAt ?? "Not scheduled"} → {selectedEdition?.endAt ?? "Not scheduled"}</b></p><p><span className="text-muted-foreground">Stages</span><br /><b>{selectedFestival.stageCount}</b></p><p><span className="text-muted-foreground">Confirmed bands</span><br /><b>{selectedFestival.activeContractCount}</b></p><p><span className="text-muted-foreground">System check warnings</span><br /><b>{selectedFestival.dataHealthWarnings.length}</b></p><p><span className="text-muted-foreground">Edition</span><br /><b>{selectedEdition?.title ?? "No edition has been created for this festival."}</b></p></CardContent></Card></div>;
+}
+
+function Applications({ festivalId }: { festivalId?: string }) {
+  const [selectedApplication, setSelectedApplication] = useState<any>(null); const [adminNotes, setAdminNotes] = useState(""); const [offeredPayment, setOfferedPayment] = useState("");
+  const { applications, isLoading, reviewApplication, isReviewing } = useFestivalSlotApplications(festivalId);
+  const pending = applications?.filter((a) => a.status === "pending") ?? []; const reviewed = applications?.filter((a) => a.status !== "pending") ?? [];
+  const submit = (status: "accepted" | "rejected") => { if (!selectedApplication) return; reviewApplication({ applicationId: selectedApplication.id, status, adminNotes: adminNotes || undefined, offeredPayment: offeredPayment ? Number(offeredPayment) : undefined }); setSelectedApplication(null); setAdminNotes(""); setOfferedPayment(""); };
+  if (!festivalId) return <Card><CardContent className="p-6 text-muted-foreground">Select a festival before reviewing applications.</CardContent></Card>;
+  if (isLoading) return <Card><CardContent className="p-6">Loading festival applications…</CardContent></Card>;
+  return <div className="space-y-4"><Card><CardHeader><CardTitle>Pending applications</CardTitle><CardDescription>Review offered payment and add admin notes before accepting or rejecting.</CardDescription></CardHeader><CardContent className="space-y-3">{pending.length === 0 ? <p className="text-muted-foreground">No pending applications.</p> : pending.map((app) => <div key={app.id} className="flex flex-wrap items-center justify-between gap-3 rounded border p-3"><div><b>{app.band?.name ?? "Unknown band"}</b><p className="text-sm text-muted-foreground">{app.festival?.name ?? "Selected festival"} · {app.slot_type}</p></div><Button size="sm" onClick={() => setSelectedApplication(app)}>Review</Button></div>)}</CardContent></Card><Card><CardHeader><CardTitle>Reviewed application history</CardTitle></CardHeader><CardContent>{reviewed.length === 0 ? <p className="text-muted-foreground">No reviewed applications.</p> : reviewed.map((app) => <p key={app.id} className="flex justify-between border-b py-2"><span>{app.band?.name ?? "Unknown band"}</span><Badge>{app.status}</Badge></p>)}</CardContent></Card><Dialog open={!!selectedApplication} onOpenChange={(open) => !open && setSelectedApplication(null)}><DialogContent><DialogHeader><DialogTitle>Review application</DialogTitle></DialogHeader><Label>Offered payment<Input type="number" value={offeredPayment} onChange={(e) => setOfferedPayment(e.target.value)} /></Label><Label>Admin notes<Textarea value={adminNotes} onChange={(e) => setAdminNotes(e.target.value)} /></Label><div className="flex gap-2"><Button disabled={isReviewing} onClick={() => submit("accepted")}><CheckCircle className="mr-2 h-4 w-4" />Accept</Button><Button disabled={isReviewing} variant="destructive" onClick={() => submit("rejected")}><XCircle className="mr-2 h-4 w-4" />Reject</Button></div></DialogContent></Dialog></div>;
+}
+
+export default function FestivalsAdminPage() {
+  const catalogue = useAdminFestivalCatalogue(); const rows = catalogue.data ?? [];
+  const [selectedFestivalId, setSelectedFestivalId] = useState(""); const [selectedEditionId, setSelectedEditionId] = useState("");
+  const editionsQuery = useOwnerFestivalEditions(selectedFestivalId); const selectedFestival = rows.find((row) => row.festivalId === selectedFestivalId); const selectedEdition = editionsQuery.data?.find((edition) => edition.id === selectedEditionId);
+  return <div className="space-y-6"><div><h1 className="text-3xl font-oswald">Festivals Administration</h1><p className="text-muted-foreground">Manage festivals, applications, operations, results and technical support tools from one workspace.</p></div>{catalogue.isLoading && <Card><CardContent className="p-6">Loading festivals…</CardContent></Card>}{catalogue.error && <Card><CardContent className="p-6 text-destructive">Festivals could not be loaded. You may not have permission to manage festivals.</CardContent></Card>}{!catalogue.isLoading && !catalogue.error && <FestivalEditionSelector rows={rows} selectedFestivalId={selectedFestivalId} setSelectedFestivalId={setSelectedFestivalId} selectedEditionId={selectedEditionId} setSelectedEditionId={setSelectedEditionId} />}<Tabs defaultValue="overview" className="space-y-4"><TabsList className="flex h-auto flex-wrap"><TabsTrigger value="overview">Overview</TabsTrigger><TabsTrigger value="applications">Applications</TabsTrigger><TabsTrigger value="operations">Operations</TabsTrigger><TabsTrigger value="results">Results</TabsTrigger><TabsTrigger value="advanced">Advanced</TabsTrigger></TabsList><TabsContent value="overview"><Overview selectedFestival={selectedFestival} selectedEdition={selectedEdition} /></TabsContent><TabsContent value="applications"><Applications festivalId={selectedFestivalId} /></TabsContent><TabsContent value="operations"><EditionRequired editionId={selectedEditionId}><Tabs defaultValue="stages"><TabsList className="flex h-auto flex-wrap"><TabsTrigger value="stages">Stages</TabsTrigger><TabsTrigger value="staff">Staff</TabsTrigger><TabsTrigger value="permits">Permits</TabsTrigger><TabsTrigger value="insurance">Insurance</TabsTrigger><TabsTrigger value="live">Live event</TabsTrigger></TabsList><TabsContent value="stages"><FestivalStageManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="staff"><FestivalStaffManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="permits"><FestivalPermitManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="insurance"><FestivalInsuranceManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="live"><FestivalOutcomesManagement editionId={selectedEditionId} scope="admin" /></TabsContent></Tabs></EditionRequired></TabsContent><TabsContent value="results"><EditionRequired editionId={selectedEditionId}><FestivalOutcomesManagement editionId={selectedEditionId} scope="admin" /><FestivalSettlementManagement editionId={selectedEditionId} /></EditionRequired></TabsContent><TabsContent value="advanced"><Card><CardHeader><CardTitle>Advanced technical support tools</CardTitle><CardDescription>These tools are for migration support, system checks and audit review. They are not required for normal festival management.</CardDescription></CardHeader><CardContent><Button asChild variant="outline"><Link to="/admin/festivals#system-checks"><ExternalLink className="mr-2 h-4 w-4" />System checks</Link></Button></CardContent></Card><FestivalLegacyRecordsManagement /><FestivalDataHealthManagement /><FestivalAuditLog /></TabsContent></Tabs></div>;
+}


### PR DESCRIPTION
### Motivation
- Unify multiple competing festival admin screens into one clear canonical workspace to remove duplicate routes and confusing technical UX. 
- Remove the manual free-text edition UUID workflow and prevent malformed edition management links to avoid broken navigation and operator errors. 
- Reduce visible surface area of admin tooling so normal management tasks are primary and technical/support tools are behind an Advanced section.

### Description
- Make `src/pages/admin/FestivalsAdmin.tsx` the canonical festival admin page and replace the manual edition-id input with a `FestivalEditionSelector` that loads editions via `useOwnerFestivalEditions` and auto-selects an edition using `selectPreferredFestivalEdition` (live → upcoming → most recent completed → first). 
- Add an `EditionRequired` guard so edition-specific tools in Operations/Results only load when a valid edition is selected and show a disabled `Create first edition` placeholder when none exists. 
- Update `src/features/festivals/admin/components/AdminFestivalCatalogue.tsx` to use user-friendly labels, system-check wording, and null-safe management links that only render `Open management` when a valid edition id exists, otherwise rendering a disabled `Create first edition` button. 
- Consolidate routing and navigation so `/admin/festivals` is the single primary route and legacy/duplicate routes (`/admin/city-festivals`, `/admin/festival`, `/admin/festival-admin`) redirect to it, and remove the duplicate admin nav entry for the city editor; also add docs under `docs/festivals` outlining the recovery plan and UI guide. 
- Add a unit test exercising the automatic edition-selection helper and integrate the helper into existing admin tests to protect the selection priority behaviour.

### Testing
- Ran TypeScript checks with `npm run typecheck`, which completed successfully. 
- Attempted to run the festival unit tests (`vitest`) but the test runner was unavailable in the environment so the unit test run could not be executed. 
- Attempted `npm install` to restore dev/test/build tooling but installation failed due to a registry `403` when fetching `@react-three/fiber`, preventing `vitest`, `vite`, and ESLint plugin resolution. 
- `npm run lint` and `npm run build` could not be completed due to missing local dev dependencies (`@eslint/js`, `vite`) so lint and production build were not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59e78e51c48325b8c8f8c2bf7a32ef)