### PR TITLE
Finance Phase 4: City economies, regional costs, local demand and municipal treasuries

### DIFF
--- a/docs/finance/FINANCE_PHASE4_CITY_ECONOMIES.md
+++ b/docs/finance/FINANCE_PHASE4_CITY_ECONOMIES.md
@@ -1,0 +1,90 @@
+# Finance Phase 4: city economies, regional costs, local demand and municipal treasuries
+
+## Repository audit findings
+
+Finance Phases 1–3 are present as Supabase migrations and docs: Phase 1 creates `financial_accounts`, `financial_transactions`, ledger entries and owner type `city`; Phase 2 adds recurring obligations; Phase 3 adds company operating profiles, employment contracts, job adverts, payroll batches, wage liabilities and company P&L snapshots.
+
+Current city data is stored in the existing `cities` table, which already carries `name`, `country`, `population`, travel metadata and relationships from venues, gigs, companies, studios, universities, clubs, festivals and player location fields. This PR extends that model rather than creating a parallel city model.
+
+Existing city-linked systems identified include venues/gigs, festivals, company headquarters, night clubs, studios/rehearsals, universities, travel and profile current/home city fields. Existing regional modifiers were scattered: gig completion had a city-name hash economy multiplier, city laws/tax placeholders existed, and several docs listed future city demand/cost hooks. Hard-coded or mostly fixed prices remain for some booking, nightlife, education, food/lifestyle, travel and festival flows; the financial-flow inventory lists them as compatibility work.
+
+Currency assumptions remain USD-first. Phase 4 adds `primary_currency_code` to city profiles and treasuries but does not implement exchange rates or country monetary policy.
+
+## Architecture
+
+The city economy layer is centred on `city_economic_profiles`. All indices use a baseline of `100`: below `100` means cheaper/weaker than world baseline, above `100` means more expensive/stronger. Indices are bounded and validated, never negative, and exposed with player-friendly labels.
+
+City scale is standardised as `town`, `small_city`, `regional_city`, `major_city` and `global_city`. Scale seeds population and opportunity assumptions but does not alone determine outcomes.
+
+Every city receives a primary `financial_accounts` row with owner type `city` and a `city_treasury_profiles` row. Treasury movements use `finance_transfer`, so business licence fees, grants, budget spending and admin adjustments are ledger-backed and idempotency-keyed.
+
+## Calculation model
+
+`city_price_quote` is the common pricing interface. It accepts a base amount, city, category, existing modifier and optional event context, then returns base amount, city multiplier, event multiplier, final minor-unit amount, rounding policy and explanation. The calculation order is:
+
+1. Map category to exactly one city index.
+2. Convert the index to bounded basis points.
+3. Add bounded temporary event pressure.
+4. Apply one existing modifier input.
+5. Round once to integer minor units.
+
+This avoids double-applying the same city factor and prevents unbounded multiplicative growth.
+
+`city_wage_guidance` applies the wage index to role definitions and returns recommended, minimum-market and maximum-market wage bands.
+
+`city_local_audience_demand` combines population-derived market size, local demand, consumer spending, tourism, genre popularity, fame, price sensitivity, venue capacity and competition. It returns estimated audience, confidence range and positive/negative modifier explanations. Demand modifies probability and capacity expectations; it does not guarantee revenue.
+
+## Data model introduced
+
+- `city_economic_profiles`
+- `city_treasury_profiles`
+- `city_budgets`
+- `city_economic_snapshots`
+- `city_genre_demands`
+- `city_temporary_effects`
+- `city_spending_initiatives`
+- `city_grant_programmes`
+- `city_grant_applications`
+- `city_grant_awards`
+- `city_licence_schedules`
+- `city_economic_audit_events`
+
+Integrity is surfaced through `city_economy_integrity_issues` for missing profiles, missing treasuries, invalid indices, expired active effects and paid grants without transactions.
+
+## Systems integrated in this PR
+
+- Company business licence fees can be collected from company accounts into city treasuries.
+- Commercial rent, residential rent, utilities, accommodation, fuel, transport, cost-of-living and wage guidance use the shared city quote service.
+- Company payroll guidance varies by city through wage indices.
+- Event pressure can temporarily affect demand and accommodation/transport-style categories within caps.
+- City genre demand seeds non-identical genre popularity by city.
+- Grants transfer funds from city treasury to player, band, company or venue recipients exactly once.
+- Economic snapshots aggregate city profile data, company counts, active employees, vacancies, gigs, payroll and treasury balance.
+
+## Admin, security and observability
+
+Ordinary players receive read-only access to public city profile, public treasury summaries, genre demand, public snapshots, active effects and open/closed grant programmes. Direct writes are intentionally absent from RLS policies. Trusted server-side functions perform treasury transfers, grant payments, licence collection and snapshot generation.
+
+Admin adjustments should be implemented as audited finance operations, not direct balance edits. `city_economic_audit_events` stores immutable changes and reasons.
+
+## Migration strategy
+
+`ensure_city_economy_foundations()` backfills every existing city with a gameplay-balanced profile and primary treasury account while preserving city IDs. Baselines are generated from existing population and metadata only; values are fictionalised for game balance and are not real-world economic claims. Default business licence schedules and varied genre demand are inserted idempotently.
+
+Legacy regional fields and hard-coded prices are preserved until each call site is safely migrated. New services are designed to prevent applying both legacy and new modifiers in the same calculation.
+
+## Scheduled processing
+
+The migration provides idempotent primitives for weekly snapshots and effect status rollups. A scheduler should call snapshot generation weekly per city, update active/expired temporary effects, recalculate tourism and business confidence, update employment aggregation, roll budgets and publish major city economic news when trend thresholds are crossed.
+
+## Known limitations
+
+- No country-level taxes, VAT, monetary policy, live exchange rates or national treasury logic.
+- No autonomous NPC municipal government.
+- No full housing ownership or inventory model.
+- Some existing UI routes still need to replace fixed display prices with `city_price_quote` results.
+- Screenshots were not produced in this non-interactive implementation environment.
+
+## Recommended Finance Phase 5
+
+Implement country-level taxation and national economies: country treasury accounts, tax jurisdictions, income tax, band/company taxation, payroll withholding, VAT/sales tax, tax periods/returns, national profiles, country grants and tax distribution between city and country.

--- a/docs/finance/FINANCIAL_FLOW_INVENTORY.md
+++ b/docs/finance/FINANCIAL_FLOW_INVENTORY.md
@@ -59,3 +59,28 @@ Manager, accountant, marketing, sound-engineer and customer-service roles now ha
 ### Future dependencies
 
 City cost multipliers, country taxation, local labour markets, regional rent, commercial utility prices and macroeconomic demand are deferred to Finance Phase 4 and later tax/economy phases.
+
+## Finance Phase 4 city-economy additions
+
+### City-linked costs migrated to shared city pricing
+
+- Commercial rent, residential rent, utilities, fuel, transport, accommodation, cost of living and wage guidance now have a single bounded quote contract through `city_price_quote` / `quoteCityPrice`.
+- Company business licence fees can be charged through `city_collect_business_licence_fee`, leaving the company account and entering the city treasury account through the unified ledger.
+- City grant awards can be paid through `city_pay_grant_award`, leaving the city treasury and entering the recipient account exactly once via idempotency keys.
+
+### City-linked revenues migrated
+
+- Business licence fees are the first real municipal revenue category.
+- Grant funding and budget spending are represented as treasury-backed flows rather than direct balance mutation.
+- Public treasury summaries are exposed through `city_economy_public_view` without allowing player-controlled treasury transfers.
+
+### Remaining hard-coded prices and regional values
+
+- Some gig, studio, rehearsal, nightlife, university, festival and travel surfaces still display or calculate fixed prices at the route/function level.
+- The legacy city-name hash multiplier in gig completion should be replaced by `city_local_audience_demand` and `city_price_quote` once the live-gig settlement path is fully migrated.
+- Existing city law/tax placeholders remain deferred to Finance Phase 5 country taxation work.
+
+### Systems awaiting city modifier rollout
+
+- Full hotel inventory, property ownership, detailed venue booking prices, studio engineer costs, merchandise logistics and education costs still need call-site migration.
+- Country currency, national taxation, VAT/sales tax, payroll withholding and exchange-rate support are intentionally out of scope for Phase 4.

--- a/src/features/city-economy/CityEconomyPanels.tsx
+++ b/src/features/city-economy/CityEconomyPanels.tsx
@@ -1,0 +1,105 @@
+import { calculateLocalAudienceDemand, labelForIndex, quoteCityPrice, type CityEconomicProfile } from "@/lib/cityEconomy";
+
+interface CityEconomyPanelsProps {
+  cities: CityEconomicProfile[];
+  selectedCityId?: string;
+  genreName?: string;
+}
+
+const money = (minor: number) => `$${(minor / 100).toFixed(2)}`;
+
+export function CityEconomyOverview({ city }: { city: CityEconomicProfile }) {
+  return (
+    <section aria-label={`${city.cityId} economy overview`} className="space-y-4 rounded-lg border p-4">
+      <div>
+        <h2 className="text-xl font-semibold">City economy</h2>
+        <p className="text-sm text-muted-foreground">Scale: {city.cityScale.replace("_", " ")} · Population: {city.population.toLocaleString()} · Trend: {city.economicTrend.replace("_", " ")}</p>
+      </div>
+      <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Metric label="Cost of living" value={city.costOfLivingIndex} />
+        <Metric label="Commercial rent" value={city.commercialRentIndex} />
+        <Metric label="Wages" value={city.wageIndex} />
+        <Metric label="Accommodation" value={city.accommodationCostIndex} />
+        <Metric label="Consumer spending" value={city.consumerSpendingIndex} />
+        <Metric label="Tourism" value={city.tourismIndex} />
+        <Metric label="Music market" value={city.musicMarketSize} />
+        <Metric label="Business confidence" value={city.businessConfidenceIndex} />
+      </dl>
+    </section>
+  );
+}
+
+export function CityComparisonTable({ cities }: { cities: CityEconomicProfile[] }) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full min-w-[760px] text-sm">
+        <thead><tr className="bg-muted"><th className="p-2 text-left">City</th><th>Living</th><th>Housing</th><th>Commercial</th><th>Wages</th><th>Utilities</th><th>Fuel</th><th>Tourism</th><th>Music demand</th><th>Opportunity</th></tr></thead>
+        <tbody>{cities.map((city) => <tr key={city.cityId} className="border-t"><td className="p-2 font-medium">{city.cityId}</td><td>{city.costOfLivingIndex}</td><td>{city.residentialRentIndex}</td><td>{city.commercialRentIndex}</td><td>{city.wageIndex}</td><td>{city.utilityCostIndex}</td><td>{city.fuelCostIndex}</td><td>{city.tourismIndex}</td><td>{city.localAudienceDemand}</td><td>{city.businessConfidenceIndex}</td></tr>)}</tbody>
+      </table>
+    </div>
+  );
+}
+
+export function CompanyCityInsights({ city, weeklyBaseRentMinor = 50_000, weeklyBaseUtilityMinor = 15_000 }: { city: CityEconomicProfile; weeklyBaseRentMinor?: number; weeklyBaseUtilityMinor?: number }) {
+  const rent = quoteCityPrice(city, weeklyBaseRentMinor, "commercial_rent");
+  const utilities = quoteCityPrice(city, weeklyBaseUtilityMinor, "utilities");
+  return (
+    <section aria-label="Company city insights" className="rounded-lg border p-4">
+      <h3 className="font-semibold">Local market insights</h3>
+      <ul className="mt-2 space-y-1 text-sm">
+        <li>Estimated weekly rent: {money(rent.finalAmountMinor)} ({rent.explanation.join(", ")})</li>
+        <li>Estimated utilities: {money(utilities.finalAmountMinor)} ({utilities.explanation.join(", ")})</li>
+        <li>Employment availability: {labelForIndex(city.employmentIndex)} ({city.employmentIndex})</li>
+        <li>Consumer spending: {labelForIndex(city.consumerSpendingIndex)} ({city.consumerSpendingIndex})</li>
+        <li>Main opportunity: {city.musicMarketSize > 120 ? "large music market" : "lower-cost positioning"}</li>
+        <li>Main risk: {city.commercialRentIndex > 130 ? "high premises costs" : "smaller demand ceiling"}</li>
+      </ul>
+    </section>
+  );
+}
+
+export function TourCityInsights({ city, genrePopularityIndex = 100 }: { city: CityEconomicProfile; genrePopularityIndex?: number }) {
+  const accommodation = quoteCityPrice(city, 12_000, "accommodation");
+  const transport = quoteCityPrice(city, 8_000, "transport");
+  const demand = calculateLocalAudienceDemand(city, { genrePopularityIndex, venueCapacity: 500, ticketPriceMinor: 3_000, bandFame: 60 });
+  return (
+    <section aria-label="Tour city insights" className="rounded-lg border p-4">
+      <h3 className="font-semibold">Gig planning signals</h3>
+      <ul className="mt-2 space-y-1 text-sm">
+        <li>Estimated local demand: {demand.estimatedPotentialAudience} / 500 attendees</li>
+        <li>Accommodation level: {labelForIndex(city.accommodationCostIndex)} · {money(accommodation.finalAmountMinor)} estimate</li>
+        <li>Transport costs: {labelForIndex(city.transportCostIndex)} · {money(transport.finalAmountMinor)} estimate</li>
+        <li>Consumer spending: {labelForIndex(city.consumerSpendingIndex)}</li>
+        <li>Tourism: {labelForIndex(city.tourismIndex)}</li>
+      </ul>
+    </section>
+  );
+}
+
+export function AdminCityEconomyControlsSummary({ city }: { city: CityEconomicProfile }) {
+  return (
+    <section aria-label="Admin city economy controls" className="rounded-lg border p-4">
+      <h3 className="font-semibold">Admin controls</h3>
+      <p className="text-sm text-muted-foreground">Admins can adjust indices through audited server flows. Treasury balances must be changed through finance adjustments, not direct edits.</p>
+      <pre className="mt-3 overflow-x-auto rounded bg-muted p-3 text-xs">{JSON.stringify({ cityScale: city.cityScale, costOfLivingIndex: city.costOfLivingIndex, wageIndex: city.wageIndex, tourismIndex: city.tourismIndex, businessConfidenceIndex: city.businessConfidenceIndex }, null, 2)}</pre>
+    </section>
+  );
+}
+
+export function CityEconomyPanels({ cities, selectedCityId, genreName }: CityEconomyPanelsProps) {
+  const selected = cities.find((city) => city.cityId === selectedCityId) ?? cities[0];
+  if (!selected) return null;
+  return (
+    <div className="space-y-4">
+      <CityEconomyOverview city={selected} />
+      <CityComparisonTable cities={cities} />
+      <CompanyCityInsights city={selected} />
+      <TourCityInsights city={selected} genrePopularityIndex={genreName ? 115 : 100} />
+      <AdminCityEconomyControlsSummary city={selected} />
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return <div><dt className="text-xs text-muted-foreground">{label}</dt><dd className="font-medium">{labelForIndex(value)} <span className="text-muted-foreground">({value})</span></dd></div>;
+}

--- a/src/lib/cityEconomy.test.ts
+++ b/src/lib/cityEconomy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { calculateLocalAudienceDemand, calculateWageGuidance, quoteCityPrice, validateCityEconomicProfile, type CityEconomicProfile } from "./cityEconomy";
+
+const cheapCity: CityEconomicProfile = { cityId: "cheap", countryCode: "GB", primaryCurrencyCode: "USD", population: 350000, cityScale: "small_city", prosperityIndex: 92, costOfLivingIndex: 78, commercialRentIndex: 70, residentialRentIndex: 75, wageIndex: 82, utilityCostIndex: 80, fuelCostIndex: 90, accommodationCostIndex: 76, transportCostIndex: 85, consumerSpendingIndex: 88, tourismIndex: 82, musicMarketSize: 92, localAudienceDemand: 90, businessConfidenceIndex: 96, employmentIndex: 94, infrastructureQualityIndex: 90, economicTrend: "stable" };
+const globalCity: CityEconomicProfile = { cityId: "global", countryCode: "US", primaryCurrencyCode: "USD", population: 8500000, cityScale: "global_city", prosperityIndex: 135, costOfLivingIndex: 145, commercialRentIndex: 165, residentialRentIndex: 155, wageIndex: 140, utilityCostIndex: 125, fuelCostIndex: 118, accommodationCostIndex: 170, transportCostIndex: 132, consumerSpendingIndex: 145, tourismIndex: 150, musicMarketSize: 160, localAudienceDemand: 155, businessConfidenceIndex: 130, employmentIndex: 140, infrastructureQualityIndex: 138, economicTrend: "growth" };
+
+describe("city economy calculations", () => {
+  it("validates bounded profiles and currency assumptions", () => {
+    expect(validateCityEconomicProfile(globalCity)).toEqual([]);
+    expect(validateCityEconomicProfile({ ...globalCity, primaryCurrencyCode: "usd", costOfLivingIndex: -1 })).toContain("primaryCurrencyCode must be an ISO-like 3-letter code");
+  });
+
+  it("varies commercial rent, utilities, accommodation and transport by city", () => {
+    expect(quoteCityPrice(globalCity, 100_00, "commercial_rent").finalAmountMinor).toBeGreaterThan(quoteCityPrice(cheapCity, 100_00, "commercial_rent").finalAmountMinor);
+    expect(quoteCityPrice(globalCity, 100_00, "utilities").finalAmountMinor).toBeGreaterThan(quoteCityPrice(cheapCity, 100_00, "utilities").finalAmountMinor);
+    expect(quoteCityPrice(globalCity, 100_00, "accommodation").finalAmountMinor).toBeGreaterThan(quoteCityPrice(cheapCity, 100_00, "accommodation").finalAmountMinor);
+    expect(quoteCityPrice(globalCity, 100_00, "transport").finalAmountMinor).toBeGreaterThan(quoteCityPrice(cheapCity, 100_00, "transport").finalAmountMinor);
+  });
+
+  it("applies bounded temporary event pressure and never produces negative charges", () => {
+    const quote = quoteCityPrice(globalCity, 100_00, "accommodation", { effects: [{ category: "accommodation", strengthBasisPoints: 20_000, active: true }] });
+    expect(quote.eventMultiplierBasisPoints).toBe(15_000);
+    expect(quote.finalAmountMinor).toBeGreaterThan(0);
+    expect(quoteCityPrice(globalCity, 0, "fuel").finalAmountMinor).toBe(0);
+  });
+
+  it("prevents duplicate modifier application through one category quote", () => {
+    const once = quoteCityPrice(globalCity, 100_00, "commercial_rent", { existingModifierBasisPoints: 10_000 });
+    const explicit = quoteCityPrice(globalCity, 100_00, "commercial_rent", { existingModifierBasisPoints: once.cityMultiplierBasisPoints });
+    expect(once.explanation).toHaveLength(1);
+    expect(explicit.finalAmountMinor).toBeGreaterThan(once.finalAmountMinor);
+  });
+
+  it("returns wage guidance ranges by city", () => {
+    expect(calculateWageGuidance(globalCity, 50_000).recommendedWageMinor).toBeGreaterThan(calculateWageGuidance(cheapCity, 50_000).recommendedWageMinor);
+  });
+
+  it("models demand with music market, consumer spending, tourism, genre and competition", () => {
+    const globalDemand = calculateLocalAudienceDemand(globalCity, { genrePopularityIndex: 140, bandFame: 70, ticketPriceMinor: 2500, venueCapacity: 1000, competitionIndex: 80 });
+    const cheapDemand = calculateLocalAudienceDemand(cheapCity, { genrePopularityIndex: 80, bandFame: 70, ticketPriceMinor: 2500, venueCapacity: 1000, competitionIndex: 140 });
+    expect(globalDemand.estimatedPotentialAudience).toBeGreaterThan(cheapDemand.estimatedPotentialAudience);
+    expect(globalDemand.confidenceHigh).toBeLessThanOrEqual(1000);
+  });
+});

--- a/src/lib/cityEconomy.ts
+++ b/src/lib/cityEconomy.ts
@@ -1,0 +1,130 @@
+export type CityScale = "town" | "small_city" | "regional_city" | "major_city" | "global_city";
+export type CityTrend = "strong_growth" | "growth" | "stable" | "slowing" | "decline" | "severe_decline";
+export type CostCategory = "cost_of_living" | "commercial_rent" | "residential_rent" | "wage" | "utilities" | "fuel" | "accommodation" | "transport";
+
+export interface CityEconomicProfile {
+  cityId: string;
+  countryCode: string;
+  primaryCurrencyCode: string;
+  population: number;
+  cityScale: CityScale;
+  prosperityIndex: number;
+  costOfLivingIndex: number;
+  commercialRentIndex: number;
+  residentialRentIndex: number;
+  wageIndex: number;
+  utilityCostIndex: number;
+  fuelCostIndex: number;
+  accommodationCostIndex: number;
+  transportCostIndex: number;
+  consumerSpendingIndex: number;
+  tourismIndex: number;
+  musicMarketSize: number;
+  localAudienceDemand: number;
+  businessConfidenceIndex: number;
+  employmentIndex: number;
+  infrastructureQualityIndex: number;
+  economicTrend: CityTrend;
+}
+
+export interface TemporaryCityEffect {
+  category: CostCategory | "demand";
+  strengthBasisPoints: number;
+  active: boolean;
+}
+
+export interface PriceQuote {
+  baseAmountMinor: number;
+  category: CostCategory;
+  cityMultiplierBasisPoints: number;
+  eventMultiplierBasisPoints: number;
+  existingModifierBasisPoints: number;
+  finalAmountMinor: number;
+  explanation: string[];
+}
+
+const indexByCategory: Record<CostCategory, keyof CityEconomicProfile> = {
+  cost_of_living: "costOfLivingIndex",
+  commercial_rent: "commercialRentIndex",
+  residential_rent: "residentialRentIndex",
+  wage: "wageIndex",
+  utilities: "utilityCostIndex",
+  fuel: "fuelCostIndex",
+  accommodation: "accommodationCostIndex",
+  transport: "transportCostIndex",
+};
+
+export function clampInt(value: number, min: number, max: number): number {
+  return Math.trunc(Math.min(max, Math.max(min, Number.isFinite(value) ? value : min)));
+}
+
+export function labelForIndex(index: number): string {
+  if (index < 70) return "Very low";
+  if (index < 85) return "Low";
+  if (index < 95) return "Below average";
+  if (index <= 105) return "Average";
+  if (index <= 120) return "Above average";
+  if (index <= 140) return "High";
+  return "Very high";
+}
+
+export function validateCityEconomicProfile(profile: CityEconomicProfile): string[] {
+  const errors: string[] = [];
+  if (!/^[A-Z]{3}$/.test(profile.primaryCurrencyCode)) errors.push("primaryCurrencyCode must be an ISO-like 3-letter code");
+  if (profile.population < 0) errors.push("population cannot be negative");
+  for (const [key, value] of Object.entries(profile)) {
+    if (key.endsWith("Index") || key === "musicMarketSize" || key === "localAudienceDemand") {
+      if (typeof value !== "number" || value < 1 || value > 300) errors.push(`${key} must be between 1 and 300`);
+    }
+  }
+  return errors;
+}
+
+export function quoteCityPrice(profile: CityEconomicProfile | null, baseAmountMinor: number, category: CostCategory, options: { effects?: TemporaryCityEffect[]; existingModifierBasisPoints?: number } = {}): PriceQuote {
+  if (baseAmountMinor < 0) throw new Error("baseAmountMinor cannot be negative");
+  const index = profile ? Number(profile[indexByCategory[category]]) : 100;
+  const cityMultiplierBasisPoints = clampInt(index * 100, 5_000, 20_000);
+  const effectBoost = (options.effects ?? []).filter((effect) => effect.active && effect.category === category).reduce((sum, effect) => sum + clampInt(effect.strengthBasisPoints, 0, 5_000), 0);
+  const eventMultiplierBasisPoints = clampInt(10_000 + effectBoost, 7_500, 15_000);
+  const existingModifierBasisPoints = clampInt(options.existingModifierBasisPoints ?? 10_000, 1_000, 30_000);
+  const numerator = BigInt(Math.trunc(baseAmountMinor)) * BigInt(cityMultiplierBasisPoints) * BigInt(eventMultiplierBasisPoints) * BigInt(existingModifierBasisPoints);
+  const finalAmountMinor = Number((numerator + 500_000_000_000n) / 1_000_000_000_000n);
+  return {
+    baseAmountMinor,
+    category,
+    cityMultiplierBasisPoints,
+    eventMultiplierBasisPoints,
+    existingModifierBasisPoints,
+    finalAmountMinor: Math.max(0, finalAmountMinor),
+    explanation: [`${category} index ${index} (${labelForIndex(index)})`, ...(effectBoost ? [`temporary event pressure +${effectBoost}bp`] : [])],
+  };
+}
+
+export function calculateWageGuidance(profile: CityEconomicProfile | null, baseRoleWageMinor: number) {
+  const quote = quoteCityPrice(profile, baseRoleWageMinor, "wage");
+  return {
+    ...quote,
+    recommendedWageMinor: quote.finalAmountMinor,
+    minimumMarketMinor: Math.trunc((quote.finalAmountMinor * 85) / 100),
+    maximumMarketMinor: Math.trunc((quote.finalAmountMinor * 120) / 100),
+  };
+}
+
+export function calculateLocalAudienceDemand(profile: CityEconomicProfile | null, input: { genrePopularityIndex?: number; bandFame?: number; ticketPriceMinor?: number; venueCapacity: number; competitionIndex?: number; effects?: TemporaryCityEffect[] }) {
+  const p = profile ?? ({ consumerSpendingIndex: 100, tourismIndex: 100, musicMarketSize: 100, localAudienceDemand: 100 } as CityEconomicProfile);
+  const genre = clampInt(input.genrePopularityIndex ?? 100, 1, 250);
+  const demandBasisPoints = clampInt(p.localAudienceDemand * 35 + p.musicMarketSize * 25 + p.consumerSpendingIndex * 15 + p.tourismIndex * 10 + genre * 15, 3_000, 25_000);
+  const eventBoost = (input.effects ?? []).filter((effect) => effect.active && effect.category === "demand").reduce((sum, effect) => sum + effect.strengthBasisPoints, 0);
+  const eventBasisPoints = clampInt(10_000 + eventBoost, 7_500, 15_000);
+  const priceBasisPoints = clampInt(11_000 - Math.trunc(Math.max(0, (input.ticketPriceMinor ?? 2_500) - 2_500) / 100), 6_000, 14_000);
+  const fameBasisPoints = clampInt(5_000 + (input.bandFame ?? 50) * 100, 1_000, 20_000);
+  const competitionBasisPoints = clampInt(20_000 - (input.competitionIndex ?? 100) * 75, 5_000, 15_000);
+  const potential = Math.trunc((input.venueCapacity * demandBasisPoints * eventBasisPoints * priceBasisPoints * fameBasisPoints * competitionBasisPoints) / 10_000 ** 5);
+  return {
+    estimatedPotentialAudience: clampInt(potential, 0, input.venueCapacity),
+    priceSensitivityBasisPoints: priceBasisPoints,
+    demandMultiplierBasisPoints: demandBasisPoints,
+    confidenceLow: clampInt(Math.trunc(potential * 0.85), 0, input.venueCapacity),
+    confidenceHigh: clampInt(Math.trunc(potential * 1.15), 0, input.venueCapacity),
+  };
+}

--- a/supabase/migrations/20260717170000_finance_phase4_city_economies.sql
+++ b/supabase/migrations/20260717170000_finance_phase4_city_economies.sql
@@ -1,0 +1,236 @@
+-- Finance Phase 4: city economies, regional costs, local demand and municipal treasuries.
+
+ALTER TYPE public.financial_transaction_category ADD VALUE IF NOT EXISTS 'city_business_licence_fee';
+ALTER TYPE public.financial_transaction_category ADD VALUE IF NOT EXISTS 'city_venue_permit_fee';
+ALTER TYPE public.financial_transaction_category ADD VALUE IF NOT EXISTS 'city_grant_payment';
+ALTER TYPE public.financial_transaction_category ADD VALUE IF NOT EXISTS 'city_budget_spend';
+ALTER TYPE public.financial_transaction_category ADD VALUE IF NOT EXISTS 'city_treasury_adjustment';
+
+DO $$ BEGIN CREATE TYPE public.city_scale AS ENUM ('town','small_city','regional_city','major_city','global_city'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE TYPE public.city_economic_trend AS ENUM ('strong_growth','growth','stable','slowing','decline','severe_decline'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE TYPE public.city_budget_status AS ENUM ('draft','active','closed','adjusted','suspended'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE TYPE public.city_effect_status AS ENUM ('scheduled','active','expired','cancelled'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE TYPE public.city_grant_status AS ENUM ('draft','open','closed','applied','approved','rejected','paid','cancelled','exhausted'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE public.cities ADD COLUMN IF NOT EXISTS primary_currency_code char(3) NOT NULL DEFAULT 'USD';
+ALTER TABLE public.cities ADD COLUMN IF NOT EXISTS city_scale public.city_scale NOT NULL DEFAULT 'regional_city';
+
+CREATE TABLE IF NOT EXISTS public.city_economic_profiles (
+  city_id uuid PRIMARY KEY REFERENCES public.cities(id) ON DELETE CASCADE,
+  country_code text NOT NULL,
+  primary_currency_code char(3) NOT NULL DEFAULT 'USD',
+  population bigint NOT NULL DEFAULT 100000 CHECK (population >= 0),
+  active_player_population integer NOT NULL DEFAULT 0 CHECK (active_player_population >= 0),
+  city_scale public.city_scale NOT NULL DEFAULT 'regional_city',
+  prosperity_index integer NOT NULL DEFAULT 100,
+  cost_of_living_index integer NOT NULL DEFAULT 100,
+  commercial_rent_index integer NOT NULL DEFAULT 100,
+  residential_rent_index integer NOT NULL DEFAULT 100,
+  wage_index integer NOT NULL DEFAULT 100,
+  utility_cost_index integer NOT NULL DEFAULT 100,
+  fuel_cost_index integer NOT NULL DEFAULT 100,
+  accommodation_cost_index integer NOT NULL DEFAULT 100,
+  transport_cost_index integer NOT NULL DEFAULT 100,
+  consumer_spending_index integer NOT NULL DEFAULT 100,
+  tourism_index integer NOT NULL DEFAULT 100,
+  music_market_size integer NOT NULL DEFAULT 100,
+  local_audience_demand integer NOT NULL DEFAULT 100,
+  business_confidence_index integer NOT NULL DEFAULT 100,
+  employment_index integer NOT NULL DEFAULT 100,
+  infrastructure_quality_index integer NOT NULL DEFAULT 100,
+  safety_risk_index integer NOT NULL DEFAULT 100,
+  inflation_pressure_index integer NOT NULL DEFAULT 100,
+  economic_trend public.city_economic_trend NOT NULL DEFAULT 'stable',
+  last_calculated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  configuration_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT city_profile_currency_format CHECK (primary_currency_code ~ '^[A-Z]{3}$'),
+  CONSTRAINT city_profile_indices_bounded CHECK (
+    prosperity_index BETWEEN 1 AND 250 AND cost_of_living_index BETWEEN 1 AND 250 AND commercial_rent_index BETWEEN 1 AND 300 AND
+    residential_rent_index BETWEEN 1 AND 300 AND wage_index BETWEEN 1 AND 250 AND utility_cost_index BETWEEN 1 AND 250 AND
+    fuel_cost_index BETWEEN 1 AND 250 AND accommodation_cost_index BETWEEN 1 AND 300 AND transport_cost_index BETWEEN 1 AND 250 AND
+    consumer_spending_index BETWEEN 1 AND 250 AND tourism_index BETWEEN 1 AND 250 AND music_market_size BETWEEN 1 AND 250 AND
+    local_audience_demand BETWEEN 1 AND 250 AND business_confidence_index BETWEEN 1 AND 250 AND employment_index BETWEEN 1 AND 250 AND
+    infrastructure_quality_index BETWEEN 1 AND 250 AND safety_risk_index BETWEEN 1 AND 250 AND inflation_pressure_index BETWEEN 1 AND 250)
+);
+
+CREATE TABLE IF NOT EXISTS public.city_treasury_profiles (
+  city_id uuid PRIMARY KEY REFERENCES public.cities(id) ON DELETE CASCADE,
+  treasury_account_id uuid NOT NULL UNIQUE REFERENCES public.financial_accounts(id),
+  financial_status text NOT NULL DEFAULT 'stable',
+  upcoming_obligations_minor bigint NOT NULL DEFAULT 0 CHECK (upcoming_obligations_minor >= 0),
+  budget_allocations_minor bigint NOT NULL DEFAULT 0 CHECK (budget_allocations_minor >= 0),
+  funding_commitments_minor bigint NOT NULL DEFAULT 0 CHECK (funding_commitments_minor >= 0),
+  public_summary_enabled boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE TABLE IF NOT EXISTS public.city_budgets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, period_start date NOT NULL, period_end date NOT NULL,
+  opening_treasury_balance_minor bigint NOT NULL DEFAULT 0, forecast_revenue_minor bigint NOT NULL DEFAULT 0, forecast_expenses_minor bigint NOT NULL DEFAULT 0,
+  actual_revenue_minor bigint NOT NULL DEFAULT 0, actual_expenses_minor bigint NOT NULL DEFAULT 0, reserved_commitments_minor bigint NOT NULL DEFAULT 0, closing_balance_minor bigint NOT NULL DEFAULT 0,
+  spending_allocations jsonb NOT NULL DEFAULT '{}'::jsonb, status public.city_budget_status NOT NULL DEFAULT 'draft', created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), approved_at timestamptz, closed_at timestamptz,
+  CONSTRAINT city_budget_period CHECK (period_end >= period_start), UNIQUE(city_id, period_start, period_end)
+);
+
+CREATE TABLE IF NOT EXISTS public.city_genre_demands (
+  city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, genre_id uuid, genre_name text NOT NULL,
+  popularity_index integer NOT NULL DEFAULT 100 CHECK (popularity_index BETWEEN 1 AND 250), trend public.city_economic_trend NOT NULL DEFAULT 'stable', audience_size integer NOT NULL DEFAULT 0 CHECK (audience_size >= 0), competition_index integer NOT NULL DEFAULT 100 CHECK (competition_index BETWEEN 1 AND 250), last_calculated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  PRIMARY KEY(city_id, genre_name)
+);
+
+CREATE TABLE IF NOT EXISTS public.city_temporary_effects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, event_name text NOT NULL, source_type text NOT NULL DEFAULT 'admin', source_id uuid,
+  starts_at timestamptz NOT NULL, ends_at timestamptz NOT NULL, strength_basis_points integer NOT NULL DEFAULT 1000 CHECK (strength_basis_points BETWEEN 0 AND 5000), affected_categories text[] NOT NULL DEFAULT '{}', status public.city_effect_status NOT NULL DEFAULT 'scheduled', created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  CONSTRAINT city_effect_period CHECK (ends_at >= starts_at)
+);
+
+CREATE TABLE IF NOT EXISTS public.city_economic_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, period_start date NOT NULL, period_end date NOT NULL,
+  population bigint NOT NULL DEFAULT 0, active_players integer NOT NULL DEFAULT 0, prosperity_index integer NOT NULL DEFAULT 100, cost_of_living_index integer NOT NULL DEFAULT 100,
+  commercial_rent_index integer NOT NULL DEFAULT 100, residential_rent_index integer NOT NULL DEFAULT 100, wage_index integer NOT NULL DEFAULT 100, utility_cost_index integer NOT NULL DEFAULT 100,
+  fuel_cost_index integer NOT NULL DEFAULT 100, accommodation_cost_index integer NOT NULL DEFAULT 100, consumer_spending_index integer NOT NULL DEFAULT 100, tourism_index integer NOT NULL DEFAULT 100,
+  music_demand_index integer NOT NULL DEFAULT 100, company_count integer NOT NULL DEFAULT 0, active_employee_count integer NOT NULL DEFAULT 0, vacancies integer NOT NULL DEFAULT 0,
+  company_revenue_minor bigint NOT NULL DEFAULT 0, company_payroll_minor bigint NOT NULL DEFAULT 0, gig_activity integer NOT NULL DEFAULT 0, ticket_sales_minor bigint NOT NULL DEFAULT 0,
+  accommodation_usage integer NOT NULL DEFAULT 0, treasury_income_minor bigint NOT NULL DEFAULT 0, treasury_expenses_minor bigint NOT NULL DEFAULT 0, treasury_balance_minor bigint NOT NULL DEFAULT 0,
+  economic_trend public.city_economic_trend NOT NULL DEFAULT 'stable', created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), UNIQUE(city_id, period_start, period_end)
+);
+
+CREATE TABLE IF NOT EXISTS public.city_grant_programmes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, name text NOT NULL, grant_type text NOT NULL,
+  eligibility_rules jsonb NOT NULL DEFAULT '{}'::jsonb, available_budget_minor bigint NOT NULL CHECK (available_budget_minor >= 0), award_amount_minor bigint NOT NULL CHECK (award_amount_minor > 0), recipient_type public.financial_owner_type NOT NULL CHECK (recipient_type IN ('player','band','company','venue')),
+  status public.city_grant_status NOT NULL DEFAULT 'draft', approved_by_profile_id uuid REFERENCES public.profiles(id), linked_budget_id uuid REFERENCES public.city_budgets(id), created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), paid_out_minor bigint NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS public.city_grant_applications (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), programme_id uuid NOT NULL REFERENCES public.city_grant_programmes(id) ON DELETE CASCADE, applicant_profile_id uuid REFERENCES public.profiles(id), recipient_type public.financial_owner_type NOT NULL, recipient_id uuid NOT NULL, status public.city_grant_status NOT NULL DEFAULT 'applied', application_note text, reviewed_by_profile_id uuid REFERENCES public.profiles(id), created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), reviewed_at timestamptz, UNIQUE(programme_id, recipient_type, recipient_id));
+CREATE TABLE IF NOT EXISTS public.city_grant_awards (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), application_id uuid UNIQUE REFERENCES public.city_grant_applications(id) ON DELETE CASCADE, programme_id uuid NOT NULL REFERENCES public.city_grant_programmes(id) ON DELETE CASCADE, city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, recipient_type public.financial_owner_type NOT NULL, recipient_id uuid NOT NULL, amount_minor bigint NOT NULL CHECK (amount_minor > 0), status public.city_grant_status NOT NULL DEFAULT 'approved', approved_by_profile_id uuid REFERENCES public.profiles(id), transaction_id uuid UNIQUE REFERENCES public.financial_transactions(id), idempotency_key text NOT NULL UNIQUE, created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), paid_at timestamptz);
+
+CREATE TABLE IF NOT EXISTS public.city_licence_schedules (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, licence_type text NOT NULL, company_type text, operating_tier public.company_operating_tier, base_amount_minor bigint NOT NULL CHECK (base_amount_minor >= 0), frequency public.recurring_obligation_frequency NOT NULL DEFAULT 'monthly', grace_period_days integer NOT NULL DEFAULT 14, is_active boolean NOT NULL DEFAULT true, effective_from date NOT NULL DEFAULT CURRENT_DATE, effective_to date, metadata jsonb NOT NULL DEFAULT '{}'::jsonb);
+CREATE UNIQUE INDEX IF NOT EXISTS city_licence_schedules_unique_idx ON public.city_licence_schedules(city_id, licence_type, COALESCE(company_type,'*'), COALESCE(operating_tier::text,'*'), effective_from);
+CREATE TABLE IF NOT EXISTS public.city_spending_initiatives (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), city_id uuid NOT NULL REFERENCES public.cities(id) ON DELETE CASCADE, spending_category text NOT NULL, amount_minor bigint NOT NULL CHECK (amount_minor > 0), starts_at timestamptz NOT NULL, ends_at timestamptz NOT NULL, target_metric text NOT NULL, effect_strength_basis_points integer NOT NULL CHECK (effect_strength_basis_points BETWEEN 0 AND 5000), decay_basis_points integer NOT NULL DEFAULT 10000 CHECK (decay_basis_points BETWEEN 0 AND 10000), source_budget_id uuid REFERENCES public.city_budgets(id), linked_transaction_id uuid UNIQUE REFERENCES public.financial_transactions(id), status public.city_effect_status NOT NULL DEFAULT 'scheduled', created_at timestamptz NOT NULL DEFAULT timezone('utc', now()));
+CREATE TABLE IF NOT EXISTS public.city_economic_audit_events (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), actor_profile_id uuid REFERENCES public.profiles(id), action text NOT NULL, city_id uuid REFERENCES public.cities(id) ON DELETE CASCADE, related_entity_type text, related_entity_id uuid, previous_value jsonb, new_value jsonb, reason text, created_at timestamptz NOT NULL DEFAULT timezone('utc', now()), metadata jsonb NOT NULL DEFAULT '{}'::jsonb);
+
+CREATE OR REPLACE FUNCTION public.city_index_label(p_index integer) RETURNS text LANGUAGE sql IMMUTABLE AS $$ SELECT CASE WHEN p_index < 70 THEN 'Very low' WHEN p_index < 85 THEN 'Low' WHEN p_index < 95 THEN 'Below average' WHEN p_index <= 105 THEN 'Average' WHEN p_index <= 120 THEN 'Above average' WHEN p_index <= 140 THEN 'High' ELSE 'Very high' END $$;
+
+CREATE OR REPLACE FUNCTION public.city_price_quote(p_city_id uuid, p_base_amount_minor bigint, p_cost_category text, p_existing_modifier_basis_points integer DEFAULT 10000, p_context jsonb DEFAULT '{}'::jsonb)
+RETURNS jsonb LANGUAGE plpgsql STABLE SET search_path=public AS $$
+DECLARE p public.city_economic_profiles; idx integer := 100; event_bp integer := 10000; city_bp integer; final_amount bigint; applied text[] := ARRAY[]::text[];
+BEGIN
+  IF p_base_amount_minor < 0 THEN RAISE EXCEPTION 'base amount cannot be negative'; END IF;
+  SELECT * INTO p FROM public.city_economic_profiles WHERE city_id=p_city_id;
+  IF p.city_id IS NULL THEN idx := 100; ELSE
+    idx := CASE p_cost_category WHEN 'cost_of_living' THEN p.cost_of_living_index WHEN 'commercial_rent' THEN p.commercial_rent_index WHEN 'residential_rent' THEN p.residential_rent_index WHEN 'wage' THEN p.wage_index WHEN 'utilities' THEN p.utility_cost_index WHEN 'fuel' THEN p.fuel_cost_index WHEN 'accommodation' THEN p.accommodation_cost_index WHEN 'transport' THEN p.transport_cost_index ELSE 100 END;
+  END IF;
+  city_bp := GREATEST(5000, LEAST(20000, idx * 100));
+  SELECT COALESCE(10000 + SUM(strength_basis_points),10000) INTO event_bp FROM public.city_temporary_effects WHERE city_id=p_city_id AND status='active' AND now() BETWEEN starts_at AND ends_at AND p_cost_category = ANY(affected_categories);
+  event_bp := GREATEST(7500, LEAST(15000, event_bp));
+  final_amount := GREATEST(0, (p_base_amount_minor * city_bp * event_bp * GREATEST(1000, LEAST(30000, p_existing_modifier_basis_points)) + 500000000000) / 1000000000000);
+  IF idx <> 100 THEN applied := applied || format('%s city index %s (%s)', p_cost_category, idx, public.city_index_label(idx)); END IF;
+  IF event_bp <> 10000 THEN applied := applied || format('temporary event pressure %s bp', event_bp); END IF;
+  RETURN jsonb_build_object('baseAmountMinor',p_base_amount_minor,'cityId',p_city_id,'costCategory',p_cost_category,'cityMultiplierBasisPoints',city_bp,'eventMultiplierBasisPoints',event_bp,'existingModifierBasisPoints',p_existing_modifier_basis_points,'finalAmountMinor',final_amount,'rounding','nearest minor unit after bounded basis-point stacking','explanation',applied);
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.city_wage_guidance(p_city_id uuid, p_role_key text)
+RETURNS jsonb LANGUAGE plpgsql STABLE SET search_path=public AS $$
+DECLARE base bigint; quote jsonb; amount bigint;
+BEGIN
+  SELECT COALESCE(salary_guidance_minor,50000) INTO base FROM public.employment_role_definitions WHERE role_key=p_role_key;
+  quote := public.city_price_quote(p_city_id, COALESCE(base,50000), 'wage'); amount := (quote->>'finalAmountMinor')::bigint;
+  RETURN quote || jsonb_build_object('roleKey',p_role_key,'recommendedWageMinor',amount,'minimumMarketMinor',(amount*85)/100,'maximumMarketMinor',(amount*120)/100);
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.city_local_audience_demand(p_city_id uuid, p_genre_name text, p_band_fame integer DEFAULT 50, p_ticket_price_minor bigint DEFAULT 2500, p_venue_capacity integer DEFAULT 100, p_competition_index integer DEFAULT 100)
+RETURNS jsonb LANGUAGE plpgsql STABLE SET search_path=public AS $$
+DECLARE p public.city_economic_profiles; g public.city_genre_demands; demand_bp integer; price_bp integer; audience integer; positives text[] := ARRAY[]::text[]; negatives text[] := ARRAY[]::text[];
+BEGIN
+  SELECT * INTO p FROM public.city_economic_profiles WHERE city_id=p_city_id; IF p.city_id IS NULL THEN p.local_audience_demand := 100; p.consumer_spending_index := 100; p.tourism_index := 100; p.music_market_size := 100; END IF;
+  SELECT * INTO g FROM public.city_genre_demands WHERE city_id=p_city_id AND lower(genre_name)=lower(p_genre_name) LIMIT 1; IF g.city_id IS NULL THEN g.popularity_index := 100; g.competition_index := 100; END IF;
+  demand_bp := GREATEST(3000, LEAST(25000, (p.local_audience_demand*35 + p.music_market_size*25 + p.consumer_spending_index*15 + p.tourism_index*10 + g.popularity_index*15)));
+  price_bp := GREATEST(6000, LEAST(14000, 11000 - ((GREATEST(0,p_ticket_price_minor-2500)/100))::integer));
+  audience := LEAST(GREATEST(0,p_venue_capacity), GREATEST(0, (p_venue_capacity * demand_bp * price_bp * GREATEST(1000, LEAST(20000, 5000 + p_band_fame*100)))/(10000*10000*10000)));
+  IF p.consumer_spending_index > 110 THEN positives := positives || 'high local consumer spending'; END IF; IF p.tourism_index > 110 THEN positives := positives || 'tourism expands reachable audience'; END IF; IF g.popularity_index > 110 THEN positives := positives || 'genre is locally popular'; END IF;
+  IF p_ticket_price_minor > 5000 THEN negatives := negatives || 'ticket price increases sensitivity'; END IF; IF p_competition_index > 120 OR g.competition_index > 120 THEN negatives := negatives || 'local competition is elevated'; END IF;
+  RETURN jsonb_build_object('estimatedPotentialAudience',audience,'priceSensitivityBasisPoints',price_bp,'demandConfidenceRange',jsonb_build_object('low',GREATEST(0,(audience*85)/100),'high',LEAST(p_venue_capacity,(audience*115)/100)),'demandMultiplierBasisPoints',demand_bp,'keyPositiveModifiers',positives,'keyNegativeModifiers',negatives);
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.ensure_city_economy_foundations() RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE r record; acct public.financial_accounts; n integer := 0; pop bigint; scale public.city_scale;
+BEGIN
+  FOR r IN SELECT * FROM public.cities LOOP
+    pop := COALESCE(r.population,100000); scale := CASE WHEN pop >= 8000000 THEN 'global_city'::public.city_scale WHEN pop >= 2500000 THEN 'major_city'::public.city_scale WHEN pop >= 750000 THEN 'regional_city'::public.city_scale WHEN pop >= 150000 THEN 'small_city'::public.city_scale ELSE 'town'::public.city_scale END;
+    INSERT INTO public.city_economic_profiles(city_id,country_code,primary_currency_code,population,city_scale,prosperity_index,cost_of_living_index,commercial_rent_index,residential_rent_index,wage_index,utility_cost_index,fuel_cost_index,accommodation_cost_index,transport_cost_index,consumer_spending_index,tourism_index,music_market_size,local_audience_demand,business_confidence_index,employment_index,infrastructure_quality_index,configuration_metadata)
+    VALUES(r.id, COALESCE(r.country,'Unknown'), COALESCE(r.primary_currency_code,'USD'), pop, scale, LEAST(160,90 + (pop/1000000)::int*4), LEAST(170,85 + (pop/1000000)::int*5), LEAST(190,80 + (pop/1000000)::int*7), LEAST(180,82 + (pop/1000000)::int*6), LEAST(170,88 + (pop/1000000)::int*4), 100, 100, LEAST(180,85 + (pop/1000000)::int*5), 100, LEAST(165,90 + (pop/1000000)::int*3), LEAST(170,85 + (pop/1000000)::int*4), LEAST(180,80 + (pop/1000000)::int*5), LEAST(175,85 + (pop/1000000)::int*4), 100, 100, 100, jsonb_build_object('baseline','gameplay-balanced seed from city population and existing metadata'))
+    ON CONFLICT (city_id) DO NOTHING;
+    acct := public.get_or_create_primary_financial_account('city', r.id, r.name || ' city treasury', COALESCE(r.primary_currency_code,'USD'));
+    INSERT INTO public.city_treasury_profiles(city_id,treasury_account_id) VALUES(r.id,acct.id) ON CONFLICT (city_id) DO NOTHING;
+    n := n + 1;
+  END LOOP;
+  RETURN n;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.city_collect_business_licence_fee(p_company_id uuid, p_idempotency_key text)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE c record; sched record; quote jsonb; amount bigint; tx uuid;
+BEGIN
+  SELECT id, company_type, operating_tier, headquarters_city_id INTO c FROM public.companies WHERE id=p_company_id;
+  IF c.id IS NULL THEN RAISE EXCEPTION 'company not found'; END IF; IF c.headquarters_city_id IS NULL THEN RAISE EXCEPTION 'company city is required'; END IF;
+  SELECT * INTO sched FROM public.city_licence_schedules WHERE city_id=c.headquarters_city_id AND is_active AND licence_type='business' AND (company_type IS NULL OR company_type=c.company_type) AND (operating_tier IS NULL OR operating_tier=c.operating_tier) ORDER BY company_type NULLS LAST, operating_tier NULLS LAST LIMIT 1;
+  IF sched.id IS NULL THEN amount := 2500; ELSE amount := sched.base_amount_minor; END IF;
+  quote := public.city_price_quote(c.headquarters_city_id, amount, 'commercial_rent'); amount := (quote->>'finalAmountMinor')::bigint;
+  SELECT public.finance_transfer('company',p_company_id,'city',c.headquarters_city_id,amount,'city_business_licence_fee','City business licence fee',p_idempotency_key,'city_licence_schedule',sched.id,NULL,quote) INTO tx;
+  INSERT INTO public.city_economic_audit_events(action,city_id,related_entity_type,related_entity_id,new_value,reason) VALUES('business_licence_fee_collected',c.headquarters_city_id,'company',p_company_id,jsonb_build_object('amountMinor',amount,'transactionId',tx),'server-side licence collection');
+  RETURN tx;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.city_pay_grant_award(p_award_id uuid)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE a record; tx uuid;
+BEGIN
+  SELECT * INTO a FROM public.city_grant_awards WHERE id=p_award_id FOR UPDATE;
+  IF a.id IS NULL THEN RAISE EXCEPTION 'award not found'; END IF; IF a.status='paid' AND a.transaction_id IS NOT NULL THEN RETURN a.transaction_id; END IF; IF a.status <> 'approved' THEN RAISE EXCEPTION 'award is not approved'; END IF;
+  SELECT public.finance_transfer('city',a.city_id,a.recipient_type,a.recipient_id,a.amount_minor,'city_grant_payment','City grant award',a.idempotency_key,'city_grant_award',a.id,NULL,'{}'::jsonb) INTO tx;
+  UPDATE public.city_grant_awards SET status='paid', transaction_id=tx, paid_at=timezone('utc',now()) WHERE id=a.id;
+  UPDATE public.city_grant_programmes SET paid_out_minor=paid_out_minor+a.amount_minor WHERE id=a.programme_id;
+  RETURN tx;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.generate_city_economic_snapshot(p_city_id uuid, p_period_start date, p_period_end date)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE p public.city_economic_profiles; acct public.financial_accounts; snap uuid;
+BEGIN
+  SELECT * INTO p FROM public.city_economic_profiles WHERE city_id=p_city_id; IF p.city_id IS NULL THEN PERFORM public.ensure_city_economy_foundations(); SELECT * INTO p FROM public.city_economic_profiles WHERE city_id=p_city_id; END IF;
+  SELECT * INTO acct FROM public.financial_accounts WHERE owner_type='city' AND owner_id=p_city_id AND is_primary LIMIT 1;
+  INSERT INTO public.city_economic_snapshots(city_id,period_start,period_end,population,active_players,prosperity_index,cost_of_living_index,commercial_rent_index,residential_rent_index,wage_index,utility_cost_index,fuel_cost_index,accommodation_cost_index,consumer_spending_index,tourism_index,music_demand_index,company_count,active_employee_count,vacancies,company_revenue_minor,company_payroll_minor,gig_activity,ticket_sales_minor,treasury_balance_minor,economic_trend)
+  SELECT p_city_id,p_period_start,p_period_end,p.population,p.active_player_population,p.prosperity_index,p.cost_of_living_index,p.commercial_rent_index,p.residential_rent_index,p.wage_index,p.utility_cost_index,p.fuel_cost_index,p.accommodation_cost_index,p.consumer_spending_index,p.tourism_index,p.local_audience_demand,
+    (SELECT count(*) FROM public.companies c WHERE c.headquarters_city_id=p_city_id), (SELECT count(*) FROM public.company_employees e JOIN public.companies c ON c.id=e.company_id WHERE c.headquarters_city_id=p_city_id AND e.status='active'), (SELECT count(*) FROM public.company_job_advertisements j JOIN public.companies c ON c.id=j.company_id WHERE c.headquarters_city_id=p_city_id AND j.status='published'),
+    0, (SELECT COALESCE(sum(net_pay_minor),0) FROM public.company_payroll_lines l JOIN public.company_payroll_batches b ON b.id=l.batch_id JOIN public.companies c ON c.id=b.company_id WHERE c.headquarters_city_id=p_city_id), (SELECT count(*) FROM public.gigs g JOIN public.venues v ON v.id=g.venue_id WHERE v.city_id=p_city_id), 0, COALESCE(acct.current_balance_minor,0), p.economic_trend
+  ON CONFLICT(city_id,period_start,period_end) DO UPDATE SET treasury_balance_minor=EXCLUDED.treasury_balance_minor, created_at=timezone('utc',now()) RETURNING id INTO snap;
+  RETURN snap;
+END; $$;
+
+CREATE OR REPLACE VIEW public.city_economy_public_view AS SELECT c.id city_id, c.name city_name, c.country country_code, p.primary_currency_code, p.population, p.city_scale, p.prosperity_index, public.city_index_label(p.prosperity_index) prosperity_label, p.cost_of_living_index, public.city_index_label(p.cost_of_living_index) cost_of_living_label, p.commercial_rent_index, p.residential_rent_index, p.wage_index, p.utility_cost_index, p.fuel_cost_index, p.accommodation_cost_index, p.transport_cost_index, p.consumer_spending_index, p.tourism_index, p.music_market_size, p.local_audience_demand, p.business_confidence_index, p.employment_index, p.infrastructure_quality_index, p.economic_trend, fa.current_balance_minor treasury_balance_minor FROM public.cities c JOIN public.city_economic_profiles p ON p.city_id=c.id LEFT JOIN public.city_treasury_profiles tp ON tp.city_id=c.id LEFT JOIN public.financial_accounts fa ON fa.id=tp.treasury_account_id AND tp.public_summary_enabled;
+CREATE OR REPLACE VIEW public.city_economy_integrity_issues AS SELECT 'missing_economic_profile' issue_type, c.id::text subject_id FROM public.cities c LEFT JOIN public.city_economic_profiles p ON p.city_id=c.id WHERE p.city_id IS NULL UNION ALL SELECT 'missing_treasury_account', c.id::text FROM public.cities c LEFT JOIN public.city_treasury_profiles tp ON tp.city_id=c.id WHERE tp.city_id IS NULL UNION ALL SELECT 'invalid_index_values', city_id::text FROM public.city_economic_profiles WHERE NOT (prosperity_index BETWEEN 1 AND 250 AND cost_of_living_index BETWEEN 1 AND 250) UNION ALL SELECT 'expired_effect_still_active', id::text FROM public.city_temporary_effects WHERE status='active' AND ends_at < now() UNION ALL SELECT 'grant_payment_without_transaction', id::text FROM public.city_grant_awards WHERE status='paid' AND transaction_id IS NULL;
+
+ALTER TABLE public.city_economic_profiles ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_treasury_profiles ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_budgets ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_genre_demands ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_temporary_effects ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_economic_snapshots ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_grant_programmes ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_grant_applications ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_grant_awards ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_licence_schedules ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_spending_initiatives ENABLE ROW LEVEL SECURITY; ALTER TABLE public.city_economic_audit_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS city_economic_profiles_public_select ON public.city_economic_profiles;
+DROP POLICY IF EXISTS city_treasury_profiles_public_select ON public.city_treasury_profiles;
+DROP POLICY IF EXISTS city_budgets_public_select ON public.city_budgets;
+DROP POLICY IF EXISTS city_genre_demands_public_select ON public.city_genre_demands;
+DROP POLICY IF EXISTS city_temporary_effects_public_select ON public.city_temporary_effects;
+DROP POLICY IF EXISTS city_economic_snapshots_public_select ON public.city_economic_snapshots;
+DROP POLICY IF EXISTS city_grant_programmes_public_select ON public.city_grant_programmes;
+CREATE POLICY city_economic_profiles_public_select ON public.city_economic_profiles FOR SELECT USING (true);
+CREATE POLICY city_treasury_profiles_public_select ON public.city_treasury_profiles FOR SELECT USING (public_summary_enabled);
+CREATE POLICY city_budgets_public_select ON public.city_budgets FOR SELECT USING (status IN ('active','closed','adjusted'));
+CREATE POLICY city_genre_demands_public_select ON public.city_genre_demands FOR SELECT USING (true);
+CREATE POLICY city_temporary_effects_public_select ON public.city_temporary_effects FOR SELECT USING (status IN ('active','scheduled'));
+CREATE POLICY city_economic_snapshots_public_select ON public.city_economic_snapshots FOR SELECT USING (true);
+CREATE POLICY city_grant_programmes_public_select ON public.city_grant_programmes FOR SELECT USING (status IN ('open','closed','exhausted'));
+
+SELECT public.ensure_city_economy_foundations();
+INSERT INTO public.city_licence_schedules(city_id, licence_type, company_type, operating_tier, base_amount_minor)
+SELECT id, 'business', NULL, NULL, 2500 FROM public.cities ON CONFLICT DO NOTHING;
+INSERT INTO public.city_genre_demands(city_id, genre_name, popularity_index, audience_size, competition_index)
+SELECT c.id, g.genre, 85 + ((abs(hashtext(c.name || g.genre)) % 50)), GREATEST(1000, COALESCE(c.population,100000)/100), 80 + ((abs(hashtext(g.genre || c.name)) % 60))
+FROM public.cities c CROSS JOIN (VALUES ('Rock'),('Pop'),('Metal'),('Electronic'),('Hip Hop'),('Indie')) AS g(genre) ON CONFLICT DO NOTHING;

--- a/supabase/tests/finance_phase4_city_economies_harness.sql
+++ b/supabase/tests/finance_phase4_city_economies_harness.sql
@@ -1,0 +1,28 @@
+\i supabase/migrations/20260717090000_finance_phase1_ledger.sql
+\i supabase/migrations/20260717120000_finance_phase2_player_band_management.sql
+\i supabase/migrations/20260717153000_finance_phase3_company_operations.sql
+\i supabase/migrations/20260717170000_finance_phase4_city_economies.sql
+
+DO $$
+DECLARE city_a uuid; city_b uuid; company_id uuid; quote_a jsonb; quote_b jsonb; tx uuid; award uuid; snap uuid;
+BEGIN
+  SELECT id INTO city_a FROM public.cities ORDER BY population NULLS LAST LIMIT 1;
+  SELECT id INTO city_b FROM public.cities WHERE id <> city_a ORDER BY population DESC NULLS LAST LIMIT 1;
+  IF city_a IS NULL OR city_b IS NULL THEN RAISE EXCEPTION 'expected at least two cities'; END IF;
+  IF EXISTS (SELECT 1 FROM public.city_economy_integrity_issues WHERE issue_type IN ('missing_economic_profile','missing_treasury_account','invalid_index_values')) THEN RAISE EXCEPTION 'city economy integrity issues exist'; END IF;
+
+  quote_a := public.city_price_quote(city_a, 10000, 'commercial_rent');
+  quote_b := public.city_price_quote(city_b, 10000, 'commercial_rent');
+  IF (quote_a->>'finalAmountMinor')::bigint < 0 OR (quote_b->>'finalAmountMinor')::bigint < 0 THEN RAISE EXCEPTION 'negative city price quote'; END IF;
+
+  INSERT INTO public.companies(name, owner_id, company_type, headquarters_city_id, operating_tier) SELECT 'Phase 4 Harness Company', id, 'venue', city_a, 'micro' FROM public.profiles LIMIT 1 RETURNING id INTO company_id;
+  IF company_id IS NOT NULL THEN
+    PERFORM public.finance_credit_owner('company', company_id, 100000, 'owner_investment', 'Harness company float', 'phase4-company-float-' || company_id);
+    tx := public.city_collect_business_licence_fee(company_id, 'phase4-licence-' || company_id);
+    IF NOT EXISTS (SELECT 1 FROM public.financial_transactions WHERE id=tx AND transaction_category='city_business_licence_fee') THEN RAISE EXCEPTION 'licence transaction missing'; END IF;
+  END IF;
+
+  INSERT INTO public.city_grant_programmes(city_id,name,grant_type,available_budget_minor,award_amount_minor,recipient_type,status) VALUES(city_a,'Harness Music Grant','local_artist_support',50000,10000,'company','open') RETURNING id INTO award;
+  snap := public.generate_city_economic_snapshot(city_a, CURRENT_DATE - 7, CURRENT_DATE);
+  IF snap IS NULL THEN RAISE EXCEPTION 'snapshot not generated'; END IF;
+END $$;


### PR DESCRIPTION
### Motivation
- Introduce a canonical city economy layer so each city meaningfully affects costs, demand and municipal finances without coupling to national taxation yet.
- Provide ledger-backed city treasuries, auditable revenue/expense flows and a central pricing/demand calculation service to replace scattered hard-coded regional modifiers.
- Seed playable defaults and admin tooling so gameplay systems (companies, gigs, travel, venues) can consume consistent city modifiers and produce reproducible snapshots and trends.

### Description
- Database: adds a migration `supabase/migrations/20260717170000_finance_phase4_city_economies.sql` that creates `city_economic_profiles`, `city_treasury_profiles`, `city_budgets`, `city_economic_snapshots`, `city_genre_demands`, `city_temporary_effects`, `city_grant_*`, `city_licence_schedules`, `city_spending_initiatives`, audit events, public views and integrity checks; seeds licence schedules and genre demand; and provides server-side functions `city_price_quote`, `city_wage_guidance`, `city_local_audience_demand`, `ensure_city_economy_foundations`, `city_collect_business_licence_fee`, `city_pay_grant_award` and `generate_city_economic_snapshot` for idempotent, ledger-backed flows.
- Application lib: adds `src/lib/cityEconomy.ts` implementing the client/server-safe calculation helpers (profile validation, bounded index labels, `quoteCityPrice` pattern, wage guidance and local audience demand) and unitable logic for modifier stacking and rounding.
- Tests: adds `src/lib/cityEconomy.test.ts` with unit scenarios for profile validation, price quoting, bounded event pressure, wage guidance and demand differences.
- UI/UX: adds presentational components `src/features/city-economy/CityEconomyPanels.tsx` for city overview, comparison, company insights, tour planning signals and admin controls to expose player-facing information and explanations.
- Docs & inventory: new Phase 4 design doc `docs/finance/FINANCE_PHASE4_CITY_ECONOMIES.md` and updates to `docs/finance/FINANCIAL_FLOW_INVENTORY.md` describing migrations, integrations, limitations and Phase 5 guidance.
- DB harness: adds `supabase/tests/finance_phase4_city_economies_harness.sql` to validate integrity, quoting and basic flows in a Supabase/psql environment.

### Testing
- `npm run typecheck` (`tsc --noEmit`) passed locally, confirming TypeScript surface checks succeeded.
- `git diff --check` passed, ensuring no whitespace/merge-errors in the diff.
- Unit tests (`npm run test:unit -- src/lib/cityEconomy.test.ts`) could not be executed in this environment because `vitest` is not installed and `npm install` failed due to an external registry 403 for a dependency, so unit assertions were not run here.
- Build (`npm run build`) and lint (`npm run lint`) could not be completed in this environment because dev tools (`vite`, `@eslint/js`) are not available; these should be run in CI where dev dependencies are resolvable.
- Supabase DB harness (`supabase`/`psql`) was not executed because the environment lacks the required CLI and DB connection; the harness SQL was added and is idempotent for use in an integration DB job.

Runbook: to fully validate this PR run CI with `npm ci` then `npm run test:unit`, `npm run lint`, `npm run build`, and execute `supabase`/`psql` harness `supabase/tests/finance_phase4_city_economies_harness.sql` against a populated test DB.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a605016608325bc1bdf0317afdfec)