### PR TITLE
Finance Phase 8B.7: close generic band-expense endpoint and add finance verification CI

### DIFF
--- a/.github/workflows/finance-verification.yml
+++ b/.github/workflows/finance-verification.yml
@@ -1,0 +1,43 @@
+name: Finance verification
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/finance-verification.yml'
+  workflow_dispatch:
+
+jobs:
+  finance-verification:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: npm ci
+      - run: supabase db start
+      - run: supabase db reset
+      - run: supabase db lint
+      - run: supabase test db
+      - run: supabase gen types typescript --local > src/integrations/supabase/types.generated.ts
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm run test -- --run
+      - run: npm run build
+      - name: Browser E2E availability
+        run: |
+          if [ -d tests ] && find tests -name '*.spec.ts' -print -quit | grep -q .; then
+            npx playwright install --with-deps chromium
+            npx playwright test --project=chromium
+          else
+            echo "No browser E2E specs found; finance workflow will run them automatically when specs exist."
+          fi

--- a/docs/finance/FINANCE_PHASE8B7_EXECUTABLE_STABILISATION_AUDIT.md
+++ b/docs/finance/FINANCE_PHASE8B7_EXECUTABLE_STABILISATION_AUDIT.md
@@ -1,0 +1,96 @@
+# Finance Phase 8B.7 executable stabilisation audit
+
+## Scope of this PR
+
+This PR starts Phase 8B.7 by closing the most urgent security gap from PR #1246: the browser-callable generic band-expense payment path. It deliberately does **not** begin Finance Phase 8C.
+
+## Environment diagnostics
+
+Commands recorded in the Codex container on 2026-07-20:
+
+```text
+npm config list
+npm config get registry
+npm config get proxy
+npm config get https-proxy
+env | sort | grep -Ei '(^|_)(http|https|no)_?proxy='
+node -e "const fs=require('fs'); const p='package-lock.json'; if(fs.existsSync(p)){ const lock=JSON.parse(fs.readFileSync(p,'utf8')); const urls=new Set(); for (const pkg of Object.values(lock.packages||{})) if(pkg && pkg.resolved) urls.add(pkg.resolved); console.log([...urls].slice(0,40).join('\n')); console.error('resolved URL count', urls.size); }"
+```
+
+The finance verification workflow avoids installing the Supabase CLI through npm and uses the official `supabase/setup-cli` GitHub Action instead.
+
+## Migration result
+
+A clean Supabase reset could not be completed inside this Codex pass because the local validation environment is not guaranteed to have Docker/Supabase services running. The new CI workflow is now the canonical executable gate and runs:
+
+```text
+npm ci
+supabase db start
+supabase db reset
+supabase db lint
+supabase test db
+supabase gen types typescript --local
+npm run typecheck
+npm run lint
+npm run test -- --run
+npm run build
+```
+
+## Security stabilization performed
+
+- The generic browser confirmation API no longer accepts a browser-supplied destination account.
+- The old `resolve_and_pay_band_expense` function is dropped and replaced by `resolve_and_pay_band_expense_internal`.
+- The internal resolver is explicitly revoked from `PUBLIC`, `anon`, and `authenticated`, and granted only to `service_role`.
+- The authenticated generic confirmation wrapper now returns a structured `requires_feature_booking_confirmation` response instead of moving money.
+- The preview RPC uses `char(3)` currency signatures and no longer calls `get_or_create_band_treasury_account`; missing treasury accounts return `band_treasury_missing`.
+
+## Remaining Phase 8B.7 work
+
+The following acceptance criteria remain for later, narrower PRs:
+
+- Real rehearsal and recording booking wrapper integration.
+- Atomic booking/payment commits.
+- Source-aware refunds.
+- Mortgage trigger and schedule-version repair.
+- Full obligation idempotency and collection-policy repairs.
+- Band treasury and insufficient-funds UI.
+- Behavioural SQL and browser E2E coverage for every supported flow.
+
+## Captured npm/proxy output
+
+```text
+npm config list
+npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+; "env" config from environment
+
+http-proxy = "http://proxy:8080"
+https-proxy = "http://proxy:8080"
+
+; node bin location = /root/.nvm/versions/node/v20.20.2/bin/node
+; node version = v20.20.2
+; npm local prefix = /workspace/rockmundo-genesis-project
+; npm version = 11.4.2
+; cwd = /workspace/rockmundo-genesis-project
+; HOME = /root
+
+npm config get registry
+https://registry.npmjs.org/
+
+npm config get proxy
+null
+
+npm config get https-proxy
+http://proxy:8080
+
+proxy environment variables
+HTTPS_PROXY=http://proxy:8080
+HTTP_PROXY=http://proxy:8080
+NO_PROXY=browser
+YARN_HTTPS_PROXY=http://proxy:8080
+YARN_HTTP_PROXY=http://proxy:8080
+http_proxy=http://proxy:8080
+https_proxy=http://proxy:8080
+no_proxy=localhost,127.0.0.1,::1
+npm_config_http_proxy=http://proxy:8080
+npm_config_https_proxy=http://proxy:8080
+```

--- a/src/components/finance/FinancialObligationsPanel.tsx
+++ b/src/components/finance/FinancialObligationsPanel.tsx
@@ -7,15 +7,15 @@ const money = (amount: number, currency: string | null = "GBP") => new Intl.Numb
 
 type State = { obligations: FinancialObligation[]; schedule: ObligationScheduleLine[]; debts: DebtRecord[]; creditHistory: CreditHistoryEvent[]; creditScore: CreditScore | null };
 
-export function FinancialObligationsPanel({ profileId }: { profileId?: string }) {
+export function FinancialObligationsPanel() {
   const [state, setState] = useState<State | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
-    loadFinancialObligationsDashboard(profileId).then((data) => { if (alive) setState(data); }).catch((err) => { if (alive) setError(err.message ?? "Unable to load obligations"); });
+    loadFinancialObligationsDashboard().then((data) => { if (alive) setState(data); }).catch((err) => { if (alive) setError(err.message ?? "Unable to load obligations"); });
     return () => { alive = false; };
-  }, [profileId]);
+  }, []);
 
   if (error) return <Card><CardHeader><CardTitle>Financial obligations</CardTitle><CardDescription>{error}</CardDescription></CardHeader></Card>;
   if (!state) return <Card><CardHeader><CardTitle>Financial obligations</CardTitle><CardDescription>Loading universal payment schedule…</CardDescription></CardHeader></Card>;
@@ -23,7 +23,7 @@ export function FinancialObligationsPanel({ profileId }: { profileId?: string })
   return <div className="grid gap-6 lg:grid-cols-2">
     <Card><CardHeader><CardTitle>Upcoming payments</CardTitle><CardDescription>Universal obligations engine covering mortgages, rent, loans, insurance and future recurring bills.</CardDescription></CardHeader><CardContent className="space-y-3">{state.obligations.length === 0 ? <p className="text-sm text-muted-foreground">No active obligations yet.</p> : state.obligations.map((o) => <div key={o.id} className="rounded-lg border p-3"><div className="flex items-center justify-between gap-3"><div><p className="font-semibold capitalize">{o.obligation_type.replaceAll("_", " ")}</p><p className="text-sm text-muted-foreground">Due {o.next_due_date} · {o.frequency} · grace {o.grace_period_days} days</p></div><Badge variant={o.status === "active" ? "default" : "secondary"}>{o.status}</Badge></div><p className="mt-2 text-sm">{money(o.amount_minor, o.currency_code)} due · {money(o.outstanding_balance_minor, o.currency_code)} outstanding · {o.missed_payment_count} missed</p></div>)}</CardContent></Card>
     <Card><CardHeader><CardTitle>Credit profile</CardTitle><CardDescription>Private server-side score and non-public credit events.</CardDescription></CardHeader><CardContent className="space-y-3"><div className="rounded-lg border p-3"><p className="text-2xl font-bold">{state.creditScore?.credit_score ?? "—"}</p><p className="text-sm text-muted-foreground">{state.creditScore?.credit_band ?? "Building"}</p></div>{state.creditHistory.slice(0, 5).map((e) => <div key={e.id} className="flex justify-between text-sm"><span className="capitalize">{e.event_type.replaceAll("_", " ")}</span><span>{e.event_date} · {e.score_delta > 0 ? "+" : ""}{e.score_delta}</span></div>)}</CardContent></Card>
-    <Card><CardHeader><CardTitle>Payment history</CardTitle></CardHeader><CardContent className="space-y-2">{state.schedule.slice(0, 8).map((s) => <div key={s.id} className="flex justify-between text-sm"><span>{s.due_date}</span><span>{money(s.amount_minor)} · {s.status}</span></div>)}</CardContent></Card>
+    <Card><CardHeader><CardTitle>Payment history</CardTitle></CardHeader><CardContent className="space-y-2">{state.schedule.slice(0, 8).map((s) => <div key={s.id} className="flex justify-between text-sm"><span>{s.due_date}</span><span>{money(s.amount_minor, s.currency_code)} · {s.status}</span></div>)}</CardContent></Card>
     <Card><CardHeader><CardTitle>Debt recovery</CardTitle><CardDescription>Configurable collection stages from reminder through recovery.</CardDescription></CardHeader><CardContent className="space-y-2">{state.debts.length === 0 ? <p className="text-sm text-muted-foreground">No open player debts.</p> : state.debts.map((d) => <div key={d.id} className="rounded-lg border p-3 text-sm"><p className="font-medium capitalize">{d.collection_stage.replaceAll("_", " ")}</p><p>{money(d.outstanding_balance_minor, d.currency_code)} outstanding · {d.status}</p></div>)}</CardContent></Card>
   </div>;
 }

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -120,7 +120,7 @@ const Finances = () => {
         </TabsContent>
 
         <TabsContent value="obligations" className="space-y-6">
-          <FinancialObligationsPanel profileId={profileId ?? undefined} />
+          <FinancialObligationsPanel />
         </TabsContent>
 
         <TabsContent value="charity" className="space-y-6">

--- a/supabase/migrations/20260720150000_finance_phase8b7_close_generic_band_expense_endpoint.sql
+++ b/supabase/migrations/20260720150000_finance_phase8b7_close_generic_band_expense_endpoint.sql
@@ -1,0 +1,129 @@
+-- Finance Phase 8B.7: immediately close the generic band-expense transfer endpoint.
+-- This migration does not start Phase 8C. It narrows the Phase 8B.6 prototype so that
+-- browsers can preview funding only; payment must be invoked by future trusted,
+-- feature-specific booking wrappers that calculate price and destination server-side.
+
+DROP FUNCTION IF EXISTS public.confirm_band_expense_funding(uuid,text,uuid,uuid,bigint,char,text,uuid,text);
+DROP FUNCTION IF EXISTS public.preview_band_expense_funding(uuid,text,uuid,bigint,char,text,uuid);
+DROP FUNCTION IF EXISTS public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,char(3),text,uuid,uuid,text);
+DROP FUNCTION IF EXISTS public.resolve_and_pay_band_expense(uuid,text,uuid,uuid,bigint,char,text,uuid,uuid,text);
+
+CREATE OR REPLACE FUNCTION public.preview_band_expense_funding(
+  p_band_id uuid,
+  p_expense_type text,
+  p_expense_id uuid,
+  p_amount_minor bigint,
+  p_currency_code char(3),
+  p_requested_payment_source text,
+  p_personal_bank_account_id uuid DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  pid uuid:=public.current_player_profile_id();
+  treasury uuid;
+  band_bal bigint:=0;
+  ba public.bank_accounts;
+  fa public.financial_accounts;
+  personal_bal bigint:=0;
+  band_part bigint:=0;
+  personal_part bigint:=0;
+  can_use_band boolean;
+  is_member boolean;
+BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile required'; END IF;
+  IF p_amount_minor<=0 THEN RAISE EXCEPTION 'amount must be positive'; END IF;
+  IF p_currency_code IS NULL OR length(trim(p_currency_code::text))<>3 THEN RAISE EXCEPTION 'three-character currency code required'; END IF;
+  IF p_requested_payment_source NOT IN ('band_only','personal_only','band_then_personal_shortfall') THEN RAISE EXCEPTION 'unsupported payment source'; END IF;
+
+  is_member:=EXISTS(SELECT 1 FROM public.band_members WHERE band_id=p_band_id AND profile_id=pid AND COALESCE(member_status,'active')='active');
+  can_use_band:=public.user_has_band_finance_permission(p_band_id,pid,'pay_band_expenses'::public.band_finance_permission);
+
+  SELECT id, available_balance_minor INTO treasury, band_bal
+  FROM public.financial_accounts
+  WHERE owner_type='band'
+    AND owner_id=p_band_id
+    AND currency_code=p_currency_code
+    AND account_status='active'
+    AND metadata->>'account_role'='band_treasury'
+  ORDER BY is_primary DESC, created_at
+  LIMIT 1;
+
+  IF p_personal_bank_account_id IS NOT NULL THEN
+    SELECT * INTO ba FROM public.bank_accounts WHERE id=p_personal_bank_account_id;
+    SELECT * INTO fa FROM public.financial_accounts WHERE id=ba.linked_finance_account_id;
+    IF ba.owner_type='player' AND ba.owner_id=pid AND ba.status='active' AND fa.account_status='active' AND ba.currency_code=p_currency_code THEN
+      personal_bal:=fa.available_balance_minor;
+    END IF;
+  END IF;
+
+  IF p_requested_payment_source='band_only' THEN band_part:=LEAST(p_amount_minor,COALESCE(band_bal,0)); personal_part:=0;
+  ELSIF p_requested_payment_source='personal_only' THEN band_part:=0; personal_part:=p_amount_minor;
+  ELSE band_part:=LEAST(p_amount_minor,COALESCE(band_bal,0)); personal_part:=p_amount_minor-band_part;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'status',CASE
+      WHEN NOT is_member THEN 'permission_denied'
+      WHEN treasury IS NULL THEN 'band_treasury_missing'
+      WHEN band_part>0 AND NOT can_use_band THEN 'permission_denied'
+      WHEN p_requested_payment_source='band_only' AND COALESCE(band_bal,0)<p_amount_minor THEN 'insufficient_band_funds'
+      WHEN personal_part>0 AND personal_bal<personal_part THEN 'insufficient_personal_funds'
+      ELSE 'ready'
+    END,
+    'totalAmountMinor',p_amount_minor,
+    'bandAvailableMinor',COALESCE(band_bal,0),
+    'shortfallMinor',GREATEST(0,p_amount_minor-COALESCE(band_bal,0)),
+    'currencyCode',p_currency_code,
+    'personalPaymentEligible',is_member AND p_personal_bank_account_id IS NOT NULL,
+    'bandFundedAmountMinor',band_part,
+    'personalAmountMinor',personal_part,
+    'personalAvailableBalanceMinor',personal_bal,
+    'resultingBandBalanceMinor',COALESCE(band_bal,0)-band_part,
+    'resultingPersonalBalanceMinor',personal_bal-personal_part,
+    'permission',jsonb_build_object('member',is_member,'useBandFunds',can_use_band),
+    'requiresTrustedBookingConfirmation',true
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.resolve_and_pay_band_expense_internal(
+  p_band_id uuid,
+  p_expense_type text,
+  p_expense_id uuid,
+  p_destination_account_id uuid,
+  p_amount_minor bigint,
+  p_currency_code char(3),
+  p_requested_payment_source text,
+  p_personal_bank_account_id uuid,
+  p_initiating_player_id uuid,
+  p_idempotency_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+BEGIN
+  RAISE EXCEPTION 'band expense payments must use trusted feature-specific booking functions' USING ERRCODE='42501';
+END $$;
+
+COMMENT ON FUNCTION public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,char(3),text,uuid,uuid,text)
+  IS 'Internal-only Phase 8B.7 guard. Feature-specific booking functions must calculate destination, amount and permission before payment.';
+
+CREATE OR REPLACE FUNCTION public.confirm_band_expense_funding(
+  p_band_id uuid,
+  p_expense_type text,
+  p_expense_id uuid,
+  p_amount_minor bigint,
+  p_currency_code char(3),
+  p_requested_payment_source text,
+  p_personal_bank_account_id uuid,
+  p_idempotency_key text
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+BEGIN
+  RETURN jsonb_build_object(
+    'status','requires_feature_booking_confirmation',
+    'message','Generic band expense confirmation is disabled. Use a trusted booking-specific confirmation RPC that derives amount and destination server-side.',
+    'expenseType',p_expense_type,
+    'expenseId',p_expense_id
+  );
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,char(3),text,uuid,uuid,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,char(3),text,uuid,uuid,text) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.preview_band_expense_funding(uuid,text,uuid,bigint,char(3),text,uuid), public.confirm_band_expense_funding(uuid,text,uuid,bigint,char(3),text,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.preview_band_expense_funding(uuid,text,uuid,bigint,char(3),text,uuid), public.confirm_band_expense_funding(uuid,text,uuid,bigint,char(3),text,uuid,text) TO authenticated;

--- a/supabase/tests/finance_phase8b6_obligations_security_band_expense_harness.sql
+++ b/supabase/tests/finance_phase8b6_obligations_security_band_expense_harness.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(18);
+SELECT plan(21);
 
 SELECT has_table('public','financial_obligations','financial obligations table exists');
 SELECT has_table('public','financial_obligation_schedule','obligation schedule table exists');
@@ -21,11 +21,14 @@ SELECT ok((SELECT relrowsecurity FROM pg_class WHERE oid='public.player_credit_s
 SELECT has_function('public','get_my_financial_obligations_dashboard',ARRAY[]::name[],'player dashboard RPC exists');
 SELECT has_function('public','retry_my_financial_obligation_payment',ARRAY['uuid','text']::name[],'player retry RPC exists');
 SELECT has_function('public','preview_band_expense_funding',ARRAY['uuid','text','uuid','bigint','character','text','uuid']::name[],'band preview RPC exists');
-SELECT has_function('public','confirm_band_expense_funding',ARRAY['uuid','text','uuid','uuid','bigint','character','text','uuid','text']::name[],'band confirm RPC exists');
+SELECT has_function('public','confirm_band_expense_funding',ARRAY['uuid','text','uuid','bigint','character','text','uuid','text']::name[],'band confirm RPC no longer accepts browser destination account');
+SELECT has_function('public','resolve_and_pay_band_expense_internal',ARRAY['uuid','text','uuid','uuid','bigint','character','text','uuid','uuid','text']::name[],'internal band expense resolver exists');
 
 SELECT isnt(has_function_privilege('authenticated','public.process_financial_obligation_payment(uuid,text)','EXECUTE'),true,'authenticated cannot execute internal payment processor');
 SELECT isnt(has_function_privilege('authenticated','public.process_due_financial_obligations(date,integer)','EXECUTE'),true,'authenticated cannot execute due processor');
 SELECT ok(has_function_privilege('authenticated','public.get_my_financial_obligations_dashboard()','EXECUTE'),'authenticated can execute dashboard wrapper');
+SELECT isnt(has_function_privilege('authenticated','public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,character,text,uuid,uuid,text)','EXECUTE'),true,'authenticated cannot execute internal band expense resolver');
+SELECT isnt(has_function_privilege('anon','public.resolve_and_pay_band_expense_internal(uuid,text,uuid,uuid,bigint,character,text,uuid,uuid,text)','EXECUTE'),true,'anon cannot execute internal band expense resolver');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
### Motivation

- Close an urgent security gap by preventing browsers from calling a generic money-transfer endpoint and force feature-specific booking wrappers to calculate destination and amount server-side.
- Keep previews available to the UI while ensuring they are side‑effect free and use the canonical three-character currency type.
- Provide an executable CI gate for finance migrations and DB tests that does not rely on installing the Supabase CLI via npm.
- Remove obsolete frontend plumbing and ensure per-line schedule currency rendering in the obligations panel.

### Description

- Add a Phase 8B.7 migration that drops the old generic resolver and preview signatures and introduces `resolve_and_pay_band_expense_internal` as an internal guard which raises instead of posting payments; `preview_band_expense_funding` now requires a `char(3)` currency and is side‑effect free. (`supabase/migrations/20260720150000_finance_phase8b7_close_generic_band_expense_endpoint.sql`).
- Revoke execute on the internal resolver from `PUBLIC`, `anon`, and `authenticated` and grant it only to `service_role`, and make the authenticated generic confirm wrapper return a `requires_feature_booking_confirmation` response instead of performing payments. (see migration). 
- Add a dedicated finance verification GitHub Actions workflow that installs the Supabase CLI via `supabase/setup-cli` and runs `npm ci`, `supabase db start`, `supabase db reset`, `supabase db lint`, `supabase test db`, generated types, `npm run typecheck`, `npm run lint`, unit tests and `npm run build` (`.github/workflows/finance-verification.yml`).
- Update the SQL test harness to assert the new internal resolver exists and that `authenticated`/`anon` cannot execute it, and adjust the preview/confirm expectations (`supabase/tests/finance_phase8b6_obligations_security_band_expense_harness.sql`).
- Add an executable stabilization audit documenting the CI plan and local npm/proxy diagnostics (`docs/finance/FINANCE_PHASE8B7_EXECUTABLE_STABILISATION_AUDIT.md`).
- Remove obsolete `profileId` plumbing from `FinancialObligationsPanel` and fix per-line schedule currency rendering (`src/components/finance/FinancialObligationsPanel.tsx` and `src/pages/Finances.tsx`).

### Testing

- Ran `npm run typecheck`, which completed successfully. 
- Ran `git diff --check` / basic repo hygiene checks, which passed. 
- `npm ci` failed in the local container due to a registry/proxy 403 for `@react-three/fiber`, so dependency install and downstream `lint`/`build` could not complete in this environment. 
- `npm run lint` and `npm run build` could not finish because dependencies were not available locally (`@eslint/js` / `vite` missing after failed install). 
- `supabase test db` and the SQL harness were not run locally because the Supabase CLI is not installed in the Codex container; the new CI workflow installs it and will run DB tests in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0919d568832589ae5401e38c4624)