### PR TITLE
feat(festivals): restore canonical festival creation workflow

### DIFF
--- a/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
+++ b/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Why the admin interface is being simplified
 
-Festival administration had drifted into multiple competing admin pages, duplicate catalogue tabs, manual database UUID entry, and technical support tooling shown as normal admin workflow. Phase 0 stabilises the current canonical implementation without restoring legacy `game_events` writes or rebuilding festival creation.
+Festival administration had drifted into multiple competing admin pages, duplicate catalogue tabs, manual database UUID entry, and technical support tooling shown as normal admin workflow. Phase 0 (completed) stabilises the current canonical implementation without restoring legacy `game_events` writes or rebuilding festival creation.
 
 ## Canonical page and routes
 
@@ -37,7 +37,7 @@ Administrators select a festival from the canonical catalogue. Once a festival i
 3. Most recently completed edition.
 4. First available edition.
 
-Administrators no longer paste a festival edition UUID. When a festival has no edition, the UI displays `No edition has been created for this festival.` and a disabled `Create first edition` action. First-edition creation is deliberately deferred.
+Administrators no longer paste a festival edition UUID. When a festival has no edition, the UI displays `No edition has been created for this festival.` and the `Create first edition` action opens the guided edition setup workflow.
 
 ## Retained functionality
 
@@ -46,16 +46,16 @@ Administrators no longer paste a festival edition UUID. When a festival has no e
 - Edition-scoped operational tools for stages, staff, permits, insurance, live operation, outcomes, and settlement.
 - Legacy records, system checks, and audit log access in Advanced.
 
-## Deferred functionality
+## Completed Phase 1 functionality
 
 - New festival creation.
 - New first-edition creation.
-- Full festival creation wizard.
-- Major schema replacement or legacy `game_events` restoration.
+- Guided festival creation wizard.
+- Transactional canonical RPCs without restoring legacy `game_events` festival writes.
 
 ## Planned next phases
 
-- **Phase 1:** Restore festival creation and first-edition setup.
+- **Phase 1 (completed by this PR):** Restore festival creation and first-edition setup.
 - **Phase 2:** Unified stage, slot, lineup and application management.
 - **Phase 3:** Commercial, staffing and operating decisions.
 - **Phase 4:** Live festival execution and outcomes.

--- a/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
+++ b/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
@@ -1,0 +1,25 @@
+# Festival Creation Workflow
+
+Administrators create festivals from `/admin/festivals` with the **Create Festival** action. The wizard uses user-facing language for festival identity, first event, location, dates, stages, tickets, commercial setup and lifecycle status; it does not ask administrators for database IDs.
+
+## Flows
+
+- **Create Festival** creates the permanent festival and the first edition in one server transaction.
+- **Create first edition** opens the same wizard with the permanent festival identity locked and creates setup for an existing festival with no editions.
+- **Add new edition** creates a later edition for an existing festival. Safe setup can be entered from blank; contracts, applications, financial transactions, settlement records, outcomes, performance sessions and audit history are not copied silently.
+
+## Fields and validation
+
+The wizard validates required identity, future edition timestamps, application windows, city and venue selection, capacity, ticket ranges, at least one uniquely named stage, positive stage capacities, minimum five-minute changeovers, supported currency and supported time zone. Money is entered as major units and sent as integer minor units.
+
+## Server transaction
+
+`admin_create_festival_with_first_edition` and `admin_create_festival_edition_with_setup` are authenticated admin RPCs. They validate admin authority, city and venue references, dates, currency, stages and ticket ranges; create the festival or edition; insert initial stages; persist commercial setup on the edition metadata/budget fields; write lifecycle history through the canonical edition creation path; and write admin audit records. Any exception rolls back the full aggregate.
+
+## Idempotency and ownership
+
+The wizard generates one stable idempotency key when it opens. Retries reuse the same key. The server stores a request hash and returns the original aggregate for identical retries, while rejecting materially different payloads. Administrator-created festivals are platform/admin created with no arbitrary browser-supplied owner profile assignment.
+
+## Lifecycle and recovery
+
+New editions start in `planning`. Final submission is disabled while pending, form data is retained after recoverable failures, and the success state offers continuation, management workspace and public page links. If a later catalogue refresh fails, the returned route remains available from the creation result.

--- a/src/features/festivals/admin/__tests__/festivalCreationValidation.test.ts
+++ b/src/features/festivals/admin/__tests__/festivalCreationValidation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { defaultFestivalCreationDraft, hasCreationErrors, stagePreset, validateFestivalCreationDraft } from "../creationValidation";
+
+describe("festival creation validation", () => {
+  it("requires festival identity fields", () => {
+    const draft = defaultFestivalCreationDraft("create_festival");
+    expect(validateFestivalCreationDraft(draft).identity).toContain("Festival name is required.");
+  });
+
+  it("accepts a complete future draft and keeps stable idempotency", () => {
+    const draft = defaultFestivalCreationDraft("create_festival");
+    draft.identity.name = "Test Fest";
+    draft.identity.shortDescription = "Short";
+    draft.identity.fullDescription = "Full";
+    draft.identity.primaryGenres = ["Rock"];
+    draft.edition.title = "Test Fest 2027";
+    draft.location.cityId = "city-1";
+    const key = draft.idempotencyKey;
+    expect(hasCreationErrors(validateFestivalCreationDraft(draft))).toBe(false);
+    expect(draft.idempotencyKey).toBe(key);
+  });
+
+  it("rejects invalid dates, ticket ranges and duplicate stages", () => {
+    const draft = defaultFestivalCreationDraft("create_festival");
+    draft.identity.name = "Bad Fest";
+    draft.identity.shortDescription = "Short";
+    draft.identity.fullDescription = "Full";
+    draft.identity.primaryGenres = ["Rock"];
+    draft.edition.title = "Bad Fest";
+    draft.edition.endAt = draft.edition.startAt;
+    draft.location.cityId = "city-1";
+    draft.location.minTicketPriceCents = 9000;
+    draft.location.maxTicketPriceCents = 1000;
+    draft.stages = [stagePreset("small", 1000)[0], stagePreset("small", 1000)[0]];
+    const errors = validateFestivalCreationDraft(draft);
+    expect(errors.edition).toContain("End must be after start.");
+    expect(errors.location).toContain("Minimum ticket price cannot exceed maximum ticket price.");
+    expect(errors.stages).toContain("Stage names must be unique within the event.");
+  });
+
+  it("populates stage presets", () => {
+    expect(stagePreset("small", 1000)).toHaveLength(1);
+    expect(stagePreset("medium", 1000).map((stage) => stage.name)).toEqual(["Main Stage", "Second Stage"]);
+    expect(stagePreset("large", 1000).map((stage) => stage.name)).toEqual(["Main Stage", "Second Stage", "New Music Stage"]);
+  });
+});

--- a/src/features/festivals/admin/components/AdminFestivalCatalogue.tsx
+++ b/src/features/festivals/admin/components/AdminFestivalCatalogue.tsx
@@ -3,41 +3,270 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { AlertTriangle, CalendarDays, ExternalLink, HeartPulse } from "lucide-react";
+import {
+  AlertTriangle,
+  CalendarDays,
+  ExternalLink,
+  HeartPulse,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 import { useAdminFestivalCatalogue } from "../hooks";
 import { formatFestivalMoney } from "../mappers";
 
-export function AdminFestivalCatalogue() {
+export function AdminFestivalCatalogue({
+  selectedFestivalId,
+  onSelectFestival,
+  onCreateFestival,
+  onCreateEdition,
+  onOpenManagement,
+}: {
+  selectedFestivalId?: string;
+  onSelectFestival?: (festivalId: string) => void;
+  onCreateFestival?: () => void;
+  onCreateEdition?: (
+    festivalId: string,
+    mode: "create_first_edition" | "add_edition",
+  ) => void;
+  onOpenManagement?: (festivalId: string, editionId: string) => void;
+} = {}) {
   const { data, isLoading, error } = useAdminFestivalCatalogue();
   const [filter, setFilter] = useState("");
-  const rows = useMemo(() => (data ?? []).filter((row) => [row.brandName, row.cityName, row.lifecycleState].join(" ").toLowerCase().includes(filter.toLowerCase())), [data, filter]);
+  const rows = useMemo(
+    () =>
+      (data ?? []).filter((row) =>
+        [row.brandName, row.cityName, row.lifecycleState]
+          .join(" ")
+          .toLowerCase()
+          .includes(filter.toLowerCase()),
+      ),
+    [data, filter],
+  );
 
-  if (isLoading) return <Card><CardContent className="p-6">Loading festivals…</CardContent></Card>;
-  if (error) return <Card><CardContent className="p-6 text-destructive">Festivals could not be loaded.</CardContent></Card>;
-
-  const warnings = (data ?? []).reduce((sum, row) => sum + row.dataHealthWarnings.length, 0);
-  return <div className="space-y-4">
-    <div className="grid gap-3 md:grid-cols-4">
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Festivals</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.length ?? 0}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Upcoming editions</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.filter((r) => r.nextEditionId).length ?? 0}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Live / settling</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{data?.filter((r) => r.lifecycleState === "live" || r.lifecycleState === "settling").length ?? 0}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">System check warnings</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{warnings}</CardContent></Card>
-    </div>
-    <Input placeholder="Filter by festival, city or lifecycle…" value={filter} onChange={(event) => setFilter(event.target.value)} />
-    <div className="grid gap-3">
-      {rows.map((row) => <Card key={row.festivalId}>
-        <CardHeader><CardTitle className="flex flex-wrap items-center gap-2"><CalendarDays className="h-5 w-5" />{row.brandName}<Badge>{row.lifecycleState ?? "no edition"}</Badge>{row.dataHealthWarnings.length > 0 && <Badge variant="destructive"><AlertTriangle className="mr-1 h-3 w-3" />{row.dataHealthWarnings.length}</Badge>}</CardTitle></CardHeader>
-        <CardContent className="grid gap-3 md:grid-cols-6">
-          <div><p className="text-xs text-muted-foreground">City</p><p>{row.cityName ?? "—"}</p></div>
-          <div><p className="text-xs text-muted-foreground">Festival edition</p><p>{row.currentEditionTitle ?? row.currentEditionId ?? "No edition"}</p></div>
-          <div><p className="text-xs text-muted-foreground">Stages / contracts</p><p>{row.stageCount} / {row.activeContractCount}</p></div>
-          <div><p className="text-xs text-muted-foreground">Sessions / outcomes</p><p>{row.performanceSessionCount} / {row.outcomeCount}</p></div>
-          <div><p className="text-xs text-muted-foreground">Forecast</p><p>{formatFestivalMoney(row.projectedFinanceCents, row.currencyCode)}</p></div>
-          <div className="flex flex-wrap items-end gap-2">{(() => { const editionId = row.currentEditionId || row.nextEditionId || row.completedEditionId; return editionId ? <Button asChild variant="outline" size="sm"><Link to={`/festivals/${row.festivalId}/manage/editions/${editionId}`}><HeartPulse className="mr-2 h-4 w-4" />Open management</Link></Button> : <Button variant="outline" size="sm" disabled>Create first edition</Button>; })()}<Button asChild variant="ghost" size="sm"><Link to={`/festivals/${row.festivalId}`}><ExternalLink className="mr-2 h-4 w-4" />View public page</Link></Button><Button asChild variant="ghost" size="sm"><Link to="/admin/festivals#system-checks">View system checks</Link></Button></div>
-          {row.dataHealthWarnings.length > 0 && <div className="md:col-span-6 text-sm text-muted-foreground">{row.dataHealthWarnings.map((issue) => issue.message).join(" · ")}</div>}
+  if (isLoading)
+    return (
+      <Card>
+        <CardContent className="p-6">Loading festivals…</CardContent>
+      </Card>
+    );
+  if (error)
+    return (
+      <Card>
+        <CardContent className="p-6 text-destructive">
+          Festivals could not be loaded.
         </CardContent>
-      </Card>)}
+      </Card>
+    );
+
+  const warnings = (data ?? []).reduce(
+    (sum, row) => sum + row.dataHealthWarnings.length,
+    0,
+  );
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button onClick={onCreateFestival}>Create Festival</Button>
+      </div>
+      <div className="grid gap-3 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Festivals</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {data?.length ?? 0}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Upcoming editions</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {data?.filter((r) => r.nextEditionId).length ?? 0}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Live / settling</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {data?.filter(
+              (r) =>
+                r.lifecycleState === "live" || r.lifecycleState === "settling",
+            ).length ?? 0}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">System check warnings</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{warnings}</CardContent>
+        </Card>
+      </div>
+      <Input
+        placeholder="Filter by festival, city or lifecycle…"
+        value={filter}
+        onChange={(event) => setFilter(event.target.value)}
+      />
+      <div className="grid gap-3">
+        {rows.length === 0 && (
+          <Card>
+            <CardContent className="flex items-center justify-between gap-3 p-6">
+              <span>No festivals have been created yet.</span>
+              <Button onClick={onCreateFestival}>Create Festival</Button>
+            </CardContent>
+          </Card>
+        )}
+        {rows.map((row) => (
+          <Card
+            key={row.festivalId}
+            className={
+              row.festivalId === selectedFestivalId
+                ? "border-primary ring-1 ring-primary"
+                : ""
+            }
+            onClick={() => onSelectFestival?.(row.festivalId)}
+          >
+            <CardHeader>
+              <CardTitle className="flex flex-wrap items-center gap-2">
+                <CalendarDays className="h-5 w-5" />
+                {row.brandName}
+                <Badge>{row.lifecycleState ?? "no edition"}</Badge>
+                {row.dataHealthWarnings.length > 0 && (
+                  <Badge variant="destructive">
+                    <AlertTriangle className="mr-1 h-3 w-3" />
+                    {row.dataHealthWarnings.length}
+                  </Badge>
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-3 md:grid-cols-6">
+              <div>
+                <p className="text-xs text-muted-foreground">City</p>
+                <p>{row.cityName ?? "—"}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  Festival edition
+                </p>
+                <p>
+                  {row.currentEditionTitle ??
+                    row.currentEditionId ??
+                    "No edition"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  Stages / contracts
+                </p>
+                <p>
+                  {row.stageCount} / {row.activeContractCount}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  Sessions / outcomes
+                </p>
+                <p>
+                  {row.performanceSessionCount} / {row.outcomeCount}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Forecast</p>
+                <p>
+                  {formatFestivalMoney(
+                    row.projectedFinanceCents,
+                    row.currencyCode,
+                  )}
+                </p>
+              </div>
+              <div className="flex flex-wrap items-end gap-2">
+                {(() => {
+                  const editionId =
+                    row.currentEditionId ||
+                    row.nextEditionId ||
+                    row.completedEditionId;
+                  return editionId ? (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onSelectFestival?.(row.festivalId);
+                        }}
+                      >
+                        Manage
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onCreateEdition?.(row.festivalId, "add_edition");
+                        }}
+                      >
+                        Add edition
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onOpenManagement?.(row.festivalId, editionId);
+                        }}
+                      >
+                        <HeartPulse className="mr-2 h-4 w-4" />
+                        Open full management workspace
+                      </Button>
+                    </>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCreateEdition?.(
+                          row.festivalId,
+                          "create_first_edition",
+                        );
+                      }}
+                    >
+                      Create first edition
+                    </Button>
+                  );
+                })()}
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <Link to={`/festivals/${row.festivalId}`}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    View public page
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <Link to="/admin/festivals#system-checks">
+                    View system checks
+                  </Link>
+                </Button>
+              </div>
+              {row.dataHealthWarnings.length > 0 && (
+                <div className="md:col-span-6 text-sm text-muted-foreground">
+                  {row.dataHealthWarnings
+                    .map((issue) => issue.message)
+                    .join(" · ")}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
-  </div>;
+  );
 }

--- a/src/features/festivals/admin/components/FestivalCreationWizard.tsx
+++ b/src/features/festivals/admin/components/FestivalCreationWizard.tsx
@@ -1,0 +1,772 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  defaultFestivalCreationDraft,
+  validateFestivalCreationDraft,
+  hasCreationErrors,
+  stagePreset,
+  moneyToCents,
+  centsToMoney,
+  buildEditionTitle,
+  FESTIVAL_TYPE_OPTIONS,
+  SUPPORTED_CURRENCIES,
+  SUPPORTED_TIMEZONES,
+} from "../creationValidation";
+import {
+  useCreateFestivalFromWizard,
+  useFestivalReferenceData,
+} from "../hooks";
+import type {
+  AdminFestivalCatalogueRow,
+  FestivalCreationDraft,
+  FestivalCreationResult,
+} from "../types";
+
+const genres = [
+  "Rock",
+  "Pop",
+  "Electronic",
+  "Metal",
+  "Indie",
+  "Folk",
+  "Hip Hop",
+  "Jazz",
+];
+const stepNames = [
+  "Festival",
+  "First event",
+  "Location",
+  "Stages",
+  "Commercial",
+  "Review",
+];
+export function FestivalCreationWizard({
+  open,
+  mode,
+  festival,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  mode: FestivalCreationDraft["mode"];
+  festival?: AdminFestivalCatalogueRow;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (result: FestivalCreationResult) => void;
+}) {
+  const [draft, setDraft] = useState(() =>
+    defaultFestivalCreationDraft(mode, festival?.festivalId),
+  );
+  const [step, setStep] = useState(0);
+  const refs = useFestivalReferenceData();
+  const create = useCreateFestivalFromWizard();
+  useEffect(() => {
+    if (open) {
+      const next = defaultFestivalCreationDraft(mode, festival?.festivalId);
+      if (festival) {
+        next.identity.name = festival.brandName;
+        next.identity.shortDescription = festival.brandName;
+        next.identity.fullDescription = festival.brandName;
+        next.location.cityName = festival.cityName;
+      }
+      setDraft(next);
+      setStep(mode === "create_festival" ? 0 : 1);
+    }
+  }, [open, mode, festival]);
+  const errors = useMemo(() => validateFestivalCreationDraft(draft), [draft]);
+  const currentErrors =
+    errors[
+      ["identity", "edition", "location", "stages", "commercial", "submit"][
+        step
+      ] as keyof typeof errors
+    ] ?? [];
+  const update = (patch: Partial<FestivalCreationDraft>) =>
+    setDraft((d) => ({ ...d, ...patch }));
+  const submit = () =>
+    create.mutate(draft, { onSuccess: (result) => onCreated(result) });
+  const cities = refs.data?.cities ?? [];
+  const venues = (refs.data?.venues ?? []).filter(
+    (v: any) => v.city_id === draft.location.cityId,
+  );
+  const canNext =
+    step === 5 ? !hasCreationErrors(errors) : currentErrors.length === 0;
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (
+          !v &&
+          !create.isPending &&
+          confirm("Discard this festival setup draft?")
+        )
+          onOpenChange(false);
+        if (v) onOpenChange(true);
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "create_festival"
+              ? "Create Festival"
+              : mode === "create_first_edition"
+                ? "Create first edition"
+                : "Add new edition"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-wrap gap-2">
+          {stepNames.map((name, i) => (
+            <Button
+              key={name}
+              size="sm"
+              variant={i === step ? "default" : "outline"}
+              disabled={mode !== "create_festival" && i === 0}
+              onClick={() => setStep(i)}
+            >
+              {i + 1}. {name}
+            </Button>
+          ))}
+        </div>
+        {mode !== "create_festival" && (
+          <Card>
+            <CardContent className="p-3 text-sm">
+              Festival: <b>{festival?.brandName}</b>. The permanent festival
+              identity is locked; this flow creates edition setup only.
+            </CardContent>
+          </Card>
+        )}
+        {step === 0 && (
+          <div className="grid gap-3">
+            <Label>
+              Festival name
+              <Input
+                value={draft.identity.name}
+                onChange={(e) => {
+                  const name = e.target.value;
+                  update({
+                    identity: { ...draft.identity, name },
+                    edition: {
+                      ...draft.edition,
+                      title:
+                        draft.edition.title ||
+                        buildEditionTitle(name, draft.edition.startAt),
+                    },
+                  });
+                }}
+              />
+            </Label>
+            <Label>
+              Short description
+              <Input
+                value={draft.identity.shortDescription}
+                onChange={(e) =>
+                  update({
+                    identity: {
+                      ...draft.identity,
+                      shortDescription: e.target.value,
+                    },
+                  })
+                }
+              />
+            </Label>
+            <Label>
+              Full description
+              <Textarea
+                value={draft.identity.fullDescription}
+                onChange={(e) =>
+                  update({
+                    identity: {
+                      ...draft.identity,
+                      fullDescription: e.target.value,
+                    },
+                  })
+                }
+              />
+            </Label>
+            <Label>
+              Festival type
+              <Select
+                value={draft.identity.festivalType}
+                onValueChange={(v) =>
+                  update({ identity: { ...draft.identity, festivalType: v } })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FESTIVAL_TYPE_OPTIONS.map((type) => (
+                    <SelectItem key={type} value={type}>
+                      {type.replace("_", " ")}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+            <Label>
+              Image reference
+              <Input
+                value={draft.identity.imageUrl ?? ""}
+                onChange={(e) =>
+                  update({
+                    identity: { ...draft.identity, imageUrl: e.target.value },
+                  })
+                }
+              />
+            </Label>
+            <div className="grid grid-cols-2 gap-2">
+              {genres.map((genre) => (
+                <Label key={genre} className="flex items-center gap-2">
+                  <Checkbox
+                    checked={draft.identity.primaryGenres.includes(genre)}
+                    onCheckedChange={(checked) =>
+                      update({
+                        identity: {
+                          ...draft.identity,
+                          primaryGenres: checked
+                            ? [...draft.identity.primaryGenres, genre]
+                            : draft.identity.primaryGenres.filter(
+                                (g) => g !== genre,
+                              ),
+                        },
+                      })
+                    }
+                  />
+                  {genre}
+                </Label>
+              ))}
+            </div>
+            <Label className="flex items-center gap-2">
+              <Checkbox
+                checked={draft.identity.isPublic}
+                onCheckedChange={(checked) =>
+                  update({
+                    identity: { ...draft.identity, isPublic: Boolean(checked) },
+                  })
+                }
+              />
+              Visible on public festival lists when lifecycle allows
+            </Label>
+          </div>
+        )}
+        {step === 1 && (
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              Edition title
+              <Input
+                value={draft.edition.title}
+                onChange={(e) =>
+                  update({
+                    edition: { ...draft.edition, title: e.target.value },
+                  })
+                }
+              />
+            </Label>
+            <Label>
+              Edition number
+              <Input
+                type="number"
+                value={draft.edition.editionNumber}
+                onChange={(e) =>
+                  update({
+                    edition: {
+                      ...draft.edition,
+                      editionNumber: Number(e.target.value),
+                    },
+                  })
+                }
+              />
+            </Label>
+            {[
+              "startAt",
+              "endAt",
+              "applicationsOpenAt",
+              "applicationsCloseAt",
+              "bookingDeadlineAt",
+            ].map((key) => (
+              <Label key={key}>
+                {key.replace(/([A-Z])/g, " $1")}
+                <Input
+                  type="datetime-local"
+                  value={(draft.edition as any)[key] ?? ""}
+                  onChange={(e) =>
+                    update({
+                      edition: {
+                        ...draft.edition,
+                        [key]: e.target.value,
+                      } as any,
+                    })
+                  }
+                />
+              </Label>
+            ))}
+            <Label>
+              Time zone
+              <Select
+                value={draft.edition.timezone}
+                onValueChange={(v) =>
+                  update({ edition: { ...draft.edition, timezone: v } })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SUPPORTED_TIMEZONES.map((tz) => (
+                    <SelectItem key={tz} value={tz}>
+                      {tz}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+            <Label>
+              Currency
+              <Select
+                value={draft.edition.currencyCode}
+                onValueChange={(v) =>
+                  update({ edition: { ...draft.edition, currencyCode: v } })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <SelectItem key={currency} value={currency}>
+                      {currency}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+          </div>
+        )}
+        {step === 2 && (
+          <div className="grid gap-3 md:grid-cols-2">
+            <Label>
+              City
+              <Select
+                value={draft.location.cityId}
+                onValueChange={(cityId) => {
+                  const city = cities.find((c: any) => c.id === cityId);
+                  update({
+                    location: {
+                      ...draft.location,
+                      cityId,
+                      cityName: city?.name,
+                      country: city?.country ?? "",
+                    },
+                    edition: {
+                      ...draft.edition,
+                      timezone: city?.timezone || draft.edition.timezone,
+                    },
+                  });
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select city" />
+                </SelectTrigger>
+                <SelectContent>
+                  {cities.map((city: any) => (
+                    <SelectItem key={city.id} value={city.id}>
+                      {city.name}, {city.country}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+            <Label>
+              Venue or festival site
+              <Select
+                value={draft.location.venueId || "custom"}
+                onValueChange={(venueId) =>
+                  update({
+                    location: {
+                      ...draft.location,
+                      venueId: venueId === "custom" ? "" : venueId,
+                    },
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="custom">
+                    Public festival site name
+                  </SelectItem>
+                  {venues.map((venue: any) => (
+                    <SelectItem key={venue.id} value={venue.id}>
+                      {venue.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+            <Label>
+              Public site name
+              <Input
+                value={draft.location.siteName ?? ""}
+                onChange={(e) =>
+                  update({
+                    location: { ...draft.location, siteName: e.target.value },
+                  })
+                }
+              />
+            </Label>
+            <Label>
+              Overall capacity
+              <Input
+                type="number"
+                value={draft.location.capacity}
+                onChange={(e) =>
+                  update({
+                    location: {
+                      ...draft.location,
+                      capacity: Number(e.target.value),
+                    },
+                  })
+                }
+              />
+            </Label>
+            {[
+              ["Minimum ticket", "minTicketPriceCents"],
+              ["Maximum ticket", "maxTicketPriceCents"],
+              ["Default ticket", "defaultTicketPriceCents"],
+            ].map(([label, key]) => (
+              <Label key={key}>
+                {label}
+                <Input
+                  type="number"
+                  value={centsToMoney((draft.location as any)[key])}
+                  onChange={(e) =>
+                    update({
+                      location: {
+                        ...draft.location,
+                        [key]: moneyToCents(e.target.value),
+                      } as any,
+                    })
+                  }
+                />
+              </Label>
+            ))}
+          </div>
+        )}
+        {step === 3 && (
+          <div className="space-y-3">
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() =>
+                  update({
+                    stages: stagePreset("small", draft.location.capacity),
+                  })
+                }
+              >
+                Small preset
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  update({
+                    stages: stagePreset("medium", draft.location.capacity),
+                  })
+                }
+              >
+                Medium preset
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  update({
+                    stages: stagePreset("large", draft.location.capacity),
+                  })
+                }
+              >
+                Large preset
+              </Button>
+              <Button
+                onClick={() =>
+                  update({
+                    stages: [
+                      ...draft.stages,
+                      stagePreset("small", draft.location.capacity)[0],
+                    ],
+                  })
+                }
+              >
+                Add stage
+              </Button>
+            </div>
+            {draft.stages.map((stage, index) => (
+              <Card key={index}>
+                <CardHeader>
+                  <CardTitle>{stage.name || "Stage"}</CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-2 md:grid-cols-4">
+                  <Input
+                    value={stage.name}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index ? { ...s, name: e.target.value } : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    value={stage.type}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index ? { ...s, type: e.target.value } : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    type="number"
+                    value={stage.capacity}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index
+                            ? { ...s, capacity: Number(e.target.value) }
+                            : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    type="number"
+                    value={stage.changeoverMinutes}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index
+                            ? {
+                                ...s,
+                                changeoverMinutes: Number(e.target.value),
+                              }
+                            : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    value={stage.curfew}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index ? { ...s, curfew: e.target.value } : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    value={stage.weatherProtection}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index
+                            ? { ...s, weatherProtection: e.target.value }
+                            : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    value={stage.soundCapability}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index
+                            ? { ...s, soundCapability: e.target.value }
+                            : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Input
+                    value={stage.lightingCapability}
+                    onChange={(e) =>
+                      update({
+                        stages: draft.stages.map((s, i) =>
+                          i === index
+                            ? { ...s, lightingCapability: e.target.value }
+                            : s,
+                        ),
+                      })
+                    }
+                  />
+                  <Button
+                    variant="destructive"
+                    onClick={() =>
+                      update({
+                        stages: draft.stages.filter((_, i) => i !== index),
+                      })
+                    }
+                  >
+                    Remove
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+        {step === 4 && (
+          <div className="grid gap-3 md:grid-cols-2">
+            {[
+              ["Estimated attendance", "estimatedAttendance", 1],
+              ["Operating budget", "operatingBudgetCents", 100],
+              ["Performer budget", "performerBudgetCents", 100],
+              ["Staffing budget", "staffingBudgetCents", 100],
+              ["Marketing budget", "marketingBudgetCents", 100],
+            ].map(([label, key, div]) => (
+              <Label key={String(key)}>
+                {label}
+                <Input
+                  type="number"
+                  value={Number((draft.commercial as any)[key]) / Number(div)}
+                  onChange={(e) =>
+                    update({
+                      commercial: {
+                        ...draft.commercial,
+                        [key]: Number(e.target.value) * Number(div),
+                      } as any,
+                    })
+                  }
+                />
+              </Label>
+            ))}
+            {[
+              ["Sponsorship", "sponsorshipEnabled"],
+              ["Merchandise", "merchandiseEnabled"],
+              ["Food and drink", "concessionsEnabled"],
+            ].map(([label, key]) => (
+              <Label key={key} className="flex items-center gap-2">
+                <Checkbox
+                  checked={Boolean((draft.commercial as any)[key])}
+                  onCheckedChange={(checked) =>
+                    update({
+                      commercial: {
+                        ...draft.commercial,
+                        [key]: Boolean(checked),
+                      } as any,
+                    })
+                  }
+                />
+                {label} enabled
+              </Label>
+            ))}
+          </div>
+        )}
+        {step === 5 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Review and create</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p>
+                <b>Festival:</b> {draft.identity.name || festival?.brandName}
+              </p>
+              <p>
+                <b>Type:</b> {draft.identity.festivalType}
+              </p>
+              <p>
+                <b>Genres:</b>{" "}
+                {draft.identity.primaryGenres.join(", ") ||
+                  "Stored on festival"}
+              </p>
+              <p>
+                <b>Location:</b> {draft.location.cityName}{" "}
+                {draft.location.siteName}
+              </p>
+              <p>
+                <b>Edition:</b> {draft.edition.title} · planning
+              </p>
+              <p>
+                <b>Dates:</b> {draft.edition.startAt} → {draft.edition.endAt}
+              </p>
+              <p>
+                <b>Applications:</b> {draft.edition.applicationsOpenAt} →{" "}
+                {draft.edition.applicationsCloseAt}
+              </p>
+              <p>
+                <b>Capacity:</b> {draft.location.capacity}
+              </p>
+              <p>
+                <b>Tickets:</b>{" "}
+                {centsToMoney(draft.location.minTicketPriceCents)}–
+                {centsToMoney(draft.location.maxTicketPriceCents)}{" "}
+                {draft.edition.currencyCode}
+              </p>
+              <p>
+                <b>Stages:</b> {draft.stages.map((s) => s.name).join(", ")}
+              </p>
+              <p>
+                <b>Budget:</b>{" "}
+                {centsToMoney(draft.commercial.operatingBudgetCents)}{" "}
+                {draft.edition.currencyCode}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+        {currentErrors.length > 0 && (
+          <div className="rounded border border-destructive p-3 text-sm text-destructive">
+            {currentErrors.map((error) => (
+              <p key={error}>{error}</p>
+            ))}
+          </div>
+        )}
+        {create.error && (
+          <p className="text-sm text-destructive">
+            The festival could not be created. No records were saved. Reference
+            FESTIVAL_CREATE_TRANSACTION.
+          </p>
+        )}
+        <div className="flex justify-between">
+          <Button
+            variant="outline"
+            disabled={step === 0 || create.isPending}
+            onClick={() =>
+              setStep(Math.max(mode === "create_festival" ? 0 : 1, step - 1))
+            }
+          >
+            Back
+          </Button>
+          {step < 5 ? (
+            <Button disabled={!canNext} onClick={() => setStep(step + 1)}>
+              Continue
+            </Button>
+          ) : (
+            <Button disabled={!canNext || create.isPending} onClick={submit}>
+              {create.isPending
+                ? "Creating…"
+                : mode === "create_festival"
+                  ? "Create festival"
+                  : "Create edition"}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
+++ b/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { transitionAdminFestivalEdition } from "../service";
+import { festivalAdminQueryKeys } from "../queryKeys";
+import type { FestivalLifecycleState } from "../types";
+
+const nextStates: Record<string, FestivalLifecycleState[]> = {
+  concept: ["planning"],
+  planning: ["applications_open", "booking"],
+  applications_open: ["booking"],
+  booking: ["announced"],
+  announced: ["on_sale", "setup"],
+  on_sale: ["setup"],
+  setup: ["live"],
+  live: ["settling"],
+  settling: ["completed"],
+};
+export function FestivalLifecycleControls({
+  editionId,
+  status,
+}: {
+  editionId?: string;
+  status?: FestivalLifecycleState | null;
+}) {
+  const qc = useQueryClient();
+  const [target, setTarget] = useState<FestivalLifecycleState | "">("");
+  const [reason, setReason] = useState("");
+  const mutation = useMutation({
+    mutationFn: () =>
+      transitionAdminFestivalEdition(
+        editionId as string,
+        target as FestivalLifecycleState,
+        reason,
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue });
+      if (editionId)
+        qc.invalidateQueries({
+          queryKey: festivalAdminQueryKeys.operations("admin", editionId),
+        });
+      setReason("");
+      setTarget("");
+    },
+  });
+  if (!editionId || !status)
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Lifecycle controls</CardTitle>
+          <CardDescription>
+            Select an edition to see available transitions.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  const options = nextStates[status] ?? [];
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Lifecycle controls</CardTitle>
+        <CardDescription>
+          Current status is {status}. Transitions are submitted through the
+          canonical server transition service.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Label>
+            Next status
+            <Select
+              value={target}
+              onValueChange={(v) => setTarget(v as FestivalLifecycleState)}
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    options.length
+                      ? "Choose next status"
+                      : "No standard transition available"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map((state) => (
+                  <SelectItem key={state} value={state}>
+                    {state.replaceAll("_", " ")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Label>
+          <Label>
+            Administrator reason
+            <Input
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder="Reason required for audit history"
+            />
+          </Label>
+        </div>
+        {options.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            This edition has no standard forward transition from its current
+            state.
+          </p>
+        )}
+        {mutation.error && (
+          <p className="text-sm text-destructive">
+            The lifecycle transition could not be completed. No records were
+            changed.
+          </p>
+        )}
+        <Button
+          disabled={!target || !reason.trim() || mutation.isPending}
+          onClick={() => mutation.mutate()}
+        >
+          {mutation.isPending ? "Updating…" : "Apply lifecycle transition"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/festivals/admin/creationValidation.ts
+++ b/src/features/festivals/admin/creationValidation.ts
@@ -1,0 +1,205 @@
+import type {
+  FestivalCreationDraft,
+  FestivalCreationValidationErrors,
+  FestivalStageCreationInput,
+} from "./types";
+
+export const FESTIVAL_TYPE_OPTIONS = [
+  "national",
+  "city",
+  "community",
+  "genre",
+  "showcase",
+  "charity",
+] as const;
+export const SUPPORTED_CURRENCIES = ["USD", "EUR", "GBP"] as const;
+export const SUPPORTED_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Paris",
+] as const;
+
+export function moneyToCents(value: string | number) {
+  return Math.round(Number(value || 0) * 100);
+}
+export function centsToMoney(value: number) {
+  return (value / 100).toFixed(2);
+}
+
+export function stagePreset(
+  preset: "small" | "medium" | "large",
+  capacity: number,
+): FestivalStageCreationInput[] {
+  const base = (name: string, ratio: number): FestivalStageCreationInput => ({
+    name,
+    type: name === "Main Stage" ? "main" : "secondary",
+    capacity: Math.max(1, Math.floor(capacity * ratio)),
+    changeoverMinutes: 30,
+    curfew: "23:00",
+    weatherProtection: "covered",
+    soundCapability: "standard_pa",
+    lightingCapability: "standard_lighting",
+  });
+  if (preset === "small") return [base("Main Stage", 1)];
+  if (preset === "medium")
+    return [base("Main Stage", 0.7), base("Second Stage", 0.45)];
+  return [
+    base("Main Stage", 0.7),
+    base("Second Stage", 0.45),
+    base("New Music Stage", 0.25),
+  ];
+}
+
+export function defaultFestivalCreationDraft(
+  mode: FestivalCreationDraft["mode"] = "create_festival",
+  existingFestivalId?: string,
+): FestivalCreationDraft {
+  const now = new Date();
+  const start = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 60);
+  const end = new Date(start.getTime() + 1000 * 60 * 60 * 8);
+  const appOpen = new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7);
+  const appClose = new Date(start.getTime() - 1000 * 60 * 60 * 24 * 14);
+  const capacity = 1000;
+  return {
+    mode,
+    existingFestivalId,
+    idempotencyKey: crypto.randomUUID(),
+    identity: {
+      name: "",
+      shortDescription: "",
+      fullDescription: "",
+      festivalType: "city",
+      primaryGenres: [],
+      imageUrl: "",
+      isPublic: false,
+    },
+    edition: {
+      title: "",
+      editionNumber: mode === "add_edition" ? 2 : 1,
+      startAt: toLocalInput(start),
+      endAt: toLocalInput(end),
+      applicationsOpenAt: toLocalInput(appOpen),
+      applicationsCloseAt: toLocalInput(appClose),
+      bookingDeadlineAt: toLocalInput(appClose),
+      timezone: "UTC",
+      currencyCode: "USD",
+    },
+    location: {
+      country: "",
+      cityId: "",
+      cityName: "",
+      venueId: "",
+      siteName: "",
+      capacity,
+      minTicketPriceCents: 2500,
+      maxTicketPriceCents: 12500,
+      defaultTicketPriceCents: 5000,
+      festivalDays: 1,
+    },
+    stages: stagePreset("small", capacity),
+    commercial: {
+      estimatedAttendance: 750,
+      operatingBudgetCents: 1000000,
+      performerBudgetCents: 500000,
+      staffingBudgetCents: 200000,
+      marketingBudgetCents: 150000,
+      sponsorshipEnabled: true,
+      merchandiseEnabled: true,
+      concessionsEnabled: true,
+    },
+  };
+}
+
+export function toLocalInput(date: Date) {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16);
+}
+export function buildEditionTitle(name: string, startAt: string) {
+  const year = startAt
+    ? new Date(startAt).getFullYear()
+    : new Date().getFullYear();
+  return `${name.trim() || "Festival"} ${year}`;
+}
+
+export function validateFestivalCreationDraft(
+  draft: FestivalCreationDraft,
+  current = new Date(),
+): FestivalCreationValidationErrors {
+  const errors: FestivalCreationValidationErrors = {};
+  if (draft.mode === "create_festival") {
+    const identity: string[] = [];
+    if (!draft.identity.name.trim())
+      identity.push("Festival name is required.");
+    if (draft.identity.name.trim().length > 120)
+      identity.push("Festival name must be 120 characters or fewer.");
+    if (!draft.identity.shortDescription.trim())
+      identity.push("Short description is required.");
+    if (!draft.identity.fullDescription.trim())
+      identity.push("Full description is required.");
+    if (!draft.identity.primaryGenres.length)
+      identity.push("Select at least one primary genre.");
+    if (identity.length) errors.identity = identity;
+  }
+  const edition: string[] = [];
+  const start = new Date(draft.edition.startAt);
+  const end = new Date(draft.edition.endAt);
+  const appOpen = new Date(draft.edition.applicationsOpenAt);
+  const appClose = new Date(draft.edition.applicationsCloseAt);
+  if (!draft.edition.title.trim()) edition.push("Edition title is required.");
+  if (draft.edition.editionNumber < 1)
+    edition.push("Edition number must be positive.");
+  if (!(end > start)) edition.push("End must be after start.");
+  if (start < current) edition.push("Dates in the past are not allowed.");
+  if (appClose < appOpen)
+    edition.push("Applications cannot close before they open.");
+  if (!(appClose < start))
+    edition.push("Applications must close before the festival begins.");
+  if (!SUPPORTED_CURRENCIES.includes(draft.edition.currencyCode as never))
+    edition.push("Currency is not supported.");
+  if (!SUPPORTED_TIMEZONES.includes(draft.edition.timezone as never))
+    edition.push("Time zone is not supported.");
+  if (edition.length) errors.edition = edition;
+  const location: string[] = [];
+  if (!draft.location.cityId) location.push("Select a city.");
+  if (draft.location.capacity <= 0)
+    location.push("Capacity must be greater than zero.");
+  if (draft.location.minTicketPriceCents > draft.location.maxTicketPriceCents)
+    location.push("Minimum ticket price cannot exceed maximum ticket price.");
+  if (
+    draft.location.defaultTicketPriceCents <
+      draft.location.minTicketPriceCents ||
+    draft.location.defaultTicketPriceCents > draft.location.maxTicketPriceCents
+  )
+    location.push("Default ticket price must be within the configured range.");
+  if (location.length) errors.location = location;
+  const stages: string[] = [];
+  if (draft.stages.length === 0) stages.push("At least one stage is required.");
+  const names = new Set<string>();
+  draft.stages.forEach((stage) => {
+    const key = stage.name.trim().toLowerCase();
+    if (!key) stages.push("Stage names are required.");
+    if (names.has(key))
+      stages.push("Stage names must be unique within the event.");
+    names.add(key);
+    if (stage.capacity <= 0)
+      stages.push(`${stage.name || "Stage"} capacity must be positive.`);
+    if (stage.capacity > draft.location.capacity)
+      stages.push(
+        `${stage.name || "Stage"} capacity cannot exceed overall capacity.`,
+      );
+    if (stage.changeoverMinutes < 5)
+      stages.push(
+        `${stage.name || "Stage"} changeover must be at least five minutes.`,
+      );
+    if (!/^\d{2}:\d{2}$/.test(stage.curfew))
+      stages.push(`${stage.name || "Stage"} curfew must be a valid time.`);
+  });
+  if (stages.length) errors.stages = Array.from(new Set(stages));
+  return errors;
+}
+export function hasCreationErrors(errors: FestivalCreationValidationErrors) {
+  return Object.values(errors).some((list) => list && list.length > 0);
+}

--- a/src/features/festivals/admin/hooks.ts
+++ b/src/features/festivals/admin/hooks.ts
@@ -1,23 +1,226 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { fetchAdminFestivalCatalogue, fetchOwnerManagementBootstrap, fetchOwnerFestivalEditions, fetchFestivalEditionOperations, createFestivalEditionStage, generateFestivalStageSlots, hireFestivalEditionStaff, applyForFestivalEditionPermit, quoteFestivalEditionInsurance, purchaseFestivalEditionInsurance, fetchFestivalEditionFinanceSummary, fetchFestivalAdminDataHealth, fetchFestivalLegacyRecords, fetchFestivalAuditEvents, repairFestivalDataHealthIssue, previewLegacyFestivalMigration, applyLegacyFestivalMigration, reviewFestivalEditionPermit } from "./service";
+import {
+  fetchAdminFestivalCatalogue,
+  fetchOwnerManagementBootstrap,
+  fetchOwnerFestivalEditions,
+  fetchFestivalEditionOperations,
+  createFestivalEditionStage,
+  generateFestivalStageSlots,
+  hireFestivalEditionStaff,
+  applyForFestivalEditionPermit,
+  quoteFestivalEditionInsurance,
+  purchaseFestivalEditionInsurance,
+  fetchFestivalEditionFinanceSummary,
+  fetchFestivalAdminDataHealth,
+  fetchFestivalLegacyRecords,
+  fetchFestivalAuditEvents,
+  repairFestivalDataHealthIssue,
+  previewLegacyFestivalMigration,
+  applyLegacyFestivalMigration,
+  reviewFestivalEditionPermit,
+  createFestivalWithFirstEdition,
+  createFestivalEditionFromWizard,
+  fetchFestivalReferenceData,
+} from "./service";
 import { festivalAdminQueryKeys } from "./queryKeys";
-import type { SlotGenerationInput, StaffHireInput, StageInput } from "./types";
+import type {
+  SlotGenerationInput,
+  StaffHireInput,
+  StageInput,
+  FestivalCreationDraft,
+} from "./types";
 
-export function useAdminFestivalCatalogue() { return useQuery({ queryKey: festivalAdminQueryKeys.catalogue, queryFn: fetchAdminFestivalCatalogue }); }
-export function useOwnerManagementBootstrap(identifier: string | undefined) { return useQuery({ queryKey: festivalAdminQueryKeys.ownerBootstrap(identifier ?? "missing"), queryFn: () => fetchOwnerManagementBootstrap(identifier as string), enabled: Boolean(identifier) }); }
-export function useOwnerFestivalEditions(festivalId: string | undefined) { return useQuery({ queryKey: festivalAdminQueryKeys.ownerEditions(festivalId ?? "missing"), queryFn: () => fetchOwnerFestivalEditions(festivalId as string), enabled: Boolean(festivalId) }); }
-export function useFestivalEditionOperations(editionId?: string, scope: "owner" | "admin" = "owner") { return useQuery({ queryKey: festivalAdminQueryKeys.operations(scope, editionId ?? "missing"), queryFn: () => fetchFestivalEditionOperations(editionId as string), enabled: Boolean(editionId) }); }
-export function useFestivalEditionFinance(editionId?: string, scope: "owner" | "admin" = "owner") { return useQuery({ queryKey: festivalAdminQueryKeys.finance(scope, editionId ?? "missing"), queryFn: () => fetchFestivalEditionFinanceSummary(editionId as string), enabled: Boolean(editionId) }); }
-export function useAdminDataHealth() { return useQuery({ queryKey: festivalAdminQueryKeys.dataHealth, queryFn: fetchFestivalAdminDataHealth }); }
-export function useAdminLegacyRecords() { return useQuery({ queryKey: festivalAdminQueryKeys.legacyRecords, queryFn: fetchFestivalLegacyRecords }); }
-export function useAdminAuditEvents(filters: Record<string, string>) { return useQuery({ queryKey: festivalAdminQueryKeys.audit(filters), queryFn: () => fetchFestivalAuditEvents(filters) }); }
+export function useAdminFestivalCatalogue() {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.catalogue,
+    queryFn: fetchAdminFestivalCatalogue,
+  });
+}
+export function useFestivalReferenceData() {
+  return useQuery({
+    queryKey: ["festivals", "admin", "reference-data"],
+    queryFn: fetchFestivalReferenceData,
+  });
+}
+export function useOwnerManagementBootstrap(identifier: string | undefined) {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.ownerBootstrap(identifier ?? "missing"),
+    queryFn: () => fetchOwnerManagementBootstrap(identifier as string),
+    enabled: Boolean(identifier),
+  });
+}
+export function useOwnerFestivalEditions(festivalId: string | undefined) {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.ownerEditions(festivalId ?? "missing"),
+    queryFn: () => fetchOwnerFestivalEditions(festivalId as string),
+    enabled: Boolean(festivalId),
+  });
+}
+export function useFestivalEditionOperations(
+  editionId?: string,
+  scope: "owner" | "admin" = "owner",
+) {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.operations(scope, editionId ?? "missing"),
+    queryFn: () => fetchFestivalEditionOperations(editionId as string),
+    enabled: Boolean(editionId),
+  });
+}
+export function useFestivalEditionFinance(
+  editionId?: string,
+  scope: "owner" | "admin" = "owner",
+) {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.finance(scope, editionId ?? "missing"),
+    queryFn: () => fetchFestivalEditionFinanceSummary(editionId as string),
+    enabled: Boolean(editionId),
+  });
+}
+export function useAdminDataHealth() {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.dataHealth,
+    queryFn: fetchFestivalAdminDataHealth,
+  });
+}
+export function useAdminLegacyRecords() {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.legacyRecords,
+    queryFn: fetchFestivalLegacyRecords,
+  });
+}
+export function useAdminAuditEvents(filters: Record<string, string>) {
+  return useQuery({
+    queryKey: festivalAdminQueryKeys.audit(filters),
+    queryFn: () => fetchFestivalAuditEvents(filters),
+  });
+}
 
-export function useCreateFestivalStage(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (input: Omit<StageInput, "editionId" | "idempotencyKey">) => createFestivalEditionStage({ ...input, editionId, idempotencyKey: `stage:${editionId}:${input.name}` }), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useGenerateFestivalSlots(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (input: Omit<SlotGenerationInput, "idempotencyKey">) => generateFestivalStageSlots({ ...input, idempotencyKey: `slots:${input.stageId}:${input.date}:${input.apply ? "apply" : "preview"}` }), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useHireFestivalStaff(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (input: Omit<StaffHireInput, "editionId" | "idempotencyKey">) => hireFestivalEditionStaff({ ...input, editionId, idempotencyKey: `staff:${editionId}:${input.candidateId}:${input.role}` }), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useApplyFestivalPermit(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (requirementCode: string) => applyForFestivalEditionPermit(editionId, requirementCode, `permit:${editionId}:${requirementCode}`), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useFestivalInsuranceQuote(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: () => quoteFestivalEditionInsurance(editionId), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useFestivalInsurancePurchase(editionId: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (quoteId: string) => purchaseFestivalEditionInsurance(quoteId, `insurance:${quoteId}`), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("owner", editionId) }) }); }
-export function useRepairDataHealth() { const qc = useQueryClient(); return useMutation({ mutationFn: (input: { issueId: string; action: string; reason?: string }) => repairFestivalDataHealthIssue(input), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.dataHealth }) }); }
-export function useLegacyMigration() { const qc = useQueryClient(); return useMutation({ mutationFn: (input: { mappingId: string; apply?: boolean }) => input.apply ? applyLegacyFestivalMigration(input.mappingId) : previewLegacyFestivalMigration(input.mappingId), onSuccess: () => qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.legacyRecords }) }); }
-export function useReviewPermit(editionId?: string) { const qc = useQueryClient(); return useMutation({ mutationFn: (input: { permitId: string; action: string; reason?: string }) => reviewFestivalEditionPermit(input), onSuccess: () => { qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue }); if (editionId) qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("admin", editionId) }); } }); }
+export function useCreateFestivalStage(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: Omit<StageInput, "editionId" | "idempotencyKey">) =>
+      createFestivalEditionStage({
+        ...input,
+        editionId,
+        idempotencyKey: `stage:${editionId}:${input.name}`,
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useGenerateFestivalSlots(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: Omit<SlotGenerationInput, "idempotencyKey">) =>
+      generateFestivalStageSlots({
+        ...input,
+        idempotencyKey: `slots:${input.stageId}:${input.date}:${input.apply ? "apply" : "preview"}`,
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useHireFestivalStaff(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: Omit<StaffHireInput, "editionId" | "idempotencyKey">) =>
+      hireFestivalEditionStaff({
+        ...input,
+        editionId,
+        idempotencyKey: `staff:${editionId}:${input.candidateId}:${input.role}`,
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useApplyFestivalPermit(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (requirementCode: string) =>
+      applyForFestivalEditionPermit(
+        editionId,
+        requirementCode,
+        `permit:${editionId}:${requirementCode}`,
+      ),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useFestivalInsuranceQuote(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => quoteFestivalEditionInsurance(editionId),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useFestivalInsurancePurchase(editionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (quoteId: string) =>
+      purchaseFestivalEditionInsurance(quoteId, `insurance:${quoteId}`),
+    onSuccess: () =>
+      qc.invalidateQueries({
+        queryKey: festivalAdminQueryKeys.operations("owner", editionId),
+      }),
+  });
+}
+export function useRepairDataHealth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { issueId: string; action: string; reason?: string }) =>
+      repairFestivalDataHealthIssue(input),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.dataHealth }),
+  });
+}
+export function useLegacyMigration() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { mappingId: string; apply?: boolean }) =>
+      input.apply
+        ? applyLegacyFestivalMigration(input.mappingId)
+        : previewLegacyFestivalMigration(input.mappingId),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.legacyRecords }),
+  });
+}
+export function useReviewPermit(editionId?: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      permitId: string;
+      action: string;
+      reason?: string;
+    }) => reviewFestivalEditionPermit(input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue });
+      if (editionId)
+        qc.invalidateQueries({
+          queryKey: festivalAdminQueryKeys.operations("admin", editionId),
+        });
+    },
+  });
+}
+
+export function useCreateFestivalFromWizard() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: FestivalCreationDraft) =>
+      input.mode === "create_festival"
+        ? createFestivalWithFirstEdition(input)
+        : createFestivalEditionFromWizard(input),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue }),
+  });
+}

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -1,9 +1,23 @@
 import { z } from "zod";
 import { supabase } from "@/integrations/supabase/client";
-import { mapCatalogueRow, mapOwnerEdition, mapOwnerManagementBootstrap } from "./mappers";
-import type { AdminBrandInput, AdminEditionInput, AdminFestivalCatalogueRow, FestivalLifecycleState, OwnerEditionOption, OwnerManagementBootstrap } from "./types";
+import {
+  mapCatalogueRow,
+  mapOwnerEdition,
+  mapOwnerManagementBootstrap,
+} from "./mappers";
+import type {
+  AdminBrandInput,
+  AdminEditionInput,
+  AdminFestivalCatalogueRow,
+  FestivalLifecycleState,
+  OwnerEditionOption,
+  OwnerManagementBootstrap,
+  FestivalCreationDraft,
+  FestivalCreationResult,
+} from "./types";
 
-type RpcName = keyof import("@/integrations/supabase/types").Database["public"]["Functions"];
+type RpcName =
+  keyof import("@/integrations/supabase/types").Database["public"]["Functions"];
 
 type DomainErrorCode =
   | "FESTIVAL_RPC_FAILED"
@@ -13,101 +27,592 @@ type DomainErrorCode =
   | "FESTIVAL_MIGRATION_REQUIRED";
 
 export class FestivalAdminServiceError extends Error {
-  constructor(message: string, public readonly code: DomainErrorCode, public readonly cause?: unknown) { super(`${code}: ${message}`); this.name = "FestivalAdminServiceError"; }
+  constructor(
+    message: string,
+    public readonly code: DomainErrorCode,
+    public readonly cause?: unknown,
+  ) {
+    super(`${code}: ${message}`);
+    this.name = "FestivalAdminServiceError";
+  }
 }
 
-const rpc = async <T>(fn: RpcName, args?: Record<string, unknown>, schema?: z.ZodType<T>): Promise<T> => {
+const rpc = async <T>(
+  fn: RpcName,
+  args?: Record<string, unknown>,
+  schema?: z.ZodType<T>,
+): Promise<T> => {
   const { data, error } = await supabase.rpc(fn as never, args as never);
   if (error) throw mapFestivalError(error);
   if (!schema) return data as T;
   const parsed = schema.safeParse(data);
-  if (!parsed.success) throw new FestivalAdminServiceError("The festival server returned a malformed response.", "FESTIVAL_RESPONSE_INVALID", parsed.error);
+  if (!parsed.success)
+    throw new FestivalAdminServiceError(
+      "The festival server returned a malformed response.",
+      "FESTIVAL_RESPONSE_INVALID",
+      parsed.error,
+    );
   return parsed.data;
 };
 
-export function mapFestivalError(error: { message?: string; code?: string; details?: string; hint?: string }) {
+export function mapFestivalError(error: {
+  message?: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+}) {
   const message = error.message ?? "Festival operation failed.";
-  if (/permission|not authorised|not authorized|rls/i.test(message)) return new FestivalAdminServiceError("You do not have permission to perform this festival operation.", "FESTIVAL_PERMISSION_DENIED", error);
-  if (/not found|missing/i.test(message)) return new FestivalAdminServiceError("This festival edition could not be loaded.", "FESTIVAL_EDITION_NOT_FOUND", error);
-  if (/legacy|migration|hybrid|currency|mixed/i.test(message)) return new FestivalAdminServiceError("This festival record needs admin migration or data repair before it can be managed.", "FESTIVAL_MIGRATION_REQUIRED", error);
+  if (/permission|not authorised|not authorized|rls/i.test(message))
+    return new FestivalAdminServiceError(
+      "You do not have permission to perform this festival operation.",
+      "FESTIVAL_PERMISSION_DENIED",
+      error,
+    );
+  if (/not found|missing/i.test(message))
+    return new FestivalAdminServiceError(
+      "This festival edition could not be loaded.",
+      "FESTIVAL_EDITION_NOT_FOUND",
+      error,
+    );
+  if (/legacy|migration|hybrid|currency|mixed/i.test(message))
+    return new FestivalAdminServiceError(
+      "This festival record needs admin migration or data repair before it can be managed.",
+      "FESTIVAL_MIGRATION_REQUIRED",
+      error,
+    );
   return new FestivalAdminServiceError(message, "FESTIVAL_RPC_FAILED", error);
 }
 
 const nullableString = z.string().nullable();
-const catalogueRowSchema = z.object({ festival_id: z.string(), brand_name: z.string().nullable().optional(), owner_name: nullableString.optional(), city_name: nullableString.optional(), current_edition_id: nullableString.optional(), current_edition_title: nullableString.optional(), next_edition_id: nullableString.optional(), completed_edition_id: nullableString.optional(), edition_count: z.coerce.number().optional(), lifecycle_state: z.string().nullable().optional(), stage_count: z.coerce.number().optional(), active_contract_count: z.coerce.number().optional(), performance_session_count: z.coerce.number().optional(), outcome_count: z.coerce.number().optional(), attendance: z.coerce.number().nullable().optional(), currency_code: z.string().nullable().optional(), projected_finance_cents: z.coerce.number().nullable().optional(), actual_finance_cents: z.coerce.number().nullable().optional(), legacy_mappings: z.coerce.number().optional(), operational_readiness: z.string().nullable().optional(), data_health_warnings: z.unknown().optional() }).passthrough();
-const ownerEditionSchema = z.object({ id: z.string(), festival_id: z.string(), title: z.string().nullable().optional(), edition_number: z.coerce.number(), status: z.string(), start_at: nullableString.optional(), end_at: nullableString.optional(), city_name: nullableString.optional(), currency_code: z.string().nullable().optional() }).passthrough();
+const catalogueRowSchema = z
+  .object({
+    festival_id: z.string(),
+    brand_name: z.string().nullable().optional(),
+    owner_name: nullableString.optional(),
+    city_name: nullableString.optional(),
+    current_edition_id: nullableString.optional(),
+    current_edition_title: nullableString.optional(),
+    next_edition_id: nullableString.optional(),
+    completed_edition_id: nullableString.optional(),
+    edition_count: z.coerce.number().optional(),
+    lifecycle_state: z.string().nullable().optional(),
+    stage_count: z.coerce.number().optional(),
+    active_contract_count: z.coerce.number().optional(),
+    performance_session_count: z.coerce.number().optional(),
+    outcome_count: z.coerce.number().optional(),
+    attendance: z.coerce.number().nullable().optional(),
+    currency_code: z.string().nullable().optional(),
+    projected_finance_cents: z.coerce.number().nullable().optional(),
+    actual_finance_cents: z.coerce.number().nullable().optional(),
+    legacy_mappings: z.coerce.number().optional(),
+    operational_readiness: z.string().nullable().optional(),
+    data_health_warnings: z.unknown().optional(),
+  })
+  .passthrough();
+const ownerEditionSchema = z
+  .object({
+    id: z.string(),
+    festival_id: z.string(),
+    title: z.string().nullable().optional(),
+    edition_number: z.coerce.number(),
+    status: z.string(),
+    start_at: nullableString.optional(),
+    end_at: nullableString.optional(),
+    city_name: nullableString.optional(),
+    currency_code: z.string().nullable().optional(),
+  })
+  .passthrough();
 const jsonRecord = z.record(z.unknown());
-const nonNullJson = z.unknown().refine((value) => value !== null && value !== undefined, "RPC returned no result");
+const nonNullJson = z
+  .unknown()
+  .refine(
+    (value) => value !== null && value !== undefined,
+    "RPC returned no result",
+  );
 
-export async function fetchAdminFestivalCatalogue(): Promise<AdminFestivalCatalogueRow[]> {
-  const data = await rpc("admin_festival_catalogue" as RpcName, undefined, z.array(catalogueRowSchema));
+export async function fetchAdminFestivalCatalogue(): Promise<
+  AdminFestivalCatalogueRow[]
+> {
+  const data = await rpc(
+    "admin_festival_catalogue" as RpcName,
+    undefined,
+    z.array(catalogueRowSchema),
+  );
   return data.map(mapCatalogueRow);
 }
 
+const creationResultSchema = z
+  .object({
+    festival_id: z.string(),
+    edition_id: z.string(),
+    stage_ids: z.array(z.string()).default([]),
+    lifecycle_status: z.string(),
+    public_route: z.string(),
+    management_route: z.string(),
+    created: z.boolean(),
+  })
+  .passthrough();
+export async function createFestivalWithFirstEdition(
+  input: FestivalCreationDraft,
+): Promise<FestivalCreationResult> {
+  const data = await rpc(
+    "admin_create_festival_with_first_edition" as RpcName,
+    { p_payload: input },
+    creationResultSchema,
+  );
+  return {
+    festivalId: data.festival_id,
+    editionId: data.edition_id,
+    stageIds: data.stage_ids,
+    lifecycleStatus:
+      data.lifecycle_status as FestivalCreationResult["lifecycleStatus"],
+    publicRoute: data.public_route,
+    managementRoute: data.management_route,
+    created: data.created,
+  };
+}
+export async function createFestivalEditionFromWizard(
+  input: FestivalCreationDraft,
+): Promise<FestivalCreationResult> {
+  const data = await rpc(
+    "admin_create_festival_edition_with_setup" as RpcName,
+    { p_festival_id: input.existingFestivalId, p_payload: input },
+    creationResultSchema,
+  );
+  return {
+    festivalId: data.festival_id,
+    editionId: data.edition_id,
+    stageIds: data.stage_ids,
+    lifecycleStatus:
+      data.lifecycle_status as FestivalCreationResult["lifecycleStatus"],
+    publicRoute: data.public_route,
+    managementRoute: data.management_route,
+    created: data.created,
+  };
+}
+export async function fetchFestivalReferenceData() {
+  const client = supabase as any;
+  const [cities, venues] = await Promise.all([
+    client
+      .from("cities")
+      .select("id,name,country,timezone")
+      .order("country")
+      .order("name"),
+    client.from("venues").select("id,name,city_id,capacity").order("name"),
+  ]);
+  if (cities.error) throw mapFestivalError(cities.error);
+  if (venues.error) throw mapFestivalError(venues.error);
+  return { cities: cities.data ?? [], venues: venues.data ?? [] };
+}
+
 export async function createAdminFestivalBrand(input: AdminBrandInput) {
-  return rpc("admin_create_festival_brand" as RpcName, { p_name: input.name, p_home_city_id: input.homeCityId ?? null, p_description: input.description ?? null, p_genre_identity: input.genre ?? null, p_scale: input.scale ?? null, p_brand_type: input.brandType ?? "recurring", p_recurring_policy: input.recurringPolicy ?? "annual", p_owner_profile_id: input.ownerProfileId ?? null, p_public_metadata: input.publicMetadata ?? {}, p_idempotency_key: input.idempotencyKey }, nonNullJson);
+  return rpc(
+    "admin_create_festival_brand" as RpcName,
+    {
+      p_name: input.name,
+      p_home_city_id: input.homeCityId ?? null,
+      p_description: input.description ?? null,
+      p_genre_identity: input.genre ?? null,
+      p_scale: input.scale ?? null,
+      p_brand_type: input.brandType ?? "recurring",
+      p_recurring_policy: input.recurringPolicy ?? "annual",
+      p_owner_profile_id: input.ownerProfileId ?? null,
+      p_public_metadata: input.publicMetadata ?? {},
+      p_idempotency_key: input.idempotencyKey,
+    },
+    nonNullJson,
+  );
 }
 
 export async function createAdminFestivalEdition(input: AdminEditionInput) {
-  return rpc("create_festival_edition" as RpcName, { p_festival_id: input.festivalId, p_title: input.title, p_start_at: input.startAt, p_end_at: input.endAt, p_city_id: input.cityId ?? null, p_venue_id: null, p_expected_attendance: input.expectedAttendance ?? null, p_capacity: input.capacity ?? null, p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null, p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null, p_public_metadata: {}, p_idempotency_key: input.idempotencyKey }, nonNullJson);
+  return rpc(
+    "create_festival_edition" as RpcName,
+    {
+      p_festival_id: input.festivalId,
+      p_title: input.title,
+      p_start_at: input.startAt,
+      p_end_at: input.endAt,
+      p_city_id: input.cityId ?? null,
+      p_venue_id: null,
+      p_expected_attendance: input.expectedAttendance ?? null,
+      p_capacity: input.capacity ?? null,
+      p_minimum_ticket_price_cents: input.minimumTicketPriceCents ?? null,
+      p_maximum_ticket_price_cents: input.maximumTicketPriceCents ?? null,
+      p_public_metadata: {},
+      p_idempotency_key: input.idempotencyKey,
+    },
+    nonNullJson,
+  );
 }
 
-export async function transitionAdminFestivalEdition(editionId: string, targetStatus: FestivalLifecycleState, reason: string, override = false) {
-  return rpc("admin_transition_festival_edition" as RpcName, { p_edition_id: editionId, p_target_status: targetStatus, p_reason: reason, p_override: override, p_metadata: { source: "admin_festival_workspace" }, p_idempotency_key: crypto.randomUUID() }, nonNullJson);
+export async function transitionAdminFestivalEdition(
+  editionId: string,
+  targetStatus: FestivalLifecycleState,
+  reason: string,
+  override = false,
+) {
+  return rpc(
+    "admin_transition_festival_edition" as RpcName,
+    {
+      p_edition_id: editionId,
+      p_target_status: targetStatus,
+      p_reason: reason,
+      p_override: override,
+      p_metadata: { source: "admin_festival_workspace" },
+      p_idempotency_key: crypto.randomUUID(),
+    },
+    nonNullJson,
+  );
 }
 
-export async function fetchOwnerManagementBootstrap(identifier: string): Promise<OwnerManagementBootstrap> {
+export async function fetchOwnerManagementBootstrap(
+  identifier: string,
+): Promise<OwnerManagementBootstrap> {
   try {
-    const data = await rpc("festival_owner_management_bootstrap" as RpcName, { p_identifier: identifier }, jsonRecord);
+    const data = await rpc(
+      "festival_owner_management_bootstrap" as RpcName,
+      { p_identifier: identifier },
+      jsonRecord,
+    );
     return mapOwnerManagementBootstrap(data);
   } catch (error) {
-    const cause = error instanceof FestivalAdminServiceError ? error.cause as { code?: string; message?: string; details?: string; hint?: string } | undefined : undefined;
-    const message = error instanceof Error ? error.message : "Festival management bootstrap failed.";
-    if (cause?.code === "PGRST202" || /festival_owner_management_bootstrap|schema cache|function/i.test(message)) {
-      return { status: "rpc_unavailable", inputId: identifier, identifierType: null, festival: null, authority: { isOwner: false, isAdmin: false, delegatedRoles: [], canCreateEdition: false, canManage: false }, editions: [], preferredEditionId: null, migration: { required: false, issues: [] }, availableActions: [], message: `Owner-management bootstrap RPC is not deployed. ${cause?.message ?? message}` };
+    const cause =
+      error instanceof FestivalAdminServiceError
+        ? (error.cause as
+            | {
+                code?: string;
+                message?: string;
+                details?: string;
+                hint?: string;
+              }
+            | undefined)
+        : undefined;
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Festival management bootstrap failed.";
+    if (
+      cause?.code === "PGRST202" ||
+      /festival_owner_management_bootstrap|schema cache|function/i.test(message)
+    ) {
+      return {
+        status: "rpc_unavailable",
+        inputId: identifier,
+        identifierType: null,
+        festival: null,
+        authority: {
+          isOwner: false,
+          isAdmin: false,
+          delegatedRoles: [],
+          canCreateEdition: false,
+          canManage: false,
+        },
+        editions: [],
+        preferredEditionId: null,
+        migration: { required: false, issues: [] },
+        availableActions: [],
+        message: `Owner-management bootstrap RPC is not deployed. ${cause?.message ?? message}`,
+      };
     }
     throw error;
   }
 }
 
-export async function fetchOwnerFestivalEditions(festivalId: string): Promise<OwnerEditionOption[]> {
-  const data = await rpc("festival_owner_edition_options" as RpcName, { p_festival_id: festivalId }, z.array(ownerEditionSchema));
+export async function fetchOwnerFestivalEditions(
+  festivalId: string,
+): Promise<OwnerEditionOption[]> {
+  const data = await rpc(
+    "festival_owner_edition_options" as RpcName,
+    { p_festival_id: festivalId },
+    z.array(ownerEditionSchema),
+  );
   return data.map(mapOwnerEdition);
 }
 
-export async function createFestivalEditionStage(input: import("./types").StageInput) { return rpc("create_festival_edition_stage" as RpcName, { p_edition_id: input.editionId, p_name: input.name, p_type: input.type ?? "main", p_capacity: input.capacity ?? 0, p_genre_focus: input.genreFocus ?? null, p_stage_size: input.stageSize ?? null, p_sound_capability: input.soundCapability ?? null, p_lighting_capability: input.lightingCapability ?? null, p_backstage_capability: input.backstageCapability ?? null, p_weather_protection: input.weatherProtection ?? null, p_changeover_duration: input.changeoverDuration ?? 30, p_curfew: input.curfew ?? null, p_technical_metadata: input.technicalMetadata ?? {}, p_public_metadata: input.publicMetadata ?? {}, p_idempotency_key: input.idempotencyKey }, nonNullJson); }
-export async function generateFestivalStageSlots(input: import("./types").SlotGenerationInput) { return rpc("generate_festival_stage_slots" as RpcName, { p_stage_id: input.stageId, p_date: input.date, p_opening_time: input.openingTime, p_curfew: input.curfew, p_slot_templates: input.templates, p_changeover_duration: input.changeoverDuration ?? 30, p_soundcheck_policy: input.soundcheckPolicy ?? {}, p_idempotency_key: input.idempotencyKey, p_apply: input.apply ?? false }, jsonRecord); }
-export async function hireFestivalEditionStaff(input: import("./types").StaffHireInput) { return rpc("hire_festival_edition_staff" as RpcName, { p_edition_id: input.editionId, p_candidate_id: input.candidateId, p_role: input.role, p_wage_cents: input.wageCents, p_assignment_scope: input.assignmentScope ?? {}, p_shift_start_at: input.shiftStartAt ?? null, p_shift_end_at: input.shiftEndAt ?? null, p_idempotency_key: input.idempotencyKey }, nonNullJson); }
-export async function applyForFestivalEditionPermit(editionId: string, requirementCode: string, idempotencyKey: string) { return rpc("apply_for_festival_edition_permit" as RpcName, { p_edition_id: editionId, p_requirement_code: requirementCode, p_idempotency_key: idempotencyKey }, nonNullJson); }
-export async function quoteFestivalEditionInsurance(editionId: string, provider = "RockMundo Mutual", coverageType = "standard") { return rpc("quote_festival_edition_insurance" as RpcName, { p_edition_id: editionId, p_provider: provider, p_coverage_type: coverageType }, jsonRecord); }
-export async function purchaseFestivalEditionInsurance(quoteId: string, idempotencyKey: string) { return rpc("purchase_festival_edition_insurance" as RpcName, { p_quote_id: quoteId, p_idempotency_key: idempotencyKey }, nonNullJson); }
-export async function fetchFestivalEditionFinanceSummary(editionId: string) { return rpc("festival_edition_finance_summary" as RpcName, { p_edition_id: editionId }, jsonRecord); }
-export async function previewCopyFestivalEdition(sourceEditionId: string, targetEditionId?: string | null) { return rpc("preview_copy_festival_edition" as RpcName, { p_source_edition_id: sourceEditionId, p_target_edition_id: targetEditionId ?? null }, jsonRecord); }
+export async function createFestivalEditionStage(
+  input: import("./types").StageInput,
+) {
+  return rpc(
+    "create_festival_edition_stage" as RpcName,
+    {
+      p_edition_id: input.editionId,
+      p_name: input.name,
+      p_type: input.type ?? "main",
+      p_capacity: input.capacity ?? 0,
+      p_genre_focus: input.genreFocus ?? null,
+      p_stage_size: input.stageSize ?? null,
+      p_sound_capability: input.soundCapability ?? null,
+      p_lighting_capability: input.lightingCapability ?? null,
+      p_backstage_capability: input.backstageCapability ?? null,
+      p_weather_protection: input.weatherProtection ?? null,
+      p_changeover_duration: input.changeoverDuration ?? 30,
+      p_curfew: input.curfew ?? null,
+      p_technical_metadata: input.technicalMetadata ?? {},
+      p_public_metadata: input.publicMetadata ?? {},
+      p_idempotency_key: input.idempotencyKey,
+    },
+    nonNullJson,
+  );
+}
+export async function generateFestivalStageSlots(
+  input: import("./types").SlotGenerationInput,
+) {
+  return rpc(
+    "generate_festival_stage_slots" as RpcName,
+    {
+      p_stage_id: input.stageId,
+      p_date: input.date,
+      p_opening_time: input.openingTime,
+      p_curfew: input.curfew,
+      p_slot_templates: input.templates,
+      p_changeover_duration: input.changeoverDuration ?? 30,
+      p_soundcheck_policy: input.soundcheckPolicy ?? {},
+      p_idempotency_key: input.idempotencyKey,
+      p_apply: input.apply ?? false,
+    },
+    jsonRecord,
+  );
+}
+export async function hireFestivalEditionStaff(
+  input: import("./types").StaffHireInput,
+) {
+  return rpc(
+    "hire_festival_edition_staff" as RpcName,
+    {
+      p_edition_id: input.editionId,
+      p_candidate_id: input.candidateId,
+      p_role: input.role,
+      p_wage_cents: input.wageCents,
+      p_assignment_scope: input.assignmentScope ?? {},
+      p_shift_start_at: input.shiftStartAt ?? null,
+      p_shift_end_at: input.shiftEndAt ?? null,
+      p_idempotency_key: input.idempotencyKey,
+    },
+    nonNullJson,
+  );
+}
+export async function applyForFestivalEditionPermit(
+  editionId: string,
+  requirementCode: string,
+  idempotencyKey: string,
+) {
+  return rpc(
+    "apply_for_festival_edition_permit" as RpcName,
+    {
+      p_edition_id: editionId,
+      p_requirement_code: requirementCode,
+      p_idempotency_key: idempotencyKey,
+    },
+    nonNullJson,
+  );
+}
+export async function quoteFestivalEditionInsurance(
+  editionId: string,
+  provider = "RockMundo Mutual",
+  coverageType = "standard",
+) {
+  return rpc(
+    "quote_festival_edition_insurance" as RpcName,
+    {
+      p_edition_id: editionId,
+      p_provider: provider,
+      p_coverage_type: coverageType,
+    },
+    jsonRecord,
+  );
+}
+export async function purchaseFestivalEditionInsurance(
+  quoteId: string,
+  idempotencyKey: string,
+) {
+  return rpc(
+    "purchase_festival_edition_insurance" as RpcName,
+    { p_quote_id: quoteId, p_idempotency_key: idempotencyKey },
+    nonNullJson,
+  );
+}
+export async function fetchFestivalEditionFinanceSummary(editionId: string) {
+  return rpc(
+    "festival_edition_finance_summary" as RpcName,
+    { p_edition_id: editionId },
+    jsonRecord,
+  );
+}
+export async function previewCopyFestivalEdition(
+  sourceEditionId: string,
+  targetEditionId?: string | null,
+) {
+  return rpc(
+    "preview_copy_festival_edition" as RpcName,
+    {
+      p_source_edition_id: sourceEditionId,
+      p_target_edition_id: targetEditionId ?? null,
+    },
+    jsonRecord,
+  );
+}
 
-const callMaybeRpc = async <T>(fn: string, args?: Record<string, unknown>, fallback?: () => Promise<T>): Promise<T> => {
-  try { return await rpc(fn as RpcName, args, jsonRecord as z.ZodType<T>); } catch (error) { if (fallback) { try { return await fallback(); } catch { /* graceful */ return ({} as T); } } throw error; }
+const callMaybeRpc = async <T>(
+  fn: string,
+  args?: Record<string, unknown>,
+  fallback?: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await rpc(fn as RpcName, args, jsonRecord as z.ZodType<T>);
+  } catch (error) {
+    if (fallback) {
+      try {
+        return await fallback();
+      } catch {
+        /* graceful */ return {} as T;
+      }
+    }
+    throw error;
+  }
 };
 
 export async function fetchFestivalEditionOperations(editionId: string) {
-  return callMaybeRpc("festival_edition_operations_summary", { p_edition_id: editionId }, async () => {
-    const client = supabase as any;
-    const [stages, slots, staff, permits, insurance] = await Promise.all([
-      client.from("festival_stages").select("*").eq("edition_id", editionId),
-      client.from("festival_stage_slots").select("*").eq("edition_id", editionId),
-      client.from("festival_staff").select("*").eq("edition_id", editionId),
-      client.from("festival_permits").select("*").eq("edition_id", editionId),
-      client.from("festival_insurance_policies").select("*").eq("edition_id", editionId),
-    ]);
-    const firstError = [stages, slots, staff, permits, insurance].find((r) => r.error)?.error;
-    if (firstError) throw mapFestivalError(firstError);
-    return { stages: stages.data ?? [], slots: slots.data ?? [], staff: staff.data ?? [], candidates: [], permit_requirements: permits.data ?? [], insurance_quotes: [], insurance_policies: insurance.data ?? [], permissions: {}, lifecycle: {} };
-  });
+  return callMaybeRpc(
+    "festival_edition_operations_summary",
+    { p_edition_id: editionId },
+    async () => {
+      const client = supabase as any;
+      const [stages, slots, staff, permits, insurance] = await Promise.all([
+        client.from("festival_stages").select("*").eq("edition_id", editionId),
+        client
+          .from("festival_stage_slots")
+          .select("*")
+          .eq("edition_id", editionId),
+        client.from("festival_staff").select("*").eq("edition_id", editionId),
+        client.from("festival_permits").select("*").eq("edition_id", editionId),
+        client
+          .from("festival_insurance_policies")
+          .select("*")
+          .eq("edition_id", editionId),
+      ]);
+      const firstError = [stages, slots, staff, permits, insurance].find(
+        (r) => r.error,
+      )?.error;
+      if (firstError) throw mapFestivalError(firstError);
+      return {
+        stages: stages.data ?? [],
+        slots: slots.data ?? [],
+        staff: staff.data ?? [],
+        candidates: [],
+        permit_requirements: permits.data ?? [],
+        insurance_quotes: [],
+        insurance_policies: insurance.data ?? [],
+        permissions: {},
+        lifecycle: {},
+      };
+    },
+  );
 }
 
-export async function fetchFestivalAdminDataHealth() { return callMaybeRpc("admin_festival_data_health", {}, async () => { try { const { data } = await (supabase as any).from("festival_migration_issues").select("*").order("created_at", { ascending: false }).limit(100); return { issues: data ?? [] }; } catch { return { issues: [] }; } }); }
-export async function fetchFestivalLegacyRecords() { return callMaybeRpc("admin_festival_legacy_records", {}, async () => { try { const { data } = await (supabase as any).from("festival_legacy_mappings").select("*").order("created_at", { ascending: false }).limit(100); return { records: data ?? [] }; } catch { return { records: [] }; } }); }
-export async function fetchFestivalAuditEvents(filters: Record<string, string>) { return callMaybeRpc("admin_festival_audit_events", { p_filters: filters }, async () => { try { const { data } = await (supabase as any).from("festival_admin_audit_events").select("*").order("created_at", { ascending: false }).limit(100); return { events: data ?? [] }; } catch { return { events: [] }; } }); }
-export async function repairFestivalDataHealthIssue(input: { issueId: string; action: string; reason?: string }) { return callMaybeRpc("repair_festival_data_health_issue", { p_issue_id: input.issueId, p_action: input.action, p_reason: input.reason ?? null }, async () => ({ unavailable: true, message: "Data-health repair RPC is unavailable in this environment." })); }
-export async function previewLegacyFestivalMigration(mappingId: string) { return callMaybeRpc("preview_festival_legacy_migration", { p_mapping_id: mappingId }, async () => ({ unavailable: true, preview_hash: null, message: "Legacy migration preview RPC is unavailable in this environment." })); }
-export async function applyLegacyFestivalMigration(mappingId: string) { return callMaybeRpc("apply_festival_legacy_migration", { p_mapping_id: mappingId, p_idempotency_key: `legacy:${mappingId}` }, async () => ({ unavailable: true, message: "Legacy migration apply RPC is unavailable in this environment." })); }
-export async function reviewFestivalEditionPermit(input: { permitId: string; action: string; reason?: string }) { return callMaybeRpc("admin_review_festival_edition_permit", { p_permit_id: input.permitId, p_action: input.action, p_reason: input.reason ?? null, p_idempotency_key: `permit-review:${input.permitId}:${input.action}` }, async () => ({ unavailable: true, message: "Permit review RPC is unavailable in this environment." })); }
+export async function fetchFestivalAdminDataHealth() {
+  return callMaybeRpc("admin_festival_data_health", {}, async () => {
+    try {
+      const { data } = await (supabase as any)
+        .from("festival_migration_issues")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(100);
+      return { issues: data ?? [] };
+    } catch {
+      return { issues: [] };
+    }
+  });
+}
+export async function fetchFestivalLegacyRecords() {
+  return callMaybeRpc("admin_festival_legacy_records", {}, async () => {
+    try {
+      const { data } = await (supabase as any)
+        .from("festival_legacy_mappings")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(100);
+      return { records: data ?? [] };
+    } catch {
+      return { records: [] };
+    }
+  });
+}
+export async function fetchFestivalAuditEvents(
+  filters: Record<string, string>,
+) {
+  return callMaybeRpc(
+    "admin_festival_audit_events",
+    { p_filters: filters },
+    async () => {
+      try {
+        const { data } = await (supabase as any)
+          .from("festival_admin_audit_events")
+          .select("*")
+          .order("created_at", { ascending: false })
+          .limit(100);
+        return { events: data ?? [] };
+      } catch {
+        return { events: [] };
+      }
+    },
+  );
+}
+export async function repairFestivalDataHealthIssue(input: {
+  issueId: string;
+  action: string;
+  reason?: string;
+}) {
+  return callMaybeRpc(
+    "repair_festival_data_health_issue",
+    {
+      p_issue_id: input.issueId,
+      p_action: input.action,
+      p_reason: input.reason ?? null,
+    },
+    async () => ({
+      unavailable: true,
+      message: "Data-health repair RPC is unavailable in this environment.",
+    }),
+  );
+}
+export async function previewLegacyFestivalMigration(mappingId: string) {
+  return callMaybeRpc(
+    "preview_festival_legacy_migration",
+    { p_mapping_id: mappingId },
+    async () => ({
+      unavailable: true,
+      preview_hash: null,
+      message:
+        "Legacy migration preview RPC is unavailable in this environment.",
+    }),
+  );
+}
+export async function applyLegacyFestivalMigration(mappingId: string) {
+  return callMaybeRpc(
+    "apply_festival_legacy_migration",
+    { p_mapping_id: mappingId, p_idempotency_key: `legacy:${mappingId}` },
+    async () => ({
+      unavailable: true,
+      message: "Legacy migration apply RPC is unavailable in this environment.",
+    }),
+  );
+}
+export async function reviewFestivalEditionPermit(input: {
+  permitId: string;
+  action: string;
+  reason?: string;
+}) {
+  return callMaybeRpc(
+    "admin_review_festival_edition_permit",
+    {
+      p_permit_id: input.permitId,
+      p_action: input.action,
+      p_reason: input.reason ?? null,
+      p_idempotency_key: `permit-review:${input.permitId}:${input.action}`,
+    },
+    async () => ({
+      unavailable: true,
+      message: "Permit review RPC is unavailable in this environment.",
+    }),
+  );
+}

--- a/src/features/festivals/admin/types.ts
+++ b/src/features/festivals/admin/types.ts
@@ -1,6 +1,17 @@
 export type FestivalLifecycleState =
-  | "concept" | "planning" | "applications_open" | "booking" | "announced" | "on_sale"
-  | "setup" | "live" | "settling" | "completed" | "postponed" | "cancelled" | "abandoned";
+  | "concept"
+  | "planning"
+  | "applications_open"
+  | "booking"
+  | "announced"
+  | "on_sale"
+  | "setup"
+  | "live"
+  | "settling"
+  | "completed"
+  | "postponed"
+  | "cancelled"
+  | "abandoned";
 
 export type FestivalDataHealthIssue = {
   code: string;
@@ -28,7 +39,11 @@ export type AdminFestivalCatalogueRow = {
   projectedFinanceCents: number;
   actualFinanceCents: number;
   legacyMappings: number;
-  operationalReadiness: "missing_edition" | "needs_stages" | "needs_contracts" | "ready";
+  operationalReadiness:
+    | "missing_edition"
+    | "needs_stages"
+    | "needs_contracts"
+    | "ready";
   dataHealthWarnings: FestivalDataHealthIssue[];
 };
 
@@ -70,14 +85,32 @@ export type OwnerEditionOption = {
   currencyCode: string;
 };
 
-export type OwnerManagementBootstrapStatus = "ready" | "no_editions" | "not_found" | "access_denied" | "migration_blocked" | "unauthenticated" | "rpc_unavailable";
+export type OwnerManagementBootstrapStatus =
+  | "ready"
+  | "no_editions"
+  | "not_found"
+  | "access_denied"
+  | "migration_blocked"
+  | "unauthenticated"
+  | "rpc_unavailable";
 
 export type OwnerManagementBootstrap = {
   status: OwnerManagementBootstrapStatus;
   inputId: string | null;
   identifierType: string | null;
-  festival: { id: string; name: string; ownerType: string | null; ownerProfileId: string | null } | null;
-  authority: { isOwner: boolean; isAdmin: boolean; delegatedRoles: string[]; canCreateEdition: boolean; canManage: boolean };
+  festival: {
+    id: string;
+    name: string;
+    ownerType: string | null;
+    ownerProfileId: string | null;
+  } | null;
+  authority: {
+    isOwner: boolean;
+    isAdmin: boolean;
+    delegatedRoles: string[];
+    canCreateEdition: boolean;
+    canManage: boolean;
+  };
   editions: OwnerEditionOption[];
   preferredEditionId: string | null;
   migration: { required: boolean; issues: FestivalDataHealthIssue[] };
@@ -85,9 +118,26 @@ export type OwnerManagementBootstrap = {
   message: string | null;
 };
 
-export type PermissionRole = "platform_admin" | "festival_owner" | "delegated_manager" | "talent_booker" | "finance_manager" | "operations_manager" | "stage_manager" | "safety_officer";
+export type PermissionRole =
+  | "platform_admin"
+  | "festival_owner"
+  | "delegated_manager"
+  | "talent_booker"
+  | "finance_manager"
+  | "operations_manager"
+  | "stage_manager"
+  | "safety_officer";
 
-export type PermissionProjection = Record<"manageBrand" | "manageEdition" | "manageLifecycle" | "manageLineup" | "manageFinance" | "manageOperations" | "viewOutcomes", boolean>;
+export type PermissionProjection = Record<
+  | "manageBrand"
+  | "manageEdition"
+  | "manageLifecycle"
+  | "manageLineup"
+  | "manageFinance"
+  | "manageOperations"
+  | "viewOutcomes",
+  boolean
+>;
 
 export type StageInput = {
   editionId: string;
@@ -108,7 +158,14 @@ export type StageInput = {
 };
 
 export type SlotTemplate = {
-  type: "opener" | "support" | "headline" | "dj_intermission" | "host" | "flexible" | "reserved_emergency";
+  type:
+    | "opener"
+    | "support"
+    | "headline"
+    | "dj_intermission"
+    | "host"
+    | "flexible"
+    | "reserved_emergency";
   start_time: string;
   duration_minutes: number;
 };
@@ -134,4 +191,86 @@ export type StaffHireInput = {
   shiftStartAt?: string | null;
   shiftEndAt?: string | null;
   idempotencyKey: string;
+};
+
+export type FestivalCreationMode =
+  | "create_festival"
+  | "create_first_edition"
+  | "add_edition";
+export type FestivalIdentityInput = {
+  name: string;
+  shortDescription: string;
+  fullDescription: string;
+  festivalType: string;
+  primaryGenres: string[];
+  imageUrl?: string | null;
+  isPublic: boolean;
+};
+export type FestivalEditionCreationInput = {
+  title: string;
+  editionNumber: number;
+  startAt: string;
+  endAt: string;
+  applicationsOpenAt: string;
+  applicationsCloseAt: string;
+  bookingDeadlineAt?: string | null;
+  timezone: string;
+  currencyCode: string;
+};
+export type FestivalLocationInput = {
+  country: string;
+  cityId: string;
+  cityName?: string | null;
+  venueId?: string | null;
+  siteName?: string | null;
+  capacity: number;
+  minTicketPriceCents: number;
+  maxTicketPriceCents: number;
+  defaultTicketPriceCents: number;
+  festivalDays: number;
+};
+export type FestivalStageCreationInput = {
+  name: string;
+  type: string;
+  capacity: number;
+  changeoverMinutes: number;
+  curfew: string;
+  weatherProtection: string;
+  soundCapability: string;
+  lightingCapability: string;
+};
+export type FestivalCommercialConfig = {
+  estimatedAttendance: number;
+  operatingBudgetCents: number;
+  performerBudgetCents: number;
+  staffingBudgetCents: number;
+  marketingBudgetCents: number;
+  sponsorshipEnabled: boolean;
+  merchandiseEnabled: boolean;
+  concessionsEnabled: boolean;
+};
+export type FestivalCreationDraft = {
+  mode: FestivalCreationMode;
+  existingFestivalId?: string;
+  identity: FestivalIdentityInput;
+  edition: FestivalEditionCreationInput;
+  location: FestivalLocationInput;
+  stages: FestivalStageCreationInput[];
+  commercial: FestivalCommercialConfig;
+  idempotencyKey: string;
+};
+export type FestivalCreationValidationErrors = Partial<
+  Record<
+    "identity" | "edition" | "location" | "stages" | "commercial" | "submit",
+    string[]
+  >
+>;
+export type FestivalCreationResult = {
+  festivalId: string;
+  editionId: string;
+  stageIds: string[];
+  lifecycleStatus: FestivalLifecycleState;
+  publicRoute: string;
+  managementRoute: string;
+  created: boolean;
 };

--- a/src/pages/admin/FestivalsAdmin.tsx
+++ b/src/pages/admin/FestivalsAdmin.tsx
@@ -10,72 +10,672 @@ import { FestivalOutcomesManagement } from "@/features/festivals/admin/component
 import { FestivalSettlementManagement } from "@/features/festivals/admin/components/FestivalSettlementManagement";
 import { FestivalDataHealthManagement } from "@/features/festivals/admin/components/FestivalDataHealthManagement";
 import { FestivalLegacyRecordsManagement } from "@/features/festivals/admin/components/FestivalLegacyRecordsManagement";
+import { FestivalLifecycleControls } from "@/features/festivals/admin/components/FestivalLifecycleControls";
+import { FestivalCreationWizard } from "@/features/festivals/admin/components/FestivalCreationWizard";
 import { FestivalAuditLog } from "@/features/festivals/admin/components/FestivalAuditLog";
-import { useAdminFestivalCatalogue, useOwnerFestivalEditions } from "@/features/festivals/admin/hooks";
-import type { AdminFestivalCatalogueRow, OwnerEditionOption } from "@/features/festivals/admin/types";
+import {
+  useAdminFestivalCatalogue,
+  useOwnerFestivalEditions,
+} from "@/features/festivals/admin/hooks";
+import type {
+  AdminFestivalCatalogueRow,
+  OwnerEditionOption,
+} from "@/features/festivals/admin/types";
 import { useFestivalSlotApplications } from "@/hooks/useFestivalSlotApplications";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 
 export function selectPreferredFestivalEdition(editions: OwnerEditionOption[]) {
   const ranked = [
     (e: OwnerEditionOption) => e.status === "live",
-    (e: OwnerEditionOption) => ["applications_open", "booking", "announced", "on_sale", "setup", "planning", "concept"].includes(e.status),
+    (e: OwnerEditionOption) =>
+      [
+        "applications_open",
+        "booking",
+        "announced",
+        "on_sale",
+        "setup",
+        "planning",
+        "concept",
+      ].includes(e.status),
     (e: OwnerEditionOption) => e.status === "completed",
     () => true,
   ];
   for (const match of ranked) {
-    const candidates = editions.filter(match).sort((a, b) => String(b.endAt ?? b.startAt ?? "").localeCompare(String(a.endAt ?? a.startAt ?? "")));
+    const candidates = editions
+      .filter(match)
+      .sort((a, b) =>
+        String(b.endAt ?? b.startAt ?? "").localeCompare(
+          String(a.endAt ?? a.startAt ?? ""),
+        ),
+      );
     if (candidates[0]) return candidates[0];
   }
   return undefined;
 }
 
-function EditionRequired({ editionId, children }: { editionId?: string; children: React.ReactNode }) {
+function EditionRequired({
+  editionId,
+  children,
+  onCreateFirstEdition,
+}: {
+  editionId?: string;
+  children: React.ReactNode;
+  onCreateFirstEdition?: () => void;
+}) {
   if (editionId) return <>{children}</>;
-  return <Card><CardHeader><CardTitle>Festival operations are unavailable until an edition is selected.</CardTitle></CardHeader><CardContent className="space-y-3 text-sm text-muted-foreground"><p>Select a festival edition above before loading edition-specific tools.</p><Button disabled>Create first edition</Button></CardContent></Card>;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          Festival operations are unavailable until an edition is selected.
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <p>
+          Select or create a festival edition before loading edition-specific
+          tools.
+        </p>
+        <Button onClick={onCreateFirstEdition}>Create first edition</Button>
+      </CardContent>
+    </Card>
+  );
 }
 
-function FestivalEditionSelector({ rows, selectedFestivalId, setSelectedFestivalId, selectedEditionId, setSelectedEditionId }: { rows: AdminFestivalCatalogueRow[]; selectedFestivalId?: string; setSelectedFestivalId: (id: string) => void; selectedEditionId?: string; setSelectedEditionId: (id: string) => void }) {
+function FestivalEditionSelector({
+  rows,
+  selectedFestivalId,
+  setSelectedFestivalId,
+  selectedEditionId,
+  setSelectedEditionId,
+}: {
+  rows: AdminFestivalCatalogueRow[];
+  selectedFestivalId?: string;
+  setSelectedFestivalId: (id: string) => void;
+  selectedEditionId?: string;
+  setSelectedEditionId: (id: string) => void;
+}) {
   const editionsQuery = useOwnerFestivalEditions(selectedFestivalId);
   const editions = editionsQuery.data ?? [];
   useEffect(() => {
-    if (!selectedFestivalId && rows[0]) setSelectedFestivalId(rows[0].festivalId);
+    if (!selectedFestivalId && rows[0])
+      setSelectedFestivalId(rows[0].festivalId);
   }, [rows, selectedFestivalId, setSelectedFestivalId]);
   useEffect(() => {
     if (!selectedFestivalId) return;
-    if (editions.length === 0) { setSelectedEditionId(""); return; }
-    if (!editions.some((edition) => edition.id === selectedEditionId)) setSelectedEditionId(selectPreferredFestivalEdition(editions)?.id ?? "");
+    if (editions.length === 0) {
+      setSelectedEditionId("");
+      return;
+    }
+    if (!editions.some((edition) => edition.id === selectedEditionId))
+      setSelectedEditionId(selectPreferredFestivalEdition(editions)?.id ?? "");
   }, [editions, selectedFestivalId, selectedEditionId, setSelectedEditionId]);
 
-  return <Card><CardHeader><CardTitle>Festival and edition selection</CardTitle><CardDescription>Choose the festival workspace. The most relevant edition is selected automatically when possible.</CardDescription></CardHeader><CardContent className="grid gap-4 md:grid-cols-2"><div><Label>Festival</Label><Select value={selectedFestivalId} onValueChange={setSelectedFestivalId}><SelectTrigger><SelectValue placeholder="Select a festival" /></SelectTrigger><SelectContent>{rows.map((row) => <SelectItem key={row.festivalId} value={row.festivalId}>{row.brandName}</SelectItem>)}</SelectContent></Select></div><div><Label>Festival edition</Label><Select value={selectedEditionId} onValueChange={setSelectedEditionId} disabled={editionsQuery.isLoading || editions.length === 0}><SelectTrigger><SelectValue placeholder={editions.length ? "Select an edition" : "No edition available"} /></SelectTrigger><SelectContent>{editions.map((edition) => <SelectItem key={edition.id} value={edition.id}>{edition.title} · {edition.status}</SelectItem>)}</SelectContent></Select>{editionsQuery.isLoading && <p className="mt-2 text-sm text-muted-foreground">Loading festival editions…</p>}{editionsQuery.error && <p className="mt-2 text-sm text-destructive">Festival editions could not be loaded.</p>}{!editionsQuery.isLoading && editions.length === 0 && <p className="mt-2 text-sm text-muted-foreground">No edition has been created for this festival.</p>}</div></CardContent></Card>;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Festival and edition selection</CardTitle>
+        <CardDescription>
+          Choose the festival workspace. The most relevant edition is selected
+          automatically when possible.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-2">
+        <div>
+          <Label>Festival</Label>
+          <Select
+            value={selectedFestivalId}
+            onValueChange={setSelectedFestivalId}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select a festival" />
+            </SelectTrigger>
+            <SelectContent>
+              {rows.map((row) => (
+                <SelectItem key={row.festivalId} value={row.festivalId}>
+                  {row.brandName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label>Festival edition</Label>
+          <Select
+            value={selectedEditionId}
+            onValueChange={setSelectedEditionId}
+            disabled={editionsQuery.isLoading || editions.length === 0}
+          >
+            <SelectTrigger>
+              <SelectValue
+                placeholder={
+                  editions.length ? "Select an edition" : "No edition available"
+                }
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {editions.map((edition) => (
+                <SelectItem key={edition.id} value={edition.id}>
+                  {edition.title} · {edition.status}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {editionsQuery.isLoading && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              Loading festival editions…
+            </p>
+          )}
+          {editionsQuery.error && (
+            <p className="mt-2 text-sm text-destructive">
+              Festival editions could not be loaded.
+            </p>
+          )}
+          {!editionsQuery.isLoading && editions.length === 0 && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              No edition has been created for this festival.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
 }
 
-function Overview({ selectedFestival, selectedEdition }: { selectedFestival?: AdminFestivalCatalogueRow; selectedEdition?: OwnerEditionOption }) {
-  if (!selectedFestival) return <Card><CardContent className="p-6 text-muted-foreground">No festivals have been created yet.</CardContent></Card>;
-  return <div className="space-y-4"><AdminFestivalCatalogue /><Card><CardHeader><CardTitle>Selected festival summary</CardTitle><CardDescription>Lifecycle controls are shown after a valid festival edition is selected.</CardDescription></CardHeader><CardContent className="grid gap-3 md:grid-cols-4"><p><span className="text-muted-foreground">Festival</span><br /><b>{selectedFestival.brandName}</b></p><p><span className="text-muted-foreground">City</span><br /><b>{selectedFestival.cityName ?? "Not set"}</b></p><p><span className="text-muted-foreground">Lifecycle</span><br /><b>{selectedEdition?.status ?? selectedFestival.lifecycleState ?? "No edition"}</b></p><p><span className="text-muted-foreground">Dates</span><br /><b>{selectedEdition?.startAt ?? "Not scheduled"} → {selectedEdition?.endAt ?? "Not scheduled"}</b></p><p><span className="text-muted-foreground">Stages</span><br /><b>{selectedFestival.stageCount}</b></p><p><span className="text-muted-foreground">Confirmed bands</span><br /><b>{selectedFestival.activeContractCount}</b></p><p><span className="text-muted-foreground">System check warnings</span><br /><b>{selectedFestival.dataHealthWarnings.length}</b></p><p><span className="text-muted-foreground">Edition</span><br /><b>{selectedEdition?.title ?? "No edition has been created for this festival."}</b></p></CardContent></Card></div>;
+function Overview({
+  selectedFestival,
+  selectedEdition,
+  onCreateFestival,
+  onCreateEdition,
+  onSelectFestival,
+  onOpenManagement,
+}: {
+  selectedFestival?: AdminFestivalCatalogueRow;
+  selectedEdition?: OwnerEditionOption;
+  onCreateFestival: () => void;
+  onCreateEdition: (
+    festivalId: string,
+    mode: "create_first_edition" | "add_edition",
+  ) => void;
+  onSelectFestival: (festivalId: string) => void;
+  onOpenManagement: (festivalId: string, editionId: string) => void;
+}) {
+  if (!selectedFestival)
+    return (
+      <div className="space-y-4">
+        <AdminFestivalCatalogue
+          selectedFestivalId={selectedFestival?.festivalId}
+          onCreateFestival={onCreateFestival}
+          onCreateEdition={onCreateEdition}
+          onSelectFestival={onSelectFestival}
+          onOpenManagement={onOpenManagement}
+        />
+        <Card>
+          <CardContent className="flex items-center justify-between p-6 text-muted-foreground">
+            <span>No festivals have been created yet.</span>
+            <Button onClick={onCreateFestival}>Create Festival</Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  return (
+    <div className="space-y-4">
+      <AdminFestivalCatalogue
+        selectedFestivalId={selectedFestival.festivalId}
+        onCreateFestival={onCreateFestival}
+        onCreateEdition={onCreateEdition}
+        onSelectFestival={onSelectFestival}
+        onOpenManagement={onOpenManagement}
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle>Selected festival summary</CardTitle>
+          <CardDescription>
+            Lifecycle controls are shown after a valid festival edition is
+            selected.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-4">
+          <p>
+            <span className="text-muted-foreground">Festival</span>
+            <br />
+            <b>{selectedFestival.brandName}</b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">City</span>
+            <br />
+            <b>{selectedFestival.cityName ?? "Not set"}</b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">Lifecycle</span>
+            <br />
+            <b>
+              {selectedEdition?.status ??
+                selectedFestival.lifecycleState ??
+                "No edition"}
+            </b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">Dates</span>
+            <br />
+            <b>
+              {selectedEdition?.startAt ?? "Not scheduled"} →{" "}
+              {selectedEdition?.endAt ?? "Not scheduled"}
+            </b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">Stages</span>
+            <br />
+            <b>{selectedFestival.stageCount}</b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">Confirmed bands</span>
+            <br />
+            <b>{selectedFestival.activeContractCount}</b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">System check warnings</span>
+            <br />
+            <b>{selectedFestival.dataHealthWarnings.length}</b>
+          </p>
+          <p>
+            <span className="text-muted-foreground">Edition</span>
+            <br />
+            <b>
+              {selectedEdition?.title ??
+                "No edition has been created for this festival."}
+            </b>
+          </p>
+        </CardContent>
+      </Card>
+      <FestivalLifecycleControls
+        editionId={selectedEdition?.id}
+        status={selectedEdition?.status ?? selectedFestival.lifecycleState}
+      />
+    </div>
+  );
 }
 
-function Applications({ festivalId }: { festivalId?: string }) {
-  const [selectedApplication, setSelectedApplication] = useState<any>(null); const [adminNotes, setAdminNotes] = useState(""); const [offeredPayment, setOfferedPayment] = useState("");
-  const { applications, isLoading, reviewApplication, isReviewing } = useFestivalSlotApplications(festivalId);
-  const pending = applications?.filter((a) => a.status === "pending") ?? []; const reviewed = applications?.filter((a) => a.status !== "pending") ?? [];
-  const submit = (status: "accepted" | "rejected") => { if (!selectedApplication) return; reviewApplication({ applicationId: selectedApplication.id, status, adminNotes: adminNotes || undefined, offeredPayment: offeredPayment ? Number(offeredPayment) : undefined }); setSelectedApplication(null); setAdminNotes(""); setOfferedPayment(""); };
-  if (!festivalId) return <Card><CardContent className="p-6 text-muted-foreground">Select a festival before reviewing applications.</CardContent></Card>;
-  if (isLoading) return <Card><CardContent className="p-6">Loading festival applications…</CardContent></Card>;
-  return <div className="space-y-4"><Card><CardHeader><CardTitle>Pending applications</CardTitle><CardDescription>Review offered payment and add admin notes before accepting or rejecting.</CardDescription></CardHeader><CardContent className="space-y-3">{pending.length === 0 ? <p className="text-muted-foreground">No pending applications.</p> : pending.map((app) => <div key={app.id} className="flex flex-wrap items-center justify-between gap-3 rounded border p-3"><div><b>{app.band?.name ?? "Unknown band"}</b><p className="text-sm text-muted-foreground">{app.festival?.name ?? "Selected festival"} · {app.slot_type}</p></div><Button size="sm" onClick={() => setSelectedApplication(app)}>Review</Button></div>)}</CardContent></Card><Card><CardHeader><CardTitle>Reviewed application history</CardTitle></CardHeader><CardContent>{reviewed.length === 0 ? <p className="text-muted-foreground">No reviewed applications.</p> : reviewed.map((app) => <p key={app.id} className="flex justify-between border-b py-2"><span>{app.band?.name ?? "Unknown band"}</span><Badge>{app.status}</Badge></p>)}</CardContent></Card><Dialog open={!!selectedApplication} onOpenChange={(open) => !open && setSelectedApplication(null)}><DialogContent><DialogHeader><DialogTitle>Review application</DialogTitle></DialogHeader><Label>Offered payment<Input type="number" value={offeredPayment} onChange={(e) => setOfferedPayment(e.target.value)} /></Label><Label>Admin notes<Textarea value={adminNotes} onChange={(e) => setAdminNotes(e.target.value)} /></Label><div className="flex gap-2"><Button disabled={isReviewing} onClick={() => submit("accepted")}><CheckCircle className="mr-2 h-4 w-4" />Accept</Button><Button disabled={isReviewing} variant="destructive" onClick={() => submit("rejected")}><XCircle className="mr-2 h-4 w-4" />Reject</Button></div></DialogContent></Dialog></div>;
+function Applications({
+  festivalId,
+  editionId,
+}: {
+  festivalId?: string;
+  editionId?: string;
+}) {
+  const [selectedApplication, setSelectedApplication] = useState<any>(null);
+  const [adminNotes, setAdminNotes] = useState("");
+  const [offeredPayment, setOfferedPayment] = useState("");
+  const { applications, isLoading, reviewApplication, isReviewing } =
+    useFestivalSlotApplications(editionId || festivalId);
+  const pending = applications?.filter((a) => a.status === "pending") ?? [];
+  const reviewed = applications?.filter((a) => a.status !== "pending") ?? [];
+  const submit = (status: "accepted" | "rejected") => {
+    if (!selectedApplication) return;
+    reviewApplication({
+      applicationId: selectedApplication.id,
+      status,
+      adminNotes: adminNotes || undefined,
+      offeredPayment: offeredPayment ? Number(offeredPayment) : undefined,
+    });
+    setSelectedApplication(null);
+    setAdminNotes("");
+    setOfferedPayment("");
+  };
+  if (!festivalId)
+    return (
+      <Card>
+        <CardContent className="p-6 text-muted-foreground">
+          Select a festival before reviewing applications.
+        </CardContent>
+      </Card>
+    );
+  if (isLoading)
+    return (
+      <Card>
+        <CardContent className="p-6">
+          Loading festival applications…
+        </CardContent>
+      </Card>
+    );
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Pending applications</CardTitle>
+          <CardDescription>
+            Edition-scoped queue. Review offered payment and add admin notes
+            before accepting or rejecting.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {pending.length === 0 ? (
+            <p className="text-muted-foreground">No pending applications.</p>
+          ) : (
+            pending.map((app) => (
+              <div
+                key={app.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded border p-3"
+              >
+                <div>
+                  <b>{app.band?.name ?? "Unknown band"}</b>
+                  <p className="text-sm text-muted-foreground">
+                    {app.festival?.name ?? "Selected festival"} ·{" "}
+                    {app.slot_type}
+                  </p>
+                </div>
+                <Button size="sm" onClick={() => setSelectedApplication(app)}>
+                  Review
+                </Button>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Reviewed application history</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {reviewed.length === 0 ? (
+            <p className="text-muted-foreground">No reviewed applications.</p>
+          ) : (
+            reviewed.map((app) => (
+              <p key={app.id} className="flex justify-between border-b py-2">
+                <span>{app.band?.name ?? "Unknown band"}</span>
+                <Badge>{app.status}</Badge>
+              </p>
+            ))
+          )}
+        </CardContent>
+      </Card>
+      <Dialog
+        open={!!selectedApplication}
+        onOpenChange={(open) => !open && setSelectedApplication(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Review application</DialogTitle>
+          </DialogHeader>
+          <Label>
+            Offered payment
+            <Input
+              type="number"
+              value={offeredPayment}
+              onChange={(e) => setOfferedPayment(e.target.value)}
+            />
+          </Label>
+          <Label>
+            Admin notes
+            <Textarea
+              value={adminNotes}
+              onChange={(e) => setAdminNotes(e.target.value)}
+            />
+          </Label>
+          <div className="flex gap-2">
+            <Button disabled={isReviewing} onClick={() => submit("accepted")}>
+              <CheckCircle className="mr-2 h-4 w-4" />
+              Accept
+            </Button>
+            <Button
+              disabled={isReviewing}
+              variant="destructive"
+              onClick={() => submit("rejected")}
+            >
+              <XCircle className="mr-2 h-4 w-4" />
+              Reject
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }
 
 export default function FestivalsAdminPage() {
-  const catalogue = useAdminFestivalCatalogue(); const rows = catalogue.data ?? [];
-  const [selectedFestivalId, setSelectedFestivalId] = useState(""); const [selectedEditionId, setSelectedEditionId] = useState("");
-  const editionsQuery = useOwnerFestivalEditions(selectedFestivalId); const selectedFestival = rows.find((row) => row.festivalId === selectedFestivalId); const selectedEdition = editionsQuery.data?.find((edition) => edition.id === selectedEditionId);
-  return <div className="space-y-6"><div><h1 className="text-3xl font-oswald">Festivals Administration</h1><p className="text-muted-foreground">Manage festivals, applications, operations, results and technical support tools from one workspace.</p></div>{catalogue.isLoading && <Card><CardContent className="p-6">Loading festivals…</CardContent></Card>}{catalogue.error && <Card><CardContent className="p-6 text-destructive">Festivals could not be loaded. You may not have permission to manage festivals.</CardContent></Card>}{!catalogue.isLoading && !catalogue.error && <FestivalEditionSelector rows={rows} selectedFestivalId={selectedFestivalId} setSelectedFestivalId={setSelectedFestivalId} selectedEditionId={selectedEditionId} setSelectedEditionId={setSelectedEditionId} />}<Tabs defaultValue="overview" className="space-y-4"><TabsList className="flex h-auto flex-wrap"><TabsTrigger value="overview">Overview</TabsTrigger><TabsTrigger value="applications">Applications</TabsTrigger><TabsTrigger value="operations">Operations</TabsTrigger><TabsTrigger value="results">Results</TabsTrigger><TabsTrigger value="advanced">Advanced</TabsTrigger></TabsList><TabsContent value="overview"><Overview selectedFestival={selectedFestival} selectedEdition={selectedEdition} /></TabsContent><TabsContent value="applications"><Applications festivalId={selectedFestivalId} /></TabsContent><TabsContent value="operations"><EditionRequired editionId={selectedEditionId}><Tabs defaultValue="stages"><TabsList className="flex h-auto flex-wrap"><TabsTrigger value="stages">Stages</TabsTrigger><TabsTrigger value="staff">Staff</TabsTrigger><TabsTrigger value="permits">Permits</TabsTrigger><TabsTrigger value="insurance">Insurance</TabsTrigger><TabsTrigger value="live">Live event</TabsTrigger></TabsList><TabsContent value="stages"><FestivalStageManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="staff"><FestivalStaffManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="permits"><FestivalPermitManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="insurance"><FestivalInsuranceManagement editionId={selectedEditionId} scope="admin" /></TabsContent><TabsContent value="live"><FestivalOutcomesManagement editionId={selectedEditionId} scope="admin" /></TabsContent></Tabs></EditionRequired></TabsContent><TabsContent value="results"><EditionRequired editionId={selectedEditionId}><FestivalOutcomesManagement editionId={selectedEditionId} scope="admin" /><FestivalSettlementManagement editionId={selectedEditionId} /></EditionRequired></TabsContent><TabsContent value="advanced"><Card><CardHeader><CardTitle>Advanced technical support tools</CardTitle><CardDescription>These tools are for migration support, system checks and audit review. They are not required for normal festival management.</CardDescription></CardHeader><CardContent><Button asChild variant="outline"><Link to="/admin/festivals#system-checks"><ExternalLink className="mr-2 h-4 w-4" />System checks</Link></Button></CardContent></Card><FestivalLegacyRecordsManagement /><FestivalDataHealthManagement /><FestivalAuditLog /></TabsContent></Tabs></div>;
+  const catalogue = useAdminFestivalCatalogue();
+  const rows = catalogue.data ?? [];
+  const [selectedFestivalId, setSelectedFestivalId] = useState("");
+  const [selectedEditionId, setSelectedEditionId] = useState("");
+  const [wizard, setWizard] = useState<{
+    open: boolean;
+    mode: "create_festival" | "create_first_edition" | "add_edition";
+    festival?: AdminFestivalCatalogueRow;
+  }>({ open: false, mode: "create_festival" });
+  const [success, setSuccess] = useState<null | {
+    publicRoute: string;
+    managementRoute: string;
+  }>(null);
+  const editionsQuery = useOwnerFestivalEditions(selectedFestivalId);
+  const selectedFestival = rows.find(
+    (row) => row.festivalId === selectedFestivalId,
+  );
+  const selectedEdition = editionsQuery.data?.find(
+    (edition) => edition.id === selectedEditionId,
+  );
+  const openCreateEdition = (
+    festivalId: string,
+    mode: "create_first_edition" | "add_edition",
+  ) =>
+    setWizard({
+      open: true,
+      mode,
+      festival: rows.find((row) => row.festivalId === festivalId),
+    });
+  const openManagement = (_festivalId: string, editionId: string) => {
+    window.location.href = `/festivals/${_festivalId}/manage/editions/${editionId}`;
+  };
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-oswald">Festivals Administration</h1>
+          <p className="text-muted-foreground">
+            Manage festivals, applications, operations, results and technical
+            support tools from one workspace.
+          </p>
+        </div>
+        <Button
+          onClick={() => setWizard({ open: true, mode: "create_festival" })}
+        >
+          Create Festival
+        </Button>
+      </div>
+      {success && (
+        <Card>
+          <CardContent className="flex flex-wrap items-center justify-between gap-2 p-4">
+            <span className="text-sm">
+              Festival created successfully. Continue setup from the overview or
+              open another workspace.
+            </span>
+            <span className="flex gap-2">
+              <Button asChild variant="outline">
+                <Link to={success.managementRoute}>
+                  Open management workspace
+                </Link>
+              </Button>
+              <Button asChild variant="ghost">
+                <Link to={success.publicRoute}>View public page</Link>
+              </Button>
+            </span>
+          </CardContent>
+        </Card>
+      )}
+      {catalogue.isLoading && (
+        <Card>
+          <CardContent className="p-6">Loading festivals…</CardContent>
+        </Card>
+      )}
+      {catalogue.error && (
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Festivals could not be loaded. You may not have permission to manage
+            festivals.
+          </CardContent>
+        </Card>
+      )}
+      {!catalogue.isLoading && !catalogue.error && (
+        <FestivalEditionSelector
+          rows={rows}
+          selectedFestivalId={selectedFestivalId}
+          setSelectedFestivalId={setSelectedFestivalId}
+          selectedEditionId={selectedEditionId}
+          setSelectedEditionId={setSelectedEditionId}
+        />
+      )}
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="flex h-auto flex-wrap">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="applications">Applications</TabsTrigger>
+          <TabsTrigger value="operations">Operations</TabsTrigger>
+          <TabsTrigger value="results">Results</TabsTrigger>
+          <TabsTrigger value="advanced">Advanced</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">
+          <Overview
+            selectedFestival={selectedFestival}
+            selectedEdition={selectedEdition}
+            onCreateFestival={() =>
+              setWizard({ open: true, mode: "create_festival" })
+            }
+            onCreateEdition={openCreateEdition}
+            onSelectFestival={setSelectedFestivalId}
+            onOpenManagement={openManagement}
+          />
+        </TabsContent>
+        <TabsContent value="applications">
+          <Applications
+            festivalId={selectedFestivalId}
+            editionId={selectedEditionId}
+          />
+        </TabsContent>
+        <TabsContent value="operations">
+          <EditionRequired
+            editionId={selectedEditionId}
+            onCreateFirstEdition={() =>
+              selectedFestivalId &&
+              openCreateEdition(selectedFestivalId, "create_first_edition")
+            }
+          >
+            <Tabs defaultValue="stages">
+              <TabsList className="flex h-auto flex-wrap">
+                <TabsTrigger value="stages">Stages</TabsTrigger>
+                <TabsTrigger value="staff">Staff</TabsTrigger>
+                <TabsTrigger value="permits">Permits</TabsTrigger>
+                <TabsTrigger value="insurance">Insurance</TabsTrigger>
+                <TabsTrigger value="live">Live event</TabsTrigger>
+              </TabsList>
+              <TabsContent value="stages">
+                <FestivalStageManagement
+                  editionId={selectedEditionId}
+                  scope="admin"
+                />
+              </TabsContent>
+              <TabsContent value="staff">
+                <FestivalStaffManagement
+                  editionId={selectedEditionId}
+                  scope="admin"
+                />
+              </TabsContent>
+              <TabsContent value="permits">
+                <FestivalPermitManagement
+                  editionId={selectedEditionId}
+                  scope="admin"
+                />
+              </TabsContent>
+              <TabsContent value="insurance">
+                <FestivalInsuranceManagement
+                  editionId={selectedEditionId}
+                  scope="admin"
+                />
+              </TabsContent>
+              <TabsContent value="live">
+                <FestivalOutcomesManagement
+                  editionId={selectedEditionId}
+                  scope="admin"
+                />
+              </TabsContent>
+            </Tabs>
+          </EditionRequired>
+        </TabsContent>
+        <TabsContent value="results">
+          <EditionRequired
+            editionId={selectedEditionId}
+            onCreateFirstEdition={() =>
+              selectedFestivalId &&
+              openCreateEdition(selectedFestivalId, "create_first_edition")
+            }
+          >
+            <FestivalOutcomesManagement
+              editionId={selectedEditionId}
+              scope="admin"
+            />
+            <FestivalSettlementManagement editionId={selectedEditionId} />
+          </EditionRequired>
+        </TabsContent>
+        <TabsContent value="advanced">
+          <Card>
+            <CardHeader>
+              <CardTitle>Advanced technical support tools</CardTitle>
+              <CardDescription>
+                These tools are for migration support, system checks and audit
+                review. They are not required for normal festival management.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button asChild variant="outline">
+                <Link to="/admin/festivals#system-checks">
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  System checks
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+          <FestivalLegacyRecordsManagement />
+          <FestivalDataHealthManagement />
+          <FestivalAuditLog />
+        </TabsContent>
+      </Tabs>
+      <FestivalCreationWizard
+        open={wizard.open}
+        mode={wizard.mode}
+        festival={wizard.festival}
+        onOpenChange={(open) => setWizard((current) => ({ ...current, open }))}
+        onCreated={(result) => {
+          setWizard((current) => ({ ...current, open: false }));
+          setSelectedFestivalId(result.festivalId);
+          setSelectedEditionId(result.editionId);
+          setSuccess({
+            publicRoute: result.publicRoute,
+            managementRoute: result.managementRoute,
+          });
+          catalogue.refetch();
+        }}
+      />
+    </div>
+  );
 }

--- a/supabase/migrations/20260717120000_admin_festival_creation_phase1.sql
+++ b/supabase/migrations/20260717120000_admin_festival_creation_phase1.sql
@@ -1,0 +1,109 @@
+-- Phase 1 canonical festival admin creation workflow.
+-- Creates server-authorised, idempotent aggregate operations without writing legacy game_events rows.
+
+ALTER TABLE public.festival_stages ALTER COLUMN festival_id DROP NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.admin_festival_creation_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  operation text NOT NULL,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  festival_id uuid NOT NULL REFERENCES public.festivals(id) ON DELETE CASCADE,
+  edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
+  result jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (actor_profile_id, operation, idempotency_key),
+  CHECK (length(trim(idempotency_key)) > 0)
+);
+ALTER TABLE public.admin_festival_creation_requests ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS admin_festival_creation_requests_admin_read ON public.admin_festival_creation_requests;
+CREATE POLICY admin_festival_creation_requests_admin_read ON public.admin_festival_creation_requests FOR SELECT TO authenticated USING (coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false));
+
+CREATE OR REPLACE FUNCTION public.admin_create_festival_edition_with_setup(p_festival_id uuid, p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  v_actor uuid := public.current_profile_id_safe();
+  v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key');
+  v_hash text := md5(coalesce(p_payload,'{}'::jsonb)::text);
+  v_existing public.admin_festival_creation_requests%ROWTYPE;
+  v_festival public.festivals%ROWTYPE;
+  v_edition public.festival_editions%ROWTYPE;
+  v_stage jsonb;
+  v_stage_ids uuid[] := ARRAY[]::uuid[];
+  v_stage_id uuid;
+  v_stage_number integer := 0;
+  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb);
+  v_edition_payload jsonb := coalesce(p_payload->'edition','{}'::jsonb);
+  v_commercial jsonb := coalesce(p_payload->'commercial','{}'::jsonb);
+  v_result jsonb;
+  v_start timestamptz := nullif(v_edition_payload->>'startAt','')::timestamptz;
+  v_end timestamptz := nullif(v_edition_payload->>'endAt','')::timestamptz;
+  v_app_open timestamptz := nullif(v_edition_payload->>'applicationsOpenAt','')::timestamptz;
+  v_app_close timestamptz := nullif(v_edition_payload->>'applicationsCloseAt','')::timestamptz;
+  v_city uuid := nullif(v_location->>'cityId','')::uuid;
+  v_venue uuid := nullif(v_location->>'venueId','')::uuid;
+  v_capacity integer := coalesce((v_location->>'capacity')::integer,0);
+  v_min bigint := coalesce((v_location->>'minTicketPriceCents')::bigint,0);
+  v_max bigint := coalesce((v_location->>'maxTicketPriceCents')::bigint,0);
+BEGIN
+  IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) THEN RAISE EXCEPTION 'Admin authority required'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'Idempotency key is required'; END IF;
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_profile_id IS NOT DISTINCT FROM v_actor AND operation='admin_create_festival_edition_with_setup' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different festival creation input'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Festival not found'; END IF;
+  IF v_start IS NULL OR v_end IS NULL OR v_end <= v_start OR v_start < now() THEN RAISE EXCEPTION 'Invalid date range'; END IF;
+  IF v_app_open IS NULL OR v_app_close IS NULL OR v_app_close < v_app_open OR v_app_close >= v_start THEN RAISE EXCEPTION 'Application date conflict'; END IF;
+  IF v_city IS NULL OR NOT EXISTS (SELECT 1 FROM public.cities WHERE id=v_city) THEN RAISE EXCEPTION 'Invalid city reference'; END IF;
+  IF v_venue IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND city_id=v_city) THEN RAISE EXCEPTION 'Invalid venue reference'; END IF;
+  IF coalesce(v_edition_payload->>'currencyCode','USD') NOT IN ('USD','EUR','GBP') THEN RAISE EXCEPTION 'Unsupported currency'; END IF;
+  IF v_capacity <= 0 OR v_min < 0 OR v_max < v_min THEN RAISE EXCEPTION 'Invalid capacity or ticket price range'; END IF;
+  IF jsonb_array_length(coalesce(p_payload->'stages','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'At least one stage is required'; END IF;
+
+  v_edition := public.create_festival_edition(p_festival_id, nullif(v_edition_payload->>'title',''), v_start, v_end, v_city, v_venue, coalesce((v_commercial->>'estimatedAttendance')::integer, v_capacity), v_capacity, v_min, v_max, jsonb_build_object('applications_open_at',v_app_open,'applications_close_at',v_app_close,'booking_deadline_at',v_edition_payload->>'bookingDeadlineAt','timezone',coalesce(v_edition_payload->>'timezone','UTC'),'currency_code',coalesce(v_edition_payload->>'currencyCode','USD'),'site_name',v_location->>'siteName','default_ticket_price_cents',coalesce((v_location->>'defaultTicketPriceCents')::bigint, v_min),'commercial',v_commercial), v_key || ':edition');
+  UPDATE public.festival_editions SET currency_code=coalesce(v_edition_payload->>'currencyCode','USD'), timezone=coalesce(v_edition_payload->>'timezone','UTC'), budget_cents=coalesce((v_commercial->>'operatingBudgetCents')::bigint, budget_cents), status='planning' WHERE id=v_edition.id RETURNING * INTO v_edition;
+
+  FOR v_stage IN SELECT * FROM jsonb_array_elements(p_payload->'stages') LOOP
+    IF EXISTS (SELECT 1 FROM public.festival_stages WHERE edition_id=v_edition.id AND lower(stage_name)=lower(v_stage->>'name') AND archived_at IS NULL) THEN RAISE EXCEPTION 'Duplicate stage names are not allowed'; END IF;
+    IF coalesce((v_stage->>'capacity')::integer,0) <= 0 OR coalesce((v_stage->>'capacity')::integer,0) > v_capacity THEN RAISE EXCEPTION 'Stage capacity conflict'; END IF;
+    IF coalesce((v_stage->>'changeoverMinutes')::integer,30) < 5 THEN RAISE EXCEPTION 'Stage changeover duration is invalid'; END IF;
+    v_stage_number := v_stage_number + 1;
+    INSERT INTO public.festival_stages(festival_id, edition_id, stage_name, stage_number, capacity, stage_type, sound_capability, lighting_capability, weather_protection, default_changeover_minutes, curfew_time, public_metadata, idempotency_key)
+    VALUES (NULL, v_edition.id, v_stage->>'name', v_stage_number, (v_stage->>'capacity')::integer, coalesce(v_stage->>'type','main'), v_stage->>'soundCapability', v_stage->>'lightingCapability', v_stage->>'weatherProtection', coalesce((v_stage->>'changeoverMinutes')::integer,30), nullif(v_stage->>'curfew','')::time, jsonb_build_object('created_from','admin_creation_wizard'), v_key || ':stage:' || v_stage_number) RETURNING id INTO v_stage_id;
+    v_stage_ids := array_append(v_stage_ids, v_stage_id);
+  END LOOP;
+  PERFORM public.festival_audit(v_edition.id,'edition_setup_created','festival_edition',v_edition.id,'{}',to_jsonb(v_edition),'admin festival creation wizard',v_key || ':audit');
+  v_result := jsonb_build_object('festival_id',p_festival_id,'edition_id',v_edition.id,'stage_ids',to_jsonb(v_stage_ids),'lifecycle_status',v_edition.status,'public_route','/festivals/' || p_festival_id,'management_route','/festivals/' || p_festival_id || '/manage/editions/' || v_edition.id,'created',true);
+  INSERT INTO public.admin_festival_creation_requests(actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor,'admin_create_festival_edition_with_setup',v_key,v_hash,p_festival_id,v_edition.id,v_result);
+  RETURN v_result;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.admin_create_festival_with_first_edition(p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  v_actor uuid := public.current_profile_id_safe();
+  v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key');
+  v_hash text := md5(coalesce(p_payload,'{}'::jsonb)::text);
+  v_existing public.admin_festival_creation_requests%ROWTYPE;
+  v_identity jsonb := coalesce(p_payload->'identity','{}'::jsonb);
+  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb);
+  v_festival public.festivals%ROWTYPE;
+  v_result jsonb;
+BEGIN
+  IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) THEN RAISE EXCEPTION 'Admin authority required'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'Idempotency key is required'; END IF;
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_profile_id IS NOT DISTINCT FROM v_actor AND operation='admin_create_festival_with_first_edition' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different festival creation input'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  IF nullif(trim(v_identity->>'name'),'') IS NULL THEN RAISE EXCEPTION 'Festival name is required'; END IF;
+  IF jsonb_array_length(coalesce(v_identity->'primaryGenres','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'At least one primary genre is required'; END IF;
+  INSERT INTO public.festivals(name, description, city_id, genre, scale, owner_profile_id, status, public_metadata)
+  VALUES (trim(v_identity->>'name'), coalesce(nullif(v_identity->>'fullDescription',''), v_identity->>'shortDescription'), nullif(v_location->>'cityId','')::uuid, (v_identity->'primaryGenres')->>0, v_identity->>'festivalType', NULL, 'planning', jsonb_build_object('short_description',v_identity->>'shortDescription','festival_type',v_identity->>'festivalType','primary_genres',v_identity->'primaryGenres','image_url',v_identity->>'imageUrl','public_visibility',coalesce((v_identity->>'isPublic')::boolean,false),'admin_creation_key',v_key)) RETURNING * INTO v_festival;
+  v_result := public.admin_create_festival_edition_with_setup(v_festival.id, p_payload || jsonb_build_object('mode','create_first_edition','existingFestivalId',v_festival.id,'idempotencyKey',v_key || ':edition'));
+  v_result := v_result || jsonb_build_object('festival_id',v_festival.id,'public_route','/festivals/' || v_festival.id,'management_route','/festivals/' || v_festival.id || '/manage/editions/' || (v_result->>'edition_id'),'created',true);
+  INSERT INTO public.festival_admin_audit_events(actor_profile_id, festival_id, edition_id, operation, target_type, target_id, after_snapshot, reason, idempotency_key) VALUES (v_actor, v_festival.id, (v_result->>'edition_id')::uuid, 'festival_created_with_first_edition', 'festival', v_festival.id, v_result, 'admin creation wizard', v_key);
+  INSERT INTO public.admin_festival_creation_requests(actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor,'admin_create_festival_with_first_edition',v_key,v_hash,v_festival.id,(v_result->>'edition_id')::uuid,v_result);
+  RETURN v_result;
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.admin_create_festival_with_first_edition(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_create_festival_edition_with_setup(uuid,jsonb) TO authenticated;

--- a/supabase/tests/festival_creation_phase1_harness.sql
+++ b/supabase/tests/festival_creation_phase1_harness.sql
@@ -1,0 +1,7 @@
+-- Festival creation phase 1 harness.
+-- Intended for a local Supabase test database with seeded admin auth context.
+BEGIN;
+SELECT has_function_privilege('authenticated', 'public.admin_create_festival_with_first_edition(jsonb)', 'EXECUTE') AS admin_create_festival_with_first_edition_executable;
+SELECT has_function_privilege('authenticated', 'public.admin_create_festival_edition_with_setup(uuid,jsonb)', 'EXECUTE') AS admin_create_festival_edition_with_setup_executable;
+SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='admin_festival_creation_requests' AND column_name IN ('idempotency_key','request_hash','festival_id','edition_id','result');
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Restore a complete, guided festival creation flow so platform administrators can create a permanent festival and its first edition without requiring database IDs or knowledge of legacy tables. 
- Ensure the creation is server-authorised, transactional and idempotent so partial writes cannot occur and retries return the original result. 
- Preserve security and audit behaviour while avoiding any writes to the legacy `game_events` implementation.

### Description

- Add a multi-step `FestivalCreationWizard` and helper components to collect festival identity, first-edition details, location, stages (with small/medium/large presets), commercial setup and a final review step, supporting `create_festival`, `create_first_edition` and `add_edition` modes. 
- Introduce typed creation drafts, validation and defaults (`src/features/festivals/admin/creationValidation.ts`, `types.ts`) plus a frontend unit test for validation (`__tests__/festivalCreationValidation.test.ts`).
- Add service-layer RPC wrappers and reference-data fetches (`service.ts`, `hooks.ts`) and refactor the catalogue to accept parent-controlled selection/creation callbacks and expose `Create Festival`, `Create first edition`, `Add edition` and management entry points. 
- Add Supabase migration that defines transactional, admin-authorised idempotent server functions `admin_create_festival_with_first_edition` and `admin_create_festival_edition_with_setup` with request-hash idempotency storage, stage creation, lifecycle/audit writes and a SQL test harness scaffold (`supabase/migrations/20260717120000_admin_festival_creation_phase1.sql`, `supabase/tests/festival_creation_phase1_harness.sql`).

### Testing

- `npm run typecheck` ran and passed (`tsc --noEmit`).
- `npm ci` failed with a registry error (`403 Forbidden - GET https://registry.npmjs.org/@react-three%2ffiber`), blocking dependency installation and subsequent toolchain tasks. 
- Because `npm ci` was blocked, `npm run lint`, `npm run test:unit` (Vitest) and `npm run build` (Vite) could not run in this environment due to missing dev packages, and the Supabase CLI tests were skipped because the CLI is not installed here. 
- Added a frontend unit test and a Supabase SQL harness file for DB-level verification; both are included and runnable in CI or a local environment with dependencies and Supabase CLI available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59eb01bcc083259f58a172fcdcc71c)