### PR TITLE
Implement universal financial obligations dashboard & scheduler integration

### DIFF
--- a/src/components/finance/FinancialObligationsPanel.tsx
+++ b/src/components/finance/FinancialObligationsPanel.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { loadFinancialObligationsDashboard, type CreditHistoryEvent, type CreditScore, type DebtRecord, type FinancialObligation, type ObligationScheduleLine } from "@/services/banking/financialObligations";
+
+const money = (amount: number, currency: string | null = "GBP") => new Intl.NumberFormat("en-GB", { style: "currency", currency: currency ?? "GBP" }).format(amount / 100);
+
+type State = { obligations: FinancialObligation[]; schedule: ObligationScheduleLine[]; debts: DebtRecord[]; creditHistory: CreditHistoryEvent[]; creditScore: CreditScore | null };
+
+export function FinancialObligationsPanel({ profileId }: { profileId?: string }) {
+  const [state, setState] = useState<State | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    loadFinancialObligationsDashboard(profileId).then((data) => { if (alive) setState(data); }).catch((err) => { if (alive) setError(err.message ?? "Unable to load obligations"); });
+    return () => { alive = false; };
+  }, [profileId]);
+
+  if (error) return <Card><CardHeader><CardTitle>Financial obligations</CardTitle><CardDescription>{error}</CardDescription></CardHeader></Card>;
+  if (!state) return <Card><CardHeader><CardTitle>Financial obligations</CardTitle><CardDescription>Loading universal payment schedule…</CardDescription></CardHeader></Card>;
+
+  return <div className="grid gap-6 lg:grid-cols-2">
+    <Card><CardHeader><CardTitle>Upcoming payments</CardTitle><CardDescription>Universal obligations engine covering mortgages, rent, loans, insurance and future recurring bills.</CardDescription></CardHeader><CardContent className="space-y-3">{state.obligations.length === 0 ? <p className="text-sm text-muted-foreground">No active obligations yet.</p> : state.obligations.map((o) => <div key={o.id} className="rounded-lg border p-3"><div className="flex items-center justify-between gap-3"><div><p className="font-semibold capitalize">{o.obligation_type.replaceAll("_", " ")}</p><p className="text-sm text-muted-foreground">Due {o.next_due_date} · {o.frequency} · grace {o.grace_period_days} days</p></div><Badge variant={o.status === "active" ? "default" : "secondary"}>{o.status}</Badge></div><p className="mt-2 text-sm">{money(o.amount_minor, o.currency_code)} due · {money(o.outstanding_balance_minor, o.currency_code)} outstanding · {o.missed_payment_count} missed</p></div>)}</CardContent></Card>
+    <Card><CardHeader><CardTitle>Credit profile</CardTitle><CardDescription>Private server-side score and non-public credit events.</CardDescription></CardHeader><CardContent className="space-y-3"><div className="rounded-lg border p-3"><p className="text-2xl font-bold">{state.creditScore?.credit_score ?? "—"}</p><p className="text-sm text-muted-foreground">{state.creditScore?.credit_band ?? "Building"}</p></div>{state.creditHistory.slice(0, 5).map((e) => <div key={e.id} className="flex justify-between text-sm"><span className="capitalize">{e.event_type.replaceAll("_", " ")}</span><span>{e.event_date} · {e.score_delta > 0 ? "+" : ""}{e.score_delta}</span></div>)}</CardContent></Card>
+    <Card><CardHeader><CardTitle>Payment history</CardTitle></CardHeader><CardContent className="space-y-2">{state.schedule.slice(0, 8).map((s) => <div key={s.id} className="flex justify-between text-sm"><span>{s.due_date}</span><span>{money(s.amount_minor)} · {s.status}</span></div>)}</CardContent></Card>
+    <Card><CardHeader><CardTitle>Debt recovery</CardTitle><CardDescription>Configurable collection stages from reminder through recovery.</CardDescription></CardHeader><CardContent className="space-y-2">{state.debts.length === 0 ? <p className="text-sm text-muted-foreground">No open player debts.</p> : state.debts.map((d) => <div key={d.id} className="rounded-lg border p-3 text-sm"><p className="font-medium capitalize">{d.collection_stage.replaceAll("_", " ")}</p><p>{money(d.outstanding_balance_minor, d.currency_code)} outstanding · {d.status}</p></div>)}</CardContent></Card>
+  </div>;
+}

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -18,6 +18,8 @@ import { FinancialHistoryLedger } from "@/components/finance/FinancialHistoryLed
 import { PlayerFinanceHub } from "@/components/finance/PlayerFinanceHub";
 import { Loader2, DollarSign } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { FinancialObligationsPanel } from "@/components/finance/FinancialObligationsPanel";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
 
 const Finances = () => {
   const [searchParams] = useSearchParams();
@@ -33,6 +35,7 @@ const Finances = () => {
     investmentOptions,
     isLoading,
   } = useFinances();
+  const { profileId } = useActiveProfile();
 
   if (isLoading) {
     return (
@@ -64,6 +67,7 @@ const Finances = () => {
           <TabsTrigger value="bands">Band Treasury</TabsTrigger>
           <TabsTrigger value="investments">Investments</TabsTrigger>
           <TabsTrigger value="loans">Loans</TabsTrigger>
+          <TabsTrigger value="obligations">Obligations</TabsTrigger>
           <Button asChild size="sm" variant="outline"><Link to="/finance/banking">Banking</Link></Button>
           <Button asChild size="sm" variant="outline"><Link to="/finance/properties">Properties</Link></Button>
           <TabsTrigger value="charity">Charity</TabsTrigger>
@@ -113,6 +117,10 @@ const Finances = () => {
             loanOffers={loanOffers}
             cash={summary.cash}
           />
+        </TabsContent>
+
+        <TabsContent value="obligations" className="space-y-6">
+          <FinancialObligationsPanel profileId={profileId ?? undefined} />
         </TabsContent>
 
         <TabsContent value="charity" className="space-y-6">

--- a/src/services/banking/financialObligations.ts
+++ b/src/services/banking/financialObligations.ts
@@ -1,0 +1,45 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type FinancialObligation = {
+  id: string;
+  obligation_type: string;
+  owner_type: string;
+  owner_id: string;
+  linked_asset_type: string | null;
+  linked_asset_id: string | null;
+  amount_minor: number;
+  currency_code: string;
+  frequency: string;
+  next_due_date: string;
+  grace_period_days: number;
+  status: string;
+  missed_payment_count: number;
+  outstanding_balance_minor: number;
+};
+
+export type ObligationScheduleLine = { id: string; obligation_id: string; due_date: string; amount_minor: number; status: string; paid_at: string | null };
+export type DebtRecord = { id: string; obligation_id: string | null; original_amount_minor: number; outstanding_balance_minor: number; currency_code: string; collection_stage: string; status: string; updated_at: string };
+export type CreditHistoryEvent = { id: string; event_type: string; event_date: string; amount_minor: number; currency_code: string | null; score_delta: number };
+export type CreditScore = { credit_score: number; credit_band: string; calculated_at: string };
+
+export async function loadFinancialObligationsDashboard(profileId?: string) {
+  const [obligations, schedule, debts, creditHistory, creditScore] = await Promise.all([
+    supabase.from("financial_obligations").select("id,obligation_type,owner_type,owner_id,linked_asset_type,linked_asset_id,amount_minor,currency_code,frequency,next_due_date,grace_period_days,status,missed_payment_count,outstanding_balance_minor").order("next_due_date", { ascending: true }).limit(25),
+    supabase.from("financial_obligation_schedule").select("id,obligation_id,due_date,amount_minor,status,paid_at").in("status", ["scheduled", "due", "missed", "failed", "paid"]).order("due_date", { ascending: true }).limit(25),
+    profileId ? supabase.from("debt_records").select("id,obligation_id,original_amount_minor,outstanding_balance_minor,currency_code,collection_stage,status,updated_at").eq("owner_type", "player").eq("owner_id", profileId).order("updated_at", { ascending: false }).limit(10) : Promise.resolve({ data: [], error: null }),
+    profileId ? supabase.from("player_credit_history").select("id,event_type,event_date,amount_minor,currency_code,score_delta").eq("profile_id", profileId).order("event_date", { ascending: false }).limit(20) : Promise.resolve({ data: [], error: null }),
+    profileId ? supabase.from("player_credit_scores").select("credit_score,credit_band,calculated_at").eq("profile_id", profileId).maybeSingle() : Promise.resolve({ data: null, error: null }),
+  ]);
+
+  for (const result of [obligations, schedule, debts, creditHistory, creditScore]) {
+    if (result.error) throw result.error;
+  }
+
+  return {
+    obligations: (obligations.data ?? []) as FinancialObligation[],
+    schedule: (schedule.data ?? []) as ObligationScheduleLine[],
+    debts: (debts.data ?? []) as DebtRecord[],
+    creditHistory: (creditHistory.data ?? []) as CreditHistoryEvent[],
+    creditScore: creditScore.data as CreditScore | null,
+  };
+}

--- a/supabase/functions/process-finance-phase2-weekly/index.ts
+++ b/supabase/functions/process-finance-phase2-weekly/index.ts
@@ -6,45 +6,15 @@ Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const supabase = createClient(Deno.env.get("SUPABASE_URL") ?? "", Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "");
   const today = new Date().toISOString().slice(0, 10);
-  const { data: obligations, error } = await supabase
-    .from("recurring_financial_obligations")
-    .select("*")
-    .in("status", ["active", "overdue", "failed"])
-    .lte("next_due_date", today)
-    .eq("auto_pay_enabled", true)
-    .order("priority", { ascending: true })
-    .limit(100);
-  if (error) throw error;
+  const { data, error } = await supabase.rpc("process_due_financial_obligations", {
+    p_as_of_date: today,
+    p_limit: 100,
+  });
 
-  const results = [];
-  for (const obligation of obligations ?? []) {
-    const idempotencyKey = `recurring-${obligation.id}-${obligation.next_due_date}`;
-    const { data: existing } = await supabase.from("recurring_payment_attempts").select("id,status").eq("idempotency_key", idempotencyKey).maybeSingle();
-    if (existing?.status === "paid") { results.push({ obligationId: obligation.id, status: "duplicate_skipped" }); continue; }
-    const { data: tx, error: rpcError } = await supabase.rpc("finance_debit_owner", {
-      p_owner_type: obligation.owner_type,
-      p_owner_id: obligation.owner_id,
-      p_amount_minor: obligation.amount_minor,
-      p_category: obligation.expense_category,
-      p_description: obligation.description,
-      p_idempotency_key: idempotencyKey,
-      p_created_by_profile_id: null,
-      p_metadata: { obligation_id: obligation.id, due_date: obligation.next_due_date },
-    });
-    if (rpcError) {
-      await supabase.from("recurring_payment_attempts").insert({ obligation_id: obligation.id, due_date: obligation.next_due_date, amount_minor: obligation.amount_minor, status: "failed", idempotency_key: idempotencyKey, error_code: rpcError.code, error_message: rpcError.message });
-      await supabase.from("recurring_financial_obligations").update({ status: "overdue", last_attempted_at: new Date().toISOString(), failure_count: (obligation.failure_count ?? 0) + 1 }).eq("id", obligation.id);
-      results.push({ obligationId: obligation.id, status: "failed" });
-      continue;
-    }
-    await supabase.from("recurring_payment_attempts").insert({ obligation_id: obligation.id, due_date: obligation.next_due_date, amount_minor: obligation.amount_minor, status: "paid", transaction_id: tx, idempotency_key: idempotencyKey });
-    const nextDue = new Date(obligation.next_due_date + "T00:00:00Z");
-    if (obligation.frequency === "daily") nextDue.setUTCDate(nextDue.getUTCDate() + 1);
-    if (obligation.frequency === "weekly") nextDue.setUTCDate(nextDue.getUTCDate() + 7);
-    if (obligation.frequency === "monthly") nextDue.setUTCMonth(nextDue.getUTCMonth() + 1);
-    if (obligation.frequency === "custom_interval") nextDue.setUTCDate(nextDue.getUTCDate() + (obligation.custom_interval_days ?? 1));
-    await supabase.from("recurring_financial_obligations").update({ status: "active", last_attempted_at: new Date().toISOString(), last_paid_at: new Date().toISOString(), next_due_date: nextDue.toISOString().slice(0, 10), failure_count: 0 }).eq("id", obligation.id);
-    results.push({ obligationId: obligation.id, status: "paid", transactionId: tx });
+  if (error) {
+    console.error("Universal obligations scheduler failed", error);
+    throw error;
   }
-  return new Response(JSON.stringify({ processed: results.length, results }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+
+  return new Response(JSON.stringify({ processed: data?.attempted ?? 0, result: data, engine: "financial_obligations" }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
 });

--- a/supabase/tests/finance_phase8b5_obligations_credit_harness.sql
+++ b/supabase/tests/finance_phase8b5_obligations_credit_harness.sql
@@ -1,0 +1,36 @@
+-- Finance Phase 8B.5 universal obligations, debt recovery and credit history harness.
+-- Run against a disposable Supabase database after migrations are applied.
+
+BEGIN;
+
+DO $$
+BEGIN
+  ASSERT to_regclass('public.financial_obligations') IS NOT NULL, 'financial_obligations table exists';
+  ASSERT to_regclass('public.financial_obligation_schedule') IS NOT NULL, 'financial_obligation_schedule table exists';
+  ASSERT to_regclass('public.financial_obligation_attempts') IS NOT NULL, 'financial_obligation_attempts table exists';
+  ASSERT to_regclass('public.financial_obligation_events') IS NOT NULL, 'financial_obligation_events table exists';
+  ASSERT to_regclass('public.financial_obligation_status_history') IS NOT NULL, 'financial_obligation_status_history table exists';
+  ASSERT to_regclass('public.debt_records') IS NOT NULL, 'debt_records table exists';
+  ASSERT to_regclass('public.player_credit_history') IS NOT NULL, 'player_credit_history table exists';
+  ASSERT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'process_due_financial_obligations'), 'universal scheduler RPC exists';
+  ASSERT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'process_due_mortgage_repayments'), 'legacy mortgage scheduler delegates to universal scheduler';
+  ASSERT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'create_financial_obligation_from_mortgage'), 'mortgages produce obligations';
+  ASSERT EXISTS (SELECT 1 FROM public.financial_obligation_policies WHERE obligation_type='mortgage' AND default_grace_period_days=7 AND max_attempts=3), 'mortgage retry/grace policy is seeded';
+  ASSERT EXISTS (SELECT 1 FROM public.financial_obligation_policies WHERE obligation_type='insurance' AND default_grace_period_days=0 AND max_attempts=1), 'insurance immediate cancellation/default policy is seeded';
+END $$;
+
+-- Workflow coverage checklist for seeded integration databases:
+-- 1. Successful payment: create an active obligation with funded payment/recipient accounts, schedule due today,
+--    call process_due_financial_obligations as service_role, assert schedule paid, attempt succeeded and transaction balances reconcile.
+-- 2. Failed payment: underfund the payment account, call process_financial_obligation_payment, assert failed attempt records
+--    balance_at_attempt_minor and remaining_shortfall_minor.
+-- 3. Retry and grace period: keep the due date inside grace_expires_at and assert obligation status moves to grace_period,
+--    then retry after funding and assert status returns active.
+-- 4. Escalation/collection: exceed max_attempts or grace_expires_at and assert debt_records plus debt_created events exist.
+-- 5. Credit score update: use a player-owned obligation and assert player_credit_history rows and player_credit_scores recalculation.
+-- 6. Obligation cancellation/completion: call set_financial_obligation_status and exhaust all schedule lines, asserting
+--    status history and completed_at/cancelled events.
+-- 7. Mortgage replacement: complete a mortgage and assert mortgage_schedule_lines are mirrored into
+--    financial_obligation_schedule while recurring_financial_obligations is marked cancelled.
+
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Introduce a single obligations engine and surface to replace bespoke recurring payment loops and provide a foundation for mortgages, rent, loans, insurance, utilities and other recurring payments.
- Expose obligation, schedule, debt and credit score data to the finance UI so players and admins can inspect upcoming payments and private credit state.
- Delegate legacy feature-level schedulers to the new universal RPC so processing, retries, events and collections are centralised and auditable.

### Description
- Route the existing weekly processor to the universal scheduler by calling the `process_due_financial_obligations` RPC from `supabase/functions/process-finance-phase2-weekly/index.ts` instead of the legacy per-feature loop.
- Add a typed loader service `src/services/banking/financialObligations.ts` that queries `financial_obligations`, `financial_obligation_schedule`, `debt_records`, `player_credit_history` and `player_credit_scores` for the dashboard.
- Add a UI panel `src/components/finance/FinancialObligationsPanel.tsx` and wire it into the main finance page at `src/pages/Finances.tsx` under a new `Obligations` tab to show upcoming payments, payment history, debt recovery and private credit profile data.
- Add an integration SQL harness `supabase/tests/finance_phase8b5_obligations_credit_harness.sql` that asserts the presence of the new tables, seeded policies and RPCs and documents the workflow tests to cover success, failure, retry/grace, escalation/collections and credit-score recalculation.

### Testing
- Ran static type checks with `npm run typecheck`, which succeeded.
- Attempted unit tests with `npm run test:unit -- src/services/banking/mortgagePhase8B.test.ts`, which could not run because the local `vitest` binary was not available in the environment.
- Ran `npm run lint`, which could not complete due to a missing local `@eslint/js` package in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dd96c1a748325857c179ef7b032a0)