### PR TITLE
Finalise Festival Dashboard Insurance and Add London Test Festival

### DIFF
--- a/docs/festivals/LONDON_TEST_FESTIVAL.md
+++ b/docs/festivals/LONDON_TEST_FESTIVAL.md
@@ -1,0 +1,78 @@
+# RockMundo London Test Festival
+
+Purpose: deterministic development and QA fixture for validating the complete festival owner dashboard without adding production seed data.
+
+## Seed and rerun
+
+Run manually after a local Supabase reset:
+
+```bash
+npm run seed:festival:london
+```
+
+The seed is idempotent and owns only records marked with `fixture = london-dashboard` / `fixture_key = RM-LONDON-TEST-FESTIVAL`.
+
+## Assign an owner
+
+Create or sign in with a local test account, find its profile id, then run:
+
+```sql
+select assign_london_test_festival_owner('<profile uuid>');
+```
+
+This updates only the fixture festival owner and does not weaken RLS.
+
+## Stable URLs
+
+The fixture uses deterministic ids:
+
+- Brand id: `11111111-1111-4111-8111-111111111111`
+- Edition id: `11111111-1111-4111-8111-111111111112`
+- Public URL: `/festivals/11111111-1111-4111-8111-111111111111`
+- Owner URL: `/festivals/11111111-1111-4111-8111-111111111111/manage/editions/11111111-1111-4111-8111-111111111112`
+
+Lookup query:
+
+```sql
+select f.id as festival_id, e.id as edition_id,
+       '/festivals/' || f.id as public_url,
+       '/festivals/' || f.id || '/manage/editions/' || e.id as owner_url
+from festivals f
+join festival_editions e on e.festival_id = f.id
+where f.metadata->>'fixture_key' = 'RM-LONDON-TEST-FESTIVAL';
+```
+
+## Expected dashboard values
+
+- City/currency: London, GBP
+- Capacity: 10,000
+- Tickets sold target represented by fixture metadata/dashboard checks: 3,250 / 10,000
+- Budget: £250,000 approved, £110,000 committed, £140,000 remaining, 44% used
+- Stages: Main Stage, River Stage, New Music Stage
+- Slots: 24 total, 15 occupied, 9 intentionally empty
+- Staff: seven roles arranged
+- Permits: 4 / 4 approved
+- Insurance: active canonical policy with `active = true` and `policy_status = pending_payment`
+
+## Checklist
+
+- ✓ Festival details
+- ✓ Dates and location
+- ✓ Three stages configured
+- ✓ Performance slots created
+- ⚠ Lineup partially filled
+- ⚠ Some contracts outstanding
+- ✓ Tickets configured
+- ✓ Staffing arranged
+- ✓ Four permits approved
+- ✓ Insurance active
+- ✓ Budget approved
+- ⚠ Operational readiness incomplete
+
+## Why pending-payment insurance?
+
+The canonical purchase workflow can produce a valid policy row with `active = true` and `policy_status = pending_payment`. The dashboard must recognise the `active` flag while still rejecting cancelled, expired, rejected or void policies.
+
+## Remove/reset
+
+Use `supabase db reset` to remove local fixture data, or rerun the seed to restore it. Do not run this seed as part of production deployment.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "validate:balance": "vitest run src/balance/__tests__/balance.test.ts",
     "simulate:balance": "node scripts/progression-simulations/run-balance-simulations.mjs",
     "validate:progression-programme": "node scripts/progression/validate-programme.mjs",
-    "test:festivals:db": "bash scripts/festivals/run-creation-phase1-db-gate.sh"
+    "test:festivals:db": "bash scripts/festivals/run-creation-phase1-db-gate.sh",
+    "seed:festival:london": "psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/seeds/festival_london_test.sql"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/features/festivals/admin/dashboard/buildFestivalDashboardModel.test.ts
+++ b/src/features/festivals/admin/dashboard/buildFestivalDashboardModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildFestivalDashboardModel } from "./buildFestivalDashboardModel";
+import { buildFestivalDashboardModel, isInsurancePolicyActiveForEdition } from "./buildFestivalDashboardModel";
 
 const edition = (overrides = {}) => ({ id: "ed", festivalId: "fest", title: "Summer Noise 2027", editionNumber: 1, status: "planning" as const, startAt: "2027-08-01T12:00:00Z", endAt: "2027-08-03T23:00:00Z", cityName: "London", currencyCode: "GBP", ...overrides });
 const slot = (id: string, extra = {}) => ({ id, band_id: `band-${id}`, contract_status: "signed", ...extra });
@@ -27,4 +27,46 @@ describe("buildFestivalDashboardModel", () => {
   it("omits absent sponsor and reputation data", () => { const m = build({ operations: {} }); expect(m.sponsorCount).toBeNull(); expect(m.reputation).toBeNull(); });
   it("uses only valid checklist destinations", () => { const valid = new Set(["#lineup", "#schedule", "#stages", "#staff", "#permits", "#insurance", "#finance", "#operations", "#settings"]); expect(build({}).checks.every(c=>valid.has(c.destination))).toBe(true); });
   it("never returns non-finite percentages", () => { const m = build({ operations: { ticket_summary: { capacity: 0, tickets_sold: 0 }, slots: [] }, finance: { approved_budget_cents: 0, committed_costs_cents: 0 } }); expect([m.ticketSalesPercent, m.lineupPercent, m.budgetUsedPercent].every(v=>v===null || Number.isFinite(v))).toBe(true); });
+});
+
+
+describe("canonical insurance coverage matching", () => {
+  const complete = (policy: Record<string, unknown>) => build({ operations: { insurance_policies: [policy] } }).checks.find((c) => c.key === "insurance")?.status;
+
+  it("recognises canonical active pending-payment policies", () => {
+    expect(complete({ active: true, policy_status: "pending_payment", effective_from: "2027-07-25", effective_to: "2027-08-10" })).toBe("complete");
+  });
+
+  it("recognises accepted active statuses with valid dates", () => {
+    expect(complete({ policy_status: "in_force", effective_from: "2027-07-01T00:00:00Z", effective_to: "2027-08-04T00:00:00Z" })).toBe("complete");
+  });
+
+  it("rejects inactive flags without an active status", () => {
+    expect(complete({ active: false, policy_status: "pending_payment", effective_from: "2027-07-01", effective_to: "2027-08-04" })).toBe("blocked");
+  });
+
+  it("rejects explicitly cancelled policies even when active is true", () => {
+    expect(complete({ active: true, policy_status: "cancelled", effective_from: "2027-07-01", effective_to: "2027-08-04" })).toBe("blocked");
+  });
+
+  it("rejects expired policies", () => {
+    expect(complete({ active: true, policy_status: "expired", effective_from: "2027-07-01", effective_to: "2027-08-04" })).toBe("blocked");
+  });
+
+  it("rejects policies beginning after the edition starts", () => {
+    expect(complete({ active: true, policy_status: "pending_payment", effective_from: "2027-08-02T00:00:00Z", effective_to: "2027-08-04T00:00:00Z" })).toBe("blocked");
+  });
+
+  it("rejects policies ending before the edition finishes", () => {
+    expect(complete({ active: true, policy_status: "pending_payment", effective_from: "2027-07-01T00:00:00Z", effective_to: "2027-08-03T12:00:00Z" })).toBe("blocked");
+  });
+
+  it("allows missing canonical boundaries as open ended but not invalid boundaries", () => {
+    expect(isInsurancePolicyActiveForEdition({ active: true, policy_status: "pending_payment" }, "2027-08-01T12:00:00Z", "2027-08-03T23:00:00Z")).toBe(true);
+    expect(complete({ active: true, policy_status: "pending_payment", effective_from: "not-a-date", effective_to: "2027-08-04" })).toBe("blocked");
+  });
+
+  it("keeps insurance unavailable when operations loading fails", () => {
+    expect(build({ operationsUnavailable: true, operations: { insurance_policies: [{ active: true, policy_status: "pending_payment" }] } }).checks.find((c) => c.key === "insurance")?.status).toBe("unavailable");
+  });
 });

--- a/src/features/festivals/admin/dashboard/buildFestivalDashboardModel.ts
+++ b/src/features/festivals/admin/dashboard/buildFestivalDashboardModel.ts
@@ -22,6 +22,37 @@ function check(key: string, label: string, status: DashboardCheckStatus, explana
 function isOccupied(s: Record<string, unknown>) { return Boolean(s.reservation_id || s.band_id || s.system_act_id || s.booking_id || s.act_id); }
 function isContracted(s: Record<string, unknown>) { return Boolean(s.canonical_contract_id || /signed|executed|confirmed/i.test(String(s.contract_status ?? ""))); }
 
+function parsePolicyBoundary(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const time = Date.parse(String(value));
+  return Number.isFinite(time) ? time : Number.NaN;
+}
+
+function policyBoundary(policy: Record<string, unknown>, fields: string[]): number | null {
+  for (const field of fields) {
+    if (policy[field] !== null && policy[field] !== undefined && policy[field] !== "") return parsePolicyBoundary(policy[field]);
+  }
+  return null;
+}
+
+export function isInsurancePolicyActiveForEdition(policy: Record<string, unknown>, editionStart: string | null | undefined, editionEnd: string | null | undefined): boolean {
+  const status = String(policy.policy_status ?? policy.status ?? policy.coverage_status ?? "").toLowerCase();
+  const explicitlyInactive = /cancel|expired|reject|void/.test(status);
+  const activeByFlag = policy.active === true || policy.is_active === true;
+  const activeByStatus = /active|bound|issued|covered|in_force/.test(status);
+  const isActive = !explicitlyInactive && (activeByFlag || activeByStatus);
+  if (!isActive) return false;
+
+  const eventStart = editionStart ? Date.parse(editionStart) : null;
+  const eventEnd = editionEnd ? Date.parse(editionEnd) : eventStart;
+  if ((eventStart !== null && !Number.isFinite(eventStart)) || (eventEnd !== null && !Number.isFinite(eventEnd))) return false;
+
+  const fromTime = policyBoundary(policy, ["effective_from", "coverage_start_at", "starts_at", "start_at", "effective_at"]);
+  const toTime = policyBoundary(policy, ["effective_to", "coverage_end_at", "ends_at", "end_at", "expires_at"]);
+  if (Number.isNaN(fromTime) || Number.isNaN(toTime)) return false;
+  return (eventStart === null || fromTime === null || fromTime <= eventStart) && (eventEnd === null || toTime === null || toTime >= eventEnd);
+}
+
 export function buildFestivalDashboardModel(input: { festivalName?: string | null; edition: Pick<OwnerEditionOption, "title" | "status" | "startAt" | "endAt" | "cityName" | "currencyCode"> & Partial<OwnerEditionOption>; operations?: unknown; finance?: unknown; operationsUnavailable?: boolean; financeUnavailable?: boolean; now?: Date; }): FestivalDashboardModel {
   const ops = asObject(input.operations), fin = input.financeUnavailable ? {} : asObject(input.finance ?? ops.finance);
   const stages = asArray(ops.stages), slots = asArray(ops.slots), staff = asArray(ops.staff), permits = asArray(ops.permit_requirements), policies = asArray(ops.insurance_policies);
@@ -39,9 +70,7 @@ export function buildFestivalDashboardModel(input: { festivalName?: string | nul
   const approvedPermits = permits.filter((p) => /approved|not_required/i.test(String(p.status ?? p.requirement_status ?? p.decision))).length;
   const permitsNotRequired = permits.length === 0 && Boolean(ops.permits_not_required ?? ops.permit_requirements_not_required);
   const permitsReady = permits.length > 0 ? approvedPermits === permits.length : permitsNotRequired;
-  const eventStart = input.edition.startAt ? new Date(input.edition.startAt).getTime() : null;
-  const eventEnd = input.edition.endAt ? new Date(input.edition.endAt).getTime() : eventStart;
-  const activePolicies = policies.filter((p) => { const status = String(p.policy_status ?? p.status ?? p.coverage_status ?? "").toLowerCase(); const active = /active|bound|issued|covered|in_force/.test(status) && !/cancel|expired|reject|draft|void/.test(status); const from = p.coverage_start_at ?? p.starts_at ?? p.start_at ?? p.effective_at; const to = p.coverage_end_at ?? p.ends_at ?? p.end_at ?? p.expires_at; const fromTime = from ? new Date(String(from)).getTime() : null; const toTime = to ? new Date(String(to)).getTime() : null; return active && (eventStart === null || fromTime === null || fromTime <= eventStart) && (eventEnd === null || toTime === null || toTime >= eventEnd); });
+  const activePolicies = policies.filter((p) => isInsurancePolicyActiveForEdition(p, input.edition.startAt, input.edition.endAt));
   const operationsAvailable = !input.operationsUnavailable;
   const op = (ready: boolean) => operationsAvailable ? ready : null;
   const readinessChecks = [Boolean(input.edition.startAt && input.edition.endAt), Boolean(input.edition.cityName || ops.venue_name || ops.location_name), op(stageCount > 0), op(availableSlots > 0), op(availableSlots > 0 && bookedActs >= availableSlots), op(bookedActs === 0 ? false : contractedActs >= bookedActs), op(capacity !== null && ticketsSold !== null), op(staff.length >= requiredStaff), op(permitsReady), op(activePolicies.length > 0), approvedBudgetMinor !== null && approvedBudgetMinor > 0];

--- a/supabase/seeds/festival_london_test.sql
+++ b/supabase/seeds/festival_london_test.sql
@@ -1,0 +1,96 @@
+-- Development/test-only fixture for the Festival Owner Dashboard.
+-- Run manually with: npm run seed:festival:london
+DO $$
+DECLARE
+  v_brand uuid := '11111111-1111-4111-8111-111111111111';
+  v_edition uuid := '11111111-1111-4111-8111-111111111112';
+  v_legacy uuid := '11111111-1111-4111-8111-111111111113';
+  v_venue uuid := '11111111-1111-4111-8111-111111111114';
+  v_city uuid;
+  v_start timestamptz := (current_date + 60 + time '10:00') AT TIME ZONE 'Europe/London';
+  v_end timestamptz := (current_date + 62 + time '23:00') AT TIME ZONE 'Europe/London';
+  v_stage uuid;
+  v_slot uuid;
+  v_names text[] := ARRAY['The Thames Lines','Electric Borough','Camden Static','Southbank Riot','Neon Underground','The Night Buses','Soho Feedback','Brixton Echoes','Hackney Signals','Greenwich Static','Islington Relay','Peckham Frequencies','Chelsea Riot','Wembley Afterglow','Shoreditch Arcade'];
+  v_idx int := 0;
+  v_day int;
+  v_hour int;
+  v_stage_name text;
+BEGIN
+  SELECT id INTO v_city FROM public.cities WHERE lower(name)='london' ORDER BY created_at NULLS LAST LIMIT 1;
+  IF v_city IS NULL THEN RAISE EXCEPTION 'London city fixture prerequisite is missing'; END IF;
+
+  INSERT INTO public.venues(id,name,location,capacity,venue_type,base_payment,prestige_level,requirements)
+  VALUES (v_venue,'London Test Festival Grounds','London',10000,'outdoor festival site',0,3,jsonb_build_object('fixture','london-dashboard','fixture_key','RM-LONDON-TEST-FESTIVAL'))
+  ON CONFLICT (id) DO UPDATE SET name=excluded.name, location=excluded.location, capacity=excluded.capacity, venue_type=excluded.venue_type, requirements=excluded.requirements;
+  UPDATE public.venues SET city_id=v_city WHERE id=v_venue AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='venues' AND column_name='city_id');
+
+  INSERT INTO public.festivals(id,name,city_id,venue_id,scale,status,start_date,end_date,expected_attendance,ticket_price_low,ticket_price_high,genre,description,metadata)
+  VALUES (v_brand,'RockMundo London Test Festival',v_city,v_venue,'large','upcoming',v_start::date,v_end::date,7500,55,240,'mixed','Development and QA fixture for validating the complete RockMundo festival workflow.',jsonb_build_object('fixture','london-dashboard','fixture_key','RM-LONDON-TEST-FESTIVAL','is_test_fixture',true,'slug','rockmundo-london-test-festival'))
+  ON CONFLICT (id) DO UPDATE SET name=excluded.name, city_id=excluded.city_id, venue_id=excluded.venue_id, start_date=excluded.start_date, end_date=excluded.end_date, expected_attendance=excluded.expected_attendance, metadata=excluded.metadata;
+
+  INSERT INTO public.game_events(id,title,description,event_type,start_date,end_date,max_participants,requirements,is_active)
+  VALUES (v_legacy,'RockMundo London Test Festival compatibility event','Read-only compatibility mapping for canonical London dashboard fixture.','festival',v_start,v_end,10000,jsonb_build_object('fixture','london-dashboard','canonical_festival_edition_id',v_edition,'legacy_festival_read_only',true),true)
+  ON CONFLICT (id) DO UPDATE SET title=excluded.title,start_date=excluded.start_date,end_date=excluded.end_date,requirements=excluded.requirements;
+
+  INSERT INTO public.festival_editions(id,festival_id,edition_number,edition_year,title,slug,description,city_id,venue_id,start_at,end_at,timezone,time_zone,doors_open_at,curfew_at,expected_attendance,capacity,minimum_ticket_price_cents,maximum_ticket_price_cents,currency_code,budget_cents,status,lifecycle_metadata,public_metadata,legacy_metadata)
+  VALUES (v_edition,v_brand,1,extract(year from v_start)::int,'RockMundo London Test Festival','rockmundo-london-test-festival','Development and QA fixture for validating the complete RockMundo festival workflow.',v_city,v_venue,v_start,v_end,'Europe/London','Europe/London',v_start - interval '2 hours',v_end,7500,10000,5500,24000,'GBP',25000000,'announced',jsonb_build_object('fixture','london-dashboard','is_test_fixture',true,'ticket_summary',jsonb_build_object('capacity',10000,'tickets_sold',3250,'tiers',jsonb_build_array(jsonb_build_object('name','Weekend General Admission','price_cents',12000,'inventory',6000,'sold',2100),jsonb_build_object('name','Day Ticket','price_cents',5500,'inventory',3000,'sold',900),jsonb_build_object('name','VIP Weekend','price_cents',24000,'inventory',1000,'sold',250)))),jsonb_build_object('fixture','london-dashboard','is_test_fixture',true),jsonb_build_object('compatibility_game_event_id',v_legacy))
+  ON CONFLICT (id) DO UPDATE SET start_at=excluded.start_at,end_at=excluded.end_at,edition_year=excluded.edition_year,city_id=excluded.city_id,venue_id=excluded.venue_id,budget_cents=excluded.budget_cents,status=excluded.status,public_metadata=excluded.public_metadata;
+
+  INSERT INTO public.festival_legacy_mappings(edition_id,legacy_source,legacy_id,legacy_festival_id,metadata)
+  VALUES (v_edition,'game_event',v_legacy,v_brand,jsonb_build_object('fixture','london-dashboard','read_only',true))
+  ON CONFLICT (legacy_source, legacy_id) DO UPDATE SET edition_id=excluded.edition_id, legacy_festival_id=excluded.legacy_festival_id, metadata=excluded.metadata;
+
+  DELETE FROM public.festival_stage_slots WHERE edition_id=v_edition;
+  DELETE FROM public.festival_system_acts WHERE edition_id=v_edition;
+  DELETE FROM public.festival_stages WHERE edition_id=v_edition;
+
+  FOREACH v_stage_name IN ARRAY ARRAY['Main Stage','River Stage','New Music Stage'] LOOP
+    v_stage := CASE v_stage_name WHEN 'Main Stage' THEN '11111111-1111-4111-8111-111111111120'::uuid WHEN 'River Stage' THEN '11111111-1111-4111-8111-111111111121'::uuid ELSE '11111111-1111-4111-8111-111111111122'::uuid END;
+    INSERT INTO public.festival_stages(id,festival_id,edition_id,stage_name,stage_number,capacity,genre_focus,stage_type,public_name,technical_metadata,public_metadata,idempotency_key)
+    VALUES (v_stage,v_legacy,v_edition,v_stage_name,CASE v_stage_name WHEN 'Main Stage' THEN 1 WHEN 'River Stage' THEN 2 ELSE 3 END,CASE v_stage_name WHEN 'Main Stage' THEN 7000 WHEN 'River Stage' THEN 3000 ELSE 1500 END,'mixed','outdoor',v_stage_name,jsonb_build_object('fixture','london-dashboard'),jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:'||v_stage_name);
+    FOR v_day IN 0..2 LOOP
+      FOREACH v_hour IN ARRAY CASE v_stage_name WHEN 'Main Stage' THEN ARRAY[15,17,19,21] WHEN 'River Stage' THEN ARRAY[14,16,18,20] ELSE ARRAY[13,15,17,19] END LOOP
+        IF v_idx < 24 THEN
+          v_slot := ('11111111-1111-4111-8111-' || lpad((111111111200 + v_idx)::text,12,'0'))::uuid;
+          INSERT INTO public.festival_stage_slots(id,stage_id,festival_id,edition_id,day_number,slot_number,slot_type,start_time,end_time,changeover_minutes,status,public_status,slot_template,reservation_metadata,idempotency_key)
+          VALUES (v_slot,v_stage,v_legacy,v_edition,v_day+1,(v_idx%6)+1,CASE WHEN v_hour=21 THEN 'headliner' WHEN v_hour>=19 THEN 'support' ELSE 'opener' END,(v_start::date + v_day + make_interval(hours=>v_hour)) AT TIME ZONE 'Europe/London',(v_start::date + v_day + make_interval(hours=>v_hour+1)) AT TIME ZONE 'Europe/London',30,CASE WHEN v_idx < 15 THEN 'confirmed' ELSE 'open' END,CASE WHEN v_idx < 15 THEN 'announced' ELSE 'draft' END,'london-dashboard',jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:slot:'||v_idx);
+          IF v_idx < 15 THEN
+            INSERT INTO public.festival_system_acts(id,edition_id,slot_id,deterministic_key,display_name,act_type,genre,quality_tier,public_metadata,internal_seed,status)
+            VALUES (('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,v_edition,v_slot,'RM-LONDON-ACT-'||v_idx,v_names[v_idx+1],'fixture_system_act','rock',CASE WHEN v_idx < 3 THEN 'headline' WHEN v_idx < 10 THEN 'strong' ELSE 'local' END,jsonb_build_object('fixture','london-dashboard','published',v_idx < 12),'RM-LONDON-TEST-FESTIVAL','assigned')
+            ON CONFLICT (edition_id, deterministic_key) DO UPDATE SET slot_id=excluded.slot_id, display_name=excluded.display_name, public_metadata=excluded.public_metadata, status=excluded.status;
+            UPDATE public.festival_stage_slots SET reservation_metadata=reservation_metadata || jsonb_build_object('system_act_id',('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,'contract_status',CASE WHEN v_idx < 10 THEN 'signed' WHEN v_idx < 13 THEN 'accepted' ELSE 'published' END), status='confirmed' WHERE id=v_slot;
+          END IF;
+          v_idx := v_idx + 1;
+        END IF;
+      END LOOP;
+    END LOOP;
+  END LOOP;
+
+  DELETE FROM public.festival_staff WHERE edition_id=v_edition;
+  INSERT INTO public.festival_staff(festival_id,edition_id,role,name,skill_level,weekly_wage_cents,status,metadata,idempotency_key)
+  SELECT v_brand,v_edition,role,name,skill,weekly,'active',jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:staff:'||role FROM (VALUES ('promoter','Festival Manager',85,150000),('booker','Production Manager',82,130000),('safety_officer','Security Lead',80,110000),('medic','Medical Lead',78,100000),('stage_manager','Main Stage Manager',75,90000),('stage_manager','River Stage Manager',72,85000),('stage_manager','New Music Stage Manager',70,80000)) v(role,name,skill,weekly);
+
+  DELETE FROM public.festival_permits WHERE edition_id=v_edition;
+  INSERT INTO public.festival_permits(festival_id,edition_id,city_id,permit_type,status,permit_fee_cents,approved_at,expires_on,requirement_code,reason,idempotency_key)
+  SELECT v_brand,v_edition,v_city,kind,'approved',fee,now(),(v_end + interval '30 days')::date,code,'London dashboard fixture approved permit','RM-LONDON-TEST-FESTIVAL:permit:'||code FROM (VALUES ('event','event_licence',150000),('noise','noise_permit',50000),('alcohol','temporary_alcohol_licence',75000),('safety','public_space_permit',25000)) v(kind,code,fee);
+
+  DELETE FROM public.festival_insurance_policies WHERE edition_id=v_edition;
+  INSERT INTO public.festival_insurance_policies(festival_id,edition_id,coverage_type,premium_cents,payout_ceiling_cents,weather_rider,active,effective_from,effective_to,policy_status,idempotency_key)
+  VALUES (v_brand,v_edition,'standard',250000,100000000,true,true,(v_start - interval '7 days')::date,(v_end + interval '7 days')::date,'pending_payment','RM-LONDON-TEST-FESTIVAL:insurance');
+
+  DELETE FROM public.festival_expense_ledger WHERE edition_id=v_edition;
+  INSERT INTO public.festival_expense_ledger(festival_id,edition_number,edition_id,category,direction,amount_cents,currency_code,status,description,source_type,source_id,due_at,idempotency_key)
+  SELECT v_brand,1,v_edition,category,'expense',amount,'GBP','committed',description,'london_dashboard_fixture',v_edition,v_start,'RM-LONDON-TEST-FESTIVAL:ledger:'||category FROM (VALUES ('artist_guarantee',6000000,'Artist commitments'),('stage_rental',2000000,'Venue'),('security',1200000,'Security'),('staff_wages',900000,'Staffing'),('insurance',250000,'Insurance'),('equipment_rental',650000,'Production')) v(category,amount,description);
+
+  RAISE NOTICE 'RockMundo London Test Festival seeded: brand %, edition %, public /festivals/%, owner /festivals/%/manage/editions/%', v_brand, v_edition, v_brand, v_brand, v_edition;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.assign_london_test_festival_owner(p_profile_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_brand uuid := '11111111-1111-4111-8111-111111111111'; v_edition uuid := '11111111-1111-4111-8111-111111111112';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id=p_profile_id) THEN RAISE EXCEPTION 'Profile % not found', p_profile_id; END IF;
+  UPDATE public.festivals SET owner_profile_id=p_profile_id, metadata=metadata || jsonb_build_object('fixture_owner_assigned_at',now()) WHERE id=v_brand;
+  RETURN jsonb_build_object('festival_id',v_brand,'edition_id',v_edition,'public_url','/festivals/'||v_brand,'owner_url','/festivals/'||v_brand||'/manage/editions/'||v_edition);
+END $$;

--- a/supabase/tests/festival_london_test_fixture.sql
+++ b/supabase/tests/festival_london_test_fixture.sql
@@ -1,0 +1,30 @@
+BEGIN;
+\i supabase/seeds/festival_london_test.sql
+\i supabase/seeds/festival_london_test.sql
+DO $$
+DECLARE
+  v_brand uuid := '11111111-1111-4111-8111-111111111111';
+  v_edition uuid := '11111111-1111-4111-8111-111111111112';
+  v_count int;
+  v_ops jsonb;
+  v_fin jsonb;
+BEGIN
+  IF (SELECT count(*) FROM public.festivals WHERE metadata->>'fixture_key'='RM-LONDON-TEST-FESTIVAL') <> 1 THEN RAISE EXCEPTION 'fixture brand count mismatch'; END IF;
+  IF (SELECT count(*) FROM public.festival_editions WHERE id=v_edition AND festival_id=v_brand AND start_at > now()) <> 1 THEN RAISE EXCEPTION 'fixture edition missing or not upcoming'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.festival_editions e JOIN public.cities c ON c.id=e.city_id WHERE e.id=v_edition AND lower(c.name)='london') THEN RAISE EXCEPTION 'fixture edition does not resolve to London'; END IF;
+  IF (SELECT count(*) FROM public.cities WHERE lower(name)='london') < 1 THEN RAISE EXCEPTION 'London city missing'; END IF;
+  IF (SELECT count(*) FROM public.festival_stages WHERE edition_id=v_edition AND archived_at IS NULL) <> 3 THEN RAISE EXCEPTION 'stage count mismatch'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_stage_slots a JOIN public.festival_stage_slots b ON a.stage_id=b.stage_id AND a.id<b.id WHERE a.edition_id=v_edition AND b.edition_id=v_edition AND tstzrange(a.start_time,a.end_time,'[)') && tstzrange(b.start_time,b.end_time,'[)')) THEN RAISE EXCEPTION 'same-stage slot overlap'; END IF;
+  SELECT count(*) INTO v_count FROM public.festival_stage_slots WHERE edition_id=v_edition; IF v_count <> 24 THEN RAISE EXCEPTION 'slot count mismatch %', v_count; END IF;
+  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='confirmed') <> 15 THEN RAISE EXCEPTION 'occupied slot count mismatch'; END IF;
+  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='open') <> 9 THEN RAISE EXCEPTION 'empty slot count mismatch'; END IF;
+  IF (SELECT count(*) FROM public.festival_system_acts WHERE edition_id=v_edition) <> 15 THEN RAISE EXCEPTION 'system act count mismatch'; END IF;
+  IF (SELECT capacity FROM public.festival_editions WHERE id=v_edition) <> 10000 THEN RAISE EXCEPTION 'capacity mismatch'; END IF;
+  v_fin := public.festival_edition_finance_summary(v_edition);
+  IF (v_fin->>'budget_cents')::bigint <> 25000000 OR (v_fin->>'committed_cost_cents')::bigint <> 11000000 OR v_fin->>'currency' <> 'GBP' THEN RAISE EXCEPTION 'finance summary mismatch %', v_fin; END IF;
+  IF (SELECT count(*) FROM public.festival_permits WHERE edition_id=v_edition AND status='approved') <> 4 THEN RAISE EXCEPTION 'permit approvals mismatch'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.festival_insurance_policies p JOIN public.festival_editions e ON e.id=p.edition_id WHERE p.edition_id=v_edition AND p.active AND p.policy_status='pending_payment' AND p.effective_from <= e.start_at::date AND p.effective_to >= e.end_at::date) THEN RAISE EXCEPTION 'canonical insurance missing'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_participants fp WHERE fp.festival_id=v_brand) THEN RAISE EXCEPTION 'forbidden legacy festival_participants write'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.public_festival_editions WHERE id=v_edition) THEN RAISE EXCEPTION 'public projection missing'; END IF;
+END $$;
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Fix a dashboard readiness bug where canonical insurance records with `active = true` and `policy_status = "pending_payment"` were not recognised as valid coverage. 
- Provide a deterministic, idempotent London test festival fixture to exercise the full owner-dashboard workflow (stages, slots, lineup, tickets, finance, staff, permits, insurance) without adding production seed data. 
- Keep the fixture development/test-only, avoid writing to legacy festival tables, and provide a documented owner-assign helper for safe local testing. 

### Description
- Extracted the insurance matching logic into `isInsurancePolicyActiveForEdition` and updated the dashboard to use it for policy filtering in `src/features/festivals/admin/dashboard/buildFestivalDashboardModel.ts`. 
- The helper recognises activity from `policy.active` / `policy.is_active` or accepted status strings, rejects explicit inactive statuses (`cancel|expired|reject|void`), and checks canonical date fields with safe parsing and strict range checks. 
- Added regression coverage in `src/features/festivals/admin/dashboard/buildFestivalDashboardModel.test.ts` for canonical `pending_payment` shapes, active-status recognition, cancelled/expired/in-range date handling, invalid dates, open-ended behaviour and operations-unavailable behaviour. 
- Added a deterministic, idempotent seed at `supabase/seeds/festival_london_test.sql`, a Supabase SQL test harness `supabase/tests/festival_london_test_fixture.sql`, and developer docs `docs/festivals/LONDON_TEST_FESTIVAL.md`; added `seed:festival:london` script to `package.json`. 

### Testing
- `npm run typecheck` completed successfully (`tsc --noEmit`) and `git diff --check` passed. 
- `npm ci` failed due to registry access issues (403 on some packages), so `npm run lint`, `npm run test`, `npm run build`, and Playwright desktop/mobile runs could not be executed in this environment. 
- Focused JS unit test runner (`vitest`) was not available in the environment so the new unit tests were added but not executed here. 
- Supabase / database verification (`supabase` CLI, `psql`) could not be run in this environment so the seed and SQL harness were added and are runnable locally via `npm run seed:festival:london` and `psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/festival_london_test_fixture.sql` but were not executed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e737037048325bd3e7595588153d1)