### PR TITLE
Finance Phase 8B.9: Fix band deposit account selection and contribution RPC

### DIFF
--- a/docs/finance/FINANCE_PHASE8B9_BAND_DEPOSIT_AND_REHEARSAL_FLOW_AUDIT.md
+++ b/docs/finance/FINANCE_PHASE8B9_BAND_DEPOSIT_AND_REHEARSAL_FLOW_AUDIT.md
@@ -1,0 +1,19 @@
+# Finance Phase 8B.9 — Band Deposit and Rehearsal Flow Audit
+
+## Band deposit root cause
+
+The merged Phase 8B.8 Band Finances implementation queried personal `bank_accounts` directly from the browser while `profileId` could still be unavailable. The query used a zero-UUID fallback for `owner_id`, so the first account request could legitimately return no accounts and leave the selector empty until another finance refresh happened.
+
+The same deposit path also called `contribute_personal_funds_to_band` with parameter names that did not match the deployed SQL signature. The database function expects `p_player_bank_account_id` and `p_note`; the UI sent `p_personal_bank_account_id` and `p_notes`, so a repaired selector would still fail on submission.
+
+Account-loading errors were previously ignored because the Promise result only read `data`. Relationship shape mismatches from `bank_accounts -> financial_accounts` were hidden with `any`, making an empty selector indistinguishable from RLS, join, or profile-loading problems.
+
+## Phase 8B.9 fix scope in this PR
+
+- Added `get_my_eligible_band_contribution_accounts(p_band_id, p_currency_code)` so the browser no longer supplies an owner profile ID for contribution account discovery.
+- Added `contribute_my_personal_funds_to_band(...)` as a current-player wrapper around the existing contribution RPC.
+- Updated Band Finances to wait for both `bandId` and `profileId`, expose account-section loading/errors, use typed account/contribution interfaces, preserve selection, and refresh balances/history in component state instead of reloading the page.
+
+## Remaining rehearsal-funding audit items
+
+The trusted rehearsal-funding slice still needs a follow-up implementation to make preview side-effect free, enforce the authoritative rehearsal-booking permission, validate payment status before booking insertion, wire the frontend to preview/confirm RPCs, and implement cancellation/refund routing to the original funding sources.

--- a/src/components/bands/BandFinancesTab.tsx
+++ b/src/components/bands/BandFinancesTab.tsx
@@ -3,19 +3,51 @@ import { format } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/lib/supabase-types";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import {
-  DollarSign, TrendingUp, PiggyBank, Receipt, ArrowUpRight, ArrowDownRight,
-  Music, Mic, ShoppingBag, Radio, Settings, Users, Calendar, HandCoins,
+  DollarSign,
+  TrendingUp,
+  PiggyBank,
+  Receipt,
+  ArrowUpRight,
+  ArrowDownRight,
+  Music,
+  Mic,
+  ShoppingBag,
+  Radio,
+  Settings,
+  Users,
+  Calendar,
+  HandCoins,
 } from "lucide-react";
 
 interface BandFinancesTabProps {
@@ -54,19 +86,93 @@ const sourceIcons: Record<string, React.ReactNode> = {
 };
 
 function getSourceLabel(source: string) {
-  return sourceLabels[source] ?? source
-    .split("_")
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join(" ");
+  return (
+    sourceLabels[source] ??
+    source
+      .split("_")
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(" ")
+  );
 }
 
-function formatCurrency(value: number) {
+function formatCurrency(value: number, currency = "USD") {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
+    currency,
+    maximumFractionDigits: 2,
   }).format(value);
 }
+
+interface EligibleContributionAccount {
+  id: string;
+  displayName: string;
+  providerName: string;
+  accountType: string;
+  maskedAccountNumber: string;
+  currencyCode: string;
+  currentBalanceMinor: number;
+  availableBalanceMinor: number;
+  isPrimary: boolean;
+  eligible: boolean;
+  ineligibleReason: string | null;
+}
+
+interface EligibleAccountsResponse {
+  status:
+    | "ok"
+    | "profile_missing"
+    | "not_band_member"
+    | "no_personal_accounts"
+    | "no_eligible_accounts"
+    | "currency_mismatch";
+  accounts: EligibleContributionAccount[];
+  message?: string | null;
+}
+
+interface BandContribution {
+  id: string;
+  amount_minor: number;
+  currency_code: string;
+  contribution_type: string;
+  related_expense_type: string | null;
+  related_expense_id: string | null;
+  refundable_status: string;
+  notes: string | null;
+  created_at: string;
+  contributing_player_id: string;
+}
+
+interface ContributionResult {
+  contributionId?: string;
+  transactionId?: string;
+  newPlayerAvailableBalance?: number;
+  newBandTreasuryBalance?: number;
+}
+
+interface SupabaseFinanceRpcClient {
+  rpc(
+    fn: "get_my_eligible_band_contribution_accounts",
+    args: { p_band_id: string; p_currency_code: string | null },
+  ): Promise<{
+    data: EligibleAccountsResponse | null;
+    error: { message: string } | null;
+  }>;
+  rpc(
+    fn: "contribute_my_personal_funds_to_band",
+    args: {
+      p_band_id: string;
+      p_bank_account_id: string;
+      p_amount_minor: number;
+      p_note: string | null;
+      p_idempotency_key: string;
+    },
+  ): Promise<{
+    data: ContributionResult | null;
+    error: { message: string } | null;
+  }>;
+}
+
+const financeRpc = supabase as unknown as SupabaseFinanceRpcClient;
 
 function formatDateTime(value: string) {
   try {
@@ -87,74 +193,154 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   const [weeklyPayPct, setWeeklyPayPct] = useState(0);
   const [savingPay, setSavingPay] = useState(false);
   const [memberCount, setMemberCount] = useState(0);
-  const [personalAccounts, setPersonalAccounts] = useState<any[]>([]);
+  const [personalAccounts, setPersonalAccounts] = useState<
+    EligibleContributionAccount[]
+  >([]);
+  const [accountsLoading, setAccountsLoading] = useState(false);
+  const [accountError, setAccountError] = useState<string | null>(null);
+  const [accountStatus, setAccountStatus] = useState<
+    EligibleAccountsResponse["status"] | null
+  >(null);
   const [selectedAccountId, setSelectedAccountId] = useState("");
   const [contributionAmount, setContributionAmount] = useState("");
   const [contributionNote, setContributionNote] = useState("");
   const [contributing, setContributing] = useState(false);
-  const [contributions, setContributions] = useState<any[]>([]);
+  const [contributions, setContributions] = useState<BandContribution[]>([]);
+
+  const fetchEligibleAccounts = async () => {
+    if (!bandId || !profileId) {
+      setPersonalAccounts([]);
+      setSelectedAccountId("");
+      setAccountStatus(profileId ? null : "profile_missing");
+      return;
+    }
+
+    setAccountsLoading(true);
+    setAccountError(null);
+    const { data, error } = await financeRpc.rpc(
+      "get_my_eligible_band_contribution_accounts",
+      {
+        p_band_id: bandId,
+        p_currency_code: null,
+      },
+    );
+    setAccountsLoading(false);
+
+    if (error) {
+      setPersonalAccounts([]);
+      setSelectedAccountId("");
+      setAccountStatus(null);
+      setAccountError(error.message);
+      return;
+    }
+
+    const accounts = data?.accounts ?? [];
+    setPersonalAccounts(accounts);
+    setAccountStatus(data?.status ?? "no_eligible_accounts");
+    setSelectedAccountId((current) => {
+      if (current && accounts.some((account) => account.id === current))
+        return current;
+      return (
+        accounts.find((account) => account.isPrimary)?.id ??
+        accounts[0]?.id ??
+        ""
+      );
+    });
+  };
+
+  const fetchFinances = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [
+        { data: bandData, error: bandError },
+        { data: earningData, error: earningError },
+        { data: membersData },
+        { data: contributionData, error: contributionError },
+      ] = await Promise.all([
+        supabase.from("bands").select("*").eq("id", bandId).single(),
+        supabase
+          .from("band_earnings")
+          .select("*")
+          .eq("band_id", bandId)
+          .order("created_at", { ascending: false })
+          .limit(50),
+        supabase
+          .from("band_members")
+          .select("id, is_touring_member, user_id")
+          .eq("band_id", bandId),
+        supabase
+          .from("band_financial_contributions")
+          .select(
+            "id, amount_minor, currency_code, contribution_type, related_expense_type, related_expense_id, refundable_status, notes, created_at, contributing_player_id",
+          )
+          .eq("band_id", bandId)
+          .order("created_at", { ascending: false })
+          .limit(25),
+      ]);
+
+      if (bandError) throw bandError;
+      if (earningError) throw earningError;
+      if (contributionError) throw contributionError;
+
+      const b = bandData as BandRow;
+      setBand(b);
+      setEarnings((earningData as BandEarningRow[]) ?? []);
+      setWeeklyPayPct(Number(b.weekly_pay_percent ?? 0));
+      setIsLeader(!!profileId && profileId === b.leader_id);
+      const realMembers = (membersData ?? []).filter(
+        (m) => !m.is_touring_member,
+      );
+      setMemberCount(realMembers.length);
+      setContributions((contributionData as BandContribution[]) ?? []);
+    } catch (caught) {
+      console.error("Failed to load band finances", caught);
+      setBand(null);
+      setEarnings([]);
+      setError("We were unable to load the financial data for this band.");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    let isMounted = true;
-
-    const fetchFinances = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const [{ data: bandData, error: bandError }, { data: earningData, error: earningError }, { data: membersData }, { data: accountData }, { data: contributionData }] = await Promise.all([
-          supabase.from("bands").select("*").eq("id", bandId).single(),
-          supabase.from("band_earnings").select("*").eq("band_id", bandId).order("created_at", { ascending: false }).limit(50),
-          supabase.from("band_members").select("id, is_touring_member, user_id").eq("band_id", bandId),
-          supabase.from("bank_accounts").select("id, account_type, currency_code, status, linked_finance_account_id, financial_accounts(current_balance_minor, available_balance_minor)").eq("owner_type", "player").eq("owner_id", profileId ?? "00000000-0000-0000-0000-000000000000").eq("status", "active"),
-          supabase.from("band_financial_contributions").select("id, amount_minor, currency_code, contribution_type, related_expense_type, related_expense_id, refundable_status, notes, created_at, contributing_player_id").eq("band_id", bandId).order("created_at", { ascending: false }).limit(25),
-        ]);
-
-        if (bandError) throw bandError;
-        if (earningError) throw earningError;
-
-        if (!isMounted) return;
-
-        const b = bandData as BandRow;
-        setBand(b);
-        setEarnings((earningData as BandEarningRow[]) ?? []);
-        setWeeklyPayPct(Number((b as any).weekly_pay_percent ?? 0));
-        setIsLeader(!!profileId && profileId === b.leader_id);
-        const realMembers = (membersData ?? []).filter(m => !m.is_touring_member);
-        setMemberCount(realMembers.length);
-        setPersonalAccounts((accountData as any[]) ?? []);
-        setSelectedAccountId((accountData as any[])?.[0]?.id ?? "");
-        setContributions((contributionData as any[]) ?? []);
-      } catch (caught) {
-        console.error("Failed to load band finances", caught);
-        if (isMounted) {
-          setBand(null);
-          setEarnings([]);
-          setError("We were unable to load the financial data for this band.");
-        }
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-
     void fetchFinances();
-    return () => { isMounted = false; };
+  }, [bandId, profileId]);
+
+  useEffect(() => {
+    void fetchEligibleAccounts();
   }, [bandId, profileId]);
 
   const aggregated = useMemo(() => {
     const balance = band?.band_balance ?? 0;
     if (earnings.length === 0) {
-      return { balance, totalIncome: 0, totalExpenses: 0, averageDeposit: 0, monthlyRunway: 0, recentActivity: [], bySource: {} as Record<string, number> };
+      return {
+        balance,
+        totalIncome: 0,
+        totalExpenses: 0,
+        averageDeposit: 0,
+        monthlyRunway: 0,
+        recentActivity: [],
+        bySource: {} as Record<string, number>,
+      };
     }
 
-    const deposits = earnings.filter(e => e.amount > 0);
-    const expenses = earnings.filter(e => e.amount < 0);
+    const deposits = earnings.filter((e) => e.amount > 0);
+    const expenses = earnings.filter((e) => e.amount < 0);
 
     const totalIncome = deposits.reduce((s, e) => s + e.amount, 0);
     const totalExpenses = Math.abs(expenses.reduce((s, e) => s + e.amount, 0));
 
-    const averageDeposit = deposits.length ? Math.round(totalIncome / deposits.length) : 0;
-    const averageExpense = expenses.length ? totalExpenses / expenses.length : 0;
-    const monthlyRunway = averageExpense > 0 ? Math.max(0, Math.round(balance / averageExpense)) : Math.max(0, balance);
+    const averageDeposit = deposits.length
+      ? Math.round(totalIncome / deposits.length)
+      : 0;
+    const averageExpense = expenses.length
+      ? totalExpenses / expenses.length
+      : 0;
+    const monthlyRunway =
+      averageExpense > 0
+        ? Math.max(0, Math.round(balance / averageExpense))
+        : Math.max(0, balance);
 
     const bySource: Record<string, number> = {};
     for (const e of earnings) {
@@ -162,7 +348,15 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       bySource[key] = (bySource[key] ?? 0) + e.amount;
     }
 
-    return { balance, totalIncome, totalExpenses, averageDeposit, monthlyRunway, recentActivity: earnings, bySource };
+    return {
+      balance,
+      totalIncome,
+      totalExpenses,
+      averageDeposit,
+      monthlyRunway,
+      recentActivity: earnings,
+      bySource,
+    };
   }, [band, earnings]);
 
   const topSources = useMemo(() => {
@@ -177,59 +371,101 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
     try {
       const { error } = await supabase
         .from("bands")
-        .update({ weekly_pay_percent: clamped } as any)
+        .update({ weekly_pay_percent: clamped })
         .eq("id", bandId);
       if (error) throw error;
       toast({
         title: "Weekly Pay Updated",
         description: `${clamped}% of band balance will be paid out each Saturday at 10:00 AM.`,
       });
-    } catch (e: any) {
-      toast({ title: "Error", description: e.message, variant: "destructive" });
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : "Unable to save weekly pay.";
+      toast({ title: "Error", description: message, variant: "destructive" });
     } finally {
       setSavingPay(false);
     }
   };
 
-  const refreshFinances = () => window.location.reload();
-
   const handleContribute = async () => {
     const amount = Number(contributionAmount);
     if (!selectedAccountId || !Number.isFinite(amount) || amount <= 0) {
-      toast({ title: "Contribution needs an account and positive amount", variant: "destructive" });
+      toast({
+        title: "Contribution needs an account and positive amount",
+        variant: "destructive",
+      });
       return;
     }
     setContributing(true);
     try {
-      const { error } = await supabase.rpc("contribute_personal_funds_to_band" as any, {
-        p_band_id: bandId,
-        p_personal_bank_account_id: selectedAccountId,
-        p_amount_minor: Math.round(amount * 100),
-        p_idempotency_key: `band-contribution:${bandId}:${selectedAccountId}:${Date.now()}`,
-        p_notes: contributionNote || null,
-      } as any);
+      const idempotencyKey = crypto.randomUUID();
+      const { data, error } = await financeRpc.rpc(
+        "contribute_my_personal_funds_to_band",
+        {
+          p_band_id: bandId,
+          p_bank_account_id: selectedAccountId,
+          p_amount_minor: Math.round(amount * 100),
+          p_note: contributionNote || null,
+          p_idempotency_key: idempotencyKey,
+        },
+      );
       if (error) throw error;
-      toast({ title: "Contribution posted", description: "Your personal account was debited and the band treasury was credited." });
+      toast({
+        title: "Contribution posted",
+        description:
+          "Your personal account was debited and the band treasury was credited.",
+      });
       setContributionAmount("");
       setContributionNote("");
-      refreshFinances();
-    } catch (e: any) {
-      toast({ title: "Contribution failed", description: e.message, variant: "destructive" });
+      if (data?.newPlayerAvailableBalance !== undefined) {
+        setPersonalAccounts((accounts) =>
+          accounts.map((account) =>
+            account.id === selectedAccountId
+              ? {
+                  ...account,
+                  availableBalanceMinor:
+                    data.newPlayerAvailableBalance ??
+                    account.availableBalanceMinor,
+                }
+              : account,
+          ),
+        );
+      }
+      void fetchFinances();
+      void fetchEligibleAccounts();
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : "Unable to post contribution.";
+      toast({
+        title: "Contribution failed",
+        description: message,
+        variant: "destructive",
+      });
     } finally {
       setContributing(false);
     }
   };
 
-  const projectedTotal = Math.floor((aggregated.balance * Math.max(0, Math.min(100, weeklyPayPct))) / 100);
-  const projectedPerMember = memberCount > 0 ? Math.floor(projectedTotal / memberCount) : 0;
+  const projectedTotal = Math.floor(
+    (aggregated.balance * Math.max(0, Math.min(100, weeklyPayPct))) / 100,
+  );
+  const projectedPerMember =
+    memberCount > 0 ? Math.floor(projectedTotal / memberCount) : 0;
 
   if (loading) {
     return (
       <div className="space-y-4">
         {[...Array(2)].map((_, i) => (
           <Card key={i}>
-            <CardHeader><Skeleton className="h-6 w-1/3" /><Skeleton className="h-4 w-1/2" /></CardHeader>
-            <CardContent className="space-y-3">{[...Array(4)].map((__, j) => <Skeleton key={j} className="h-4 w-full" />)}</CardContent>
+            <CardHeader>
+              <Skeleton className="h-6 w-1/3" />
+              <Skeleton className="h-4 w-1/2" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {[...Array(4)].map((__, j) => (
+                <Skeleton key={j} className="h-4 w-full" />
+              ))}
+            </CardContent>
           </Card>
         ))}
       </div>
@@ -237,10 +473,16 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   }
 
   if (error) {
-    return <Alert variant="destructive"><AlertTitle>Unable to load band finances</AlertTitle><AlertDescription>{error}</AlertDescription></Alert>;
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Unable to load band finances</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
   }
 
-  if (!band) return <p className="text-sm text-muted-foreground">Band not found.</p>;
+  if (!band)
+    return <p className="text-sm text-muted-foreground">Band not found.</p>;
 
   return (
     <div className="space-y-6">
@@ -251,25 +493,33 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
             <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
               <PiggyBank className="h-3.5 w-3.5" /> Balance
             </div>
-            <p className="text-2xl font-bold">{formatCurrency(aggregated.balance)}</p>
+            <p className="text-2xl font-bold">
+              {formatCurrency(aggregated.balance)}
+            </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-              <ArrowUpRight className="h-3.5 w-3.5 text-emerald-500" /> Total Income
+              <ArrowUpRight className="h-3.5 w-3.5 text-emerald-500" /> Total
+              Income
             </div>
-            <p className="text-2xl font-bold text-emerald-500">{formatCurrency(aggregated.totalIncome)}</p>
+            <p className="text-2xl font-bold text-emerald-500">
+              {formatCurrency(aggregated.totalIncome)}
+            </p>
           </CardContent>
         </Card>
 
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-              <ArrowDownRight className="h-3.5 w-3.5 text-destructive" /> Total Expenses
+              <ArrowDownRight className="h-3.5 w-3.5 text-destructive" /> Total
+              Expenses
             </div>
-            <p className="text-2xl font-bold text-destructive">{formatCurrency(aggregated.totalExpenses)}</p>
+            <p className="text-2xl font-bold text-destructive">
+              {formatCurrency(aggregated.totalExpenses)}
+            </p>
           </CardContent>
         </Card>
 
@@ -278,29 +528,173 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
             <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
               <TrendingUp className="h-3.5 w-3.5" /> Runway
             </div>
-            <p className="text-2xl font-bold">{aggregated.monthlyRunway} <span className="text-sm font-normal text-muted-foreground">months</span></p>
-            <Progress value={Math.min(100, aggregated.monthlyRunway * 10)} className="mt-1 h-1.5" />
+            <p className="text-2xl font-bold">
+              {aggregated.monthlyRunway}{" "}
+              <span className="text-sm font-normal text-muted-foreground">
+                months
+              </span>
+            </p>
+            <Progress
+              value={Math.min(100, aggregated.monthlyRunway * 10)}
+              className="mt-1 h-1.5"
+            />
           </CardContent>
         </Card>
       </div>
 
-
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <CardHeader className="pb-3">
-            <CardTitle className="text-base flex items-center gap-2"><HandCoins className="h-4 w-4" /> Add Money to Band</CardTitle>
-            <CardDescription>Move personal funds into the real band treasury with explicit confirmation.</CardDescription>
+            <CardTitle className="text-base flex items-center gap-2">
+              <HandCoins className="h-4 w-4" /> Add Money to Band
+            </CardTitle>
+            <CardDescription>
+              Move personal funds into the real band treasury with explicit
+              confirmation.
+            </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
-            <div className="space-y-1"><Label className="text-xs">Personal account</Label><select className="w-full rounded-md border bg-background px-3 py-2 text-sm" value={selectedAccountId} onChange={(e) => setSelectedAccountId(e.target.value)}>{personalAccounts.map((a) => <option key={a.id} value={a.id}>{a.account_type ?? "Account"} · {a.currency_code} · {formatCurrency(((a.financial_accounts as any)?.available_balance_minor ?? 0) / 100)}</option>)}</select></div>
-            <div className="grid gap-3 sm:grid-cols-2"><div className="space-y-1"><Label className="text-xs">Amount</Label><Input type="number" min="0" step="0.01" value={contributionAmount} onChange={(e) => setContributionAmount(e.target.value)} placeholder="50.00" /></div><div className="space-y-1"><Label className="text-xs">Optional note</Label><Input value={contributionNote} onChange={(e) => setContributionNote(e.target.value)} placeholder="New rehearsal fund" /></div></div>
-            <Alert><AlertTitle>Contribution warning</AlertTitle><AlertDescription>This contribution is not automatically repayable and does not grant additional band ownership or voting rights.</AlertDescription></Alert>
-            <Button onClick={handleContribute} disabled={contributing || !selectedAccountId}>{contributing ? "Contributing…" : "Contribute to band"}</Button>
+            <div className="space-y-1">
+              <Label className="text-xs">Personal account</Label>
+              <Select
+                value={selectedAccountId}
+                onValueChange={setSelectedAccountId}
+                disabled={accountsLoading || personalAccounts.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={
+                      accountsLoading
+                        ? "Loading your personal accounts…"
+                        : "Choose a personal account"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {personalAccounts.map((account) => (
+                    <SelectItem key={account.id} value={account.id}>
+                      <div className="flex flex-col text-left">
+                        <span>
+                          {account.displayName} {account.maskedAccountNumber}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {account.providerName} ·{" "}
+                          {formatCurrency(
+                            account.availableBalanceMinor / 100,
+                            account.currencyCode,
+                          )}{" "}
+                          available
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {accountsLoading && (
+                <p className="text-xs text-muted-foreground">
+                  Loading your personal accounts…
+                </p>
+              )}
+              {accountError && (
+                <p className="text-xs text-destructive">
+                  Unable to load accounts: {accountError}
+                </p>
+              )}
+              {!accountsLoading &&
+                !accountError &&
+                personalAccounts.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    No eligible personal account found. Open or fund a personal
+                    bank account before contributing to the band.{" "}
+                    {accountStatus === "currency_mismatch"
+                      ? "Only matching-currency accounts are eligible."
+                      : null}{" "}
+                    <a className="underline" href="/finance/banking">
+                      Go to personal banking
+                    </a>
+                    .
+                  </p>
+                )}
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <Label className="text-xs">Amount</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={contributionAmount}
+                  onChange={(e) => setContributionAmount(e.target.value)}
+                  placeholder="50.00"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Optional note</Label>
+                <Input
+                  value={contributionNote}
+                  onChange={(e) => setContributionNote(e.target.value)}
+                  placeholder="New rehearsal fund"
+                />
+              </div>
+            </div>
+            <Alert>
+              <AlertTitle>Contribution warning</AlertTitle>
+              <AlertDescription>
+                This contribution is not automatically repayable and does not
+                grant additional band ownership or voting rights.
+              </AlertDescription>
+            </Alert>
+            <Button
+              onClick={handleContribute}
+              disabled={contributing || accountsLoading || !selectedAccountId}
+            >
+              {contributing ? "Contributing…" : "Contribute to band"}
+            </Button>
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="pb-3"><CardTitle className="text-base">Member Contributions</CardTitle><CardDescription>Voluntary deposits, personal expense payments, shortfalls and refunds.</CardDescription></CardHeader>
-          <CardContent>{contributions.length === 0 ? <p className="text-sm text-muted-foreground">No contributions recorded yet.</p> : <div className="space-y-2">{contributions.map((c) => <div key={c.id} className="rounded-md border p-2 text-sm"><div className="flex justify-between gap-2"><span className="font-medium">{getSourceLabel(c.contribution_type)}</span><Badge>{formatCurrency((c.amount_minor ?? 0) / 100)}</Badge></div><p className="text-xs text-muted-foreground">{c.currency_code} · {formatDateTime(c.created_at)} · refund: {c.refundable_status}</p>{c.related_expense_type && <p className="text-xs text-muted-foreground">Related: {c.related_expense_type}</p>}{c.notes && <p className="text-xs">{c.notes}</p>}</div>)}</div>}</CardContent>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Member Contributions</CardTitle>
+            <CardDescription>
+              Voluntary deposits, personal expense payments, shortfalls and
+              refunds.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {contributions.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No contributions recorded yet.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {contributions.map((c) => (
+                  <div key={c.id} className="rounded-md border p-2 text-sm">
+                    <div className="flex justify-between gap-2">
+                      <span className="font-medium">
+                        {getSourceLabel(c.contribution_type)}
+                      </span>
+                      <Badge>
+                        {formatCurrency(
+                          (c.amount_minor ?? 0) / 100,
+                          c.currency_code,
+                        )}
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {c.currency_code} · {formatDateTime(c.created_at)} ·
+                      refund: {c.refundable_status}
+                    </p>
+                    {c.related_expense_type && (
+                      <p className="text-xs text-muted-foreground">
+                        Related: {c.related_expense_type}
+                      </p>
+                    )}
+                    {c.notes && <p className="text-xs">{c.notes}</p>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
         </Card>
       </div>
 
@@ -319,22 +713,31 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <p className="text-sm text-muted-foreground">No data yet.</p>
             ) : (
               topSources.map(([source, amount]) => {
-                const maxAbs = Math.max(...topSources.map(([, v]) => Math.abs(v)), 1);
+                const maxAbs = Math.max(
+                  ...topSources.map(([, v]) => Math.abs(v)),
+                  1,
+                );
                 return (
                   <div key={source} className="flex items-center gap-3">
                     <div className="flex items-center gap-1.5 w-32 shrink-0 text-xs">
-                      {sourceIcons[source] ?? <Receipt className="h-3.5 w-3.5" />}
+                      {sourceIcons[source] ?? (
+                        <Receipt className="h-3.5 w-3.5" />
+                      )}
                       <span className="truncate">{getSourceLabel(source)}</span>
                     </div>
                     <div className="flex-1">
                       <div className="h-2 rounded-full bg-muted overflow-hidden">
                         <div
                           className={`h-full rounded-full ${amount >= 0 ? "bg-emerald-500" : "bg-destructive"}`}
-                          style={{ width: `${Math.min(100, (Math.abs(amount) / maxAbs) * 100)}%` }}
+                          style={{
+                            width: `${Math.min(100, (Math.abs(amount) / maxAbs) * 100)}%`,
+                          }}
                         />
                       </div>
                     </div>
-                    <span className={`text-xs font-semibold w-16 text-right ${amount >= 0 ? "text-emerald-500" : "text-destructive"}`}>
+                    <span
+                      className={`text-xs font-semibold w-16 text-right ${amount >= 0 ? "text-emerald-500" : "text-destructive"}`}
+                    >
                       {formatCurrency(amount)}
                     </span>
                   </div>
@@ -351,32 +754,43 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <Settings className="h-4 w-4" /> Weekly Member Pay
             </CardTitle>
             <CardDescription>
-              Automatic payroll — every Saturday at 10:00 AM. A % of the band balance is split equally between real player members.
+              Automatic payroll — every Saturday at 10:00 AM. A % of the band
+              balance is split equally between real player members.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="rounded-md bg-muted/50 p-3 text-xs text-muted-foreground space-y-1">
               <div className="flex justify-between">
                 <span>Real members:</span>
-                <span className="font-semibold text-foreground">{memberCount}</span>
+                <span className="font-semibold text-foreground">
+                  {memberCount}
+                </span>
               </div>
               <div className="flex justify-between">
                 <span>Configured rate:</span>
-                <span className="font-semibold text-foreground">{weeklyPayPct}% of balance</span>
+                <span className="font-semibold text-foreground">
+                  {weeklyPayPct}% of balance
+                </span>
               </div>
               <div className="flex justify-between">
                 <span>Projected total payout:</span>
-                <span className="font-semibold text-foreground">{formatCurrency(projectedTotal)}</span>
+                <span className="font-semibold text-foreground">
+                  {formatCurrency(projectedTotal)}
+                </span>
               </div>
               <div className="flex justify-between border-t border-border pt-1 mt-1">
                 <span>Per member / week:</span>
-                <span className="font-semibold text-foreground">{formatCurrency(projectedPerMember)}</span>
+                <span className="font-semibold text-foreground">
+                  {formatCurrency(projectedPerMember)}
+                </span>
               </div>
             </div>
 
             {isLeader ? (
               <div className="space-y-2">
-                <Label htmlFor="weekly-pay" className="text-xs">% of band balance per week (0–100)</Label>
+                <Label htmlFor="weekly-pay" className="text-xs">
+                  % of band balance per week (0–100)
+                </Label>
                 <div className="flex gap-2">
                   <Input
                     id="weekly-pay"
@@ -386,21 +800,34 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                     step={0.5}
                     value={weeklyPayPct}
                     onChange={(e) =>
-                      setWeeklyPayPct(Math.max(0, Math.min(100, parseFloat(e.target.value) || 0)))
+                      setWeeklyPayPct(
+                        Math.max(
+                          0,
+                          Math.min(100, parseFloat(e.target.value) || 0),
+                        ),
+                      )
                     }
                     className="h-9"
                   />
-                  <Button onClick={handleSaveWeeklyPay} disabled={savingPay} size="sm" className="h-9 px-4">
+                  <Button
+                    onClick={handleSaveWeeklyPay}
+                    disabled={savingPay}
+                    size="sm"
+                    className="h-9 px-4"
+                  >
                     {savingPay ? "Saving…" : "Save"}
                   </Button>
                 </div>
                 <p className="text-[11px] text-muted-foreground">
-                  Example: 10% of a {formatCurrency(aggregated.balance)} balance ={" "}
-                  {formatCurrency(Math.floor(aggregated.balance * 0.1))} split between members.
+                  Example: 10% of a {formatCurrency(aggregated.balance)} balance
+                  = {formatCurrency(Math.floor(aggregated.balance * 0.1))} split
+                  between members.
                 </p>
               </div>
             ) : (
-              <p className="text-xs text-muted-foreground italic">Only the band leader can change this setting.</p>
+              <p className="text-xs text-muted-foreground italic">
+                Only the band leader can change this setting.
+              </p>
             )}
           </CardContent>
         </Card>
@@ -410,11 +837,15 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-base">Recent Transactions</CardTitle>
-          <CardDescription>Last {aggregated.recentActivity.length} financial entries</CardDescription>
+          <CardDescription>
+            Last {aggregated.recentActivity.length} financial entries
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {aggregated.recentActivity.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No transactions recorded yet.</p>
+            <p className="text-sm text-muted-foreground">
+              No transactions recorded yet.
+            </p>
           ) : (
             <div className="overflow-x-auto">
               <Table>
@@ -422,7 +853,9 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                   <TableRow>
                     <TableHead>Source</TableHead>
                     <TableHead className="text-right">Amount</TableHead>
-                    <TableHead className="hidden md:table-cell">Description</TableHead>
+                    <TableHead className="hidden md:table-cell">
+                      Description
+                    </TableHead>
                     <TableHead className="text-right">Date</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -432,14 +865,24 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                       <TableCell>
                         <div className="flex items-center gap-2">
                           <div className="text-muted-foreground">
-                            {sourceIcons[entry.source] ?? <Receipt className="h-3.5 w-3.5" />}
+                            {sourceIcons[entry.source] ?? (
+                              <Receipt className="h-3.5 w-3.5" />
+                            )}
                           </div>
-                          <span className="text-xs font-medium">{getSourceLabel(entry.source)}</span>
+                          <span className="text-xs font-medium">
+                            {getSourceLabel(entry.source)}
+                          </span>
                         </div>
                       </TableCell>
                       <TableCell className="text-right">
-                        <Badge variant={entry.amount >= 0 ? "default" : "destructive"} className="text-xs">
-                          {entry.amount >= 0 ? "+" : ""}{formatCurrency(entry.amount)}
+                        <Badge
+                          variant={
+                            entry.amount >= 0 ? "default" : "destructive"
+                          }
+                          className="text-xs"
+                        >
+                          {entry.amount >= 0 ? "+" : ""}
+                          {formatCurrency(entry.amount)}
                         </Badge>
                       </TableCell>
                       <TableCell className="hidden md:table-cell text-xs text-muted-foreground max-w-[200px] truncate">

--- a/supabase/migrations/20260720193000_finance_phase8b9_band_deposit_accounts.sql
+++ b/supabase/migrations/20260720193000_finance_phase8b9_band_deposit_accounts.sql
@@ -1,0 +1,119 @@
+-- Finance Phase 8B.9: secure band contribution account discovery and current-player deposit wrapper.
+
+CREATE OR REPLACE FUNCTION public.get_my_eligible_band_contribution_accounts(
+  p_band_id uuid,
+  p_currency_code char(3) DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  pid uuid := public.current_player_profile_id();
+  active_member boolean;
+  personal_count integer;
+  eligible_count integer;
+  mismatch_count integer;
+  accounts jsonb;
+BEGIN
+  IF pid IS NULL THEN
+    RETURN jsonb_build_object('status','profile_missing','accounts','[]'::jsonb,'message','An active player profile is required.');
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.band_members bm
+    WHERE bm.band_id = p_band_id
+      AND bm.profile_id = pid
+      AND COALESCE(bm.member_status,'active') = 'active'
+  ) INTO active_member;
+  IF NOT active_member THEN
+    RETURN jsonb_build_object('status','not_band_member','accounts','[]'::jsonb,'message','Active band membership is required.');
+  END IF;
+
+  SELECT count(*) INTO personal_count
+  FROM public.bank_accounts ba
+  WHERE ba.owner_type = 'player' AND ba.owner_id = pid;
+
+  SELECT count(*) INTO mismatch_count
+  FROM public.bank_accounts ba
+  JOIN public.financial_accounts fa ON fa.id = ba.linked_finance_account_id
+  WHERE ba.owner_type = 'player'
+    AND ba.owner_id = pid
+    AND ba.status = 'active'
+    AND fa.account_status = 'active'
+    AND p_currency_code IS NOT NULL
+    AND ba.currency_code <> p_currency_code;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'id', ba.id,
+    'displayName', COALESCE(NULLIF(ba.metadata->>'display_name',''), initcap(replace(ba.account_type::text, '_', ' ')) || ' Account'),
+    'providerName', COALESCE(bp.brand_name, 'Bank account'),
+    'accountType', ba.account_type,
+    'maskedAccountNumber', COALESCE(NULLIF(ba.metadata->>'masked_account_number',''), NULLIF(ba.metadata->>'account_mask',''), '•••• ' || right(ba.id::text, 4)),
+    'currencyCode', ba.currency_code,
+    'currentBalanceMinor', fa.current_balance_minor,
+    'availableBalanceMinor', fa.available_balance_minor,
+    'isPrimary', COALESCE(fa.is_primary, false),
+    'eligible', true,
+    'ineligibleReason', NULL
+  ) ORDER BY COALESCE(fa.is_primary,false) DESC, ba.opened_at NULLS LAST, ba.created_at), '[]'::jsonb), count(*)
+  INTO accounts, eligible_count
+  FROM public.bank_accounts ba
+  JOIN public.financial_accounts fa ON fa.id = ba.linked_finance_account_id
+  LEFT JOIN public.banking_providers bp ON bp.id = ba.provider_id
+  WHERE ba.owner_type = 'player'
+    AND ba.owner_id = pid
+    AND ba.status = 'active'
+    AND fa.account_status = 'active'
+    AND fa.available_balance_minor IS NOT NULL
+    AND (p_currency_code IS NULL OR ba.currency_code = p_currency_code)
+    AND ba.withdrawal_restrictions = '{}'::jsonb;
+
+  RETURN jsonb_build_object(
+    'status', CASE
+      WHEN personal_count = 0 THEN 'no_personal_accounts'
+      WHEN eligible_count = 0 AND mismatch_count > 0 THEN 'currency_mismatch'
+      WHEN eligible_count = 0 THEN 'no_eligible_accounts'
+      ELSE 'ok'
+    END,
+    'accounts', accounts,
+    'message', CASE
+      WHEN personal_count = 0 THEN 'No personal bank accounts were found.'
+      WHEN eligible_count = 0 AND mismatch_count > 0 THEN 'No personal accounts match the requested treasury currency.'
+      WHEN eligible_count = 0 THEN 'No eligible active personal accounts were found.'
+      ELSE NULL
+    END
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.contribute_my_personal_funds_to_band(
+  p_band_id uuid,
+  p_bank_account_id uuid,
+  p_amount_minor bigint,
+  p_note text DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  pid uuid := public.current_player_profile_id();
+  ba public.bank_accounts;
+  fa public.financial_accounts;
+BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile_missing'; END IF;
+  IF p_idempotency_key IS NULL OR length(trim(p_idempotency_key)) < 8 THEN RAISE EXCEPTION 'idempotency_key_invalid'; END IF;
+  SELECT * INTO ba FROM public.bank_accounts WHERE id = p_bank_account_id FOR UPDATE;
+  SELECT * INTO fa FROM public.financial_accounts WHERE id = ba.linked_finance_account_id FOR UPDATE;
+  IF ba.id IS NULL OR ba.owner_type <> 'player' OR ba.owner_id <> pid OR ba.status <> 'active' OR fa.account_status <> 'active' THEN
+    RAISE EXCEPTION 'personal_account_invalid';
+  END IF;
+  IF fa.available_balance_minor < p_amount_minor THEN RAISE EXCEPTION 'insufficient_personal_funds'; END IF;
+  RETURN public.contribute_personal_funds_to_band(p_band_id, p_bank_account_id, p_amount_minor, p_idempotency_key, p_note);
+END $$;
+
+GRANT EXECUTE ON FUNCTION public.get_my_eligible_band_contribution_accounts(uuid,char(3)) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.contribute_my_personal_funds_to_band(uuid,uuid,bigint,text,text) TO authenticated;

--- a/supabase/tests/finance_phase8b9_band_deposit_accounts.sql
+++ b/supabase/tests/finance_phase8b9_band_deposit_accounts.sql
@@ -1,0 +1,43 @@
+-- Finance Phase 8B.9 band deposit account-selector assertions.
+BEGIN;
+SELECT plan(8);
+
+SELECT has_function(
+  'public',
+  'get_my_eligible_band_contribution_accounts',
+  ARRAY ['uuid', 'character'],
+  'eligible contribution account RPC exists'
+);
+SELECT has_function(
+  'public',
+  'contribute_my_personal_funds_to_band',
+  ARRAY ['uuid', 'uuid', 'bigint', 'text', 'text'],
+  'current-player contribution wrapper exists'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='get_my_eligible_band_contribution_accounts' AND pg_get_functiondef(oid) LIKE '%current_player_profile_id%'$$,
+  'eligible account RPC derives the profile from the session'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='get_my_eligible_band_contribution_accounts' AND pg_get_functiondef(oid) LIKE '%not_band_member%'$$,
+  'eligible account RPC returns a structured non-member status'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='get_my_eligible_band_contribution_accounts' AND pg_get_functiondef(oid) LIKE '%no_personal_accounts%'$$,
+  'eligible account RPC returns a structured no-account status'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='get_my_eligible_band_contribution_accounts' AND pg_get_functiondef(oid) LIKE '%currency_mismatch%'$$,
+  'eligible account RPC returns a structured currency mismatch status'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='contribute_my_personal_funds_to_band' AND pg_get_functiondef(oid) LIKE '%available_balance_minor < p_amount_minor%'$$,
+  'contribution wrapper checks available personal balance before posting'
+);
+SELECT isnt_empty(
+  $$SELECT 1 FROM pg_proc WHERE proname='contribute_my_personal_funds_to_band' AND pg_get_functiondef(oid) LIKE '%contribute_personal_funds_to_band(p_band_id, p_bank_account_id, p_amount_minor, p_idempotency_key, p_note)%'$$,
+  'contribution wrapper calls the existing RPC with the effective parameter order'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- The Band Finances deposit flow was returning an empty personal-account selector and failing on submit because the browser queried `bank_accounts` before `profileId` was available and used mismatched RPC parameter names.
- The intent is to reliably surface eligible personal accounts for the current player, avoid zero-UUID fallbacks, and call a server-side current-player wrapper with correct parameters so deposits succeed without a full-page reload.

### Description

- Add a secure database RPC `get_my_eligible_band_contribution_accounts(p_band_id, p_currency_code)` that derives the player from `current_player_profile_id()`, enforces active band membership, returns typed account fields and structured statuses such as `profile_missing`, `not_band_member`, `no_personal_accounts`, `no_eligible_accounts`, and `currency_mismatch` (file: `supabase/migrations/20260720193000_finance_phase8b9_band_deposit_accounts.sql`).
- Add a current-player contribution wrapper `contribute_my_personal_funds_to_band(...)` that validates ownership/status, checks `available_balance_minor`, and calls the existing `contribute_personal_funds_to_band` with the correct argument order and names (same migration file).
- Replace fragile client-side account loading in `BandFinancesTab` with typed interfaces (`EligibleContributionAccount`, `BandContribution`, etc.), wait for both `bandId` and `profileId` before querying accounts, call the new RPC via a typed `financeRpc` wrapper, preserve previous valid selection (prefer primary), surface loading/error/empty states, show richer option labels using the project `Select` component, and remove `window.location.reload()` in favor of refreshing component state after a successful contribution (`src/components/bands/BandFinancesTab.tsx`).
- Fix RPC parameter naming and idempotency on the frontend by calling `contribute_my_personal_funds_to_band` with `p_bank_account_id`, `p_note`, and a stable UUID idempotency key; removed several `any` usages and added stronger typing and clearer error handling.
- Add documentation audit `docs/finance/FINANCE_PHASE8B9_BAND_DEPOSIT_AND_REHEARSAL_FLOW_AUDIT.md` describing root cause and follow-up rehearsal-funding items.
- Add pgTAP-style smoke assertions for the new RPCs and guards in `supabase/tests/finance_phase8b9_band_deposit_accounts.sql`.

### Testing

- Ran type checking with `npm run typecheck`, which completed successfully (`tsc --noEmit`) ✅.
- Attempted lint and build: `npm run lint` failed in this environment due to a missing local dependency (`@eslint/js`), and `npm run build` was blocked because `vite` is not available in the execution environment (these are environment dependency issues, not code regressions) ⚠️.
- Added pgTAP smoke assertions for the new RPCs (`supabase/tests/finance_phase8b9_band_deposit_accounts.sql`) and the migration (`supabase/migrations/20260720193000_finance_phase8b9_band_deposit_accounts.sql`) but the SQL smoke tests were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e2f34009083258587cec56261ecf1)