### PR TITLE
Finance Phase 8B.10: Make Band Finances treasury-authoritative

### DIFF
--- a/docs/finance/FINANCE_PHASE8B10_BAND_TREASURY_REHEARSAL_AUDIT.md
+++ b/docs/finance/FINANCE_PHASE8B10_BAND_TREASURY_REHEARSAL_AUDIT.md
@@ -1,0 +1,34 @@
+# Finance Phase 8B.10 Band Treasury and Rehearsal Audit
+
+## Decision
+
+The authoritative spendable band balance for the Band Finances page is now the active ledger treasury account balance: `financial_accounts.available_balance_minor` for the selected band treasury currency.
+
+`bands.band_balance` remains a deprecated compatibility mirror while older gameplay surfaces are migrated. New Band Finances reads must not use it for spendability.
+
+## Current model inventory
+
+| Area | Current source | Unit | Divergence risk |
+| --- | --- | --- | --- |
+| Band Finances summary | `get_band_treasury_dashboard()` reading band-owned `financial_accounts` | Minor units returned to the browser and formatted as major units | Low for ledger-backed contributions; avoids stale `bands.band_balance` |
+| Legacy commercial income/expenses | `band_earnings.amount` | Major units | Can diverge from ledger because historical earnings triggers update `bands.band_balance`, not treasury ledger accounts |
+| Legacy balance mirror | `bands.band_balance` | Major units | High; many older features still mutate it directly |
+| Voluntary contributions | `band_financial_contributions` plus `financial_transactions` and `financial_ledger_entries` | Minor units | Low when shown through the dashboard RPC |
+| Band treasury accounts | `financial_accounts` with `owner_type = 'band'` | Minor units | Authoritative for spendability |
+| Rehearsal funding | `preview_rehearsal_booking_funding` and `confirm_rehearsal_booking_with_funding` | Minor units in funding RPCs; some legacy UI paths still supply major-unit costs | Still requires the full Phase 8B.10 rehearsal vertical slice |
+
+## Direct `bands.band_balance` mutations found
+
+Several legacy browser pages, hooks and edge functions still read or mutate `bands.band_balance` directly for gigs, tours, releases, PR, vehicles, recording, label flows and weekly pay. Those flows can diverge from ledger-backed band treasury balances until each is migrated to ledger posting or a database-maintained projection.
+
+## Ledger-posting paths found
+
+The newer finance migrations use `financial_accounts`, `financial_transactions`, `financial_ledger_entries`, `band_financial_contributions`, `band_expense_payments` and related reconciliation tables. Voluntary band contributions now surface through `get_band_treasury_dashboard()` instead of requiring the browser to query contribution rows directly.
+
+## Migration strategy
+
+Preferred strategy is adopted: deprecate `bands.band_balance` from new gameplay reads and writes. Keep it temporarily only for compatibility with unmigrated legacy features. During future migration work, legacy flows should either post balanced ledger journals or write to a database-maintained projection sourced exclusively from ledger entries; they must not independently mutate the mirror.
+
+## Remaining rehearsal gap
+
+This PR begins the treasury-authoritative Band Finances slice, but the larger rehearsal booking work still needs the dedicated quote, permission, atomic confirmation, cancellation and source-aware refund implementation described in the Phase 8B.10 acceptance criteria.

--- a/src/components/bands/BandFinancesTab.tsx
+++ b/src/components/bands/BandFinancesTab.tsx
@@ -22,6 +22,16 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -95,7 +105,7 @@ function getSourceLabel(source: string) {
   );
 }
 
-function formatCurrency(value: number, currency = "USD") {
+function formatCurrency(value: number, currency = "GBP") {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
@@ -129,24 +139,52 @@ interface EligibleAccountsResponse {
   message?: string | null;
 }
 
-interface BandContribution {
-  id: string;
-  amount_minor: number;
-  currency_code: string;
-  contribution_type: string;
-  related_expense_type: string | null;
-  related_expense_id: string | null;
-  refundable_status: string;
-  notes: string | null;
-  created_at: string;
-  contributing_player_id: string;
-}
-
 interface ContributionResult {
   contributionId?: string;
   transactionId?: string;
   newPlayerAvailableBalance?: number;
   newBandTreasuryBalance?: number;
+}
+
+interface TreasuryAccount {
+  accountId: string;
+  currencyCode: string;
+  currentBalanceMinor: number;
+  reservedBalanceMinor: number;
+  availableBalanceMinor: number;
+  isPrimary: boolean;
+}
+
+interface DashboardContribution {
+  id: string;
+  amountMinor: number;
+  currencyCode: string;
+  contributionType: string;
+  refundableStatus: string;
+  notes: string | null;
+  createdAt: string;
+  contributorDisplayName: string;
+  contributorAvatarUrl: string | null;
+}
+
+interface TreasuryDashboard {
+  primaryCurrencyCode: string;
+  treasuries: TreasuryAccount[];
+  contributions: DashboardContribution[];
+}
+
+interface ContributionPreview {
+  sourceAccountDisplay: string;
+  currencyCode: string;
+  currentPersonalBalanceMinor: number;
+  amountMinor: number;
+  resultingPersonalBalanceMinor: number;
+  destinationTreasuryName: string;
+  currentTreasuryBalanceMinor: number;
+  resultingTreasuryBalanceMinor: number;
+  eligible: boolean;
+  ineligibleReason: string | null;
+  warningText: string;
 }
 
 interface SupabaseFinanceRpcClient {
@@ -155,6 +193,24 @@ interface SupabaseFinanceRpcClient {
     args: { p_band_id: string; p_currency_code: string | null },
   ): Promise<{
     data: EligibleAccountsResponse | null;
+    error: { message: string } | null;
+  }>;
+  rpc(
+    fn: "get_band_treasury_dashboard",
+    args: { p_band_id: string },
+  ): Promise<{
+    data: TreasuryDashboard | null;
+    error: { message: string } | null;
+  }>;
+  rpc(
+    fn: "preview_my_band_contribution",
+    args: {
+      p_band_id: string;
+      p_bank_account_id: string;
+      p_amount_minor: number;
+    },
+  ): Promise<{
+    data: ContributionPreview | null;
     error: { message: string } | null;
   }>;
   rpc(
@@ -205,7 +261,16 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   const [contributionAmount, setContributionAmount] = useState("");
   const [contributionNote, setContributionNote] = useState("");
   const [contributing, setContributing] = useState(false);
-  const [contributions, setContributions] = useState<BandContribution[]>([]);
+  const [previewingContribution, setPreviewingContribution] = useState(false);
+  const [contributionPreview, setContributionPreview] =
+    useState<ContributionPreview | null>(null);
+  const [contributionIdempotencyKey, setContributionIdempotencyKey] = useState<
+    string | null
+  >(null);
+  const [dashboard, setDashboard] = useState<TreasuryDashboard | null>(null);
+  const [contributions, setContributions] = useState<DashboardContribution[]>(
+    [],
+  );
 
   const fetchEligibleAccounts = async () => {
     if (!bandId || !profileId) {
@@ -221,7 +286,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       "get_my_eligible_band_contribution_accounts",
       {
         p_band_id: bandId,
-        p_currency_code: null,
+        p_currency_code: dashboard?.primaryCurrencyCode ?? null,
       },
     );
     setAccountsLoading(false);
@@ -256,7 +321,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
         { data: bandData, error: bandError },
         { data: earningData, error: earningError },
         { data: membersData },
-        { data: contributionData, error: contributionError },
+        { data: dashboardData, error: dashboardError },
       ] = await Promise.all([
         supabase.from("bands").select("*").eq("id", bandId).single(),
         supabase
@@ -269,19 +334,12 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
           .from("band_members")
           .select("id, is_touring_member, user_id")
           .eq("band_id", bandId),
-        supabase
-          .from("band_financial_contributions")
-          .select(
-            "id, amount_minor, currency_code, contribution_type, related_expense_type, related_expense_id, refundable_status, notes, created_at, contributing_player_id",
-          )
-          .eq("band_id", bandId)
-          .order("created_at", { ascending: false })
-          .limit(25),
+        financeRpc.rpc("get_band_treasury_dashboard", { p_band_id: bandId }),
       ]);
 
       if (bandError) throw bandError;
       if (earningError) throw earningError;
-      if (contributionError) throw contributionError;
+      if (dashboardError) throw dashboardError;
 
       const b = bandData as BandRow;
       setBand(b);
@@ -292,7 +350,8 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
         (m) => !m.is_touring_member,
       );
       setMemberCount(realMembers.length);
-      setContributions((contributionData as BandContribution[]) ?? []);
+      setDashboard(dashboardData);
+      setContributions(dashboardData?.contributions ?? []);
     } catch (caught) {
       console.error("Failed to load band finances", caught);
       setBand(null);
@@ -309,10 +368,19 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
 
   useEffect(() => {
     void fetchEligibleAccounts();
-  }, [bandId, profileId]);
+  }, [bandId, profileId, dashboard?.primaryCurrencyCode]);
+
+  const primaryTreasury =
+    dashboard?.treasuries.find(
+      (treasury) => treasury.currencyCode === dashboard.primaryCurrencyCode,
+    ) ??
+    dashboard?.treasuries.find((treasury) => treasury.isPrimary) ??
+    dashboard?.treasuries[0];
+  const treasuryCurrency =
+    primaryTreasury?.currencyCode ?? dashboard?.primaryCurrencyCode ?? "GBP";
 
   const aggregated = useMemo(() => {
-    const balance = band?.band_balance ?? 0;
+    const balance = (primaryTreasury?.availableBalanceMinor ?? 0) / 100;
     if (earnings.length === 0) {
       return {
         balance,
@@ -357,7 +425,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       recentActivity: earnings,
       bySource,
     };
-  }, [band, earnings]);
+  }, [primaryTreasury, earnings]);
 
   const topSources = useMemo(() => {
     return Object.entries(aggregated.bySource)
@@ -387,7 +455,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
     }
   };
 
-  const handleContribute = async () => {
+  const startContributionPreview = async () => {
     const amount = Number(contributionAmount);
     if (!selectedAccountId || !Number.isFinite(amount) || amount <= 0) {
       toast({
@@ -396,17 +464,45 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       });
       return;
     }
+    setPreviewingContribution(true);
+    try {
+      const amountMinor = Math.round(amount * 100);
+      const { data, error } = await financeRpc.rpc(
+        "preview_my_band_contribution",
+        {
+          p_band_id: bandId,
+          p_bank_account_id: selectedAccountId,
+          p_amount_minor: amountMinor,
+        },
+      );
+      if (error) throw error;
+      setContributionPreview(data);
+      setContributionIdempotencyKey(crypto.randomUUID());
+    } catch (e: unknown) {
+      const message =
+        e instanceof Error ? e.message : "Unable to preview contribution.";
+      toast({
+        title: "Contribution preview failed",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setPreviewingContribution(false);
+    }
+  };
+
+  const handleContribute = async () => {
+    if (!contributionPreview || !contributionIdempotencyKey) return;
     setContributing(true);
     try {
-      const idempotencyKey = crypto.randomUUID();
       const { data, error } = await financeRpc.rpc(
         "contribute_my_personal_funds_to_band",
         {
           p_band_id: bandId,
           p_bank_account_id: selectedAccountId,
-          p_amount_minor: Math.round(amount * 100),
+          p_amount_minor: contributionPreview.amountMinor,
           p_note: contributionNote || null,
-          p_idempotency_key: idempotencyKey,
+          p_idempotency_key: contributionIdempotencyKey,
         },
       );
       if (error) throw error;
@@ -417,6 +513,8 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       });
       setContributionAmount("");
       setContributionNote("");
+      setContributionPreview(null);
+      setContributionIdempotencyKey(null);
       if (data?.newPlayerAvailableBalance !== undefined) {
         setPersonalAccounts((accounts) =>
           accounts.map((account) =>
@@ -494,7 +592,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <PiggyBank className="h-3.5 w-3.5" /> Balance
             </div>
             <p className="text-2xl font-bold">
-              {formatCurrency(aggregated.balance)}
+              {formatCurrency(aggregated.balance, treasuryCurrency)}
             </p>
           </CardContent>
         </Card>
@@ -506,7 +604,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               Income
             </div>
             <p className="text-2xl font-bold text-emerald-500">
-              {formatCurrency(aggregated.totalIncome)}
+              {formatCurrency(aggregated.totalIncome, treasuryCurrency)}
             </p>
           </CardContent>
         </Card>
@@ -518,7 +616,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               Expenses
             </div>
             <p className="text-2xl font-bold text-destructive">
-              {formatCurrency(aggregated.totalExpenses)}
+              {formatCurrency(aggregated.totalExpenses, treasuryCurrency)}
             </p>
           </CardContent>
         </Card>
@@ -549,8 +647,8 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <HandCoins className="h-4 w-4" /> Add Money to Band
             </CardTitle>
             <CardDescription>
-              Move personal funds into the real band treasury with explicit
-              confirmation.
+              Move personal funds into the {treasuryCurrency} band treasury with
+              explicit confirmation.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -645,10 +743,17 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               </AlertDescription>
             </Alert>
             <Button
-              onClick={handleContribute}
-              disabled={contributing || accountsLoading || !selectedAccountId}
+              onClick={startContributionPreview}
+              disabled={
+                previewingContribution ||
+                contributing ||
+                accountsLoading ||
+                !selectedAccountId
+              }
             >
-              {contributing ? "Contributing…" : "Contribute to band"}
+              {previewingContribution
+                ? "Preparing preview…"
+                : "Preview contribution"}
             </Button>
           </CardContent>
         </Card>
@@ -671,24 +776,20 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                   <div key={c.id} className="rounded-md border p-2 text-sm">
                     <div className="flex justify-between gap-2">
                       <span className="font-medium">
-                        {getSourceLabel(c.contribution_type)}
+                        {c.contributorDisplayName} · {getSourceLabel(c.contributionType)}
                       </span>
                       <Badge>
                         {formatCurrency(
-                          (c.amount_minor ?? 0) / 100,
-                          c.currency_code,
+                          (c.amountMinor ?? 0) / 100,
+                          c.currencyCode,
                         )}
                       </Badge>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      {c.currency_code} · {formatDateTime(c.created_at)} ·
-                      refund: {c.refundable_status}
+                      {c.currencyCode} · {formatDateTime(c.createdAt)} ·
+                      refund: {c.refundableStatus}
                     </p>
-                    {c.related_expense_type && (
-                      <p className="text-xs text-muted-foreground">
-                        Related: {c.related_expense_type}
-                      </p>
-                    )}
+
                     {c.notes && <p className="text-xs">{c.notes}</p>}
                   </div>
                 ))}
@@ -738,7 +839,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                     <span
                       className={`text-xs font-semibold w-16 text-right ${amount >= 0 ? "text-emerald-500" : "text-destructive"}`}
                     >
-                      {formatCurrency(amount)}
+                      {formatCurrency(amount, treasuryCurrency)}
                     </span>
                   </div>
                 );
@@ -775,13 +876,13 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <div className="flex justify-between">
                 <span>Projected total payout:</span>
                 <span className="font-semibold text-foreground">
-                  {formatCurrency(projectedTotal)}
+                  {formatCurrency(projectedTotal, treasuryCurrency)}
                 </span>
               </div>
               <div className="flex justify-between border-t border-border pt-1 mt-1">
                 <span>Per member / week:</span>
                 <span className="font-semibold text-foreground">
-                  {formatCurrency(projectedPerMember)}
+                  {formatCurrency(projectedPerMember, treasuryCurrency)}
                 </span>
               </div>
             </div>
@@ -819,8 +920,8 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                   </Button>
                 </div>
                 <p className="text-[11px] text-muted-foreground">
-                  Example: 10% of a {formatCurrency(aggregated.balance)} balance
-                  = {formatCurrency(Math.floor(aggregated.balance * 0.1))} split
+                  Example: 10% of a {formatCurrency(aggregated.balance, treasuryCurrency)} balance
+                  = {formatCurrency(Math.floor(aggregated.balance * 0.1), treasuryCurrency)} split
                   between members.
                 </p>
               </div>
@@ -882,7 +983,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                           className="text-xs"
                         >
                           {entry.amount >= 0 ? "+" : ""}
-                          {formatCurrency(entry.amount)}
+                          {formatCurrency(entry.amount, treasuryCurrency)}
                         </Badge>
                       </TableCell>
                       <TableCell className="hidden md:table-cell text-xs text-muted-foreground max-w-[200px] truncate">
@@ -899,6 +1000,52 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
           )}
         </CardContent>
       </Card>
+      <AlertDialog
+        open={!!contributionPreview}
+        onOpenChange={(open) => {
+          if (!open && !contributing) setContributionPreview(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm band contribution</AlertDialogTitle>
+            <AlertDialogDescription>
+              Review the source account, destination treasury and resulting balances before posting.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {contributionPreview && (
+            <div className="space-y-3 text-sm">
+              <div className="rounded-md border p-3 space-y-1">
+                <p className="font-medium">From: {contributionPreview.sourceAccountDisplay}</p>
+                <p>Personal balance: {formatCurrency(contributionPreview.currentPersonalBalanceMinor / 100, contributionPreview.currencyCode)}</p>
+                <p>Contribution: {formatCurrency(contributionPreview.amountMinor / 100, contributionPreview.currencyCode)}</p>
+                <p>Resulting personal balance: {formatCurrency(contributionPreview.resultingPersonalBalanceMinor / 100, contributionPreview.currencyCode)}</p>
+              </div>
+              <div className="rounded-md border p-3 space-y-1">
+                <p className="font-medium">To: {contributionPreview.destinationTreasuryName}</p>
+                <p>Current treasury balance: {formatCurrency(contributionPreview.currentTreasuryBalanceMinor / 100, contributionPreview.currencyCode)}</p>
+                <p>Resulting treasury balance: {formatCurrency(contributionPreview.resultingTreasuryBalanceMinor / 100, contributionPreview.currencyCode)}</p>
+              </div>
+              <Alert>
+                <AlertTitle>Contribution warning</AlertTitle>
+                <AlertDescription>{contributionPreview.warningText}</AlertDescription>
+              </Alert>
+            </div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={contributing}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleContribute();
+              }}
+              disabled={contributing || !contributionPreview?.eligible}
+            >
+              {contributing ? "Confirming…" : "Confirm contribution"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/supabase/migrations/20260720201000_finance_phase8b10_band_treasury_dashboard.sql
+++ b/supabase/migrations/20260720201000_finance_phase8b10_band_treasury_dashboard.sql
@@ -1,0 +1,156 @@
+-- Finance Phase 8B.10: harden band contribution RPCs and expose ledger-authoritative band treasury dashboard.
+
+CREATE OR REPLACE FUNCTION public.is_bank_account_eligible_for_outgoing_payment(
+  p_bank_account_id uuid,
+  p_amount_minor bigint DEFAULT NULL,
+  p_currency_code char(3) DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  ba public.bank_accounts;
+  fa public.financial_accounts;
+  reason text := NULL;
+BEGIN
+  SELECT * INTO ba FROM public.bank_accounts WHERE id = p_bank_account_id;
+  IF ba.id IS NULL THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'account_not_found');
+  END IF;
+  IF ba.linked_finance_account_id IS NULL THEN reason := 'account_unlinked'; END IF;
+  SELECT * INTO fa FROM public.financial_accounts WHERE id = ba.linked_finance_account_id;
+  IF reason IS NULL AND ba.status <> 'active' THEN reason := 'account_closed'; END IF;
+  IF reason IS NULL AND fa.id IS NULL THEN reason := 'account_unlinked'; END IF;
+  IF reason IS NULL AND fa.account_status <> 'active' THEN reason := 'account_frozen'; END IF;
+  IF reason IS NULL AND COALESCE(ba.withdrawal_restrictions, '{}'::jsonb) ? 'withdrawals_disabled' AND COALESCE((ba.withdrawal_restrictions->>'withdrawals_disabled')::boolean, false) THEN reason := 'withdrawals_disabled'; END IF;
+  IF reason IS NULL AND COALESCE(ba.withdrawal_restrictions, '{}'::jsonb) ? 'under_review' AND COALESCE((ba.withdrawal_restrictions->>'under_review')::boolean, false) THEN reason := 'account_under_review'; END IF;
+  IF reason IS NULL AND p_currency_code IS NOT NULL AND ba.currency_code <> p_currency_code THEN reason := 'currency_mismatch'; END IF;
+  IF reason IS NULL AND p_amount_minor IS NOT NULL AND fa.available_balance_minor < p_amount_minor THEN reason := 'insufficient_available_balance'; END IF;
+  RETURN jsonb_build_object('eligible', reason IS NULL, 'reason', reason);
+END $$;
+
+CREATE OR REPLACE FUNCTION public.get_my_eligible_band_contribution_accounts(
+  p_band_id uuid,
+  p_currency_code char(3) DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  pid uuid := public.current_player_profile_id();
+  active_member boolean;
+  personal_count integer;
+  eligible_count integer;
+  mismatch_count integer;
+  accounts jsonb;
+BEGIN
+  IF pid IS NULL THEN
+    RETURN jsonb_build_object('status','profile_missing','accounts','[]'::jsonb,'message','An active player profile is required.');
+  END IF;
+  SELECT EXISTS (SELECT 1 FROM public.band_members bm WHERE bm.band_id=p_band_id AND bm.profile_id=pid AND COALESCE(bm.member_status,'active')='active') INTO active_member;
+  IF NOT active_member THEN
+    RETURN jsonb_build_object('status','not_band_member','accounts','[]'::jsonb,'message','Active band membership is required.');
+  END IF;
+  SELECT count(*) INTO personal_count FROM public.bank_accounts ba WHERE ba.owner_type='player' AND ba.owner_id=pid;
+  SELECT count(*) INTO mismatch_count FROM public.bank_accounts ba WHERE ba.owner_type='player' AND ba.owner_id=pid AND ba.status='active' AND p_currency_code IS NOT NULL AND ba.currency_code<>p_currency_code;
+  WITH candidates AS (
+    SELECT ba.*, fa.current_balance_minor, fa.available_balance_minor, fa.is_primary, bp.brand_name,
+           public.is_bank_account_eligible_for_outgoing_payment(ba.id, NULL, p_currency_code) AS eligibility
+    FROM public.bank_accounts ba
+    JOIN public.financial_accounts fa ON fa.id=ba.linked_finance_account_id
+    LEFT JOIN public.banking_providers bp ON bp.id=ba.provider_id
+    WHERE ba.owner_type='player' AND ba.owner_id=pid
+  )
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'id', id,
+    'displayName', COALESCE(NULLIF(metadata->>'display_name',''), initcap(replace(account_type::text, '_', ' ')) || ' Account'),
+    'providerName', COALESCE(brand_name, 'Bank account'),
+    'accountType', account_type,
+    'maskedAccountNumber', COALESCE(NULLIF(metadata->>'masked_account_number',''), NULLIF(metadata->>'account_mask',''), '•••• ' || right(id::text, 4)),
+    'currencyCode', currency_code,
+    'currentBalanceMinor', current_balance_minor,
+    'availableBalanceMinor', available_balance_minor,
+    'isPrimary', COALESCE(is_primary, false),
+    'eligible', (eligibility->>'eligible')::boolean,
+    'ineligibleReason', eligibility->>'reason'
+  ) ORDER BY COALESCE(is_primary,false) DESC, opened_at NULLS LAST, created_at) FILTER (WHERE (eligibility->>'eligible')::boolean), '[]'::jsonb),
+  count(*) FILTER (WHERE (eligibility->>'eligible')::boolean)
+  INTO accounts, eligible_count
+  FROM candidates;
+  RETURN jsonb_build_object('status', CASE WHEN personal_count=0 THEN 'no_personal_accounts' WHEN eligible_count=0 AND mismatch_count>0 THEN 'currency_mismatch' WHEN eligible_count=0 THEN 'no_eligible_accounts' ELSE 'ok' END, 'accounts', accounts, 'message', CASE WHEN personal_count=0 THEN 'No personal bank accounts were found.' WHEN eligible_count=0 AND mismatch_count>0 THEN 'No personal accounts match the requested treasury currency.' WHEN eligible_count=0 THEN 'No eligible active personal accounts were found.' ELSE NULL END);
+END $$;
+
+CREATE OR REPLACE FUNCTION public.get_band_treasury_dashboard(p_band_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  pid uuid := public.current_player_profile_id();
+  primary_currency char(3);
+  can_view boolean;
+  can_detail boolean;
+BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile_missing'; END IF;
+  can_view := public.user_has_band_finance_permission(p_band_id,pid,'view_band_balance'::public.band_finance_permission);
+  can_detail := public.user_has_band_finance_permission(p_band_id,pid,'view_transaction_history'::public.band_finance_permission);
+  IF NOT can_view THEN RAISE EXCEPTION 'permission_denied'; END IF;
+  SELECT COALESCE((metadata->>'primary_operating_currency')::char(3), (SELECT default_currency_code FROM public.financial_accounts WHERE owner_type='band' AND owner_id=p_band_id AND account_status='active' ORDER BY is_primary DESC, created_at LIMIT 1), 'GBP'::char(3)) INTO primary_currency FROM public.bands WHERE id=p_band_id;
+  RETURN jsonb_build_object(
+    'primaryCurrencyCode', primary_currency,
+    'treasuries', COALESCE((SELECT jsonb_agg(jsonb_build_object('accountId',id,'currencyCode',default_currency_code,'currentBalanceMinor',current_balance_minor,'reservedBalanceMinor',reserved_balance_minor,'availableBalanceMinor',available_balance_minor,'isPrimary',COALESCE(is_primary,false)) ORDER BY (default_currency_code=primary_currency) DESC, default_currency_code) FROM public.financial_accounts WHERE owner_type='band' AND owner_id=p_band_id AND account_status='active'),'[]'::jsonb),
+    'recentTransactions', COALESCE((SELECT jsonb_agg(jsonb_build_object('id',t.id,'transactionCategory',t.transaction_category,'amountMinor',t.net_amount_minor,'currencyCode',t.currency_code,'description',t.description,'createdAt',t.created_at) ORDER BY t.created_at DESC) FROM (SELECT DISTINCT t.* FROM public.financial_transactions t JOIN public.financial_ledger_entries le ON le.transaction_id=t.id JOIN public.financial_accounts fa ON fa.id=le.account_id WHERE fa.owner_type='band' AND fa.owner_id=p_band_id ORDER BY t.created_at DESC LIMIT 25) t),'[]'::jsonb),
+    'contributions', COALESCE((SELECT jsonb_agg(jsonb_build_object('id',c.id,'amountMinor',c.amount_minor,'currencyCode',c.currency_code,'contributionType',c.contribution_type,'refundableStatus',c.refundable_status,'notes',c.notes,'createdAt',c.created_at,'contributorDisplayName',COALESCE(p.display_name,p.username,'Band member'),'contributorAvatarUrl',p.avatar_url) ORDER BY c.created_at DESC) FROM public.band_financial_contributions c LEFT JOIN public.profiles p ON p.id=c.contributing_player_id WHERE c.band_id=p_band_id AND (can_detail OR c.contributing_player_id=pid) LIMIT 25),'[]'::jsonb),
+    'upcomingObligations','[]'::jsonb,
+    'reconciliation', jsonb_build_object('status','clean','exceptions','[]'::jsonb)
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.preview_my_band_contribution(p_band_id uuid,p_bank_account_id uuid,p_amount_minor bigint)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  pid uuid:=public.current_player_profile_id(); ba public.bank_accounts; fa public.financial_accounts; treasury public.financial_accounts; eligibility jsonb;
+BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile_missing'; END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN RAISE EXCEPTION 'amount_must_be_positive'; END IF;
+  SELECT * INTO ba FROM public.bank_accounts WHERE id=p_bank_account_id;
+  IF ba.owner_type <> 'player' OR ba.owner_id <> pid THEN RAISE EXCEPTION 'personal_account_invalid'; END IF;
+  SELECT * INTO fa FROM public.financial_accounts WHERE id=ba.linked_finance_account_id;
+  SELECT * INTO treasury FROM public.financial_accounts WHERE owner_type='band' AND owner_id=p_band_id AND default_currency_code=ba.currency_code AND account_status='active' ORDER BY is_primary DESC, created_at LIMIT 1;
+  IF treasury.id IS NULL THEN RAISE EXCEPTION 'band_treasury_missing'; END IF;
+  eligibility:=public.is_bank_account_eligible_for_outgoing_payment(p_bank_account_id,p_amount_minor,ba.currency_code);
+  RETURN jsonb_build_object('sourceAccountDisplay',COALESCE(NULLIF(ba.metadata->>'display_name',''),'Personal account') || ' ' || COALESCE(NULLIF(ba.metadata->>'masked_account_number',''),'•••• ' || right(ba.id::text,4)),'currencyCode',ba.currency_code,'currentPersonalBalanceMinor',fa.available_balance_minor,'amountMinor',p_amount_minor,'resultingPersonalBalanceMinor',fa.available_balance_minor-p_amount_minor,'destinationTreasuryName',treasury.account_name,'currentTreasuryBalanceMinor',treasury.available_balance_minor,'resultingTreasuryBalanceMinor',treasury.available_balance_minor+p_amount_minor,'eligible',(eligibility->>'eligible')::boolean,'ineligibleReason',eligibility->>'reason','warningText','This contribution is not automatically repayable and does not grant additional band ownership or voting rights.');
+END $$;
+
+CREATE OR REPLACE FUNCTION public.contribute_my_personal_funds_to_band(p_band_id uuid,p_bank_account_id uuid,p_amount_minor bigint,p_note text DEFAULT NULL,p_idempotency_key text DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE pid uuid:=public.current_player_profile_id(); ba public.bank_accounts; fa public.financial_accounts; eligibility jsonb; day_total bigint; BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile_missing'; END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN RAISE EXCEPTION 'amount_must_be_positive'; END IF;
+  IF p_amount_minor > 100000000 THEN RAISE EXCEPTION 'maximum_transaction_amount_exceeded'; END IF;
+  IF p_idempotency_key IS NULL OR length(trim(p_idempotency_key)) < 8 THEN RAISE EXCEPTION 'idempotency_key_invalid'; END IF;
+  SELECT * INTO ba FROM public.bank_accounts WHERE id=p_bank_account_id FOR UPDATE;
+  SELECT * INTO fa FROM public.financial_accounts WHERE id=ba.linked_finance_account_id FOR UPDATE;
+  IF ba.id IS NULL OR ba.owner_type<>'player' OR ba.owner_id<>pid THEN RAISE EXCEPTION 'personal_account_invalid'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.band_members WHERE band_id=p_band_id AND profile_id=pid AND COALESCE(member_status,'active')='active') THEN RAISE EXCEPTION 'not_band_member'; END IF;
+  eligibility:=public.is_bank_account_eligible_for_outgoing_payment(p_bank_account_id,p_amount_minor,ba.currency_code);
+  IF NOT (eligibility->>'eligible')::boolean THEN RAISE EXCEPTION '%', eligibility->>'reason'; END IF;
+  SELECT COALESCE(sum(amount_minor),0) INTO day_total FROM public.band_financial_contributions WHERE contributing_player_id=pid AND created_at>=date_trunc('day',timezone('utc',now())) AND contribution_type='voluntary_deposit';
+  IF day_total+p_amount_minor>500000000 THEN RAISE EXCEPTION 'daily_contribution_limit_exceeded'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.financial_accounts WHERE owner_type='band' AND owner_id=p_band_id AND default_currency_code=ba.currency_code AND account_status='active') THEN RAISE EXCEPTION 'band_treasury_missing'; END IF;
+  RETURN public.contribute_personal_funds_to_band(p_band_id,p_bank_account_id,p_amount_minor,p_idempotency_key,p_note);
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.get_my_eligible_band_contribution_accounts(uuid,char(3)) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.contribute_my_personal_funds_to_band(uuid,uuid,bigint,text,text) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.preview_my_band_contribution(uuid,uuid,bigint) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_band_treasury_dashboard(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_eligible_band_contribution_accounts(uuid,char(3)) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.contribute_my_personal_funds_to_band(uuid,uuid,bigint,text,text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.preview_my_band_contribution(uuid,uuid,bigint) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_band_treasury_dashboard(uuid) TO authenticated, service_role;


### PR DESCRIPTION
### Motivation
- Ensure Band Finances shows and uses the ledger-backed band treasury as the authoritative spendable balance instead of the legacy `bands.band_balance` mirror.
- Harden personal contribution flows by filtering eligible personal accounts to the treasury currency, improving account eligibility checks, and adding a preview/confirm flow with idempotency.
- Restrict execution of newly-introduced finance RPCs to authenticated and service roles and provide a single server-side treasury dashboard so the browser no longer composes finance state from multiple fragile queries.

### Description
- Add a Phase 8B.10 SQL migration that implements `is_bank_account_eligible_for_outgoing_payment`, replaces `get_my_eligible_band_contribution_accounts` to use that helper and support currency filtering, introduces `get_band_treasury_dashboard`, provides a write-free `preview_my_band_contribution`, hardens `contribute_my_personal_funds_to_band`, and explicitly revokes `PUBLIC`/`anon` before granting `authenticated` and `service_role` execution. (`supabase/migrations/20260720201000_finance_phase8b10_band_treasury_dashboard.sql`)
- Update `BandFinancesTab` to read the treasury dashboard RPC, use the selected treasury `availableBalanceMinor` and currency for formatting, filter eligible personal accounts by treasury currency, show permission-filtered contributor display names, and require a preview+confirmation modal that creates and preserves an idempotency key for the confirmation session. (`src/components/bands/BandFinancesTab.tsx`)
- Replace raw empty-JSON withdrawal checks with the structured eligibility helper which returns explicit reasons such as `currency_mismatch`, `insufficient_available_balance`, and `withdrawals_disabled`.
- Add an audit document describing the decision to treat `financial_accounts`/treasury as authoritative and cataloguing remaining migration work for legacy `bands.band_balance`. (`docs/finance/FINANCE_PHASE8B10_BAND_TREASURY_REHEARSAL_AUDIT.md`)

### Testing
- `npx tsc --noEmit --pretty false` (TypeScript typecheck) completed successfully.  
- `git diff --check` completed successfully to validate no trivial whitespace errors.  
- `npm ci` failed due to a registry `403` for an upstream package which left local node tools unavailable and prevented running `npm run lint`, `npm run test -- --run`, and `npm run build`, so those commands could not be exercised in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e346be864832591ccc72e5d587a15)