### PR TITLE
fix(festivals): correct hardening migrations and workflow state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.31.8
       - name: Festival SQL tests
         run: npm run test:festivals:db
+      - name: Upload Supabase logs on festival DB gate failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-logs
+          path: supabase/.branches/**/logs/**
+          if-no-files-found: ignore

--- a/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
+++ b/docs/festivals/FESTIVAL_ADMIN_RECOVERY_PLAN.md
@@ -63,3 +63,7 @@ Administrators no longer paste a festival edition UUID. When a festival has no e
 ## Phase 1 hardening update
 
 Festival creation now relies on server-projected reference data, server-authoritative edition numbering, authenticated actor idempotency, lifecycle/audit writes in the aggregate transaction, and explicit stage festival/edition consistency. Phase 1 is not considered fully verified unless frontend checks and the executable SQL harness pass in the target environment.
+
+## Phase 1.1 deployment correction note
+
+Phase 1 hardening is considered verified only after the new forward migration is applied and the executable checks pass. The forward migration preserves historical request rows, backfills actor identity from profiles where deterministic, enforces server creation modes, removes nested public creation for first editions, and requires one external idempotency request row per operation.

--- a/docs/festivals/FESTIVAL_CREATION_PHASE1_AUDIT.md
+++ b/docs/festivals/FESTIVAL_CREATION_PHASE1_AUDIT.md
@@ -36,3 +36,7 @@
 ## Deferred Phase 2 work
 
 - Drag-and-drop scheduling, unified lineup management, performer recommendation, offer/contract redesign, setlist readiness, live simulation, sponsorship gameplay, and player festival licensing remain out of scope.
+
+## Phase 1.1 deployment correction note
+
+Phase 1 hardening is considered verified only after the new forward migration is applied and the executable checks pass. The forward migration preserves historical request rows, backfills actor identity from profiles where deterministic, enforces server creation modes, removes nested public creation for first editions, and requires one external idempotency request row per operation.

--- a/docs/festivals/FESTIVAL_CREATION_SECURITY.md
+++ b/docs/festivals/FESTIVAL_CREATION_SECURITY.md
@@ -29,3 +29,7 @@ The hardened Phase 1 model treats festival creation as a server-authoritative ag
 
 - Edition lifecycle history and admin audit history are inserted in the same transaction as festival, edition, and stage creation.
 - Any failure during validation, audit, or stage insertion rolls back the aggregate and the request row.
+
+## Phase 1.1 deployment correction note
+
+Phase 1 hardening is considered verified only after the new forward migration is applied and the executable checks pass. The forward migration preserves historical request rows, backfills actor identity from profiles where deterministic, enforces server creation modes, removes nested public creation for first editions, and requires one external idempotency request row per operation.

--- a/docs/festivals/FESTIVAL_CREATION_TEST_MATRIX.md
+++ b/docs/festivals/FESTIVAL_CREATION_TEST_MATRIX.md
@@ -28,3 +28,7 @@
 
 - True two-session concurrent SQL execution remains a recommended database stress test outside the single-session harness.
 - Screenshot capture was not performed in this headless change because the app could not be reliably run against a seeded Supabase instance in this environment.
+
+## Phase 1.1 deployment correction note
+
+Phase 1 hardening is considered verified only after the new forward migration is applied and the executable checks pass. The forward migration preserves historical request rows, backfills actor identity from profiles where deterministic, enforces server creation modes, removes nested public creation for first editions, and requires one external idempotency request row per operation.

--- a/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
+++ b/docs/festivals/FESTIVAL_CREATION_WORKFLOW.md
@@ -27,3 +27,7 @@ New editions start in `planning`. Final submission is disabled while pending, fo
 ## Phase 1 hardening update
 
 Festival creation now relies on server-projected reference data, server-authoritative edition numbering, authenticated actor idempotency, lifecycle/audit writes in the aggregate transaction, and explicit stage festival/edition consistency. Phase 1 is not considered fully verified unless frontend checks and the executable SQL harness pass in the target environment.
+
+## Phase 1.1 deployment correction note
+
+Phase 1 hardening is considered verified only after the new forward migration is applied and the executable checks pass. The forward migration preserves historical request rows, backfills actor identity from profiles where deterministic, enforces server creation modes, removes nested public creation for first editions, and requires one external idempotency request row per operation.

--- a/docs/festivals/FESTIVAL_LIFECYCLE_ADMIN_FLOW.md
+++ b/docs/festivals/FESTIVAL_LIFECYCLE_ADMIN_FLOW.md
@@ -1,0 +1,15 @@
+# Festival Lifecycle Admin Flow
+
+Lifecycle administration is server-projected and server-authorised. The UI must not invent readiness rules; it renders the transition data returned by `admin_festival_edition_lifecycle_options`.
+
+## Transition selection
+
+Every projected transition is displayed with title, explanation, warnings and blockers. Unavailable transitions remain visible when blockers explain why the administrator cannot proceed.
+
+## Confirmation and override
+
+Transitions marked `confirmationRequired` open an application confirmation dialog. Destructive transitions require typed confirmation. Overrides are only available when `adminOverrideAllowed` is true and require an explicit toggle plus an administrator reason. Override is submitted with `p_override = true` only after confirmation.
+
+## Idempotency
+
+The frontend generates one operation key when an administrator starts a transition attempt. The key is reused for duplicate submission or network retry and replaced after success, cancellation or choosing a materially different transition.

--- a/docs/festivals/FESTIVAL_PHASE1_DEPLOYMENT_CORRECTIONS.md
+++ b/docs/festivals/FESTIVAL_PHASE1_DEPLOYMENT_CORRECTIONS.md
@@ -1,0 +1,36 @@
+# Festival Phase 1.1 Deployment Corrections
+
+## Confirmed findings from PR #1220 review
+
+1. PR #1220 edited `20260717120000_admin_festival_creation_phase1.sql` after that migration was already part of merged history.
+2. Environments that had recorded that migration would not automatically receive the edited SQL.
+3. Historical `admin_festival_creation_requests` rows can have `actor_user_id` set to null.
+4. `auth.uid()` is not a deterministic migration backfill source and can be null during database migrations.
+5. First-festival creation nested through the public edition-creation RPC.
+6. The nested request row was deleted after first-edition creation.
+7. The created first edition was updated to edition number one after insertion.
+8. `create_first_edition` and `add_edition` modes were not fully enforced by the server.
+9. Lifecycle confirmation, severity and override projection existed without complete UI handling.
+10. Wizard dirty-state detection compared against a newly generated idempotency key.
+11. Large creation/admin component splits remained incomplete and should continue incrementally after deployability is safe.
+12. The SQL harness used generic exception assertions for domain-error cases.
+13. Frontend coverage for dirty-state behaviour was missing.
+14. The implementation environment had not completed the requested lint, unit, build and SQL execution checks.
+
+## Corrections made
+
+- Added `20260717153000_harden_festival_creation_phase1_forward.sql` as a forward-only migration so deployed databases receive Phase 1.1 hardening without relying on edits to the historical Phase 1 migration.
+- Backfilled `actor_user_id` through `admin_festival_creation_requests.actor_profile_id -> profiles.id -> profiles.user_id` and preserved unresolved historical rows with `actor_resolution_status = 'historical_unresolved'`.
+- Replaced the full actor-user uniqueness with a partial idempotency index that only applies where `actor_user_id` is non-null, while public RPCs always write resolved authenticated user identities.
+- Added the private `internal_create_festival_edition_setup` helper and revoked authenticated/anon execute grants.
+- Reworked public creation RPCs so each external operation writes one request row. First-festival creation now inserts edition number `1` directly and does not delete an inner request row.
+- Enforced `create_first_edition` and `add_edition` server modes with `FESTIVAL_CREATE_FIRST_EDITION_ALREADY_EXISTS` and `FESTIVAL_CREATE_ADD_EDITION_REQUIRES_EXISTING` domain errors.
+- Improved reference-data projection with canonical fallback genres, stable country codes, city-derived time zones and projected stage-field options.
+- Improved lifecycle projection text and authority checks.
+- Added material draft dirty-state comparison that excludes idempotency keys.
+- Rendered lifecycle blockers, warnings, confirmation, destructive typed confirmation and explicit override reason handling.
+- Strengthened SQL assertions with expected message fragments and added a migration-upgrade contract harness.
+
+## Verification status
+
+Phase 1 is verified only after the forward migration and executable checks pass: typecheck, lint, unit tests, production build and the festival database gate.

--- a/scripts/festivals/run-creation-phase1-db-gate.sh
+++ b/scripts/festivals/run-creation-phase1-db-gate.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-if ! command -v supabase >/dev/null; then echo "Supabase CLI is required for the festival DB gate" >&2; exit 127; fi
+REQUIRED_SUPABASE_CLI_VERSION="${SUPABASE_CLI_VERSION:-2.31.8}"
+if ! command -v supabase >/dev/null; then echo "Supabase CLI ${REQUIRED_SUPABASE_CLI_VERSION} is required for the festival DB gate" >&2; exit 127; fi
+if ! supabase --version | grep -Fq "$REQUIRED_SUPABASE_CLI_VERSION"; then echo "Supabase CLI version must be pinned to ${REQUIRED_SUPABASE_CLI_VERSION}; found: $(supabase --version)" >&2; exit 1; fi
 if ! command -v psql >/dev/null; then echo "psql is required for the festival DB gate" >&2; exit 127; fi
+if ! command -v docker >/dev/null; then echo "Docker is required for Supabase local startup" >&2; exit 127; fi
+trap 'supabase stop --no-backup || true' EXIT
 supabase start
 supabase db reset
 DB_URL="${SUPABASE_DB_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"

--- a/src/features/festivals/admin/components/FestivalCreationWizard.tsx
+++ b/src/features/festivals/admin/components/FestivalCreationWizard.tsx
@@ -71,6 +71,7 @@ export function FestivalCreationWizard({
   const [draft, setDraft] = useState(() =>
     defaultFestivalCreationDraft(mode, festival?.festivalId),
   );
+  const [initialDraft, setInitialDraft] = useState(draft);
   const [step, setStep] = useState(0);
   const [discardPromptOpen, setDiscardPromptOpen] = useState(false);
   const refs = useFestivalReferenceData();
@@ -85,6 +86,7 @@ export function FestivalCreationWizard({
         next.location.cityName = festival.cityName;
       }
       setDraft(next);
+      setInitialDraft(next);
       setStep(mode === "create_festival" ? 0 : 1);
     }
   }, [open, mode, festival]);
@@ -98,7 +100,12 @@ export function FestivalCreationWizard({
   const update = (patch: Partial<FestivalCreationDraft>) =>
     setDraft((d) => ({ ...d, ...patch }));
   const submit = () =>
-    create.mutate(draft, { onSuccess: (result) => onCreated(result) });
+    create.mutate(draft, {
+      onSuccess: (result) => {
+        setInitialDraft(draft);
+        onCreated(result);
+      },
+    });
   const referenceData = refs.data;
   const genres = referenceData?.genres ?? [];
   const festivalTypes = referenceData?.festivalTypes ?? [];
@@ -112,7 +119,8 @@ export function FestivalCreationWizard({
   );
   const selectedVenue = venues.find((venue) => venue.id === draft.location.venueId);
   const venueCapacityExceeded = Boolean(selectedVenue?.capacity && draft.location.capacity > selectedVenue.capacity);
-  const canCloseWithoutPrompt = !open || create.isSuccess || draft.idempotencyKey === defaultFestivalCreationDraft(mode, festival?.festivalId).idempotencyKey;
+  const canCloseWithoutPrompt =
+    !open || create.isSuccess || !isFestivalCreationDraftDirty(initialDraft, draft);
   const canNext =
     step === 5 ? !hasCreationErrors(errors) : currentErrors.length === 0;
   return (
@@ -565,16 +573,23 @@ export function FestivalCreationWizard({
                       })
                     }
                   />
-                  <Input
+                  <Select
                     value={stage.type}
-                    onChange={(e) =>
+                    onValueChange={(value) =>
                       update({
                         stages: draft.stages.map((s, i) =>
-                          i === index ? { ...s, type: e.target.value } : s,
+                          i === index ? { ...s, type: value } : s,
                         ),
                       })
                     }
-                  />
+                  >
+                    <SelectTrigger><SelectValue placeholder="Stage type" /></SelectTrigger>
+                    <SelectContent>
+                      {(referenceData?.stageTypes ?? []).map((option) => (
+                        <SelectItem key={option} value={option}>{option.replace("_", " ")}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <Input
                     type="number"
                     value={stage.capacity}
@@ -614,42 +629,57 @@ export function FestivalCreationWizard({
                       })
                     }
                   />
-                  <Input
+                  <Select
                     value={stage.weatherProtection}
-                    onChange={(e) =>
+                    onValueChange={(value) =>
                       update({
                         stages: draft.stages.map((s, i) =>
-                          i === index
-                            ? { ...s, weatherProtection: e.target.value }
-                            : s,
+                          i === index ? { ...s, weatherProtection: value } : s,
                         ),
                       })
                     }
-                  />
-                  <Input
+                  >
+                    <SelectTrigger><SelectValue placeholder="Weather protection" /></SelectTrigger>
+                    <SelectContent>
+                      {(referenceData?.weatherOptions ?? []).map((option) => (
+                        <SelectItem key={option} value={option}>{option.replace("_", " ")}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
                     value={stage.soundCapability}
-                    onChange={(e) =>
+                    onValueChange={(value) =>
                       update({
                         stages: draft.stages.map((s, i) =>
-                          i === index
-                            ? { ...s, soundCapability: e.target.value }
-                            : s,
+                          i === index ? { ...s, soundCapability: value } : s,
                         ),
                       })
                     }
-                  />
-                  <Input
+                  >
+                    <SelectTrigger><SelectValue placeholder="Sound capability" /></SelectTrigger>
+                    <SelectContent>
+                      {(referenceData?.soundOptions ?? []).map((option) => (
+                        <SelectItem key={option} value={option}>{option.replace("_", " ")}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
                     value={stage.lightingCapability}
-                    onChange={(e) =>
+                    onValueChange={(value) =>
                       update({
                         stages: draft.stages.map((s, i) =>
-                          i === index
-                            ? { ...s, lightingCapability: e.target.value }
-                            : s,
+                          i === index ? { ...s, lightingCapability: value } : s,
                         ),
                       })
                     }
-                  />
+                  >
+                    <SelectTrigger><SelectValue placeholder="Lighting capability" /></SelectTrigger>
+                    <SelectContent>
+                      {(referenceData?.lightingOptions ?? []).map((option) => (
+                        <SelectItem key={option} value={option}>{option.replace("_", " ")}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <Button
                     variant="destructive"
                     onClick={() =>
@@ -812,7 +842,13 @@ export function FestivalCreationWizard({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Continue editing</AlertDialogCancel>
-          <AlertDialogAction onClick={() => { setDiscardPromptOpen(false); onOpenChange(false); }}>
+          <AlertDialogAction
+            onClick={() => {
+              setDiscardPromptOpen(false);
+              setInitialDraft(draft);
+              onOpenChange(false);
+            }}
+          >
             Discard draft
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
+++ b/src/features/festivals/admin/components/FestivalLifecycleControls.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -7,21 +9,25 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { useMemo } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { transitionAdminFestivalEdition } from "../service";
 import { useAdminFestivalLifecycleOptions } from "../hooks";
 import { festivalAdminQueryKeys } from "../queryKeys";
-import type { FestivalLifecycleState } from "../types";
+import type { FestivalLifecycleState, FestivalLifecycleTransitionOption } from "../types";
+
+const newOperationKey = () => crypto.randomUUID();
 
 export function FestivalLifecycleControls({
   editionId,
@@ -31,114 +37,145 @@ export function FestivalLifecycleControls({
   status?: FestivalLifecycleState | null;
 }) {
   const qc = useQueryClient();
-  const [target, setTarget] = useState<FestivalLifecycleState | "">("");
+  const [selected, setSelected] = useState<FestivalLifecycleTransitionOption | null>(null);
   const [reason, setReason] = useState("");
+  const [override, setOverride] = useState(false);
+  const [typedConfirmation, setTypedConfirmation] = useState("");
+  const [operationKey, setOperationKey] = useState(newOperationKey);
   const lifecycleOptions = useAdminFestivalLifecycleOptions(editionId);
-  const transitionKey = useMemo(() => target ? `lifecycle:${editionId}:${target}` : "", [editionId, target]);
+
+  const resetAttempt = () => {
+    setSelected(null);
+    setReason("");
+    setOverride(false);
+    setTypedConfirmation("");
+    setOperationKey(newOperationKey());
+  };
+
   const mutation = useMutation({
     mutationFn: () =>
       transitionAdminFestivalEdition(
         editionId as string,
-        target as FestivalLifecycleState,
+        selected?.targetState as FestivalLifecycleState,
         reason,
-        false,
-        transitionKey,
+        override,
+        operationKey,
       ),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.catalogue });
       if (editionId) {
-        qc.invalidateQueries({
-          queryKey: festivalAdminQueryKeys.operations("admin", editionId),
-        });
-        qc.invalidateQueries({
-          queryKey: ["festivals", "admin", "lifecycle-options", editionId],
-        });
+        qc.invalidateQueries({ queryKey: festivalAdminQueryKeys.operations("admin", editionId) });
+        qc.invalidateQueries({ queryKey: ["festivals", "admin", "lifecycle-options", editionId] });
       }
-      setReason("");
-      setTarget("");
+      resetAttempt();
     },
   });
+
+  const options = lifecycleOptions.data?.transitions ?? [];
+  const confirmationWord = selected?.targetState.replaceAll("_", " ") ?? "";
+  const reasonNeeded = Boolean(selected?.reasonRequired || override);
+  const destructiveConfirmed = selected?.severity !== "destructive" || typedConfirmation === confirmationWord;
+  const canSubmit = Boolean(
+    selected &&
+      selected.available &&
+      (!reasonNeeded || reason.trim()) &&
+      (!override || selected.adminOverrideAllowed) &&
+      destructiveConfirmed &&
+      !mutation.isPending,
+  );
+
+  const selectedTitle = useMemo(
+    () => selected?.targetState.replaceAll("_", " ") ?? "",
+    [selected],
+  );
+
   if (!editionId || !status)
     return (
       <Card>
         <CardHeader>
           <CardTitle>Lifecycle controls</CardTitle>
-          <CardDescription>
-            Select an edition to see available transitions.
-          </CardDescription>
+          <CardDescription>Select an edition to see available transitions.</CardDescription>
         </CardHeader>
       </Card>
     );
-  const options = (lifecycleOptions.data?.transitions ?? []).filter((option) => option.available);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Lifecycle controls</CardTitle>
         <CardDescription>
-          Current status is {status}. Transitions are submitted through the
-          canonical server transition service.
+          Current status is {status}. Server-projected transitions, blockers,
+          confirmations and overrides are shown before submission.
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-3">
+      <CardContent className="space-y-4">
+        {lifecycleOptions.isLoading && <p className="text-sm text-muted-foreground">Loading server-projected lifecycle options…</p>}
+        {lifecycleOptions.error && <p className="text-sm text-destructive">Lifecycle options could not be loaded from the server.</p>}
         <div className="grid gap-3 md:grid-cols-2">
-          <Label>
-            Next status
-            <Select
-              value={target}
-              onValueChange={(v) => setTarget(v as FestivalLifecycleState)}
+          {options.map((option) => (
+            <button
+              key={option.targetState}
+              type="button"
+              disabled={!option.available}
+              onClick={() => {
+                setSelected(option);
+                setReason("");
+                setOverride(false);
+                setTypedConfirmation("");
+                setOperationKey(newOperationKey());
+              }}
+              className={`rounded border p-3 text-left ${option.available ? "hover:bg-muted" : "opacity-70"} ${option.severity === "destructive" ? "border-destructive" : option.severity === "warning" ? "border-amber-500" : ""}`}
             >
-              <SelectTrigger>
-                <SelectValue
-                  placeholder={
-                    options.length
-                      ? "Choose next status"
-                      : "No standard transition available"
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {options.map((option) => (
-                  <SelectItem key={option.targetState} value={option.targetState}>
-                    {option.targetState.replaceAll("_", " ")}
-                    {option.confirmationRequired ? " (confirmation required)" : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Label>
-          <Label>
-            Administrator reason
-            <Input
-              value={reason}
-              onChange={(event) => setReason(event.target.value)}
-              placeholder="Reason required for audit history"
-            />
-          </Label>
+              <div className="font-medium capitalize">{option.targetState.replaceAll("_", " ")}</div>
+              <p className="text-sm text-muted-foreground">{option.explanation}</p>
+              {option.blockers.length > 0 && <p className="mt-2 text-sm text-destructive">Blockers: {option.blockers.join(", ")}</p>}
+              {option.warnings.length > 0 && <p className="mt-2 text-sm text-amber-600">Warnings: {option.warnings.join(", ")}</p>}
+              {option.confirmationRequired && <p className="mt-2 text-xs uppercase tracking-wide">Confirmation required</p>}
+            </button>
+          ))}
         </div>
-        {lifecycleOptions.isLoading && (
-          <p className="text-sm text-muted-foreground">Loading server-projected lifecycle options…</p>
-        )}
-        {lifecycleOptions.error && (
-          <p className="text-sm text-destructive">Lifecycle options could not be loaded from the server.</p>
-        )}
-        {options.length === 0 && !lifecycleOptions.isLoading && (
-          <p className="text-sm text-muted-foreground">
-            The server currently exposes no standard forward transition from this state.
-          </p>
-        )}
-        {mutation.error && (
-          <p className="text-sm text-destructive">
-            The lifecycle transition could not be completed. No records were
-            changed.
-          </p>
-        )}
-        <Button
-          disabled={!target || !reason.trim() || mutation.isPending}
-          onClick={() => mutation.mutate()}
-        >
-          {mutation.isPending ? "Updating…" : "Apply lifecycle transition"}
-        </Button>
+        {mutation.error && <p className="text-sm text-destructive">The lifecycle transition could not be completed. No records were changed.</p>}
       </CardContent>
+      <AlertDialog open={Boolean(selected)} onOpenChange={(open) => { if (!open) resetAttempt(); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4" /> Confirm lifecycle transition
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Move this edition from {status} to {selectedTitle}. {selected?.explanation}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-3 text-sm">
+            {selected?.warnings.map((warning) => <p key={warning} className="text-amber-600">Warning: {warning}</p>)}
+            {selected?.blockers.map((blocker) => <p key={blocker} className="text-destructive">Blocker: {blocker}</p>)}
+            {selected?.adminOverrideAllowed && (
+              <Label className="flex items-center gap-2">
+                <Checkbox checked={override} onCheckedChange={(checked) => setOverride(Boolean(checked))} />
+                Use administrator override
+              </Label>
+            )}
+            {(reasonNeeded || selected?.confirmationRequired) && (
+              <Label>
+                Reason{reasonNeeded ? " (required)" : ""}
+                <Input value={reason} onChange={(event) => setReason(event.target.value)} placeholder="Explain the lifecycle decision" />
+              </Label>
+            )}
+            {selected?.severity === "destructive" && (
+              <Label>
+                Type “{confirmationWord}” to confirm
+                <Input value={typedConfirmation} onChange={(event) => setTypedConfirmation(event.target.value)} />
+              </Label>
+            )}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={mutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction disabled={!canSubmit} onClick={(event) => { event.preventDefault(); mutation.mutate(); }}>
+              {mutation.isPending ? "Updating…" : override ? "Confirm override" : "Confirm transition"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 }

--- a/src/features/festivals/admin/components/creation/festivalCreationDirtyState.test.ts
+++ b/src/features/festivals/admin/components/creation/festivalCreationDirtyState.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { defaultFestivalCreationDraft } from "../../creationValidation";
+import { isFestivalCreationDraftDirty } from "./festivalCreationDirtyState";
+
+describe("isFestivalCreationDraftDirty", () => {
+  it("ignores technical idempotency keys", () => {
+    const initial = defaultFestivalCreationDraft("create_festival");
+    const current = { ...initial, idempotencyKey: crypto.randomUUID() };
+    expect(isFestivalCreationDraftDirty(initial, current)).toBe(false);
+  });
+
+  it("detects material edits", () => {
+    const initial = defaultFestivalCreationDraft("create_festival");
+    const current = {
+      ...initial,
+      identity: { ...initial.identity, name: "New Festival" },
+    };
+    expect(isFestivalCreationDraftDirty(initial, current)).toBe(true);
+  });
+
+  it("treats a discarded or successful snapshot as clean", () => {
+    const initial = defaultFestivalCreationDraft("add_edition", "festival-1");
+    const edited = {
+      ...initial,
+      edition: { ...initial.edition, title: "Autumn Edition" },
+    };
+    expect(isFestivalCreationDraftDirty(edited, edited)).toBe(false);
+  });
+});

--- a/src/features/festivals/admin/components/creation/festivalCreationDirtyState.ts
+++ b/src/features/festivals/admin/components/creation/festivalCreationDirtyState.ts
@@ -1,0 +1,45 @@
+import type { FestivalCreationDraft } from "../../types";
+
+type MaterialFestivalCreationDraft = Omit<FestivalCreationDraft, "idempotencyKey">;
+
+const normalizeString = (value: unknown) =>
+  typeof value === "string" ? value.trim() : value;
+
+function normalizeDraft(draft: FestivalCreationDraft): MaterialFestivalCreationDraft {
+  return {
+    mode: draft.mode,
+    existingFestivalId: draft.existingFestivalId ?? undefined,
+    identity: {
+      ...draft.identity,
+      name: String(normalizeString(draft.identity.name)),
+      shortDescription: String(normalizeString(draft.identity.shortDescription)),
+      fullDescription: String(normalizeString(draft.identity.fullDescription)),
+      imageUrl: draft.identity.imageUrl?.trim() || "",
+      primaryGenres: [...draft.identity.primaryGenres].sort(),
+    },
+    edition: { ...draft.edition, title: draft.edition.title.trim() },
+    location: {
+      ...draft.location,
+      cityName: draft.location.cityName?.trim() || "",
+      venueId: draft.location.venueId || "",
+      siteName: draft.location.siteName?.trim() || "",
+    },
+    stages: draft.stages.map((stage) => ({
+      ...stage,
+      name: stage.name.trim(),
+      type: stage.type.trim(),
+      curfew: stage.curfew.trim(),
+      weatherProtection: stage.weatherProtection.trim(),
+      soundCapability: stage.soundCapability.trim(),
+      lightingCapability: stage.lightingCapability.trim(),
+    })),
+    commercial: { ...draft.commercial },
+  };
+}
+
+export function isFestivalCreationDraftDirty(
+  initialDraft: FestivalCreationDraft,
+  currentDraft: FestivalCreationDraft,
+): boolean {
+  return JSON.stringify(normalizeDraft(initialDraft)) !== JSON.stringify(normalizeDraft(currentDraft));
+}

--- a/src/features/festivals/admin/components/workspace/selectPreferredFestivalEdition.ts
+++ b/src/features/festivals/admin/components/workspace/selectPreferredFestivalEdition.ts
@@ -1,0 +1,30 @@
+import type { OwnerEditionOption } from "../../types";
+
+export function selectPreferredFestivalEdition(editions: OwnerEditionOption[]) {
+  const ranked = [
+    (e: OwnerEditionOption) => e.status === "live",
+    (e: OwnerEditionOption) =>
+      [
+        "applications_open",
+        "booking",
+        "announced",
+        "on_sale",
+        "setup",
+        "planning",
+        "concept",
+      ].includes(e.status),
+    (e: OwnerEditionOption) => e.status === "completed",
+    () => true,
+  ];
+  for (const match of ranked) {
+    const candidates = editions
+      .filter(match)
+      .sort((a, b) =>
+        String(b.endAt ?? b.startAt ?? "").localeCompare(
+          String(a.endAt ?? a.startAt ?? ""),
+        ),
+      );
+    if (candidates[0]) return candidates[0];
+  }
+  return undefined;
+}

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -241,7 +241,7 @@ const referenceDataSchema = z.object({
   genres: z.array(z.string()).default([]),
   currencies: z.array(z.string()).default([]),
   countries: z.array(z.object({ code: z.string(), name: z.string() })).default([]),
-  cities: z.array(z.object({ id: z.string(), name: z.string(), country: z.string(), timezone: z.string(), currencyCode: z.string() })).default([]),
+  cities: z.array(z.object({ id: z.string(), name: z.string(), country: z.string(), countryName: z.string().optional(), timezone: z.string(), currencyCode: z.string() })).default([]),
   venues: z.array(z.object({ id: z.string(), name: z.string(), cityId: z.string(), capacity: z.coerce.number().nullable() })).default([]),
   stageTypes: z.array(z.string()).default([]),
   weatherOptions: z.array(z.string()).default([]),

--- a/src/features/festivals/admin/types.ts
+++ b/src/features/festivals/admin/types.ts
@@ -270,7 +270,7 @@ export type FestivalReferenceData = {
   genres: string[];
   currencies: string[];
   countries: { code: string; name: string }[];
-  cities: { id: string; name: string; country: string; timezone: string; currencyCode: string }[];
+  cities: { id: string; name: string; country: string; countryName?: string; timezone: string; currencyCode: string }[];
   venues: { id: string; name: string; cityId: string; capacity: number | null }[];
   stageTypes: string[];
   weatherOptions: string[];

--- a/src/hooks/useFestivalSlotApplications.ts
+++ b/src/hooks/useFestivalSlotApplications.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { z } from "zod";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -7,17 +8,40 @@ type FestivalApplicationScope =
   | { scope: "festival"; festivalId: string; editionId?: never; bandId?: string }
   | { scope: "band"; bandId: string; festivalId?: string; editionId?: string };
 
+const relatedRecord = z.object({ id: z.string() }).passthrough().nullable();
+export const festivalSlotApplicationSchema = z.object({
+  id: z.string(),
+  festival_id: z.string(),
+  edition_id: z.string().nullable(),
+  band_id: z.string(),
+  slot_type: z.string().nullable(),
+  status: z.string(),
+  requested_payment: z.coerce.number().nullable().optional(),
+  offered_payment: z.coerce.number().nullable().optional(),
+  admin_notes: z.string().nullable().optional(),
+  application_message: z.string().nullable().optional(),
+  created_at: z.string().nullable().optional(),
+  updated_at: z.string().nullable().optional(),
+  reviewed_at: z.string().nullable().optional(),
+  edition: relatedRecord,
+  festival: relatedRecord,
+  band: relatedRecord,
+  setlist: relatedRecord,
+}).passthrough();
+export type FestivalSlotApplication = z.infer<typeof festivalSlotApplicationSchema>;
+
 export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const editionId = scope?.editionId;
   const festivalId = scope?.festivalId;
   const bandId = scope?.bandId;
+  const queryKey = ["festival-slot-applications", scope?.scope ?? "none", festivalId ?? null, editionId ?? null, bandId ?? null];
 
   const { data: applications, isLoading } = useQuery({
-    queryKey: ["festival-slot-applications", scope?.scope ?? "none", festivalId ?? null, editionId ?? null, bandId ?? null],
-    queryFn: async () => {
-      let query = (supabase as any)
+    queryKey,
+    queryFn: async (): Promise<FestivalSlotApplication[]> => {
+      let query = supabase
         .from("festival_slot_applications")
         .select(`
           *,
@@ -34,7 +58,7 @@ export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) =>
 
       const { data, error } = await query;
       if (error) throw error;
-      return data as any[];
+      return z.array(festivalSlotApplicationSchema).parse(data ?? []);
     },
     enabled: Boolean(scope && (editionId || festivalId || bandId)),
   });
@@ -50,35 +74,18 @@ export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) =>
       setlist_id?: string;
       application_message?: string;
     }) => {
-      const { error } = await (supabase as any)
-        .from("festival_slot_applications")
-        .insert(applicationData);
-
+      const { error } = await supabase.from("festival_slot_applications").insert(applicationData as never);
       if (error) throw error;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["festival-slot-applications"] });
-      toast({
-        title: "Application submitted!",
-        description: "Your festival slot application has been sent for review.",
-      });
+      toast({ title: "Application submitted!", description: "Your festival slot application has been sent for review." });
     },
-    onError: (error: any) => {
-      toast({
-        title: "Application failed",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
+    onError: (error: Error) => toast({ title: "Application failed", description: error.message, variant: "destructive" }),
   });
 
   const reviewApplicationMutation = useMutation({
-    mutationFn: async ({
-      applicationId,
-      status,
-      adminNotes,
-      offeredPayment,
-    }: {
+    mutationFn: async ({ applicationId, status, adminNotes, offeredPayment }: {
       applicationId: string;
       status: "accepted" | "rejected";
       adminNotes?: string;
@@ -87,7 +94,7 @@ export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) =>
       if (scope?.scope === "edition" && applications?.some((app) => app.id === applicationId && app.edition_id !== scope.editionId)) {
         throw new Error("Application does not belong to the selected edition.");
       }
-      const { error } = await (supabase as any)
+      let mutation = supabase
         .from("festival_slot_applications")
         .update({
           status,
@@ -95,26 +102,17 @@ export const useFestivalSlotApplications = (scope?: FestivalApplicationScope) =>
           reviewed_by_admin_id: (await supabase.auth.getUser()).data.user?.id,
           admin_notes: adminNotes,
           offered_payment: offeredPayment,
-        })
-        .eq("id", applicationId)
-        .match(scope?.scope === "edition" ? { edition_id: scope.editionId } : {});
-
+        } as never)
+        .eq("id", applicationId);
+      if (scope?.scope === "edition") mutation = mutation.eq("edition_id", scope.editionId);
+      const { error } = await mutation;
       if (error) throw error;
     },
     onSuccess: (_, { status }) => {
-      queryClient.invalidateQueries({ queryKey: ["festival-slot-applications", scope?.scope ?? "none", festivalId ?? null, editionId ?? null, bandId ?? null] });
-      toast({
-        title: status === "accepted" ? "Application accepted" : "Application rejected",
-        description: `The festival application has been ${status}.`,
-      });
+      queryClient.invalidateQueries({ queryKey });
+      toast({ title: status === "accepted" ? "Application accepted" : "Application rejected", description: `The festival application has been ${status}.` });
     },
-    onError: (error: any) => {
-      toast({
-        title: "Review failed",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
+    onError: (error: Error) => toast({ title: "Review failed", description: error.message, variant: "destructive" }),
   });
 
   return {

--- a/src/pages/admin/FestivalsAdmin.tsx
+++ b/src/pages/admin/FestivalsAdmin.tsx
@@ -13,6 +13,7 @@ import { FestivalLegacyRecordsManagement } from "@/features/festivals/admin/comp
 import { FestivalLifecycleControls } from "@/features/festivals/admin/components/FestivalLifecycleControls";
 import { FestivalCreationWizard } from "@/features/festivals/admin/components/FestivalCreationWizard";
 import { FestivalAuditLog } from "@/features/festivals/admin/components/FestivalAuditLog";
+import { selectPreferredFestivalEdition } from "@/features/festivals/admin/components/workspace/selectPreferredFestivalEdition";
 import {
   useAdminFestivalCatalogue,
   useOwnerFestivalEditions,
@@ -48,35 +49,6 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-
-export function selectPreferredFestivalEdition(editions: OwnerEditionOption[]) {
-  const ranked = [
-    (e: OwnerEditionOption) => e.status === "live",
-    (e: OwnerEditionOption) =>
-      [
-        "applications_open",
-        "booking",
-        "announced",
-        "on_sale",
-        "setup",
-        "planning",
-        "concept",
-      ].includes(e.status),
-    (e: OwnerEditionOption) => e.status === "completed",
-    () => true,
-  ];
-  for (const match of ranked) {
-    const candidates = editions
-      .filter(match)
-      .sort((a, b) =>
-        String(b.endAt ?? b.startAt ?? "").localeCompare(
-          String(a.endAt ?? a.startAt ?? ""),
-        ),
-      );
-    if (candidates[0]) return candidates[0];
-  }
-  return undefined;
-}
 
 function EditionRequired({
   editionId,

--- a/supabase/migrations/20260717153000_harden_festival_creation_phase1_forward.sql
+++ b/supabase/migrations/20260717153000_harden_festival_creation_phase1_forward.sql
@@ -1,0 +1,189 @@
+-- Forward-only hardening for Phase 1 admin festival creation.
+-- This migration intentionally does not modify the previously merged
+-- 20260717120000_admin_festival_creation_phase1.sql history file.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE IF EXISTS public.admin_festival_creation_requests
+  ADD COLUMN IF NOT EXISTS actor_user_id uuid;
+
+UPDATE public.admin_festival_creation_requests request
+SET actor_user_id = profile.user_id
+FROM public.profiles profile
+WHERE request.actor_user_id IS NULL
+  AND request.actor_profile_id = profile.id
+  AND profile.user_id IS NOT NULL;
+
+ALTER TABLE IF EXISTS public.admin_festival_creation_requests
+  ADD COLUMN IF NOT EXISTS actor_resolution_status text NOT NULL DEFAULT 'resolved';
+
+UPDATE public.admin_festival_creation_requests
+SET actor_resolution_status = CASE WHEN actor_user_id IS NULL THEN 'historical_unresolved' ELSE 'resolved' END
+WHERE actor_resolution_status IS NULL OR actor_resolution_status = 'resolved';
+
+ALTER TABLE public.admin_festival_creation_requests
+  DROP CONSTRAINT IF EXISTS admin_festival_creation_requests_actor_user_id_not_null;
+ALTER TABLE public.admin_festival_creation_requests
+  ADD CONSTRAINT admin_festival_creation_requests_actor_user_id_new_writes
+  CHECK (actor_user_id IS NOT NULL OR actor_resolution_status = 'historical_unresolved') NOT VALID;
+ALTER TABLE public.admin_festival_creation_requests
+  VALIDATE CONSTRAINT admin_festival_creation_requests_actor_user_id_new_writes;
+
+ALTER TABLE public.admin_festival_creation_requests
+  DROP CONSTRAINT IF EXISTS admin_festival_creation_requests_actor_profile_id_operation_idemp_key;
+ALTER TABLE public.admin_festival_creation_requests
+  DROP CONSTRAINT IF EXISTS admin_festival_creation_requests_actor_user_id_operation_idempotency_key_key;
+DROP INDEX IF EXISTS public.admin_festival_creation_requests_actor_profile_id_operation_idempo_key;
+DROP INDEX IF EXISTS public.admin_festival_creation_requests_actor_user_operation_key;
+CREATE UNIQUE INDEX IF NOT EXISTS admin_festival_creation_requests_actor_user_operation_key
+  ON public.admin_festival_creation_requests(actor_user_id, operation, idempotency_key)
+  WHERE actor_user_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.festival_creation_country_code(p_country text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE lower(trim(coalesce(p_country,'')))
+    WHEN 'united states' THEN 'US' WHEN 'usa' THEN 'US' WHEN 'us' THEN 'US'
+    WHEN 'united kingdom' THEN 'GB' WHEN 'uk' THEN 'GB' WHEN 'great britain' THEN 'GB'
+    WHEN 'france' THEN 'FR' WHEN 'germany' THEN 'DE' WHEN 'spain' THEN 'ES'
+    WHEN 'italy' THEN 'IT' WHEN 'netherlands' THEN 'NL' WHEN 'canada' THEN 'CA'
+    WHEN 'australia' THEN 'AU' WHEN '' THEN 'ZZ'
+    ELSE upper(substr(regexp_replace(trim(p_country), '[^A-Za-z]', '', 'g'), 1, 2))
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION public.festival_creation_currency_for_country(p_country text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE public.festival_creation_country_code(p_country)
+    WHEN 'GB' THEN 'GBP'
+    WHEN 'FR' THEN 'EUR' WHEN 'DE' THEN 'EUR' WHEN 'ES' THEN 'EUR' WHEN 'IT' THEN 'EUR' WHEN 'NL' THEN 'EUR'
+    WHEN 'CA' THEN 'CAD' WHEN 'AU' THEN 'AUD'
+    ELSE 'USD'
+  END
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_reference_data()
+RETURNS jsonb LANGUAGE sql STABLE SECURITY DEFINER SET search_path=public AS $$
+WITH city_rows AS (
+  SELECT c.id, c.name, c.country, public.festival_creation_country_code(c.country) AS country_code,
+         coalesce(c.timezone,'UTC') AS timezone, public.festival_creation_currency_for_country(c.country) AS currency_code
+  FROM public.cities c
+), genre_rows AS (
+  SELECT unnest(ARRAY['Rock','Pop','Metal','Electronic','Hip Hop','Country','Folk','Jazz','Punk','Indie','Alternative','R&B']) AS genre
+  UNION SELECT DISTINCT b.genre FROM public.bands b WHERE b.genre IS NOT NULL
+)
+SELECT jsonb_build_object(
+  'festivalTypes', jsonb_build_array('recurring','touring','one_off','community','showcase'),
+  'genres', (SELECT coalesce(jsonb_agg(DISTINCT genre ORDER BY genre),'[]'::jsonb) FROM genre_rows),
+  'currencies', jsonb_build_array('USD','EUR','GBP','CAD','AUD'),
+  'countries', (SELECT coalesce(jsonb_agg(DISTINCT jsonb_build_object('code',country_code,'name',coalesce(country,'Unknown'))),'[]'::jsonb) FROM city_rows),
+  'cities', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',id,'name',name,'country',country_code,'countryName',country,'timezone',timezone,'currencyCode',currency_code) ORDER BY country,name),'[]'::jsonb) FROM city_rows),
+  'venues', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',id,'name',name,'cityId',city_id,'capacity',capacity) ORDER BY name),'[]'::jsonb) FROM public.venues),
+  'stageTypes', jsonb_build_array('main','second','tent','club','acoustic','experimental'),
+  'weatherOptions', jsonb_build_array('open_air','covered','indoor'),
+  'soundOptions', jsonb_build_array('basic','standard','premium','festival_grade'),
+  'lightingOptions', jsonb_build_array('basic','standard','premium','festival_grade'),
+  'commercialDefaults', jsonb_build_object('currencyCode','USD','minimumTicketPriceCents',0,'maximumTicketPriceCents',10000,'defaultTicketPriceCents',2500,'fallbackCurrencyApplied',true)
+)
+$$;
+GRANT EXECUTE ON FUNCTION public.admin_festival_reference_data() TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.internal_create_festival_edition_setup(
+  p_festival_id uuid, p_payload jsonb, p_actor_user_id uuid, p_actor_profile_id uuid,
+  p_operation_key text, p_forced_edition_number integer DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  v_festival public.festivals%ROWTYPE; v_edition public.festival_editions%ROWTYPE; v_stage jsonb; v_stage_ids uuid[] := ARRAY[]::uuid[]; v_stage_id uuid; v_stage_number int := 0;
+  v_location jsonb := coalesce(p_payload->'location','{}'::jsonb); v_edition_payload jsonb := coalesce(p_payload->'edition','{}'::jsonb); v_commercial jsonb := coalesce(p_payload->'commercial','{}'::jsonb);
+  v_start timestamptz := nullif(v_edition_payload->>'startAt','')::timestamptz; v_end timestamptz := nullif(v_edition_payload->>'endAt','')::timestamptz; v_app_open timestamptz := nullif(v_edition_payload->>'applicationsOpenAt','')::timestamptz; v_app_close timestamptz := nullif(v_edition_payload->>'applicationsCloseAt','')::timestamptz; v_booking timestamptz := nullif(v_edition_payload->>'bookingDeadlineAt','')::timestamptz;
+  v_city uuid := nullif(v_location->>'cityId','')::uuid; v_venue uuid := nullif(v_location->>'venueId','')::uuid; v_capacity int := coalesce((v_location->>'capacity')::int,0); v_min bigint := coalesce((v_location->>'minTicketPriceCents')::bigint,0); v_max bigint := coalesce((v_location->>'maxTicketPriceCents')::bigint,0); v_default bigint := coalesce((v_location->>'defaultTicketPriceCents')::bigint,v_min); v_number int;
+BEGIN
+  IF p_actor_user_id IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  SELECT * INTO v_festival FROM public.festivals WHERE id=p_festival_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'FESTIVAL_CREATE_FESTIVAL_INVALID'; END IF;
+  IF p_forced_edition_number IS NULL THEN SELECT coalesce(max(edition_number),0)+1 INTO v_number FROM public.festival_editions WHERE festival_id=p_festival_id; ELSE v_number := p_forced_edition_number; END IF;
+  IF v_start IS NULL OR v_end IS NULL OR v_end <= v_start OR v_start < now() OR v_app_open IS NULL OR v_app_close IS NULL OR v_app_close < v_app_open OR v_app_close >= v_start OR (v_booking IS NOT NULL AND (v_booking < v_app_close OR v_booking > v_start)) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_INVALID_DATE'; END IF;
+  IF v_city IS NULL OR NOT EXISTS (SELECT 1 FROM public.cities WHERE id=v_city) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CITY_INVALID'; END IF;
+  IF v_venue IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND city_id=v_city) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_VENUE_INVALID'; END IF;
+  IF coalesce(v_edition_payload->>'timezone','') NOT IN (SELECT name FROM pg_timezone_names) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_TIMEZONE_INVALID'; END IF;
+  IF coalesce(v_edition_payload->>'currencyCode','') NOT IN ('USD','EUR','GBP','CAD','AUD') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CURRENCY_INVALID'; END IF;
+  IF v_capacity <= 0 OR v_min < 0 OR v_max < v_min OR v_default < v_min OR v_default > v_max THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CAPACITY_OR_PRICE_INVALID'; END IF;
+  IF v_venue IS NOT NULL AND EXISTS (SELECT 1 FROM public.venues WHERE id=v_venue AND capacity IS NOT NULL AND v_capacity > capacity) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_CAPACITY_EXCEEDED'; END IF;
+  IF jsonb_array_length(coalesce(p_payload->'stages','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_REQUIRED'; END IF;
+  IF coalesce((v_commercial->>'operatingBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'performerBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'staffingBudgetCents')::bigint,0) < 0 OR coalesce((v_commercial->>'marketingBudgetCents')::bigint,0) < 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_BUDGET_INVALID'; END IF;
+  INSERT INTO public.festival_editions(festival_id, edition_number, edition_year, title, description, city_id, venue_id, start_at, end_at, timezone, expected_attendance, capacity, minimum_ticket_price_cents, maximum_ticket_price_cents, currency_code, budget_cents, status, public_metadata, created_by, legacy_metadata)
+  VALUES (p_festival_id, v_number, extract(year from v_start)::int, coalesce(nullif(v_edition_payload->>'title',''), v_festival.name || ' Edition ' || v_number), nullif(v_edition_payload->>'description',''), v_city, v_venue, v_start, v_end, v_edition_payload->>'timezone', coalesce((v_commercial->>'estimatedAttendance')::int, v_capacity), v_capacity, v_min, v_max, v_edition_payload->>'currencyCode', coalesce((v_commercial->>'operatingBudgetCents')::bigint,0), 'planning', jsonb_build_object('applications_open_at',v_app_open,'applications_close_at',v_app_close,'booking_deadline_at',v_booking,'site_name',v_location->>'siteName','default_ticket_price_cents',v_default,'commercial',v_commercial), p_actor_profile_id, jsonb_build_object('source','admin_creation_wizard')) RETURNING * INTO v_edition;
+  INSERT INTO public.festival_edition_lifecycle_events(edition_id, from_status, to_status, actor_profile_id, reason, metadata, idempotency_key) VALUES (v_edition.id, NULL, v_edition.status, p_actor_profile_id, 'admin_edition_created', jsonb_build_object('source','admin_creation_wizard'), p_operation_key || ':lifecycle');
+  FOR v_stage IN SELECT * FROM jsonb_array_elements(p_payload->'stages') LOOP
+    IF nullif(trim(v_stage->>'name'),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_INVALID'; END IF;
+    IF EXISTS (SELECT 1 FROM public.festival_stages WHERE edition_id=v_edition.id AND lower(trim(stage_name))=lower(trim(v_stage->>'name')) AND archived_at IS NULL) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_DUPLICATE'; END IF;
+    IF coalesce(v_stage->>'type','main') NOT IN ('main','second','tent','club','acoustic','experimental') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_TYPE_INVALID'; END IF;
+    IF coalesce((v_stage->>'capacity')::integer,0) <= 0 OR coalesce((v_stage->>'capacity')::integer,0) > v_capacity THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_CAPACITY_INVALID'; END IF;
+    IF coalesce((v_stage->>'changeoverMinutes')::integer,30) < 5 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_STAGE_CHANGEOVER_INVALID'; END IF;
+    v_stage_number := v_stage_number + 1;
+    INSERT INTO public.festival_stages(festival_id, edition_id, stage_name, stage_number, capacity, stage_type, sound_capability, lighting_capability, weather_protection, default_changeover_minutes, curfew_time, public_metadata, idempotency_key)
+    VALUES (p_festival_id, v_edition.id, trim(v_stage->>'name'), v_stage_number, (v_stage->>'capacity')::integer, coalesce(v_stage->>'type','main'), v_stage->>'soundCapability', v_stage->>'lightingCapability', v_stage->>'weatherProtection', coalesce((v_stage->>'changeoverMinutes')::integer,30), nullif(v_stage->>'curfew','')::time, jsonb_build_object('created_from','admin_creation_wizard'), p_operation_key || ':stage:' || v_stage_number) RETURNING id INTO v_stage_id;
+    v_stage_ids := array_append(v_stage_ids, v_stage_id);
+  END LOOP;
+  PERFORM public.festival_audit(v_edition.id,'edition_setup_created','festival_edition',v_edition.id,'{}',to_jsonb(v_edition),'admin festival creation wizard',p_operation_key || ':audit');
+  RETURN jsonb_build_object('festival_id',p_festival_id,'edition_id',v_edition.id,'stage_ids',to_jsonb(v_stage_ids),'lifecycle_status',v_edition.status,'public_route','/festivals/' || p_festival_id,'management_route','/festivals/' || p_festival_id || '/manage/editions/' || v_edition.id,'created',true);
+END $$;
+REVOKE ALL ON FUNCTION public.internal_create_festival_edition_setup(uuid,jsonb,uuid,uuid,text,integer) FROM PUBLIC, authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.internal_create_festival_edition_setup(uuid,jsonb,uuid,uuid,text,integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.admin_create_festival_edition_with_setup(p_festival_id uuid, p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_actor_user uuid := auth.uid(); v_actor uuid := public.current_profile_id_safe(); v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key'); v_hash text := public.festival_creation_request_hash(p_payload); v_existing public.admin_festival_creation_requests%ROWTYPE; v_count bigint; v_mode text := coalesce(p_payload->>'mode','add_edition'); v_number int; v_result jsonb;
+BEGIN
+  IF v_actor_user IS NULL OR NOT coalesce(public.has_role(v_actor_user,'admin'::public.app_role), false) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_REQUIRED'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_actor_user::text || ':admin_create_festival_edition_with_setup:' || v_key, 0));
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_user_id=v_actor_user AND operation='admin_create_festival_edition_with_setup' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  PERFORM 1 FROM public.festivals WHERE id=p_festival_id FOR UPDATE; IF NOT FOUND THEN RAISE EXCEPTION 'FESTIVAL_CREATE_FESTIVAL_INVALID'; END IF;
+  SELECT count(*), coalesce(max(edition_number),0)+1 INTO v_count, v_number FROM public.festival_editions WHERE festival_id=p_festival_id;
+  IF v_mode = 'create_first_edition' THEN
+    IF v_count <> 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_FIRST_EDITION_ALREADY_EXISTS'; END IF;
+    v_number := 1;
+  ELSIF v_mode = 'add_edition' THEN
+    IF v_count = 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_ADD_EDITION_REQUIRES_EXISTING'; END IF;
+  ELSE
+    RAISE EXCEPTION 'FESTIVAL_CREATE_MODE_INVALID';
+  END IF;
+  v_result := public.internal_create_festival_edition_setup(p_festival_id,p_payload,v_actor_user,v_actor,v_key,v_number);
+  INSERT INTO public.admin_festival_creation_requests(actor_user_id,actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result,actor_resolution_status) VALUES (v_actor_user,v_actor,'admin_create_festival_edition_with_setup',v_key,v_hash,p_festival_id,(v_result->>'edition_id')::uuid,v_result,'resolved');
+  RETURN v_result;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.admin_create_festival_with_first_edition(p_payload jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_actor_user uuid := auth.uid(); v_actor uuid := public.current_profile_id_safe(); v_key text := coalesce(p_payload->>'idempotencyKey', p_payload->>'idempotency_key'); v_hash text := public.festival_creation_request_hash(p_payload); v_existing public.admin_festival_creation_requests%ROWTYPE; v_identity jsonb := coalesce(p_payload->'identity','{}'::jsonb); v_location jsonb := coalesce(p_payload->'location','{}'::jsonb); v_festival public.festivals%ROWTYPE; v_result jsonb; v_name text := trim(coalesce(v_identity->>'name',''));
+BEGIN
+  IF v_actor_user IS NULL OR NOT coalesce(public.has_role(v_actor_user,'admin'::public.app_role), false) THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  IF nullif(trim(v_key),'') IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_REQUIRED'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_actor_user::text || ':admin_create_festival_with_first_edition:' || v_key, 0));
+  SELECT * INTO v_existing FROM public.admin_festival_creation_requests WHERE actor_user_id=v_actor_user AND operation='admin_create_festival_with_first_edition' AND idempotency_key=v_key FOR UPDATE;
+  IF FOUND THEN IF v_existing.request_hash <> v_hash THEN RAISE EXCEPTION 'FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT'; END IF; RETURN v_existing.result || jsonb_build_object('created', false); END IF;
+  IF length(v_name) < 3 OR length(v_name) > 120 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_NAME_INVALID'; END IF;
+  IF length(coalesce(v_identity->>'shortDescription','')) > 240 OR length(coalesce(v_identity->>'fullDescription','')) > 5000 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_DESCRIPTION_INVALID'; END IF;
+  IF coalesce(v_identity->>'festivalType','') NOT IN ('recurring','touring','one_off','community','showcase') THEN RAISE EXCEPTION 'FESTIVAL_CREATE_TYPE_INVALID'; END IF;
+  IF jsonb_array_length(coalesce(v_identity->'primaryGenres','[]'::jsonb)) = 0 THEN RAISE EXCEPTION 'FESTIVAL_CREATE_GENRE_INVALID'; END IF;
+  INSERT INTO public.festivals(name, description, city_id, genre, scale, owner_profile_id, status, public_metadata)
+  VALUES (v_name, coalesce(nullif(v_identity->>'fullDescription',''), v_identity->>'shortDescription'), nullif(v_location->>'cityId','')::uuid, (v_identity->'primaryGenres')->>0, v_identity->>'festivalType', NULL, 'planning', jsonb_build_object('short_description',v_identity->>'shortDescription','festival_type',v_identity->>'festivalType','primary_genres',v_identity->'primaryGenres','image_url',v_identity->>'imageUrl','public_visibility',coalesce((v_identity->>'isPublic')::boolean,false),'admin_creation_key',v_key)) RETURNING * INTO v_festival;
+  v_result := public.internal_create_festival_edition_setup(v_festival.id, p_payload || jsonb_build_object('mode','create_first_edition','existingFestivalId',v_festival.id), v_actor_user, v_actor, v_key, 1);
+  v_result := v_result || jsonb_build_object('festival_id',v_festival.id,'public_route','/festivals/' || v_festival.id,'management_route','/festivals/' || v_festival.id || '/manage/editions/' || (v_result->>'edition_id'),'created',true);
+  INSERT INTO public.festival_admin_audit_events(actor_profile_id, festival_id, edition_id, operation, target_type, target_id, after_snapshot, reason, idempotency_key) VALUES (v_actor, v_festival.id, (v_result->>'edition_id')::uuid, 'festival_created_with_first_edition', 'festival', v_festival.id, v_result, 'admin creation wizard', v_key);
+  INSERT INTO public.admin_festival_creation_requests(actor_user_id,actor_profile_id,operation,idempotency_key,request_hash,festival_id,edition_id,result,actor_resolution_status) VALUES (v_actor_user,v_actor,'admin_create_festival_with_first_edition',v_key,v_hash,v_festival.id,(v_result->>'edition_id')::uuid,v_result,'resolved');
+  RETURN v_result;
+END $$;
+GRANT EXECUTE ON FUNCTION public.admin_create_festival_with_first_edition(jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_create_festival_edition_with_setup(uuid,jsonb) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_edition_lifecycle_options(p_edition_id uuid)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_status public.festival_edition_status; v_targets public.festival_edition_status[] := ARRAY['concept','planning','applications_open','booking','announced','on_sale','setup','live','settling','completed','postponed','cancelled','abandoned']::public.festival_edition_status[]; v_is_admin boolean := coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false);
+BEGIN
+  IF auth.uid() IS NULL OR NOT v_is_admin THEN RAISE EXCEPTION 'FESTIVAL_CREATE_PERMISSION_DENIED'; END IF;
+  SELECT status INTO v_status FROM public.festival_editions WHERE id=p_edition_id;
+  IF v_status IS NULL THEN RAISE EXCEPTION 'FESTIVAL_CREATE_EDITION_INVALID'; END IF;
+  RETURN jsonb_build_object('editionId',p_edition_id,'currentState',v_status,'transitions',(SELECT jsonb_agg(jsonb_build_object('targetState',t,'available',public.validate_festival_edition_transition(v_status,t) AND t<>v_status,'blockers',CASE WHEN public.validate_festival_edition_transition(v_status,t) AND t<>v_status THEN '[]'::jsonb ELSE jsonb_build_array('Transition is not valid from current state') END,'warnings',CASE WHEN t IN ('live','postponed','cancelled','abandoned') THEN jsonb_build_array('This transition changes public operations and may notify players.') ELSE '[]'::jsonb END,'adminOverrideAllowed',t IN ('postponed','cancelled','abandoned'),'reasonRequired',t IN ('postponed','cancelled','abandoned'),'confirmationRequired',t IN ('live','postponed','cancelled','abandoned'),'severity',CASE WHEN t IN ('cancelled','abandoned') THEN 'destructive' WHEN t IN ('live','postponed') THEN 'warning' ELSE 'standard' END,'explanation',CASE WHEN t='applications_open' THEN 'Open band applications for this edition.' WHEN t='booking' THEN 'Close applications and begin booking decisions.' WHEN t='announced' THEN 'Publish confirmed festival details.' WHEN t='on_sale' THEN 'Open ticket sales for the announced edition.' WHEN t='setup' THEN 'Move operations into final event setup.' WHEN t='live' THEN 'Start live operation for the festival edition.' WHEN t='settling' THEN 'Close live operation and prepare settlement.' WHEN t='completed' THEN 'Mark settlement and outcomes complete.' WHEN t='postponed' THEN 'Postpone this edition and preserve its data.' WHEN t='cancelled' THEN 'Cancel this edition.' WHEN t='abandoned' THEN 'Abandon an unrecoverable edition.' ELSE 'Move the edition to ' || replace(t::text,'_',' ') || '.' END)) FROM unnest(v_targets) t));
+END $$;
+GRANT EXECUTE ON FUNCTION public.admin_festival_edition_lifecycle_options(uuid) TO authenticated, service_role;

--- a/supabase/tests/festival_creation_phase1_forward_migration_upgrade.sql
+++ b/supabase/tests/festival_creation_phase1_forward_migration_upgrade.sql
@@ -1,0 +1,25 @@
+-- Static upgrade contract for the Phase 1.1 forward migration.
+-- Full behaviour is covered by festival_creation_phase1_harness.sql after supabase db reset.
+BEGIN;
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_attribute WHERE attrelid='public.admin_festival_creation_requests'::regclass AND attname='actor_resolution_status' AND NOT attisdropped) THEN
+    RAISE EXCEPTION 'actor_resolution_status column missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='admin_festival_creation_requests_actor_user_id_new_writes') THEN
+    RAISE EXCEPTION 'actor identity preservation check missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname='admin_festival_creation_requests_actor_user_operation_key' AND indexdef ILIKE '%WHERE (actor_user_id IS NOT NULL)%') THEN
+    RAISE EXCEPTION 'partial actor-user idempotency index missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='internal_create_festival_edition_setup' AND NOT has_function_privilege('authenticated', oid, 'EXECUTE')) THEN
+    RAISE EXCEPTION 'internal creation helper must not be executable by authenticated users';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='admin_create_festival_edition_with_setup' AND pg_get_functiondef(oid) ILIKE '%FESTIVAL_CREATE_FIRST_EDITION_ALREADY_EXISTS%' AND pg_get_functiondef(oid) ILIKE '%FESTIVAL_CREATE_ADD_EDITION_REQUIRES_EXISTING%') THEN
+    RAISE EXCEPTION 'server creation mode enforcement missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname='admin_create_festival_with_first_edition' AND pg_get_functiondef(oid) NOT ILIKE '%DELETE FROM public.admin_festival_creation_requests%' AND pg_get_functiondef(oid) NOT ILIKE '%admin_create_festival_edition_with_setup%') THEN
+    RAISE EXCEPTION 'first-edition RPC still appears to nest public creation';
+  END IF;
+END $$;
+ROLLBACK;

--- a/supabase/tests/festival_creation_phase1_harness.sql
+++ b/supabase/tests/festival_creation_phase1_harness.sql
@@ -13,6 +13,13 @@ BEGIN EXECUTE 'SET LOCAL ROLE service_role'; PERFORM set_config('request.jwt.cla
 CREATE OR REPLACE FUNCTION test_festival_creation.assert_true(label text, actual boolean) RETURNS void LANGUAGE plpgsql AS $$ BEGIN IF actual IS DISTINCT FROM true THEN RAISE EXCEPTION 'assertion failed: %', label; END IF; END $$;
 CREATE OR REPLACE FUNCTION test_festival_creation.assert_eq(label text, actual bigint, expected bigint) RETURNS void LANGUAGE plpgsql AS $$ BEGIN IF actual IS DISTINCT FROM expected THEN RAISE EXCEPTION 'assertion failed: %, expected %, got %', label, expected, actual; END IF; END $$;
 CREATE OR REPLACE FUNCTION test_festival_creation.assert_raises(label text, statement text) RETURNS void LANGUAGE plpgsql AS $$ BEGIN BEGIN EXECUTE statement; EXCEPTION WHEN OTHERS THEN RETURN; END; RAISE EXCEPTION 'assertion failed: % should have raised', label; END $$;
+CREATE OR REPLACE FUNCTION test_festival_creation.assert_raises_code(label text, statement text, expected_message_fragment text) RETURNS void LANGUAGE plpgsql AS $$
+DECLARE actual text;
+BEGIN
+  BEGIN EXECUTE statement; EXCEPTION WHEN OTHERS THEN actual := SQLERRM; END;
+  IF actual IS NULL THEN RAISE EXCEPTION 'assertion failed: % should have raised %', label, expected_message_fragment; END IF;
+  IF position(expected_message_fragment in actual) = 0 THEN RAISE EXCEPTION 'assertion failed: % expected %, got %', label, expected_message_fragment, actual; END IF;
+END $$;
 
 DO $$
 DECLARE
@@ -23,7 +30,7 @@ DECLARE
 BEGIN
   IF NOT has_function_privilege('authenticated', 'public.admin_create_festival_with_first_edition(jsonb)', 'EXECUTE') THEN RAISE EXCEPTION 'create first-edition RPC grant missing'; END IF;
   IF NOT has_function_privilege('authenticated', 'public.admin_create_festival_edition_with_setup(uuid,jsonb)', 'EXECUTE') THEN RAISE EXCEPTION 'add edition RPC grant missing'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='admin_festival_creation_requests' AND column_name='actor_user_id' AND is_nullable='NO') THEN RAISE EXCEPTION 'actor_user_id must be non-null'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='admin_festival_creation_requests_actor_user_id_new_writes') THEN RAISE EXCEPTION 'new creation requests must require actor identity'; END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND tablename='admin_festival_creation_requests' AND indexname='admin_festival_creation_requests_actor_user_operation_key') THEN RAISE EXCEPTION 'actor-user idempotency unique index missing'; END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='tg_festival_stage_edition_consistency') THEN RAISE EXCEPTION 'stage consistency trigger missing'; END IF;
 
@@ -37,9 +44,9 @@ BEGIN
   payload := jsonb_build_object('mode','create_festival','idempotencyKey','phase1-key-1','identity',jsonb_build_object('name','Phase 1 Harness Fest','shortDescription','safe','fullDescription','safe festival','festivalType','recurring','primaryGenres',jsonb_build_array('Rock'),'isPublic',true),'edition',jsonb_build_object('title','Phase 1 2027','editionNumber',99,'startAt','2027-07-17T18:00:00Z','endAt','2027-07-19T23:00:00Z','applicationsOpenAt','2027-01-01T00:00:00Z','applicationsCloseAt','2027-03-01T00:00:00Z','bookingDeadlineAt','2027-05-01T00:00:00Z','timezone','America/New_York','currencyCode','USD'),'location',jsonb_build_object('country','United States','cityId',city_a,'venueId',venue_a,'capacity',4000,'minTicketPriceCents',2500,'maxTicketPriceCents',7500,'defaultTicketPriceCents',5000,'festivalDays',3),'stages',jsonb_build_array(jsonb_build_object('name','Main Stage','type','main','capacity',3000,'changeoverMinutes',30,'curfew','23:00','weatherProtection','covered','soundCapability','festival_grade','lightingCapability','premium')),'commercial',jsonb_build_object('estimatedAttendance',3500,'operatingBudgetCents',10000000,'performerBudgetCents',5000000,'staffingBudgetCents',2000000,'marketingBudgetCents',1000000,'sponsorshipEnabled',true,'merchandiseEnabled',true,'concessionsEnabled',true));
 
   PERFORM test_festival_creation.as_anon();
-  PERFORM test_festival_creation.assert_raises('anonymous creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text));
+  PERFORM test_festival_creation.assert_raises_code('anonymous creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text), 'FESTIVAL_CREATE_PERMISSION_DENIED');
   PERFORM test_festival_creation.as_user(normal_user);
-  PERFORM test_festival_creation.assert_raises('non-admin creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text));
+  PERFORM test_festival_creation.assert_raises_code('non-admin creation denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload::text), 'FESTIVAL_CREATE_PERMISSION_DENIED');
 
   PERFORM test_festival_creation.as_user(admin_user);
   SELECT count(*) INTO before_f FROM public.festivals; SELECT count(*) INTO before_e FROM public.festival_editions; SELECT count(*) INTO before_s FROM public.festival_stages;
@@ -57,18 +64,20 @@ BEGIN
   res_retry := public.admin_create_festival_with_first_edition(payload);
   PERFORM test_festival_creation.assert_true('idempotent retry returns original', (res_retry->>'festival_id')::uuid=festival AND (res_retry->>'edition_id')::uuid=edition AND (res_retry->>'created')::boolean=false);
   payload2 := jsonb_set(payload,'{identity,name}','"Changed Harness Fest"');
-  PERFORM test_festival_creation.assert_raises('payload mismatch denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload2::text));
+  PERFORM test_festival_creation.assert_raises_code('payload mismatch denied', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', payload2::text), 'FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT');
 
-  PERFORM test_festival_creation.assert_raises('invalid dates rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dates"') #- '{edition,endAt}' || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('endAt','2027-01-01T00:00:00Z'))));
-  PERFORM test_festival_creation.assert_raises('invalid city rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('cityId','00000000-0000-0000-0000-000000000000'))));
-  PERFORM test_festival_creation.assert_raises('venue city mismatch rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-venue-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('venueId',venue_b))));
-  PERFORM test_festival_creation.assert_raises('duplicate stages rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dupe-stage"') || jsonb_build_object('stages',jsonb_build_array(payload->'stages'->0,payload->'stages'->0))));
-  PERFORM test_festival_creation.assert_raises('unsupported currency rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-currency"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('currencyCode','BTC'))));
-  PERFORM test_festival_creation.assert_raises('unsupported timezone rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-timezone"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('timezone','Mars/Base'))));
+  PERFORM test_festival_creation.assert_raises_code('invalid dates rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dates"') #- '{edition,endAt}' || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('endAt','2027-01-01T00:00:00Z'))), 'FESTIVAL_CREATE_INVALID_DATE');
+  PERFORM test_festival_creation.assert_raises_code('invalid city rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('cityId','00000000-0000-0000-0000-000000000000'))), 'FESTIVAL_CREATE_CITY_INVALID');
+  PERFORM test_festival_creation.assert_raises_code('venue city mismatch rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-venue-city"') || jsonb_build_object('location',(payload->'location') || jsonb_build_object('venueId',venue_b))), 'FESTIVAL_CREATE_VENUE_INVALID');
+  PERFORM test_festival_creation.assert_raises_code('duplicate stages rollback', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-dupe-stage"') || jsonb_build_object('stages',jsonb_build_array(payload->'stages'->0,payload->'stages'->0))), 'FESTIVAL_CREATE_STAGE_DUPLICATE');
+  PERFORM test_festival_creation.assert_raises_code('unsupported currency rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-currency"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('currencyCode','BTC'))), 'FESTIVAL_CREATE_CURRENCY_INVALID');
+  PERFORM test_festival_creation.assert_raises_code('unsupported timezone rejected', format('SELECT public.admin_create_festival_with_first_edition(%L::jsonb)', jsonb_set(payload,'{idempotencyKey}','"bad-timezone"') || jsonb_build_object('edition',(payload->'edition') || jsonb_build_object('timezone','Mars/Base'))), 'FESTIVAL_CREATE_TIMEZONE_INVALID');
 
   res := public.admin_create_festival_edition_with_setup(festival, (payload || jsonb_build_object('mode','add_edition','existingFestivalId',festival,'idempotencyKey','phase1-add-2','edition',(payload->'edition') || jsonb_build_object('title','Phase 1 2028','startAt','2028-07-17T18:00:00Z','endAt','2028-07-19T23:00:00Z','applicationsOpenAt','2028-01-01T00:00:00Z','applicationsCloseAt','2028-03-01T00:00:00Z','bookingDeadlineAt','2028-05-01T00:00:00Z'))));
   res := public.admin_create_festival_edition_with_setup(festival, (payload || jsonb_build_object('mode','add_edition','existingFestivalId',festival,'idempotencyKey','phase1-add-3','edition',(payload->'edition') || jsonb_build_object('title','Phase 1 2029','startAt','2029-07-17T18:00:00Z','endAt','2029-07-19T23:00:00Z','applicationsOpenAt','2029-01-01T00:00:00Z','applicationsCloseAt','2029-03-01T00:00:00Z','bookingDeadlineAt','2029-05-01T00:00:00Z'))));
   PERFORM test_festival_creation.assert_true('later edition gets next number', EXISTS (SELECT 1 FROM public.festival_editions WHERE id=(res->>'edition_id')::uuid AND festival_id=festival AND edition_number=3));
+  PERFORM test_festival_creation.assert_raises_code('create first edition rejects existing edition', format('SELECT public.admin_create_festival_edition_with_setup(%L::uuid,%L::jsonb)', festival::text, ((payload || jsonb_build_object('mode','create_first_edition','existingFestivalId',festival,'idempotencyKey','phase1-first-again'))::text)), 'FESTIVAL_CREATE_FIRST_EDITION_ALREADY_EXISTS');
   PERFORM test_festival_creation.assert_true('request rows do not outlive failed aggregates', NOT EXISTS (SELECT 1 FROM public.admin_festival_creation_requests WHERE idempotency_key LIKE 'bad-%'));
+  PERFORM test_festival_creation.assert_true('internal helper is not granted to authenticated', NOT has_function_privilege('authenticated', 'public.internal_create_festival_edition_setup(uuid,jsonb,uuid,uuid,text,integer)', 'EXECUTE'));
 END $$;
 ROLLBACK;


### PR DESCRIPTION
### Motivation

- Preserve Phase 1 deployment history and safely apply hardening without editing the already-merged migration file. 
- Ensure historical request rows are migrated deterministically and that new writes always include a valid authenticated actor identity. 
- Prevent nested public RPC creation for first-edition creation and enforce server-side creation modes and idempotency semantics. 
- Repair UI/UX regressions from the hardening (wizard dirty state, lifecycle confirmation/override rendering, typed stage fields) and strengthen SQL test assertions.

### Description

- Added a new forward migration `supabase/migrations/20260717153000_harden_festival_creation_phase1_forward.sql` that idempotently backfills `actor_user_id` from `profiles.user_id`, marks unresolved historical rows via `actor_resolution_status`, creates a partial unique idempotency index for non-null `actor_user_id`, and updates admin RPCs and reference-data functions (country/currency helpers and canonical genres). 
- Introduced `public.internal_create_festival_edition_setup(...)` as a private, SECURITY DEFINER helper and reworked `admin_create_festival_edition_with_setup` / `admin_create_festival_with_first_edition` to call it so each external operation writes exactly one request row, first editions are inserted with edition number `1`, and server modes `create_first_edition` / `add_edition` are enforced with domain errors. 
- Strengthened SQL harnesses and upgrade contract: added `supabase/tests/festival_creation_phase1_forward_migration_upgrade.sql` and hardened `supabase/tests/festival_creation_phase1_harness.sql` to assert specific domain error fragments and private-grant/constraint expectations. 
- Frontend fixes: extracted `isFestivalCreationDraftDirty` and unit tests, wired the wizard to hold an immutable initial snapshot (ignore idempotencyKey in dirty checks), replaced free-text stage fields with projected selectors, implemented lifecycle transition UX (blockers, warnings, confirmation dialog, typed destructive confirmation, explicit override and per-attempt operation keys), typed and Zod-validated festival application rows in `useFestivalSlotApplications`, and moved `selectPreferredFestivalEdition` to a workspace utility. 
- CI and tooling: added a pinned Supabase CLI check and log upload to the festival DB gate script `scripts/festivals/run-creation-phase1-db-gate.sh` and updated the CI workflow to pin the Supabase CLI and upload logs on gate failure. 
- Documentation: added `docs/festivals/FESTIVAL_PHASE1_DEPLOYMENT_CORRECTIONS.md` and `docs/festivals/FESTIVAL_LIFECYCLE_ADMIN_FLOW.md` and recorded Phase 1.1 notes in existing festival docs.

### Testing

- `npm ci` — attempted but failed in this environment due to a registry error (403 Forbidden for `@react-three/fiber`), so full dependency install could not be performed. (failed)
- `npm run typecheck` — TypeScript check executed and passed. (passed)
- `npm run lint` — executed but failed after dependency install could not provide ESLint peer packages (`@eslint/js` not resolved). (failed)
- `npm run test:unit` (single new dirty-state spec) — could not run because test runner binaries were not installed after the failed `npm ci` (`vitest` not found). (not executed / failed due to env)
- `npm run build` — could not run because build tooling (`vite`) was not installed after the failed `npm ci`. (not executed / failed due to env)
- `npm run test:festivals:db` — DB gate script was checked and updated to require pinned Supabase CLI `2.31.8`, but the CLI is not present in this container so the database gate did not run here; the SQL harness and forward-migration upgrade contract are included and will run in CI when the gate is available. (not executed / failed in env)
- `git diff --check` — whitespace/check passed. (passed)

Notes: migration, SQL harness and frontend unit additions are committed on branch `codex/festival-phase1-deployment-corrections`; full verification (SQL gate, unit/browser tests, lint and production build) requires dependency installation and Supabase CLI availability in CI or a provisioning environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fdf76ca88325a7f0c0ac8cb15923)