### PR TITLE
Finance Regression Repair 2: forward-repair band treasury dashboard

### DIFF
--- a/src/components/bands/BandFinancesTab.test.tsx
+++ b/src/components/bands/BandFinancesTab.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@/integrations/supabase/client", () => ({
 }));
 
 vi.mock("@/hooks/useActiveProfile", () => ({
-  useActiveProfile: () => ({ profileId: "profile-1" }),
+  useActiveProfile: () => ({ profileId: "profile-1", userId: "user-1" }),
 }));
 
 vi.mock("@/hooks/use-toast", () => ({
@@ -63,14 +63,12 @@ function mockCoreQueries() {
     if (table === "band_members") {
       return {
         select: vi.fn().mockReturnThis(),
-        eq: vi
-          .fn()
-          .mockResolvedValue({
-            data: [
-              { id: "member-1", is_touring_member: false, user_id: "user-1" },
-            ],
-            error: null,
-          }),
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { id: "member-1", is_touring_member: false, user_id: "user-1" },
+          ],
+          error: null,
+        }),
       };
     }
     throw new Error(`Unexpected table ${table}`);
@@ -108,6 +106,9 @@ describe("BandFinancesTab treasury regression handling", () => {
       screen.getByText("Your other finance information is still available."),
     ).toBeInTheDocument();
     expect(
+      screen.getByText("invalid input value for enum"),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByText("Unable to load band finances"),
     ).not.toBeInTheDocument();
     expect(
@@ -115,7 +116,7 @@ describe("BandFinancesTab treasury regression handling", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Add Money to Band")).toBeInTheDocument();
     expect(screen.getByText("Weekly Member Pay")).toBeInTheDocument();
-    expect(screen.getByText(/\$1,234/)).toBeInTheDocument();
+    expect(screen.getByText(/£1,234.00/)).toBeInTheDocument();
   });
 
   it("does not replace a legacy balance with zero when no treasury exists", async () => {
@@ -142,8 +143,83 @@ describe("BandFinancesTab treasury regression handling", () => {
     expect(
       await screen.findByText("Band treasury is not available yet."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/\$1,234/)).toBeInTheDocument();
-    expect(screen.queryByText(/\$0\.00/)).not.toBeInTheDocument();
+    expect(screen.getByText(/£1,234.00/)).toBeInTheDocument();
+    expect(screen.queryByText(/£0\.00/)).not.toBeInTheDocument();
+  });
+
+  it("does not activate legacy fallback after treasury permission denial", async () => {
+    rpc.mockImplementation((fn: string) => {
+      if (fn === "get_band_treasury_dashboard") {
+        return Promise.resolve({
+          data: {
+            status: "permission_denied",
+            primaryCurrencyCode: "GBP",
+            treasuries: [],
+            contributions: [
+              {
+                id: "hidden",
+                amountMinor: 5000,
+                currencyCode: "GBP",
+                contributionType: "voluntary_deposit",
+                refundableStatus: "not_refundable",
+                notes: "protected",
+                createdAt: "2026-07-20T12:00:00Z",
+                contributorDisplayName: "Hidden Member",
+                contributorAvatarUrl: null,
+              },
+            ],
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({
+        data: { status: "no_eligible_accounts", accounts: [] },
+        error: null,
+      });
+    });
+
+    render(<BandFinancesTab bandId="band-1" />);
+
+    expect(
+      await screen.findByText("Band treasury permission required."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Legacy balance fallback active"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Hidden Member")).not.toBeInTheDocument();
+    expect(screen.getByText("£0.00")).toBeInTheDocument();
+  });
+
+  it("shows active profile errors without contribution controls enabled", async () => {
+    rpc.mockImplementation((fn: string) => {
+      if (fn === "get_band_treasury_dashboard") {
+        return Promise.resolve({
+          data: {
+            status: "profile_missing",
+            primaryCurrencyCode: "GBP",
+            treasuries: [],
+            contributions: [],
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({
+        data: { status: "profile_missing", accounts: [] },
+        error: null,
+      });
+    });
+
+    render(<BandFinancesTab bandId="band-1" />);
+
+    expect(
+      await screen.findByText("Active profile required."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Legacy balance fallback active"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Preview contribution/i }),
+    ).toBeDisabled();
   });
 
   it("isolates personal account RPC failures to the contribution section", async () => {

--- a/src/components/bands/BandFinancesTab.tsx
+++ b/src/components/bands/BandFinancesTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { format } from "date-fns";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/lib/supabase-types";
@@ -168,7 +168,12 @@ interface DashboardContribution {
 }
 
 interface TreasuryDashboard {
-  status?: "ok" | "treasury_missing" | "profile_missing" | "permission_denied";
+  status?:
+    | "ok"
+    | "treasury_missing"
+    | "profile_missing"
+    | "permission_denied"
+    | "band_missing";
   primaryCurrencyCode: string;
   treasuries: TreasuryAccount[];
   contributions: DashboardContribution[];
@@ -231,6 +236,20 @@ interface SupabaseFinanceRpcClient {
 
 const financeRpc = supabase as unknown as SupabaseFinanceRpcClient;
 
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return fallback;
+}
+
 function formatDateTime(value: string) {
   try {
     return format(new Date(value), "MMM d, yyyy h:mm a");
@@ -274,12 +293,17 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   const [contributions, setContributions] = useState<DashboardContribution[]>(
     [],
   );
+  const treasuryRequestId = useRef(0);
+  const accountsRequestId = useRef(0);
 
   const fetchEligibleAccounts = async () => {
+    const requestId = ++accountsRequestId.current;
     if (!bandId || !profileId) {
-      setPersonalAccounts([]);
-      setSelectedAccountId("");
-      setAccountStatus(profileId ? null : "profile_missing");
+      if (requestId === accountsRequestId.current) {
+        setPersonalAccounts([]);
+        setSelectedAccountId("");
+        setAccountStatus(profileId ? null : "profile_missing");
+      }
       return;
     }
 
@@ -293,13 +317,14 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
           dashboard?.primaryCurrencyCode ?? (band ? "GBP" : null),
       },
     );
+    if (requestId !== accountsRequestId.current) return;
     setAccountsLoading(false);
 
     if (error) {
       setPersonalAccounts([]);
       setSelectedAccountId("");
       setAccountStatus(null);
-      setAccountError(error.message);
+      setAccountError(getErrorMessage(error, "Unable to load accounts."));
       return;
     }
 
@@ -318,6 +343,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   };
 
   const fetchTreasuryDashboard = async () => {
+    const requestId = ++treasuryRequestId.current;
     if (!bandId || !profileId) return;
     setDashboardLoading(true);
     setDashboardError(null);
@@ -329,19 +355,21 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
         },
       );
       if (error) throw error;
+      if (requestId !== treasuryRequestId.current) return;
       setDashboard(data);
       setContributions(data?.contributions ?? []);
     } catch (caught) {
-      const message =
-        caught instanceof Error
-          ? caught.message
-          : "Unable to load treasury dashboard.";
+      if (requestId !== treasuryRequestId.current) return;
+      const message = getErrorMessage(
+        caught,
+        "Unable to load treasury dashboard.",
+      );
       console.error("Failed to load band treasury dashboard", caught);
       setDashboard(null);
       setContributions([]);
       setDashboardError(message);
     } finally {
-      setDashboardLoading(false);
+      if (requestId === treasuryRequestId.current) setDashboardLoading(false);
     }
   };
 
@@ -352,7 +380,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       const [
         { data: bandData, error: bandError },
         { data: earningData, error: earningError },
-        { data: membersData },
+        { data: membersData, error: membersError },
       ] = await Promise.all([
         supabase.from("bands").select("*").eq("id", bandId).single(),
         supabase
@@ -369,6 +397,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
 
       if (bandError) throw bandError;
       if (earningError) throw earningError;
+      if (membersError) throw membersError;
 
       const b = bandData as BandRow;
       setBand(b);
@@ -391,6 +420,15 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
   };
 
   useEffect(() => {
+    treasuryRequestId.current += 1;
+    accountsRequestId.current += 1;
+    setDashboard(null);
+    setDashboardError(null);
+    setContributions([]);
+    setPersonalAccounts([]);
+    setSelectedAccountId("");
+    setContributionPreview(null);
+    setContributionIdempotencyKey(null);
     void fetchFinances();
   }, [bandId, profileId]);
 
@@ -404,7 +442,17 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
     ) ??
     dashboard?.treasuries.find((treasury) => treasury.isPrimary) ??
     dashboard?.treasuries[0];
-  const balanceSource = primaryTreasury ? "ledger" : "legacy_fallback";
+  const dashboardStatus = dashboard?.status ?? null;
+  const canUseLegacyFallback =
+    !primaryTreasury &&
+    !!band &&
+    (dashboardStatus === "treasury_missing" ||
+      (!!dashboardError && dashboardStatus !== "permission_denied"));
+  const balanceSource = primaryTreasury
+    ? "ledger"
+    : canUseLegacyFallback
+      ? "legacy_fallback"
+      : "unavailable";
   const treasuryCurrency =
     primaryTreasury?.currencyCode ?? dashboard?.primaryCurrencyCode ?? "GBP";
 
@@ -412,7 +460,9 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
     const balance =
       primaryTreasury?.availableBalanceMinor !== undefined
         ? primaryTreasury.availableBalanceMinor / 100
-        : Number(band?.band_balance ?? 0);
+        : canUseLegacyFallback
+          ? Number(band?.band_balance ?? 0)
+          : 0;
     if (earnings.length === 0) {
       return {
         balance,
@@ -457,7 +507,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       recentActivity: earnings,
       bySource,
     };
-  }, [primaryTreasury, band?.band_balance, earnings]);
+  }, [primaryTreasury, canUseLegacyFallback, band?.band_balance, earnings]);
 
   const topSources = useMemo(() => {
     return Object.entries(aggregated.bySource)
@@ -479,8 +529,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
         description: `${clamped}% of band balance will be paid out each Saturday at 10:00 AM.`,
       });
     } catch (e: unknown) {
-      const message =
-        e instanceof Error ? e.message : "Unable to save weekly pay.";
+      const message = getErrorMessage(e, "Unable to save weekly pay.");
       toast({ title: "Error", description: message, variant: "destructive" });
     } finally {
       setSavingPay(false);
@@ -511,8 +560,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       setContributionPreview(data);
       setContributionIdempotencyKey(crypto.randomUUID());
     } catch (e: unknown) {
-      const message =
-        e instanceof Error ? e.message : "Unable to preview contribution.";
+      const message = getErrorMessage(e, "Unable to preview contribution.");
       toast({
         title: "Contribution preview failed",
         description: message,
@@ -564,8 +612,7 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
       void fetchFinances();
       void fetchEligibleAccounts();
     } catch (e: unknown) {
-      const message =
-        e instanceof Error ? e.message : "Unable to post contribution.";
+      const message = getErrorMessage(e, "Unable to post contribution.");
       toast({
         title: "Contribution failed",
         description: message,
@@ -640,6 +687,32 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
           <AlertDescription>
             Showing the legacy band balance until a ledger treasury is
             available.
+          </AlertDescription>
+        </Alert>
+      )}
+      {!dashboardError && dashboard?.status === "permission_denied" && (
+        <Alert variant="destructive">
+          <AlertTitle>Band treasury permission required.</AlertTitle>
+          <AlertDescription>
+            You do not have permission to view this band treasury. Legacy
+            balance fallback is disabled for explicit permission denials.
+          </AlertDescription>
+        </Alert>
+      )}
+      {!dashboardError && dashboard?.status === "profile_missing" && (
+        <Alert variant="destructive">
+          <AlertTitle>Active profile required.</AlertTitle>
+          <AlertDescription>
+            Select or create an active player profile before using Band
+            Finances.
+          </AlertDescription>
+        </Alert>
+      )}
+      {!dashboardError && dashboard?.status === "band_missing" && (
+        <Alert variant="destructive">
+          <AlertTitle>Band not found.</AlertTitle>
+          <AlertDescription>
+            This band could not be found by the treasury dashboard.
           </AlertDescription>
         </Alert>
       )}
@@ -725,7 +798,13 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
               <Select
                 value={selectedAccountId}
                 onValueChange={setSelectedAccountId}
-                disabled={accountsLoading || personalAccounts.length === 0}
+                disabled={
+                  accountsLoading ||
+                  personalAccounts.length === 0 ||
+                  dashboardStatus === "permission_denied" ||
+                  dashboardStatus === "profile_missing" ||
+                  dashboardStatus === "band_missing"
+                }
               >
                 <SelectTrigger>
                   <SelectValue
@@ -816,7 +895,10 @@ export function BandFinancesTab({ bandId }: BandFinancesTabProps) {
                 previewingContribution ||
                 contributing ||
                 accountsLoading ||
-                !selectedAccountId
+                !selectedAccountId ||
+                dashboardStatus === "permission_denied" ||
+                dashboardStatus === "profile_missing" ||
+                dashboardStatus === "band_missing"
               }
             >
               {previewingContribution

--- a/supabase/migrations/20291217080000_fix_deployed_band_treasury_dashboard.sql
+++ b/supabase/migrations/20291217080000_fix_deployed_band_treasury_dashboard.sql
@@ -1,0 +1,109 @@
+-- Finance Regression Repair 2: forward repair for deployed band treasury RPCs.
+-- Audit note: PR #1250 deployed the initial 20260720201000 Phase 8B.10
+-- function definitions. PRs #1251/#1252 edited that historical migration, but
+-- editing an already-applied Supabase migration does not update existing
+-- databases. This migration reapplies the repaired definitions forward so
+-- production, staging, and clean reset databases converge on the same behavior.
+
+CREATE OR REPLACE FUNCTION public.get_band_treasury_dashboard(p_band_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  pid uuid := public.current_player_profile_id();
+  primary_currency char(3) := 'GBP'::char(3);
+  active_member boolean := false;
+  can_detail boolean := false;
+  band_exists boolean := false;
+BEGIN
+  IF pid IS NULL THEN
+    RETURN jsonb_build_object('status','profile_missing','primaryCurrencyCode','GBP','treasuries','[]'::jsonb,'contributions','[]'::jsonb);
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM public.bands b WHERE b.id = p_band_id) INTO band_exists;
+  IF NOT band_exists THEN
+    RETURN jsonb_build_object('status','band_missing','primaryCurrencyCode','GBP','treasuries','[]'::jsonb,'contributions','[]'::jsonb);
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.band_members bm
+    WHERE bm.band_id = p_band_id
+      AND bm.profile_id = pid
+      AND COALESCE(bm.member_status,'active') = 'active'
+  ) INTO active_member;
+
+  IF NOT active_member THEN
+    RETURN jsonb_build_object('status','permission_denied','primaryCurrencyCode','GBP','treasuries','[]'::jsonb,'contributions','[]'::jsonb);
+  END IF;
+
+  can_detail := public.user_has_band_finance_permission(p_band_id,pid,'view_detailed_income_expenses'::public.band_finance_permission);
+
+  SELECT COALESCE(
+    (SELECT COALESCE(fa.currency_code, fa.default_currency_code) FROM public.financial_accounts fa WHERE fa.owner_type='band' AND fa.owner_id=p_band_id AND fa.account_status='active' ORDER BY fa.is_primary DESC, fa.created_at LIMIT 1),
+    'GBP'::char(3)
+  ) INTO primary_currency;
+
+  primary_currency := COALESCE(primary_currency, 'GBP'::char(3));
+
+  RETURN jsonb_build_object(
+    'status', CASE WHEN EXISTS (SELECT 1 FROM public.financial_accounts fa WHERE fa.owner_type='band' AND fa.owner_id=p_band_id AND fa.account_status='active') THEN 'ok' ELSE 'treasury_missing' END,
+    'primaryCurrencyCode', primary_currency,
+    'treasuries', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'accountId', fa.id,
+        'currencyCode', COALESCE(fa.currency_code, fa.default_currency_code),
+        'currentBalanceMinor', fa.current_balance_minor,
+        'availableBalanceMinor', fa.available_balance_minor,
+        'isPrimary', COALESCE(fa.is_primary,false)
+      ) ORDER BY (COALESCE(fa.currency_code, fa.default_currency_code)=primary_currency) DESC, fa.is_primary DESC, fa.created_at)
+      FROM public.financial_accounts fa
+      WHERE fa.owner_type='band' AND fa.owner_id=p_band_id AND fa.account_status='active'
+    ),'[]'::jsonb),
+    'contributions', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', contribution_rows.id,
+        'amountMinor', contribution_rows.amount_minor,
+        'currencyCode', contribution_rows.currency_code,
+        'contributionType', contribution_rows.contribution_type,
+        'refundableStatus', contribution_rows.refundable_status,
+        'notes', contribution_rows.notes,
+        'createdAt', contribution_rows.created_at,
+        'contributorDisplayName', COALESCE(p.display_name,p.username,'Band member'),
+        'contributorAvatarUrl', p.avatar_url
+      ) ORDER BY contribution_rows.created_at DESC)
+      FROM (
+        SELECT c.id, c.amount_minor, c.currency_code, c.contribution_type, c.refundable_status, c.notes, c.created_at, c.contributing_player_id
+        FROM public.band_financial_contributions c
+        WHERE c.band_id=p_band_id AND (can_detail OR c.contributing_player_id=pid)
+        ORDER BY c.created_at DESC
+        LIMIT 25
+      ) contribution_rows
+      LEFT JOIN public.profiles p ON p.id=contribution_rows.contributing_player_id
+    ),'[]'::jsonb)
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.preview_my_band_contribution(p_band_id uuid,p_bank_account_id uuid,p_amount_minor bigint)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  pid uuid:=public.current_player_profile_id(); ba public.bank_accounts; fa public.financial_accounts; treasury public.financial_accounts; eligibility jsonb;
+BEGIN
+  IF pid IS NULL THEN RAISE EXCEPTION 'profile_missing'; END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN RAISE EXCEPTION 'amount_must_be_positive'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.bands WHERE id=p_band_id) THEN RAISE EXCEPTION 'band_missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.band_members WHERE band_id=p_band_id AND profile_id=pid AND COALESCE(member_status,'active')='active') THEN RAISE EXCEPTION 'not_band_member'; END IF;
+  SELECT * INTO ba FROM public.bank_accounts WHERE id=p_bank_account_id;
+  IF ba.id IS NULL OR ba.owner_type <> 'player' OR ba.owner_id <> pid THEN RAISE EXCEPTION 'personal_account_invalid'; END IF;
+  SELECT * INTO fa FROM public.financial_accounts WHERE id=ba.linked_finance_account_id;
+  SELECT * INTO treasury FROM public.financial_accounts WHERE owner_type='band' AND owner_id=p_band_id AND COALESCE(currency_code, default_currency_code)=ba.currency_code AND account_status='active' ORDER BY is_primary DESC, created_at LIMIT 1;
+  IF treasury.id IS NULL THEN RAISE EXCEPTION 'band_treasury_missing'; END IF;
+  eligibility:=public.is_bank_account_eligible_for_outgoing_payment(p_bank_account_id,p_amount_minor,ba.currency_code);
+  RETURN jsonb_build_object('sourceAccountDisplay',COALESCE(NULLIF(ba.metadata->>'display_name',''),'Personal account') || ' ' || COALESCE(NULLIF(ba.metadata->>'masked_account_number',''),'•••• ' || right(ba.id::text,4)),'currencyCode',ba.currency_code,'currentPersonalBalanceMinor',fa.available_balance_minor,'amountMinor',p_amount_minor,'resultingPersonalBalanceMinor',fa.available_balance_minor-p_amount_minor,'destinationTreasuryName',treasury.account_name,'currentTreasuryBalanceMinor',treasury.available_balance_minor,'resultingTreasuryBalanceMinor',treasury.available_balance_minor+p_amount_minor,'eligible',(eligibility->>'eligible')::boolean,'ineligibleReason',eligibility->>'reason','warningText','This contribution is not automatically repayable and does not grant additional band ownership or voting rights.');
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.preview_my_band_contribution(uuid,uuid,bigint) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.get_band_treasury_dashboard(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.preview_my_band_contribution(uuid,uuid,bigint) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_band_treasury_dashboard(uuid) TO authenticated, service_role;


### PR DESCRIPTION
### Motivation
- Ensure the deployed production database receives the repaired treasury RPCs by adding a forward-only migration instead of editing an already-applied migration. 
- Prevent a treasury RPC failure from blanking or misrepresenting the Band Finances UI and avoid exposing legacy balances after explicit permission/profile/band denials. 
- Reduce stale-response races and fragile error handling in the Band Finances frontend so contribution flows and account selection remain isolated from treasury failures.

### Description
- Adds a new forward-only migration `supabase/migrations/20291217080000_fix_deployed_band_treasury_dashboard.sql` that reapplies repaired function definitions and includes an audit note explaining why a forward migration is required for already-applied migrations; the migration uses `CREATE OR REPLACE FUNCTION` for `get_band_treasury_dashboard` and `preview_my_band_contribution`, returns explicit statuses (`ok | treasury_missing | permission_denied | profile_missing | band_missing`), and limits contribution aggregation via an inner subquery with `LIMIT 25`.
- Updates `src/components/bands/BandFinancesTab.tsx` to add a safe error parser (`getErrorMessage`), request-generation guards (`useRef` counters) for treasury/account RPCs, clear stale state when `bandId` or `profileId` change, and tighten fallback logic so legacy balance fallback is only used for `treasury_missing` or technical failures (not for `permission_denied`/`profile_missing`/`band_missing`).
- Adds explicit UI handling for `permission_denied`, `profile_missing`, and `band_missing` states and disables contribution/account controls in those cases while preserving other page sections when the treasury is unavailable.
- Repairs component tests in `src/components/bands/BandFinancesTab.test.tsx` to mock the actual `useActiveProfile` shape, expect GBP-formatted currency output (e.g. `£1,234.00`), preserve Supabase object error messages in assertions, and add tests for `permission_denied` and `profile_missing` behaviors.

### Testing
- `npm run typecheck` (`tsc --noEmit`) executed and passed in this environment.
- `npm ci` failed due to registry access (`403 Forbidden`) for some packages, which prevented installing dev/runtime deps; as a result `npm run lint`, `npm run test`, and `npm run build` could not be completed here because required tools (`@eslint/js`, `vitest`, `vite`, etc.) were not available.
- Supabase-related DB verification commands (`supabase db start`, `supabase db reset`, `supabase db lint`, `supabase test db`) and browser tests (`npx playwright test tests/finance`) were not executed because the Supabase CLI and test runner dependencies are not installed in this environment or registry access failed.  
- Local automated typechecking succeeded, but full verification (migration application, DB unit tests, and component/browser tests) must run in CI or a developer machine with registry and Supabase CLI access before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e481371f08325995e48631c1e43dc)