### PR TITLE
fix(festivals): harden creation transactions and admin workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
         run: npm run test:smoke -- --reporter=default
       - name: Build
         run: npm run build
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Festival SQL tests
+        run: npm run test:festivals:db

--- a/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
+++ b/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
@@ -59,3 +59,7 @@ Administrators no longer paste a festival edition UUID. When a festival has no e
 - **Phase 2:** Unified stage, slot, lineup and application management.
 - **Phase 3:** Commercial, staffing and operating decisions.
 - **Phase 4:** Live festival execution and outcomes.
+
+## Phase 1 hardening update
+
+Festival creation now relies on server-projected reference data, server-authoritative edition numbering, authenticated actor idempotency, lifecycle/audit writes in the aggregate transaction, and explicit stage festival/edition consistency. Phase 1 is not considered fully verified unless frontend checks and the executable SQL harness pass in the target environment.

--- a/docs/festivals/FESTIVAL_ADMIN_UI_GUIDE.md
+++ b/docs/festivals/FESTIVAL_ADMIN_UI_GUIDE.md
@@ -12,3 +12,7 @@ The page flow is:
 Administrators should not paste database UUIDs. If a festival has no edition, the page shows `No edition has been created for this festival.` and a disabled `Create first edition` placeholder until Phase 1 restores creation.
 
 Technical support tools such as legacy records, system checks, and audit logs are available from Advanced and are not required for normal festival management.
+
+## Phase 1 hardening update
+
+Festival creation now relies on server-projected reference data, server-authoritative edition numbering, authenticated actor idempotency, lifecycle/audit writes in the aggregate transaction, and explicit stage festival/edition consistency. Phase 1 is not considered fully verified unless frontend checks and the executable SQL harness pass in the target environment.

--- a/docs/festivals/FESTIVAL_CREATION_PHASE1_AUDIT.md
+++ b/docs/festivals/FESTIVAL_CREATION_PHASE1_AUDIT.md
@@ -1,0 +1,38 @@
+# Festival Creation Phase 1 Audit
+
+## Confirmed working behaviour
+
+- The merged workflow exposed admin festival creation from `FestivalsAdmin` and routed submissions through `admin_create_festival_with_first_edition` and `admin_create_festival_edition_with_setup`.
+- Existing canonical edition constraints already include `UNIQUE (festival_id, edition_number)`, which is retained as the authoritative duplicate-edition guard.
+- Existing lifecycle and audit tables are available and the hardened creation RPC now writes both lifecycle history and admin audit events in the same transaction as the aggregate creation.
+
+## Untested behaviour before this PR
+
+- The previous SQL harness only asserted function and column existence; it did not execute the RPCs under anonymous, non-admin, or admin authentication contexts.
+- Rollback behaviour for invalid dates, invalid locations, duplicate stages, and unsupported reference values was not executable in CI.
+- Retry behaviour and material-payload mismatch handling were not proven.
+
+## Defects found
+
+- Idempotency uniqueness used nullable `actor_profile_id`, allowing duplicate request rows for the same actor/key when a profile could not be resolved.
+- First-festival creation called the public edition creation RPC with a derived key, leaving nested request semantics that could confuse retries.
+- The frontend treated a single location selector as both country and city, and queried `cities`/`venues` directly instead of using a server-projected admin reference-data contract.
+- Lifecycle controls hardcoded transition options in React.
+- Application review code passed `editionId || festivalId` into a hook whose implementation filtered only by `festival_id`.
+- `festival_stages.festival_id` had been made nullable even though legacy projections, joins, and compatibility queries still use it.
+
+## Security risks
+
+- Browser-provided payloads could influence edition numbering and reference-like fields without complete server-side validation.
+- Admin authority checks existed, but idempotency actor identity was profile-based instead of `auth.uid()`-based.
+- Creation retry conflicts were surfaced as generic errors.
+
+## Compatibility risks
+
+- Older code joins `festival_stages` by `festival_id`; leaving it nullable could hide stages from admin and public projections.
+- Direct frontend reference table reads are more brittle than a stable projection and can overexpose future columns.
+- Copy-from-previous-edition services exist, but their safe category model requires a dedicated follow-up before claiming full copy support.
+
+## Deferred Phase 2 work
+
+- Drag-and-drop scheduling, unified lineup management, performer recommendation, offer/contract redesign, setlist readiness, live simulation, sponsorship gameplay, and player festival licensing remain out of scope.

--- a/docs/festivals/FESTIVAL_CREATION_SECURITY.md
+++ b/docs/festivals/FESTIVAL_CREATION_SECURITY.md
@@ -1,0 +1,31 @@
+# Festival Creation Security
+
+The hardened Phase 1 model treats festival creation as a server-authoritative aggregate operation.
+
+## Authority
+
+- Public RPCs require `auth.uid()` and the `admin` application role.
+- Actor identity is stored as non-null `actor_user_id`; `actor_profile_id` is retained only for audit display when available.
+
+## Idempotency
+
+- Request identity is `actor_user_id + operation + idempotency_key`.
+- The RPC acquires an advisory transaction lock based on actor, operation, and key before checking or inserting the request record.
+- Material payload hashes use SHA-256 through `pgcrypto` and a normalized JSONB object containing only server-material fields.
+- Repeating the same material request returns the original aggregate; changing material input for the same key raises `FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT`.
+
+## Validation
+
+- The server validates dates, city, venue/city ownership, venue capacity, currency, time zone, budgets, stage uniqueness, stage type, stage capacity, and ticket ranges.
+- First-edition numbering is assigned by the server; add-edition numbering is allocated from `MAX(edition_number) + 1` while the festival row is locked.
+
+## Stage ownership consistency
+
+- `festival_stages.edition_id` is authoritative.
+- The compatibility `festival_id` column is populated from the selected edition by trigger and restored to `NOT NULL`.
+- Mismatched stage festival/edition IDs are corrected before write, preventing split ownership.
+
+## Audit
+
+- Edition lifecycle history and admin audit history are inserted in the same transaction as festival, edition, and stage creation.
+- Any failure during validation, audit, or stage insertion rolls back the aggregate and the request row.

--- a/docs/festivals/FESTIVAL_CREATION_TEST_MATRIX.md
+++ b/docs/festivals/FESTIVAL_CREATION_TEST_MATRIX.md
@@ -1,0 +1,30 @@
+# Festival Creation Test Matrix
+
+## Executable SQL harness
+
+`supabase/tests/festival_creation_phase1_harness.sql` now executes the creation RPCs inside a rollback-only transaction and verifies:
+
+- Anonymous and non-admin creation rejection.
+- Admin creation success.
+- Festival, first edition, stage, lifecycle history, and audit history creation.
+- City, currency, timezone, ticket values, edition status, and stage ownership persistence.
+- No `game_events` festival row creation.
+- Stable idempotent retry result.
+- Material idempotency conflict rejection.
+- Rollback for invalid dates, invalid city, venue/city mismatch, duplicate stage names, unsupported currency, and unsupported timezone.
+- Server-authoritative later-edition numbering through edition 3.
+- Request rows do not remain for failed creation attempts.
+
+## Frontend checks added
+
+- Reference data is loaded from `admin_festival_reference_data`.
+- Country filters city options; city filters venue options.
+- City selection projects timezone and currency into the draft.
+- Venue capacity is displayed and blocks advancing when exceeded.
+- Lifecycle controls render server-projected options.
+- Application queries are explicitly edition-, festival-, or band-scoped.
+
+## Not yet fully automated
+
+- True two-session concurrent SQL execution remains a recommended database stress test outside the single-session harness.
+- Screenshot capture was not performed in this headless change because the app could not be reliably run against a seeded Supabase instance in this environment.

--- a/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
+++ b/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
@@ -23,3 +23,7 @@ The wizard generates one stable idempotency key when it opens. Retries reuse the
 ## Lifecycle and recovery
 
 New editions start in `planning`. Final submission is disabled while pending, form data is retained after recoverable failures, and the success state offers continuation, management workspace and public page links. If a later catalogue refresh fails, the returned route remains available from the creation result.
+
+## Phase 1 hardening update
+
+Festival creation now relies on server-projected reference data, server-authoritative edition numbering, authenticated actor idempotency, lifecycle/audit writes in the aggregate transaction, and explicit stage festival/edition consistency. Phase 1 is not considered fully verified unless frontend checks and the executable SQL harness pass in the target environment.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:achievements": "vitest run src/features/achievements/__tests__/validator.test.ts",
     "validate:balance": "vitest run src/balance/__tests__/balance.test.ts",
     "simulate:balance": "node scripts/progression-simulations/run-balance-simulations.mjs",
-    "validate:progression-programme": "node scripts/progression/validate-programme.mjs"
+    "validate:progression-programme": "node scripts/progression/validate-programme.mjs",
+    "test:festivals:db": "bash scripts/festivals/run-creation-phase1-db-gate.sh"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/festivals/run-creation-phase1-db-gate.sh
+++ b/scripts/festivals/run-creation-phase1-db-gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if ! command -v supabase >/dev/null; then echo "Supabase CLI is required for the festival DB gate" >&2; exit 127; fi
+if ! command -v psql >/dev/null; then echo "psql is required for the festival DB gate" >&2; exit 127; fi
+supabase start
+supabase db reset
+DB_URL="${SUPABASE_DB_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
+psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/festival_creation_phase1_harness.sql

--- a/src/components/festivals/FestivalManagementTabs.tsx
+++ b/src/components/festivals/FestivalManagementTabs.tsx
@@ -11,7 +11,7 @@ interface FestivalManagementTabsProps {
 }
 
 export const FestivalManagementTabs = ({ bandId }: FestivalManagementTabsProps) => {
-  const { applications, isLoading } = useFestivalSlotApplications(undefined, bandId);
+  const { applications, isLoading } = useFestivalSlotApplications(bandId ? { scope: "band", bandId } : undefined);
 
   const pendingApps = applications?.filter((a) => a.status === "pending") || [];
   const acceptedApps = applications?.filter((a) => a.status === "accepted") || [];

--- a/src/features/festivals/admin/components/FestivalCreationWizard.tsx
+++ b/src/features/festivals/admin/components/FestivalCreationWizard.tsx
@@ -19,6 +19,16 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   defaultFestivalCreationDraft,
   validateFestivalCreationDraft,
   hasCreationErrors,
@@ -26,9 +36,6 @@ import {
   moneyToCents,
   centsToMoney,
   buildEditionTitle,
-  FESTIVAL_TYPE_OPTIONS,
-  SUPPORTED_CURRENCIES,
-  SUPPORTED_TIMEZONES,
 } from "../creationValidation";
 import {
   useCreateFestivalFromWizard,
@@ -40,16 +47,6 @@ import type {
   FestivalCreationResult,
 } from "../types";
 
-const genres = [
-  "Rock",
-  "Pop",
-  "Electronic",
-  "Metal",
-  "Indie",
-  "Folk",
-  "Hip Hop",
-  "Jazz",
-];
 const stepNames = [
   "Festival",
   "First event",
@@ -75,6 +72,7 @@ export function FestivalCreationWizard({
     defaultFestivalCreationDraft(mode, festival?.festivalId),
   );
   const [step, setStep] = useState(0);
+  const [discardPromptOpen, setDiscardPromptOpen] = useState(false);
   const refs = useFestivalReferenceData();
   const create = useCreateFestivalFromWizard();
   useEffect(() => {
@@ -101,23 +99,34 @@ export function FestivalCreationWizard({
     setDraft((d) => ({ ...d, ...patch }));
   const submit = () =>
     create.mutate(draft, { onSuccess: (result) => onCreated(result) });
-  const cities = refs.data?.cities ?? [];
-  const venues = (refs.data?.venues ?? []).filter(
-    (v: any) => v.city_id === draft.location.cityId,
+  const referenceData = refs.data;
+  const genres = referenceData?.genres ?? [];
+  const festivalTypes = referenceData?.festivalTypes ?? [];
+  const currencies = referenceData?.currencies ?? [];
+  const countries = referenceData?.countries ?? [];
+  const cities = (referenceData?.cities ?? []).filter(
+    (city) => !draft.location.country || city.country === draft.location.country,
   );
+  const venues = (referenceData?.venues ?? []).filter(
+    (venue) => venue.cityId === draft.location.cityId,
+  );
+  const selectedVenue = venues.find((venue) => venue.id === draft.location.venueId);
+  const venueCapacityExceeded = Boolean(selectedVenue?.capacity && draft.location.capacity > selectedVenue.capacity);
+  const canCloseWithoutPrompt = !open || create.isSuccess || draft.idempotencyKey === defaultFestivalCreationDraft(mode, festival?.festivalId).idempotencyKey;
   const canNext =
     step === 5 ? !hasCreationErrors(errors) : currentErrors.length === 0;
   return (
+    <>
     <Dialog
       open={open}
       onOpenChange={(v) => {
-        if (
-          !v &&
-          !create.isPending &&
-          confirm("Discard this festival setup draft?")
-        )
-          onOpenChange(false);
-        if (v) onOpenChange(true);
+        if (v) {
+          onOpenChange(true);
+          return;
+        }
+        if (create.isPending) return;
+        if (canCloseWithoutPrompt) onOpenChange(false);
+        else setDiscardPromptOpen(true);
       }}
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
@@ -136,8 +145,9 @@ export function FestivalCreationWizard({
               key={name}
               size="sm"
               variant={i === step ? "default" : "outline"}
-              disabled={mode !== "create_festival" && i === 0}
-              onClick={() => setStep(i)}
+              aria-current={i === step ? "step" : undefined}
+              disabled={(mode !== "create_festival" && i === 0) || i > step + 1 || (i > step && currentErrors.length > 0)}
+              onClick={() => { if (i <= step || currentErrors.length === 0) setStep(i); }}
             >
               {i + 1}. {name}
             </Button>
@@ -211,7 +221,7 @@ export function FestivalCreationWizard({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {FESTIVAL_TYPE_OPTIONS.map((type) => (
+                  {festivalTypes.map((type) => (
                     <SelectItem key={type} value={type}>
                       {type.replace("_", " ")}
                     </SelectItem>
@@ -328,7 +338,7 @@ export function FestivalCreationWizard({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {SUPPORTED_TIMEZONES.map((tz) => (
+                  {[draft.edition.timezone].filter(Boolean).map((tz) => (
                     <SelectItem key={tz} value={tz}>
                       {tz}
                     </SelectItem>
@@ -348,7 +358,7 @@ export function FestivalCreationWizard({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {SUPPORTED_CURRENCIES.map((currency) => (
+                  {currencies.map((currency) => (
                     <SelectItem key={currency} value={currency}>
                       {currency}
                     </SelectItem>
@@ -361,6 +371,22 @@ export function FestivalCreationWizard({
         {step === 2 && (
           <div className="grid gap-3 md:grid-cols-2">
             <Label>
+              Country
+              <Select
+                value={draft.location.country}
+                onValueChange={(country) => update({
+                  location: { ...draft.location, country, cityId: "", cityName: "", venueId: "" },
+                })}
+              >
+                <SelectTrigger><SelectValue placeholder="Select country" /></SelectTrigger>
+                <SelectContent>
+                  {countries.map((country) => (
+                    <SelectItem key={country.code} value={country.code}>{country.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Label>
+            <Label>
               City
               <Select
                 value={draft.location.cityId}
@@ -372,10 +398,12 @@ export function FestivalCreationWizard({
                       cityId,
                       cityName: city?.name,
                       country: city?.country ?? "",
+                      venueId: "",
                     },
                     edition: {
                       ...draft.edition,
                       timezone: city?.timezone || draft.edition.timezone,
+                      currencyCode: city?.currencyCode || draft.edition.currencyCode,
                     },
                   });
                 }}
@@ -384,7 +412,7 @@ export function FestivalCreationWizard({
                   <SelectValue placeholder="Select city" />
                 </SelectTrigger>
                 <SelectContent>
-                  {cities.map((city: any) => (
+                  {cities.map((city) => (
                     <SelectItem key={city.id} value={city.id}>
                       {city.name}, {city.country}
                     </SelectItem>
@@ -412,7 +440,7 @@ export function FestivalCreationWizard({
                   <SelectItem value="custom">
                     Public festival site name
                   </SelectItem>
-                  {venues.map((venue: any) => (
+                  {venues.map((venue) => (
                     <SelectItem key={venue.id} value={venue.id}>
                       {venue.name}
                     </SelectItem>
@@ -431,6 +459,12 @@ export function FestivalCreationWizard({
                 }
               />
             </Label>
+            {selectedVenue?.capacity && (
+              <p className={venueCapacityExceeded ? "text-sm text-destructive" : "text-sm text-muted-foreground"}>
+                Venue capacity: {selectedVenue.capacity.toLocaleString()}
+                {venueCapacityExceeded ? " — requested capacity exceeds this venue." : ""}
+              </p>
+            )}
             <Label>
               Overall capacity
               <Input
@@ -753,7 +787,7 @@ export function FestivalCreationWizard({
             Back
           </Button>
           {step < 5 ? (
-            <Button disabled={!canNext} onClick={() => setStep(step + 1)}>
+            <Button disabled={!canNext || venueCapacityExceeded} onClick={() => setStep(step + 1)}>
               Continue
             </Button>
           ) : (
@@ -768,5 +802,22 @@ export function FestivalCreationWizard({
         </div>
       </DialogContent>
     </Dialog>
+    <AlertDialog open={discardPromptOpen} onOpenChange={setDiscardPromptOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard this festival setup draft?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Continue editing to keep this setup, or discard the draft and lose unsaved festival creation changes.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Continue editing</AlertDialogCancel>
+          <AlertDialogAction onClick={() => { setDiscardPromptOpen(false); onOpenChange(false); }}>
+            Discard draft
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+    </>
   );
 }

--- a/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
+++ b/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
@@ -16,22 +16,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useMemo } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { transitionAdminFestivalEdition } from "../service";
+import { useAdminFestivalLifecycleOptions } from "../hooks";
 import { festivalAdminQueryKeys } from "../queryKeys";
 import type { FestivalLifecycleState } from "../types";
 
-const nextStates: Record<string, FestivalLifecycleState[]> = {
-  concept: ["planning"],
-  planning: ["applications_open", "booking"],
-  applications_open: ["booking"],
-  booking: ["announced"],
-  announced: ["on_sale", "setup"],
-  on_sale: ["setup"],
-  setup: ["live"],
-  live: ["settling"],
-  settling: ["completed"],
-};
 export function FestivalLifecycleControls({
   editionId,
   status,
@@ -42,19 +33,27 @@ export function FestivalLifecycleControls({
   const qc = useQueryClient();
   const [target, setTarget] = useState<FestivalLifecycleState | "">("");
   const [reason, setReason] = useState("");
+  const lifecycleOptions = useAdminFestivalLifecycleOptions(editionId);
+  const transitionKey = useMemo(() => target ? `lifecycle:${editionId}:${target}` : "", [editionId, target]);
   const mutation = useMutation({
     mutationFn: () =>
       transitionAdminFestivalEdition(
         editionId as string,
         target as FestivalLifecycleState,
         reason,
+        false,
+        transitionKey,
       ),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue });
-      if (editionId)
+      if (editionId) {
         qc.invalidateQueries({
           queryKey: festivalAdminQueryKeys.operations("admin", editionId),
         });
+        qc.invalidateQueries({
+          queryKey: ["festivals", "admin", "lifecycle-options", editionId],
+        });
+      }
       setReason("");
       setTarget("");
     },
@@ -70,7 +69,7 @@ export function FestivalLifecycleControls({
         </CardHeader>
       </Card>
     );
-  const options = nextStates[status] ?? [];
+  const options = (lifecycleOptions.data?.transitions ?? []).filter((option) => option.available);
   return (
     <Card>
       <CardHeader>
@@ -98,9 +97,10 @@ export function FestivalLifecycleControls({
                 />
               </SelectTrigger>
               <SelectContent>
-                {options.map((state) => (
-                  <SelectItem key={state} value={state}>
-                    {state.replaceAll("_", " ")}
+                {options.map((option) => (
+                  <SelectItem key={option.targetState} value={option.targetState}>
+                    {option.targetState.replaceAll("_", " ")}
+                    {option.confirmationRequired ? " (confirmation required)" : ""}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -115,10 +115,15 @@ export function FestivalLifecycleControls({
             />
           </Label>
         </div>
-        {options.length === 0 && (
+        {lifecycleOptions.isLoading && (
+          <p className="text-sm text-muted-foreground">Loading server-projected lifecycle options…</p>
+        )}
+        {lifecycleOptions.error && (
+          <p className="text-sm text-destructive">Lifecycle options could not be loaded from the server.</p>
+        )}
+        {options.length === 0 && !lifecycleOptions.isLoading && (
           <p className="text-sm text-muted-foreground">
-            This edition has no standard forward transition from its current
-            state.
+            The server currently exposes no standard forward transition from this state.
           </p>
         )}
         {mutation.error && (

--- a/src/features/festivals/admin/hooks.ts
+++ b/src/features/festivals/admin/hooks.ts
@@ -21,6 +21,7 @@ import {
   createFestivalWithFirstEdition,
   createFestivalEditionFromWizard,
   fetchFestivalReferenceData,
+  fetchAdminFestivalLifecycleOptions,
 } from "./service";
 import { festivalAdminQueryKeys } from "./queryKeys";
 import type {
@@ -54,6 +55,13 @@ export function useOwnerFestivalEditions(festivalId: string | undefined) {
     queryKey: festivalAdminQueryKeys.ownerEditions(festivalId ?? "missing"),
     queryFn: () => fetchOwnerFestivalEditions(festivalId as string),
     enabled: Boolean(festivalId),
+  });
+}
+export function useAdminFestivalLifecycleOptions(editionId?: string) {
+  return useQuery({
+    queryKey: ["festivals", "admin", "lifecycle-options", editionId ?? "missing"],
+    queryFn: () => fetchAdminFestivalLifecycleOptions(editionId as string),
+    enabled: Boolean(editionId),
   });
 }
 export function useFestivalEditionOperations(

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -14,6 +14,8 @@ import type {
   OwnerManagementBootstrap,
   FestivalCreationDraft,
   FestivalCreationResult,
+  FestivalReferenceData,
+  FestivalLifecycleOptions,
 } from "./types";
 
 type RpcName =
@@ -24,7 +26,15 @@ type DomainErrorCode =
   | "FESTIVAL_RESPONSE_INVALID"
   | "FESTIVAL_PERMISSION_DENIED"
   | "FESTIVAL_EDITION_NOT_FOUND"
-  | "FESTIVAL_MIGRATION_REQUIRED";
+  | "FESTIVAL_MIGRATION_REQUIRED"
+  | "FESTIVAL_CREATE_INVALID_DATE"
+  | "FESTIVAL_CREATE_CITY_INVALID"
+  | "FESTIVAL_CREATE_VENUE_INVALID"
+  | "FESTIVAL_CREATE_CAPACITY_EXCEEDED"
+  | "FESTIVAL_CREATE_STAGE_DUPLICATE"
+  | "FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT"
+  | "FESTIVAL_CREATE_REFERENCE_DATA_UNAVAILABLE"
+  | "FESTIVAL_CREATE_TRANSACTION_FAILED";
 
 export class FestivalAdminServiceError extends Error {
   constructor(
@@ -62,7 +72,43 @@ export function mapFestivalError(error: {
   hint?: string;
 }) {
   const message = error.message ?? "Festival operation failed.";
-  if (/permission|not authorised|not authorized|rls/i.test(message))
+  if (/FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT/i.test(message))
+    return new FestivalAdminServiceError(
+      "This retry key was already used for different festival creation details.",
+      "FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT",
+      error,
+    );
+  if (/FESTIVAL_CREATE_INVALID_DATE|date/i.test(message))
+    return new FestivalAdminServiceError(
+      "Check the festival, application and booking dates before trying again.",
+      "FESTIVAL_CREATE_INVALID_DATE",
+      error,
+    );
+  if (/FESTIVAL_CREATE_CITY_INVALID/i.test(message))
+    return new FestivalAdminServiceError(
+      "Select a supported festival city from the current reference data.",
+      "FESTIVAL_CREATE_CITY_INVALID",
+      error,
+    );
+  if (/FESTIVAL_CREATE_VENUE_INVALID/i.test(message))
+    return new FestivalAdminServiceError(
+      "Select a venue that belongs to the selected city, or use a named custom site.",
+      "FESTIVAL_CREATE_VENUE_INVALID",
+      error,
+    );
+  if (/FESTIVAL_CREATE_CAPACITY_EXCEEDED/i.test(message))
+    return new FestivalAdminServiceError(
+      "The requested capacity exceeds the selected venue capacity.",
+      "FESTIVAL_CREATE_CAPACITY_EXCEEDED",
+      error,
+    );
+  if (/FESTIVAL_CREATE_STAGE_DUPLICATE/i.test(message))
+    return new FestivalAdminServiceError(
+      "Stage names must be unique within an edition.",
+      "FESTIVAL_CREATE_STAGE_DUPLICATE",
+      error,
+    );
+  if (/permission|not authorised|not authorized|rls|FESTIVAL_CREATE_PERMISSION_DENIED/i.test(message))
     return new FestivalAdminServiceError(
       "You do not have permission to perform this festival operation.",
       "FESTIVAL_PERMISSION_DENIED",
@@ -190,19 +236,34 @@ export async function createFestivalEditionFromWizard(
     created: data.created,
   };
 }
-export async function fetchFestivalReferenceData() {
-  const client = supabase as any;
-  const [cities, venues] = await Promise.all([
-    client
-      .from("cities")
-      .select("id,name,country,timezone")
-      .order("country")
-      .order("name"),
-    client.from("venues").select("id,name,city_id,capacity").order("name"),
-  ]);
-  if (cities.error) throw mapFestivalError(cities.error);
-  if (venues.error) throw mapFestivalError(venues.error);
-  return { cities: cities.data ?? [], venues: venues.data ?? [] };
+const referenceDataSchema = z.object({
+  festivalTypes: z.array(z.string()).default([]),
+  genres: z.array(z.string()).default([]),
+  currencies: z.array(z.string()).default([]),
+  countries: z.array(z.object({ code: z.string(), name: z.string() })).default([]),
+  cities: z.array(z.object({ id: z.string(), name: z.string(), country: z.string(), timezone: z.string(), currencyCode: z.string() })).default([]),
+  venues: z.array(z.object({ id: z.string(), name: z.string(), cityId: z.string(), capacity: z.coerce.number().nullable() })).default([]),
+  stageTypes: z.array(z.string()).default([]),
+  weatherOptions: z.array(z.string()).default([]),
+  soundOptions: z.array(z.string()).default([]),
+  lightingOptions: z.array(z.string()).default([]),
+  commercialDefaults: z.record(z.unknown()).default({}),
+}).passthrough();
+
+export async function fetchFestivalReferenceData(): Promise<FestivalReferenceData> {
+  try {
+    return await rpc(
+      "admin_festival_reference_data" as RpcName,
+      undefined,
+      referenceDataSchema,
+    );
+  } catch (error) {
+    throw new FestivalAdminServiceError(
+      "Festival reference data is unavailable. Refresh after migrations are deployed, then try again.",
+      "FESTIVAL_CREATE_REFERENCE_DATA_UNAVAILABLE",
+      error,
+    );
+  }
 }
 
 export async function createAdminFestivalBrand(input: AdminBrandInput) {
@@ -245,11 +306,33 @@ export async function createAdminFestivalEdition(input: AdminEditionInput) {
   );
 }
 
+export async function fetchAdminFestivalLifecycleOptions(
+  editionId: string,
+): Promise<FestivalLifecycleOptions> {
+  const schema = z.object({
+    editionId: z.string(),
+    currentState: z.string(),
+    transitions: z.array(z.object({
+      targetState: z.string(),
+      available: z.boolean(),
+      blockers: z.array(z.string()).default([]),
+      warnings: z.array(z.string()).default([]),
+      adminOverrideAllowed: z.boolean().default(false),
+      reasonRequired: z.boolean().default(false),
+      confirmationRequired: z.boolean().default(false),
+      severity: z.enum(["standard", "warning", "destructive"]).default("standard"),
+      explanation: z.string().default(""),
+    })).default([]),
+  }).passthrough();
+  return rpc("admin_festival_edition_lifecycle_options" as RpcName, { p_edition_id: editionId }, schema) as Promise<FestivalLifecycleOptions>;
+}
+
 export async function transitionAdminFestivalEdition(
   editionId: string,
   targetStatus: FestivalLifecycleState,
   reason: string,
   override = false,
+  idempotencyKey = `lifecycle:${editionId}:${targetStatus}`,
 ) {
   return rpc(
     "admin_transition_festival_edition" as RpcName,
@@ -259,7 +342,7 @@ export async function transitionAdminFestivalEdition(
       p_reason: reason,
       p_override: override,
       p_metadata: { source: "admin_festival_workspace" },
-      p_idempotency_key: crypto.randomUUID(),
+      p_idempotency_key: idempotencyKey,
     },
     nonNullJson,
   );

--- a/src/features/festivals/admin/types.ts
+++ b/src/features/festivals/admin/types.ts
@@ -265,6 +265,35 @@ export type FestivalCreationValidationErrors = Partial<
     string[]
   >
 >;
+export type FestivalReferenceData = {
+  festivalTypes: string[];
+  genres: string[];
+  currencies: string[];
+  countries: { code: string; name: string }[];
+  cities: { id: string; name: string; country: string; timezone: string; currencyCode: string }[];
+  venues: { id: string; name: string; cityId: string; capacity: number | null }[];
+  stageTypes: string[];
+  weatherOptions: string[];
+  soundOptions: string[];
+  lightingOptions: string[];
+  commercialDefaults: Record<string, unknown>;
+};
+export type FestivalLifecycleTransitionOption = {
+  targetState: FestivalLifecycleState;
+  available: boolean;
+  blockers: string[];
+  warnings: string[];
+  adminOverrideAllowed: boolean;
+  reasonRequired: boolean;
+  confirmationRequired: boolean;
+  severity: "standard" | "warning" | "destructive";
+  explanation: string;
+};
+export type FestivalLifecycleOptions = {
+  editionId: string;
+  currentState: FestivalLifecycleState;
+  transitions: FestivalLifecycleTransitionOption[];
+};
 export type FestivalCreationResult = {
   festivalId: string;
   editionId: string;

--- a/src/hooks/useFestivalSlotApplications.ts
+++ b/src/hooks/useFestivalSlotApplications.ts
@@ -2,23 +2,33 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 
-export const useFestivalSlotApplications = (festivalId?: string, bandId?: string) => {
+type FestivalApplicationScope =
+  | { scope: "edition"; editionId: string; festivalId?: string; bandId?: string }
+  | { scope: "festival"; festivalId: string; editionId?: never; bandId?: string }
+  | { scope: "band"; bandId: string; festivalId?: string; editionId?: string };
+
+export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const editionId = scope?.editionId;
+  const festivalId = scope?.festivalId;
+  const bandId = scope?.bandId;
 
   const { data: applications, isLoading } = useQuery({
-    queryKey: ["festival-slot-applications", festivalId, bandId],
+    queryKey: ["festival-slot-applications", scope?.scope ?? "none", festivalId ?? null, editionId ?? null, bandId ?? null],
     queryFn: async () => {
       let query = (supabase as any)
         .from("festival_slot_applications")
         .select(`
           *,
+          edition:festival_editions(id, title, edition_number, start_at, end_at),
           festival:festivals(id, name, start_date, end_date),
           band:bands(id, name, genre, fame),
           setlist:setlists(id, name)
         `)
         .order("created_at", { ascending: false });
 
+      if (editionId) query = query.eq("edition_id", editionId);
       if (festivalId) query = query.eq("festival_id", festivalId);
       if (bandId) query = query.eq("band_id", bandId);
 
@@ -26,12 +36,13 @@ export const useFestivalSlotApplications = (festivalId?: string, bandId?: string
       if (error) throw error;
       return data as any[];
     },
-    enabled: !!festivalId || !!bandId,
+    enabled: Boolean(scope && (editionId || festivalId || bandId)),
   });
 
   const applyForSlotMutation = useMutation({
     mutationFn: async (applicationData: {
       festival_id: string;
+      edition_id?: string;
       band_id: string;
       applied_by_user_id: string;
       slot_type: string;
@@ -73,6 +84,9 @@ export const useFestivalSlotApplications = (festivalId?: string, bandId?: string
       adminNotes?: string;
       offeredPayment?: number;
     }) => {
+      if (scope?.scope === "edition" && applications?.some((app) => app.id === applicationId && app.edition_id !== scope.editionId)) {
+        throw new Error("Application does not belong to the selected edition.");
+      }
       const { error } = await (supabase as any)
         .from("festival_slot_applications")
         .update({
@@ -82,12 +96,13 @@ export const useFestivalSlotApplications = (festivalId?: string, bandId?: string
           admin_notes: adminNotes,
           offered_payment: offeredPayment,
         })
-        .eq("id", applicationId);
+        .eq("id", applicationId)
+        .match(scope?.scope === "edition" ? { edition_id: scope.editionId } : {});
 
       if (error) throw error;
     },
     onSuccess: (_, { status }) => {
-      queryClient.invalidateQueries({ queryKey: ["festival-slot-applications"] });
+      queryClient.invalidateQueries({ queryKey: ["festival-slot-applications", scope?.scope ?? "none", festivalId ?? null, editionId ?? null, bandId ?? null] });
       toast({
         title: status === "accepted" ? "Application accepted" : "Application rejected",
         description: `The festival application has been ${status}.`,

--- a/src/pages/admin/FestivalAdmin.tsx
+++ b/src/pages/admin/FestivalAdmin.tsx
@@ -39,7 +39,7 @@ export default function FestivalAdmin() {
     },
   });
 
-  const { applications, reviewApplication, isReviewing } = useFestivalSlotApplications();
+  const { applications, reviewApplication, isReviewing } = useFestivalSlotApplications(undefined);
 
   const playerCreatedFestivals = festivals?.filter(f => !f.created_by_admin);
   const adminCreatedFestivals = festivals?.filter(f => f.created_by_admin);

--- a/src/pages/admin/FestivalsAdmin.tsx
+++ b/src/pages/admin/FestivalsAdmin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { CheckCircle, ExternalLink, XCircle } from "lucide-react";
 import { AdminFestivalCatalogue } from "@/features/festivals/admin/components/AdminFestivalCatalogue";
 import { FestivalStageManagement } from "@/features/festivals/admin/components/FestivalStageManagement";
@@ -331,7 +331,7 @@ function Applications({
   const [adminNotes, setAdminNotes] = useState("");
   const [offeredPayment, setOfferedPayment] = useState("");
   const { applications, isLoading, reviewApplication, isReviewing } =
-    useFestivalSlotApplications(editionId || festivalId);
+    useFestivalSlotApplications(editionId ? { scope: "edition", editionId, festivalId } : festivalId ? { scope: "festival", festivalId } : undefined);
   const pending = applications?.filter((a) => a.status === "pending") ?? [];
   const reviewed = applications?.filter((a) => a.status !== "pending") ?? [];
   const submit = (status: "accepted" | "rejected") => {
@@ -457,6 +457,7 @@ function Applications({
 }
 
 export default function FestivalsAdminPage() {
+  const navigate = useNavigate();
   const catalogue = useAdminFestivalCatalogue();
   const rows = catalogue.data ?? [];
   const [selectedFestivalId, setSelectedFestivalId] = useState("");
@@ -487,7 +488,7 @@ export default function FestivalsAdminPage() {
       festival: rows.find((row) => row.festivalId === festivalId),
     });
   const openManagement = (_festivalId: string, editionId: string) => {
-    window.location.href = `/festivals/${_festivalId}/manage/editions/${editionId}`;
+    navigate(`/festivals/${_festivalId}/manage/editions/${editionId}`);
   };
   return (
     <div className="space-y-6">

--- a/supabase/migrations/20260717120000_admin_festival_creation_phase1.sql
+++ b/supabase/migrations/20260717120000_admin_festival_creation_phase1.sql
@@ -1,10 +1,31 @@
 -- Phase 1 canonical festival admin creation workflow.
 -- Creates server-authorised, idempotent aggregate operations without writing legacy game_events rows.
 
-ALTER TABLE public.festival_stages ALTER COLUMN festival_id DROP NOT NULL;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+UPDATE public.festival_stages st
+SET festival_id = e.festival_id
+FROM public.festival_editions e
+WHERE st.edition_id = e.id AND st.festival_id IS NULL;
+
+ALTER TABLE public.festival_stages ALTER COLUMN festival_id SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.tg_festival_stage_edition_consistency()
+RETURNS trigger LANGUAGE plpgsql SET search_path=public AS $$
+DECLARE v_festival uuid;
+BEGIN
+  IF NEW.edition_id IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_EDITION_REQUIRED'; END IF;
+  SELECT festival_id INTO v_festival FROM public.festival_editions WHERE id = NEW.edition_id;
+  IF v_festival IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_EDITION_INVALID'; END IF;
+  NEW.festival_id := v_festival;
+  RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS tg_festival_stage_edition_consistency ON public.festival_stages;
+CREATE TRIGGER tg_festival_stage_edition_consistency BEFORE INSERT OR UPDATE OF edition_id, festival_id ON public.festival_stages FOR EACH ROW EXECUTE FUNCTION public.tg_festival_stage_edition_consistency();
 
 CREATE TABLE IF NOT EXISTS public.admin_festival_creation_requests (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid,
   actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
   operation text NOT NULL,
   idempotency_key text NOT NULL,
@@ -13,95 +34,130 @@ CREATE TABLE IF NOT EXISTS public.admin_festival_creation_requests (
   edition_id uuid NOT NULL REFERENCES public.festival_editions(id) ON DELETE CASCADE,
   result jsonb NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
-  UNIQUE (actor_profile_id, operation, idempotency_key),
   CHECK (length(trim(idempotency_key)) > 0)
 );
+ALTER TABLE public.admin_festival_creation_requests ADD COLUMN IF NOT EXISTS actor_user_id uuid;
+UPDATE public.admin_festival_creation_requests SET actor_user_id = coalesce(actor_user_id, auth.uid()) WHERE actor_user_id IS NULL;
+ALTER TABLE public.admin_festival_creation_requests ALTER COLUMN actor_user_id SET NOT NULL;
+ALTER TABLE public.admin_festival_creation_requests DROP CONSTRAINT IF EXISTS admin_festival_creation_requests_actor_profile_id_operation_idemp_key;
+DROP INDEX IF EXISTS admin_festival_creation_requests_actor_profile_id_operation_idempo_key;
+CREATE UNIQUE INDEX IF NOT EXISTS admin_festival_creation_requests_actor_user_operation_key ON public.admin_festival_creation_requests(actor_user_id, operation, idempotency_key);
 ALTER TABLE public.admin_festival_creation_requests ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS admin_festival_creation_requests_admin_read ON public.admin_festival_creation_requests;
 CREATE POLICY admin_festival_creation_requests_admin_read ON public.admin_festival_creation_requests FOR SELECT TO authenticated USING (coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false));
 
+CREATE OR REPLACE FUNCTION public.festival_creation_request_hash(p_payload jsonb)
+RETURNS text LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT encode(digest(jsonb_build_object(
+    'mode', p_payload->>'mode',
+    'existingFestivalId', p_payload->>'existingFestivalId',
+    'identity', coalesce(p_payload->'identity','{}'::jsonb) - 'imagePreviewUrl',
+    'edition', coalesce(p_payload->'edition','{}'::jsonb) - 'editionNumber',
+    'location', coalesce(p_payload->'location','{}'::jsonb),
+    'stages', coalesce(p_payload->'stages','[]'::jsonb),
+    'commercial', coalesce(p_payload->'commercial','{}'::jsonb)
+  )::text, 'sha256'), 'hex')
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_reference_data()
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path=public AS $$
+SELECT jsonb_build_object(
+  'festivalTypes', jsonb_build_array('recurring','touring','one_off','community','showcase'),
+  'genres', (SELECT coalesce(jsonb_agg(DISTINCT genre ORDER BY genre),'[]') FROM bands WHERE genre IS NOT NULL),
+  'currencies', jsonb_build_array('USD','EUR','GBP'),
+  'countries', (SELECT coalesce(jsonb_agg(DISTINCT jsonb_build_object('code', coalesce(country,'Unknown'), 'name', coalesce(country,'Unknown'))),'[]') FROM cities),
+  'cities', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',id,'name',name,'country',country,'timezone',coalesce(timezone,'UTC'),'currencyCode', CASE WHEN country IN ('United Kingdom','UK') THEN 'GBP' WHEN country IN ('France','Germany','Spain','Italy','Netherlands') THEN 'EUR' ELSE 'USD' END) ORDER BY country,name),'[]') FROM cities),
+  'venues', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',id,'name',name,'cityId',city_id,'capacity',capacity) ORDER BY name),'[]') FROM venues),
+  'stageTypes', jsonb_build_array('main','second','tent','club','acoustic','experimental'),
+  'weatherOptions', jsonb_build_array('open_air','covered','indoor'),
+  'soundOptions', jsonb_build_array('basic','standard','premium','festival_grade'),
+  'lightingOptions', jsonb_build_array('basic','standard','premium','festival_grade'),
+  'commercialDefaults', jsonb_build_object('currencyCode','USD','minimumTicketPriceCents',0,'maximumTicketPriceCents',10000,'defaultTicketPriceCents',2500)
+)
+$$;
+GRANT EXECUTE ON FUNCTION public.admin_festival_reference_data() TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_edition_lifecycle_options(p_edition_id uuid)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_status public.festival_edition_status; v_targets public.festival_edition_status[] := ARRAY['concept','planning','applications_open','booking','announced','on_sale','setup','live','settling','completed','postponed','cancelled','abandoned']::public.festival_edition_status[];
+BEGIN
+  SELECT status INTO v_status FROM public.festival_editions WHERE id=p_edition_id;
+  IF v_status IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_EDITION_INVALID'; END IF;
+  RETURN jsonb_build_object('editionId',p_edition_id,'currentState',v_status,'transitions',(SELECT jsonb_agg(jsonb_build_object('targetState',t,'available',public.validate_festival_edition_transition(v_status,t) AND t<>v_status,'blockers',CASE WHEN public.validate_festival_edition_transition(v_status,t) AND t<>v_status THEN '[]'::jsonb ELSE jsonb_build_array('Transition is not valid from current state') END,'warnings','[]'::jsonb,'adminOverrideAllowed',t IN ('postponed','cancelled','abandoned'),'reasonRequired',t IN ('postponed','cancelled','abandoned'),'confirmationRequired',t IN ('live','postponed','cancelled','abandoned'),'severity',CASE WHEN t IN ('cancelled','abandoned') THEN 'destructive' WHEN t IN ('live','postponed') THEN 'warning' ELSE 'standard' END,'explanation','Server-projected lifecycle rule')) FROM unnest(v_targets) t));
+END $$;
+GRANT EXECUTE ON FUNCTION public.admin_festival_edition_lifecycle_options(uuid) TO authenticated, service_role;
+
 CREATE OR REPLACE FUNCTION public.admin_create_festival_edition_with_setup(p_festival_id uuid, p_payload jsonb)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
 DECLARE
-  v_actor uuid := public.current_profile_id_safe();
+  v_actor_user uuid := auth.uid(); v_actor uuid := public.current_profile_id_safe();
   v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key');
-  v_hash text := md5(coalesce(p_payload,'{}'::jsonb)::text);
-  v_existing public.admin_festival_creation_requests%ROWTYPE;
-  v_festival public.festivals%ROWTYPE;
-  v_edition public.festival_editions%ROWTYPE;
-  v_stage jsonb;
-  v_stage_ids uuid[] := ARRAY[]::uuid[];
-  v_stage_id uuid;
-  v_stage_number integer := 0;
-  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb);
-  v_edition_payload jsonb := coalesce(p_payload->'edition','{}'::jsonb);
-  v_commercial jsonb := coalesce(p_payload->'commercial','{}'::jsonb);
-  v_result jsonb;
-  v_start timestamptz := nullif(v_edition_payload->>'startAt','')::timestamptz;
-  v_end timestamptz := nullif(v_edition_payload->>'endAt','')::timestamptz;
-  v_app_open timestamptz := nullif(v_edition_payload->>'applicationsOpenAt','')::timestamptz;
-  v_app_close timestamptz := nullif(v_edition_payload->>'applicationsCloseAt','')::timestamptz;
-  v_city uuid := nullif(v_location->>'cityId','')::uuid;
-  v_venue uuid := nullif(v_location->>'venueId','')::uuid;
-  v_capacity integer := coalesce((v_location->>'capacity')::integer,0);
-  v_min bigint := coalesce((v_location->>'minTicketPriceCents')::bigint,0);
-  v_max bigint := coalesce((v_location->>'maxTicketPriceCents')::bigint,0);
+  v_hash text := public.festival_creation_request_hash(p_payload);
+  v_existing public.admin_festival_creation_requests%ROWTYPE; v_festival public.festivals%ROWTYPE; v_edition public.festival_editions%ROWTYPE;
+  v_stage jsonb; v_stage_ids uuid[] := ARRAY[]::uuid[]; v_stage_id uuid; v_stage_number integer := 0;
+  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb); v_edition_payload jsonb := coalesce(p_payload->'edition','{}'::jsonb); v_commercial jsonb := coalesce(p_payload->'commercial','{}'::jsonb);
+  v_result jsonb; v_start timestamptz := nullif(v_edition_payload->>'startAt','')::timestamptz; v_end timestamptz := nullif(v_edition_payload->>'endAt','')::timestamptz; v_app_open timestamptz := nullif(v_edition_payload->>'applicationsOpenAt','')::timestamptz; v_app_close timestamptz := nullif(v_edition_payload->>'applicationsCloseAt','')::timestamptz; v_booking timestamptz := nullif(v_edition_payload->>'bookingDeadlineAt','')::timestamptz;
+  v_city uuid := nullif(v_location->>'cityId','')::uuid; v_venue uuid := nullif(v_location->>'venueId','')::uuid; v_capacity integer := coalesce((v_location->>'capacity')::integer,0); v_min bigint := coalesce((v_location->>'minTicketPriceCents')::bigint,0); v_max bigint := coalesce((v_location->>'maxTicketPriceCents')::bigint,0); v_default bigint := coalesce((v_location->>'defaultTicketPriceCents')::bigint,v_min); v_next int;
 BEGIN
-  IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) THEN RAISE EXCEPTION 'Admin authority required'; END IF;
-  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'Idempotency key is required'; END IF;
-  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_profile_id IS NOT DISTINCT FROM v_actor AND operation='admin_create_festival_edition_with_setup' AND idempotency_key=v_key FOR UPDATE;
-  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different festival creation input'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
-  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'Festival not found'; END IF;
-  IF v_start IS NULL OR v_end IS NULL OR v_end <= v_start OR v_start < now() THEN RAISE EXCEPTION 'Invalid date range'; END IF;
-  IF v_app_open IS NULL OR v_app_close IS NULL OR v_app_close < v_app_open OR v_app_close >= v_start THEN RAISE EXCEPTION 'Application date conflict'; END IF;
-  IF v_city IS NULL OR NOT EXISTS (SELECT 1 FROM public.cities WHERE id=v_city) THEN RAISE EXCEPTION 'Invalid city reference'; END IF;
-  IF v_venue IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND city_id=v_city) THEN RAISE EXCEPTION 'Invalid venue reference'; END IF;
-  IF coalesce(v_edition_payload->>'currencyCode','USD') NOT IN ('USD','EUR','GBP') THEN RAISE EXCEPTION 'Unsupported currency'; END IF;
-  IF v_capacity <= 0 OR v_min < 0 OR v_max < v_min THEN RAISE EXCEPTION 'Invalid capacity or ticket price range'; END IF;
-  IF jsonb_array_length(coalesce(p_payload->'stages','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'At least one stage is required'; END IF;
-
-  v_edition := public.create_festival_edition(p_festival_id, nullif(v_edition_payload->>'title',''), v_start, v_end, v_city, v_venue, coalesce((v_commercial->>'estimatedAttendance')::integer, v_capacity), v_capacity, v_min, v_max, jsonb_build_object('applications_open_at',v_app_open,'applications_close_at',v_app_close,'booking_deadline_at',v_edition_payload->>'bookingDeadlineAt','timezone',coalesce(v_edition_payload->>'timezone','UTC'),'currency_code',coalesce(v_edition_payload->>'currencyCode','USD'),'site_name',v_location->>'siteName','default_ticket_price_cents',coalesce((v_location->>'defaultTicketPriceCents')::bigint, v_min),'commercial',v_commercial), v_key || ':edition');
-  UPDATE public.festival_editions SET currency_code=coalesce(v_edition_payload->>'currencyCode','USD'), timezone=coalesce(v_edition_payload->>'timezone','UTC'), budget_cents=coalesce((v_commercial->>'operatingBudgetCents')::bigint, budget_cents), status='planning' WHERE id=v_edition.id RETURNING * INTO v_edition;
-
+  IF v_actor_user IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF NOT coalesce(public.has_role(v_actor_user,'admin'::public.app_role), false) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_REQUIRED'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_actor_user::text || ':admin_create_festival_edition_with_setup:' || v_key, 0));
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_user_id=v_actor_user AND operation='admin_create_festival_edition_with_setup' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'FESTIVAL_CREATE_FESTIVAL_INVALID'; END IF;
+  IF v_start IS NULL OR v_end IS NULL OR v_end <= v_start OR v_start < now() OR v_app_open IS NULL OR v_app_close IS NULL OR v_app_close < v_app_open OR v_app_close >= v_start OR (v_booking IS NOT NULL AND (v_booking < v_app_close OR v_booking > v_start)) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_INVALID_DATE'; END IF;
+  IF v_city IS NULL OR NOT EXISTS (SELECT 1 FROM public.cities WHERE id=v_city) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CITY_INVALID'; END IF;
+  IF v_venue IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND city_id=v_city) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_VENUE_INVALID'; END IF;
+  IF coalesce(v_edition_payload->>'timezone','') NOT IN (SELECT name FROM pg_timezone_names) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_TIMEZONE_INVALID'; END IF;
+  IF coalesce(v_edition_payload->>'currencyCode','') NOT IN ('USD','EUR','GBP') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CURRENCY_INVALID'; END IF;
+  IF v_capacity <= 0 OR v_min < 0 OR v_max < v_min OR v_default < v_min OR v_default > v_max THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CAPACITY_OR_PRICE_INVALID'; END IF;
+  IF v_venue IS NOT NULL AND EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND capacity IS NOT NULL AND v_capacity > capacity) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CAPACITY_EXCEEDED'; END IF;
+  IF jsonb_array_length(coalesce(p_payload->'stages','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_REQUIRED'; END IF;
+  IF coalesce((v_commercial->>'operatingBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'performerBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'staffingBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'marketingBudgetCents')::bigint,0) < 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_BUDGET_INVALID'; END IF;
+  SELECT coalesce(max(edition_number),0)+1 INTO v_next FROM public.festival_editions WHERE festival_id=p_festival_id;
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, timezone, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, currency_code, budget_cents, status, public_metadata, created_by, legacy_metadata)
+  VALUES (p_festival_id, v_next, extract(year from v_start)::int, coalesce(nullif(v_edition_payload->>'title',''), v_festival.name || ' Edition ' || v_next), nullif(v_edition_payload->>'description',''), v_city, v_venue, v_start, v_end, v_edition_payload->>'timezone', coalesce((v_commercial->>'estimatedAttendance')::integer, v_capacity), v_capacity, v_min, v_max, v_edition_payload->>'currencyCode', coalesce((v_commercial->>'operatingBudgetCents')::bigint,0), 'planning', jsonb_build_object('applications_open_at',v_app_open,'applications_close_at',v_app_close,'booking_deadline_at',v_booking,'site_name',v_location->>'siteName','default_ticket_price_cents',v_default,'commercial',v_commercial), v_actor, jsonb_build_object('source','admin_creation_wizard')) RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key) VALUES (v_edition.id, NULL, v_edition.status, v_actor, 'admin_edition_created', jsonb_build_object('source','admin_creation_wizard'), v_key || ':lifecycle');
   FOR v_stage IN SELECT * FROM jsonb_array_elements(p_payload->'stages') LOOP
-    IF EXISTS (SELECT 1 FROM public.festival_stages WHERE edition_id=v_edition.id AND lower(stage_name)=lower(v_stage->>'name') AND archived_at IS NULL) THEN RAISE EXCEPTION 'Duplicate stage names are not allowed'; END IF;
-    IF coalesce((v_stage->>'capacity')::integer,0) <= 0 OR coalesce((v_stage->>'capacity')::integer,0) > v_capacity THEN RAISE EXCEPTION 'Stage capacity conflict'; END IF;
-    IF coalesce((v_stage->>'changeoverMinutes')::integer,30) < 5 THEN RAISE EXCEPTION 'Stage changeover duration is invalid'; END IF;
+    IF nullif(trim(v_stage->>'name'),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_INVALID'; END IF;
+    IF EXISTS (SELECT 1 FROM public.festival_stages WHERE edition_id=v_edition.id AND lower(trim(stage_name))=lower(trim(v_stage->>'name')) AND archived_at IS NULL) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_DUPLICATE'; END IF;
+    IF coalesce(v_stage->>'type','main') NOT IN ('main','second','tent','club','acoustic','experimental') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_TYPE_INVALID'; END IF;
+    IF coalesce((v_stage->>'capacity')::integer,0) <= 0 OR coalesce((v_stage->>'capacity')::integer,0) > v_capacity THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_CAPACITY_INVALID'; END IF;
+    IF coalesce((v_stage->>'changeoverMinutes')::integer,30) < 5 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_CHANGEOVER_INVALID'; END IF;
     v_stage_number := v_stage_number + 1;
     INSERT INTO public.festival_stages(festival_id, edition_id, stage_name, stage_number, capacity, stage_type, sound_capability, lighting_capability, weather_protection, default_changeover_minutes, curfew_time, public_metadata, idempotency_key)
-    VALUES (NULL, v_edition.id, v_stage->>'name', v_stage_number, (v_stage->>'capacity')::integer, coalesce(v_stage->>'type','main'), v_stage->>'soundCapability', v_stage->>'lightingCapability', v_stage->>'weatherProtection', coalesce((v_stage->>'changeoverMinutes')::integer,30), nullif(v_stage->>'curfew','')::time, jsonb_build_object('created_from','admin_creation_wizard'), v_key || ':stage:' || v_stage_number) RETURNING id INTO v_stage_id;
+    VALUES (p_festival_id, v_edition.id, trim(v_stage->>'name'), v_stage_number, (v_stage->>'capacity')::integer, coalesce(v_stage->>'type','main'), v_stage->>'soundCapability', v_stage->>'lightingCapability', v_stage->>'weatherProtection', coalesce((v_stage->>'changeoverMinutes')::integer,30), nullif(v_stage->>'curfew','')::time, jsonb_build_object('created_from','admin_creation_wizard'), v_key || ':stage:' || v_stage_number) RETURNING id INTO v_stage_id;
     v_stage_ids := array_append(v_stage_ids, v_stage_id);
   END LOOP;
   PERFORM public.festival_audit(v_edition.id,'edition_setup_created','festival_edition',v_edition.id,'{}',to_jsonb(v_edition),'admin festival creation wizard',v_key || ':audit');
   v_result := jsonb_build_object('festival_id',p_festival_id,'edition_id',v_edition.id,'stage_ids',to_jsonb(v_stage_ids),'lifecycle_status',v_edition.status,'public_route','/festivals/' || p_festival_id,'management_route','/festivals/' || p_festival_id || '/manage/editions/' || v_edition.id,'created',true);
-  INSERT INTO public.admin_festival_creation_requests(actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor,'admin_create_festival_edition_with_setup',v_key,v_hash,p_festival_id,v_edition.id,v_result);
+  INSERT INTO public.admin_festival_creation_requests(actor_user_id,actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor_user,v_actor,'admin_create_festival_edition_with_setup',v_key,v_hash,p_festival_id,v_edition.id,v_result);
   RETURN v_result;
 END $$;
 
 CREATE OR REPLACE FUNCTION public.admin_create_festival_with_first_edition(p_payload jsonb)
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
-DECLARE
-  v_actor uuid := public.current_profile_id_safe();
-  v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key');
-  v_hash text := md5(coalesce(p_payload,'{}'::jsonb)::text);
-  v_existing public.admin_festival_creation_requests%ROWTYPE;
-  v_identity jsonb := coalesce(p_payload->'identity','{}'::jsonb);
-  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb);
-  v_festival public.festivals%ROWTYPE;
-  v_result jsonb;
+DECLARE v_actor_user uuid := auth.uid(); v_actor uuid := public.current_profile_id_safe(); v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key'); v_hash text := public.festival_creation_request_hash(p_payload); v_existing public.admin_festival_creation_requests%ROWTYPE; v_identity jsonb := coalesce(p_payload->'identity','{}'::jsonb); v_location jsonb := coalesce(p_payload->'location','{}'::jsonb); v_festival public.festivals%ROWTYPE; v_result jsonb; v_name text := trim(coalesce(v_identity->>'name',''));
 BEGIN
-  IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) THEN RAISE EXCEPTION 'Admin authority required'; END IF;
-  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'Idempotency key is required'; END IF;
-  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_profile_id IS NOT DISTINCT FROM v_actor AND operation='admin_create_festival_with_first_edition' AND idempotency_key=v_key FOR UPDATE;
-  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'Idempotency key reused with different festival creation input'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
-  IF nullif(trim(v_identity->>'name'),'') IS NULL THEN RAISE EXCEPTION 'Festival name is required'; END IF;
-  IF jsonb_array_length(coalesce(v_identity->'primaryGenres','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'At least one primary genre is required'; END IF;
+  IF v_actor_user IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF NOT coalesce(public.has_role(v_actor_user,'admin'::public.app_role), false) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_REQUIRED'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_actor_user::text || ':admin_create_festival_with_first_edition:' || v_key, 0));
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_user_id=v_actor_user AND operation='admin_create_festival_with_first_edition' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  IF length(v_name) < 3 OR length(v_name) > 120 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_NAME_INVALID'; END IF;
+  IF length(coalesce(v_identity->>'shortDescription','')) > 240 OR length(coalesce(v_identity->>'fullDescription','')) > 5000 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_DESCRIPTION_INVALID'; END IF;
+  IF coalesce(v_identity->>'festivalType','') NOT IN ('recurring','touring','one_off','community','showcase') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_TYPE_INVALID'; END IF;
+  IF jsonb_array_length(coalesce(v_identity->'primaryGenres','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_GENRE_INVALID'; END IF;
   INSERT INTO public.festivals(name, description, city_id, genre, scale, owner_profile_id, status, public_metadata)
-  VALUES (trim(v_identity->>'name'), coalesce(nullif(v_identity->>'fullDescription',''), v_identity->>'shortDescription'), nullif(v_location->>'cityId','')::uuid, (v_identity->'primaryGenres')->>0, v_identity->>'festivalType', NULL, 'planning', jsonb_build_object('short_description',v_identity->>'shortDescription','festival_type',v_identity->>'festivalType','primary_genres',v_identity->'primaryGenres','image_url',v_identity->>'imageUrl','public_visibility',coalesce((v_identity->>'isPublic')::boolean,false),'admin_creation_key',v_key)) RETURNING * INTO v_festival;
-  v_result := public.admin_create_festival_edition_with_setup(v_festival.id, p_payload || jsonb_build_object('mode','create_first_edition','existingFestivalId',v_festival.id,'idempotencyKey',v_key || ':edition'));
+  VALUES (v_name, coalesce(nullif(v_identity->>'fullDescription',''), v_identity->>'shortDescription'), nullif(v_location->>'cityId','')::uuid, (v_identity->'primaryGenres')->>0, v_identity->>'festivalType', NULL, 'planning', jsonb_build_object('short_description',v_identity->>'shortDescription','festival_type',v_identity->>'festivalType','primary_genres',v_identity->'primaryGenres','image_url',v_identity->>'imageUrl','public_visibility',coalesce((v_identity->>'isPublic')::boolean,false),'admin_creation_key',v_key)) RETURNING * INTO v_festival;
+  v_result := public.admin_create_festival_edition_with_setup(v_festival.id, p_payload || jsonb_build_object('mode','create_first_edition','existingFestivalId',v_festival.id,'idempotencyKey',v_key || ':first-edition'));
+  DELETE FROM public.admin_festival_creation_requests WHERE actor_user_id=v_actor_user AND operation='admin_create_festival_edition_with_setup' AND idempotency_key=v_key || ':first-edition';
+  UPDATE public.festival_editions SET edition_number=1 WHERE id=(v_result->>'edition_id')::uuid;
   v_result := v_result || jsonb_build_object('festival_id',v_festival.id,'public_route','/festivals/' || v_festival.id,'management_route','/festivals/' || v_festival.id || '/manage/editions/' || (v_result->>'edition_id'),'created',true);
   INSERT INTO public.festival_admin_audit_events(actor_profile_id, festival_id, edition_id, operation, target_type, target_id, after_snapshot, reason, idempotency_key) VALUES (v_actor, v_festival.id, (v_result->>'edition_id')::uuid, 'festival_created_with_first_edition', 'festival', v_festival.id, v_result, 'admin creation wizard', v_key);
-  INSERT INTO public.admin_festival_creation_requests(actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor,'admin_create_festival_with_first_edition',v_key,v_hash,v_festival.id,(v_result->>'edition_id')::uuid,v_result);
+  INSERT INTO public.admin_festival_creation_requests(actor_user_id,actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result) VALUES (v_actor_user,v_actor,'admin_create_festival_with_first_edition',v_key,v_hash,v_festival.id,(v_result->>'edition_id')::uuid,v_result);
   RETURN v_result;
 END $$;
 

--- a/supabase/tests/festival_creation_phase1_harness.sql
+++ b/supabase/tests/festival_creation_phase1_harness.sql
@@ -1,7 +1,74 @@
--- Festival creation phase 1 harness.
--- Intended for a local Supabase test database with seeded admin auth context.
+-- Festival creation phase 1 executable harness.
+-- Run with: supabase db reset && psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/festival_creation_phase1_harness.sql
+-- The harness seeds deterministic admin/non-admin actors and rolls back all data.
+
 BEGIN;
-SELECT has_function_privilege('authenticated', 'public.admin_create_festival_with_first_edition(jsonb)', 'EXECUTE') AS admin_create_festival_with_first_edition_executable;
-SELECT has_function_privilege('authenticated', 'public.admin_create_festival_edition_with_setup(uuid,jsonb)', 'EXECUTE') AS admin_create_festival_edition_with_setup_executable;
-SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='admin_festival_creation_requests' AND column_name IN ('idempotency_key','request_hash','festival_id','edition_id','result');
+CREATE SCHEMA IF NOT EXISTS test_festival_creation;
+CREATE OR REPLACE FUNCTION test_festival_creation.as_user(user_id uuid) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN EXECUTE 'SET LOCAL ROLE authenticated'; PERFORM set_config('request.jwt.claim.sub', user_id::text, true); PERFORM set_config('request.jwt.claim.role', 'authenticated', true); END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.as_anon() RETURNS void LANGUAGE plpgsql AS $$
+BEGIN EXECUTE 'SET LOCAL ROLE anon'; PERFORM set_config('request.jwt.claim.sub', '', true); PERFORM set_config('request.jwt.claim.role', 'anon', true); END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.as_service() RETURNS void LANGUAGE plpgsql AS $$
+BEGIN EXECUTE 'SET LOCAL ROLE service_role'; PERFORM set_config('request.jwt.claim.sub', '', true); PERFORM set_config('request.jwt.claim.role', 'service_role', true); END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.assert_true(label text, actual boolean) RETURNS void LANGUAGE plpgsql AS $$ BEGIN IF actual IS DISTINCT FROM true THEN RAISE EXCEPTION 'assertion failed: %', label; END IF; END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.assert_eq(label text, actual bigint, expected bigint) RETURNS void LANGUAGE plpgsql AS $$ BEGIN IF actual IS DISTINCT FROM expected THEN RAISE EXCEPTION 'assertion failed: %, expected %, got %', label, expected, actual; END IF; END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.assert_raises(label text, statement text) RETURNS void LANGUAGE plpgsql AS $$ BEGIN BEGIN EXECUTE statement; EXCEPTION WHEN OTHERS THEN RETURN; END; RAISE EXCEPTION 'assertion failed: % should have raised', label; END $$;
+
+DO $$
+DECLARE
+  admin_user uuid := '71000000-0000-0000-0000-000000000001'; normal_user uuid := '71000000-0000-0000-0000-000000000002';
+  admin_profile uuid := '72000000-0000-0000-0000-000000000001'; normal_profile uuid := '72000000-0000-0000-0000-000000000002';
+  city_a uuid := '73000000-0000-0000-0000-000000000001'; city_b uuid := '73000000-0000-0000-0000-000000000002'; venue_a uuid := '74000000-0000-0000-0000-000000000001'; venue_b uuid := '74000000-0000-0000-0000-000000000002';
+  payload jsonb; payload2 jsonb; res jsonb; res_retry jsonb; festival uuid; edition uuid; stage uuid; before_f bigint; before_e bigint; before_s bigint; reqs bigint;
+BEGIN
+  IF NOT has_function_privilege('authenticated', 'public.admin_create_festival_with_first_edition(jsonb)', 'EXECUTE') THEN RAISE EXCEPTION 'create first-edition RPC grant missing'; END IF;
+  IF NOT has_function_privilege('authenticated', 'public.admin_create_festival_edition_with_setup(uuid,jsonb)', 'EXECUTE') THEN RAISE EXCEPTION 'add edition RPC grant missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='admin_festival_creation_requests' AND column_name='actor_user_id' AND is_nullable='NO') THEN RAISE EXCEPTION 'actor_user_id must be non-null'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND tablename='admin_festival_creation_requests' AND indexname='admin_festival_creation_requests_actor_user_operation_key') THEN RAISE EXCEPTION 'actor-user idempotency unique index missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='tg_festival_stage_edition_consistency') THEN RAISE EXCEPTION 'stage consistency trigger missing'; END IF;
+
+  PERFORM test_festival_creation.as_service();
+  INSERT INTO auth.users(id,email,role) VALUES (admin_user,'festival-phase1-admin@example.test','authenticated'), (normal_user,'festival-phase1-user@example.test','authenticated');
+  INSERT INTO public.profiles(id,user_id,username,display_name) VALUES (admin_profile,admin_user,'festival_phase1_admin','Festival Admin'), (normal_profile,normal_user,'festival_phase1_user','Festival User');
+  INSERT INTO public.user_roles(user_id,role) VALUES (admin_user,'admin'), (normal_user,'user');
+  INSERT INTO public.cities(id,name,country,timezone) VALUES (city_a,'Harness City','United States','America/New_York'), (city_b,'Mismatch City','United Kingdom','Europe/London');
+  INSERT INTO public.venues(id,name,city_id,capacity) VALUES (venue_a,'Harness Venue',city_a,5000), (venue_b,'Mismatch Venue',city_b,1000);
+
+  payload := jsonb_build_object('mode','create_festival','idempotencyKey','phase1-key-1','identity',jsonb_build_object('name','Phase 1 Harness Fest','shortDescription','safe','fullDescription','safe festival','festivalType','recurring','primaryGenres',jsonb_build_array('Rock'),'isPublic',true),'edition',jsonb_build_object('title','Phase 1 2027','editionNumber',99,'startAt','2027-07-17T18:00:00Z','endAt','2027-07-19T23:00:00Z','applicationsOpenAt','2027-01-01T00:00:00Z','applicationsCloseAt','2027-03-01T00:00:00Z','bookingDeadlineAt','2027-05-01T00:00:00Z','timezone','America/New_York','currencyCode','USD'),'location',jsonb_build_object('country','United States','cityId',city_a,'venueId',venue_a,'capacity',4000,'minTicketPriceCents',2500,'maxTicketPriceCents',7500,'defaultTicketPriceCents',5000,'festivalDays',3),'stages',jsonb_build_array(jsonb_build_object('name','Main Stage','type','main','capacity',3000,'changeoverMinutes',30,'curfew','23:00','weatherProtection','covered','soundCapability','festival_grade','lightingCapability','premium')),'commercial',jsonb_build_object('estimatedAttendance',3500,'operatingBudgetCents',10000000,'performerBudgetCents',5000000,'staffingBudgetCents',2000000,'marketingBudgetCents',1000000,'sponsorshipEnabled',true,'merchandiseEnabled',true,'concessionsEnabled',true));
+
+  PERFORM test_festival_creation.as_anon();
+  PERFORM test_festival_creation.assert_raises('anonymous creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text));
+  PERFORM test_festival_creation.as_user(normal_user);
+  PERFORM test_festival_creation.assert_raises('non-admin creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text));
+
+  PERFORM test_festival_creation.as_user(admin_user);
+  SELECT count(*) INTO before_f FROM public.festivals; SELECT count(*) INTO before_e FROM public.festival_editions; SELECT count(*) INTO before_s FROM public.festival_stages;
+  res := public.admin_create_festival_with_first_edition(payload); festival := (res->>'festival_id')::uuid; edition := (res->>'edition_id')::uuid; stage := (res->'stage_ids'->>0)::uuid;
+  PERFORM test_festival_creation.assert_eq('one festival created', (SELECT count(*) FROM public.festivals)-before_f, 1);
+  PERFORM test_festival_creation.assert_eq('one first edition created', (SELECT count(*) FROM public.festival_editions)-before_e, 1);
+  PERFORM test_festival_creation.assert_true('stage created', (SELECT count(*) FROM public.festival_stages WHERE edition_id=edition) >= 1);
+  PERFORM test_festival_creation.assert_true('edition belongs to festival', EXISTS (SELECT 1 FROM public.festival_editions WHERE id=edition AND festival_id=festival AND edition_number=1 AND status='planning' AND city_id=city_a AND currency_code='USD' AND timezone='America/New_York' AND minimum_ticket_price_cents=2500 AND maximum_ticket_price_cents=7500 AND public_metadata->>'default_ticket_price_cents'='5000'));
+  PERFORM test_festival_creation.assert_true('stage belongs to edition and festival', EXISTS (SELECT 1 FROM public.festival_stages WHERE id=stage AND edition_id=edition AND festival_id=festival));
+  PERFORM test_festival_creation.assert_true('audit written', EXISTS (SELECT 1 FROM public.festival_admin_audit_events WHERE festival_id=festival AND edition_id=edition));
+  PERFORM test_festival_creation.assert_true('lifecycle history written', EXISTS (SELECT 1 FROM public.festival_edition_lifecycle_events WHERE edition_id=edition AND to_status='planning'));
+  PERFORM test_festival_creation.assert_true('no game event created', NOT EXISTS (SELECT 1 FROM public.game_events WHERE id=festival));
+  SELECT count(*) INTO reqs FROM public.admin_festival_creation_requests WHERE festival_id=festival;
+  PERFORM test_festival_creation.assert_eq('only outer request record remains', reqs, 1);
+  res_retry := public.admin_create_festival_with_first_edition(payload);
+  PERFORM test_festival_creation.assert_true('idempotent retry returns original', (res_retry->>'festival_id')::uuid=festival AND (res_retry->>'edition_id')::uuid=edition AND (res_retry->>'created')::boolean=false);
+  payload2 := jsonb_set(payload,'{identity,name}','"Changed Harness Fest"');
+  PERFORM test_festival_creation.assert_raises('payload mismatch denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload2::text));
+
+  PERFORM test_festival_creation.assert_raises('invalid dates rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dates"') #- '{edition,endAt}' || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('endAt','2027-01-01T00:00:00Z'))));
+  PERFORM test_festival_creation.assert_raises('invalid city rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('cityId','00000000-0000-0000-0000-000000000000'))));
+  PERFORM test_festival_creation.assert_raises('venue city mismatch rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-venue-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('venueId',venue_b))));
+  PERFORM test_festival_creation.assert_raises('duplicate stages rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dupe-stage"') || jsonb_build_object('stages',jsonb_build_array(payload->'stages'->0,payload->'stages'->0))));
+  PERFORM test_festival_creation.assert_raises('unsupported currency rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-currency"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('currencyCode','BTC'))));
+  PERFORM test_festival_creation.assert_raises('unsupported timezone rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-timezone"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('timezone','Mars/Base'))));
+
+  res := public.admin_create_festival_edition_with_setup(festival, (payload || jsonb_build_object('mode','add_edition','existingFestivalId',festival,'idempotencyKey','phase1-add-2','edition',(payload->'edition') || jsonb_build_object('title','Phase 1 2028','startAt','2028-07-17T18:00:00Z','endAt','2028-07-19T23:00:00Z','applicationsOpenAt','2028-01-01T00:00:00Z','applicationsCloseAt','2028-03-01T00:00:00Z','bookingDeadlineAt','2028-05-01T00:00:00Z'))));
+  res := public.admin_create_festival_edition_with_setup(festival, (payload || jsonb_build_object('mode','add_edition','existingFestivalId',festival,'idempotencyKey','phase1-add-3','edition',(payload->'edition') || jsonb_build_object('title','Phase 1 2029','startAt','2029-07-17T18:00:00Z','endAt','2029-07-19T23:00:00Z','applicationsOpenAt','2029-01-01T00:00:00Z','applicationsCloseAt','2029-03-01T00:00:00Z','bookingDeadlineAt','2029-05-01T00:00:00Z'))));
+  PERFORM test_festival_creation.assert_true('later edition gets next number', EXISTS (SELECT 1 FROM public.festival_editions WHERE id=(res->>'edition_id')::uuid AND festival_id=festival AND edition_number=3));
+  PERFORM test_festival_creation.assert_true('request rows do not outlive failed aggregates', NOT EXISTS (SELECT 1 FROM public.admin_festival_creation_requests WHERE idempotency_key LIKE 'bad-%'));
+END $$;
 ROLLBACK;


### PR DESCRIPTION
### Motivation

- Harden the festival creation workflow introduced earlier by making server-side creation idempotent, atomic, and validated before Phase 2 work proceeds. 
- Eliminate idempotency and concurrency risks, replace brittle frontend reference data with server projections, and ensure edition numbering and stage ownership are server-authoritative.
- Improve admin UX, accessibility and recovery for the creation wizard without starting Phase 2 scheduling/lineup redesign.

### Description

- Database: restored and populated `festival_stages.festival_id`, added `tg_festival_stage_edition_consistency` trigger, introduced `admin_festival_creation_requests.actor_user_id` (non-null) with a unique index, added `festival_creation_request_hash(jsonb)` (SHA-256), added `admin_festival_reference_data()` projection and `admin_festival_edition_lifecycle_options(uuid)` projection, and hardened `admin_create_festival_with_first_edition` and `admin_create_festival_edition_with_setup` RPCs to use `auth.uid()`, advisory transaction locks, normalized payload hashing, material validation, server-assigned edition numbering, transactional lifecycle/audit insertion and safe idempotency behavior.  The migration and RPCs live in `supabase/migrations/20260717120000_admin_festival_creation_phase1.sql`.
- SQL tests: replaced the placeholder harness with an executable rollback-only harness `supabase/tests/festival_creation_phase1_harness.sql` that exercises anonymous/non-admin/admin access, idempotency retries, rollback cases, stage ownership, and next-edition numbering.
- Frontend: consume server-projected reference data via `fetchFestivalReferenceData()` and `useFestivalReferenceData()`, wire lifecycle options from `admin_festival_edition_lifecycle_options` via `fetchAdminFestivalLifecycleOptions()` and `useAdminFestivalLifecycleOptions()`, gate the creation wizard navigation and validations, replace native `confirm()` with the app `AlertDialog`, show country→city→venue filtering, display and block on venue capacity, stop using `window.location.href` in favor of React Router `navigate`, and make application queries explicitly scoped in `useFestivalSlotApplications` (edition/festival/band). Files changed include `src/features/festivals/admin/service.ts`, `.../hooks.ts`, `FestivalCreationWizard.tsx`, `FestivalLifecycleControls.tsx`, `useFestivalSlotApplications.ts`, `FestivalsAdmin.tsx`, and related types/mappers.
- CI and scripts: added `scripts/festivals/run-creation-phase1-db-gate.sh`, `package.json` script `test:festivals:db`, and extended the CI workflow to run the festival SQL gate (Supabase CLI step + `npm run test:festivals:db`).
- Documentation: added audit, security and test-matrix docs under `docs/festivals/` describing verification scope and residual Phase 2 items.

### Testing

- Ran repository checks in this environment: `npm run typecheck` succeeded and `git diff --check` succeeded.
- Database harness was authored and added (`supabase/tests/festival_creation_phase1_harness.sql`) but the harness could not be executed here because the Supabase CLI and a local Postgres (`psql`) were not available in this environment; CI will run it via the new `test:festivals:db` script once runners have Supabase CLI.
- Dependency and frontend verification were limited: `npm ci --legacy-peer-deps` could not complete in the Codex environment (install attempt hung due to environment proxy / registry conditions), so `npm run lint`, `npm run test:unit`, and `npm run build` could not be completed here; these steps are included in CI and should run there after dependency resolution.
- Summary of results in this run: typecheck ✅; lint/unit/build/db harness execution ⚠️ (not run here due to missing dependencies or Supabase CLI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f3bbdf88832592c2747f7e4aef56)