### PR TITLE
Repair and validate London festival fixture

### DIFF
--- a/docs/festivals/LONDON_TEST_FESTIVAL.md
+++ b/docs/festivals/LONDON_TEST_FESTIVAL.md
@@ -10,17 +10,18 @@ Run manually after a local Supabase reset:
 npm run seed:festival:london
 ```
 
-The seed is idempotent and owns only records marked with `fixture = london-dashboard` / `fixture_key = RM-LONDON-TEST-FESTIVAL`.
+The seed contains a hard SQL guard and refuses to run unless `app.allow_test_fixtures=true` is set. The npm script sets this via `PGOPTIONS`, so use `npm run seed:festival:london` or an equivalent `PGOPTIONS="-c app.allow_test_fixtures=true" psql ...` command. Rerunning the seed is a destructive fixture reset for deterministic fixture-owned stages, slots, acts, staff, permits, insurance and ledger rows; cleanup is scoped to fixture idempotency keys and metadata.
 
 ## Assign an owner
 
 Create or sign in with a local test account, find its profile id, then run:
 
 ```sql
-select assign_london_test_festival_owner('<profile uuid>');
+-- run with the local service-role connection
+select public.assign_london_test_festival_owner('<profile uuid>');
 ```
 
-This updates only the fixture festival owner and does not weaken RLS.
+This updates only the deterministic fixture festival owner and does not weaken RLS. The helper is `SECURITY DEFINER`, revokes `PUBLIC`, `anon` and `authenticated`, and grants execute only to `service_role` (database owner/postgres can still manage it naturally).
 
 ## Stable URLs
 
@@ -49,9 +50,9 @@ where f.metadata->>'fixture_key' = 'RM-LONDON-TEST-FESTIVAL';
 - Tickets sold target represented by fixture metadata/dashboard checks: 3,250 / 10,000
 - Budget: £250,000 approved, £110,000 committed, £140,000 remaining, 44% used
 - Stages: Main Stage, River Stage, New Music Stage
-- Slots: 24 total, 15 occupied, 9 intentionally empty
-- Staff: seven roles arranged
-- Permits: 4 / 4 approved
+- Slots: 36 total: 3 days × 3 stages × 4 slots, with 21 occupied and 15 intentionally empty
+- Staff: promoter, booker, safety officer, medic, one stage manager per stage and one sound engineer per stage
+- Permits: canonical `public_event`, `noise`, `temporary_structures`, `fire_safety` and `amplified_music` approved
 - Insurance: active canonical policy with `active = true` and `policy_status = pending_payment`
 
 ## Checklist
@@ -59,15 +60,15 @@ where f.metadata->>'fixture_key' = 'RM-LONDON-TEST-FESTIVAL';
 - ✓ Festival details
 - ✓ Dates and location
 - ✓ Three stages configured
-- ✓ Performance slots created
+- ✓ Performance slots created on all three stages
 - ⚠ Lineup partially filled
 - ⚠ Some contracts outstanding
 - ✓ Tickets configured
-- ✓ Staffing arranged
-- ✓ Four permits approved
+- ✓ Staffing arranged, including sound engineers
+- ✓ Five canonical permits approved
 - ✓ Insurance active
 - ✓ Budget approved
-- ⚠ Operational readiness incomplete
+- ✓ Operational readiness complete for fixture baseline
 
 ## Why pending-payment insurance?
 
@@ -76,3 +77,7 @@ The canonical purchase workflow can produce a valid policy row with `active = tr
 ## Remove/reset
 
 Use `supabase db reset` to remove local fixture data, or rerun the seed to restore it. Do not run this seed as part of production deployment.
+
+## Compatibility event
+
+The fixture retains a read-only `game_events` compatibility row (`11111111-1111-4111-8111-111111111113`) only for legacy route and migration mapping coverage through `festival_legacy_mappings` and resolver functions that still understand `legacy_source = 'game_event'`. Canonical stages and slots use the festival brand id in their canonical `festival_id` field; no participant, booking, finance or state mutation should be written through the compatibility event. The future removal path is to retire legacy `game_events` identifier resolution after all festival routes and RPCs accept canonical brand or edition ids only.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "simulate:balance": "node scripts/progression-simulations/run-balance-simulations.mjs",
     "validate:progression-programme": "node scripts/progression/validate-programme.mjs",
     "test:festivals:db": "bash scripts/festivals/run-creation-phase1-db-gate.sh",
-    "seed:festival:london": "psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/seeds/festival_london_test.sql"
+    "seed:festival:london": "PGOPTIONS=\"-c app.allow_test_fixtures=true\" psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/seeds/festival_london_test.sql"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/supabase/migrations/20260720120000_repair_london_fixture_operations_projection.sql
+++ b/supabase/migrations/20260720120000_repair_london_fixture_operations_projection.sql
@@ -1,0 +1,43 @@
+-- Repair canonical festival operations projection used by the London fixture and owner dashboard.
+
+CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary(p_edition_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  WITH e AS (SELECT * FROM public.festival_editions WHERE id=p_edition_id),
+  slots AS (
+    SELECT sl.*, sa.id system_act_id, sa.display_name system_act_name, sa.status system_act_status,
+      coalesce(sl.reservation_metadata->>'contract_status', CASE WHEN sa.id IS NOT NULL THEN 'published' END) contract_status
+    FROM public.festival_stage_slots sl
+    LEFT JOIN public.festival_system_acts sa ON sa.slot_id=sl.id AND sa.edition_id=sl.edition_id
+    WHERE sl.edition_id=p_edition_id AND sl.archived_at IS NULL
+  ), ticket AS (
+    SELECT coalesce((e.lifecycle_metadata->'ticket_summary'->>'capacity')::integer,e.capacity,0) capacity,
+      coalesce((e.lifecycle_metadata->'ticket_summary'->>'tickets_sold')::integer,0) tickets_sold,
+      coalesce(e.lifecycle_metadata->'ticket_summary'->'tiers','[]'::jsonb) tiers
+    FROM e
+  )
+  SELECT jsonb_build_object(
+    'edition_id',p_edition_id,
+    'festival_id',(SELECT festival_id FROM e),
+    'festival_name',(SELECT f.name FROM public.festivals f JOIN e ON e.festival_id=f.id),
+    'venue_name',(SELECT v.name FROM public.venues v JOIN e ON e.venue_id=v.id),
+    'stages',(SELECT coalesce(jsonb_agg(to_jsonb(st) ORDER BY st.stage_number),'[]'::jsonb) FROM public.festival_stages st WHERE st.edition_id=p_edition_id AND st.archived_at IS NULL),
+    'slots',(SELECT coalesce(jsonb_agg(to_jsonb(sl) || jsonb_build_object('system_act_id',sl.system_act_id,'system_act_name',sl.system_act_name,'contract_status',sl.contract_status) ORDER BY sl.day_number, sl.start_time),'[]'::jsonb) FROM slots sl),
+    'staff',(SELECT coalesce(jsonb_agg(to_jsonb(s) ORDER BY s.role, s.name),'[]'::jsonb) FROM public.festival_staff s WHERE s.edition_id=p_edition_id),
+    'permit_requirements',public.festival_edition_permit_requirements(p_edition_id),
+    'staffing_readiness',public.festival_edition_staffing_readiness(p_edition_id),
+    'insurance_policies',(SELECT coalesce(jsonb_agg(to_jsonb(p)),'[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id=p_edition_id),
+    'ticket_summary',(SELECT jsonb_build_object('capacity',capacity,'tickets_sold',tickets_sold,'tiers',tiers) FROM ticket),
+    'ticketing',(SELECT jsonb_build_object('capacity',capacity,'tickets_sold',tickets_sold,'tiers',tiers) FROM ticket),
+    'tickets_sold',(SELECT tickets_sold FROM ticket),
+    'schedule_summary',(SELECT jsonb_build_object('total_slots',count(*),'occupied_slots',count(*) FILTER (WHERE system_act_id IS NOT NULL OR reservation_metadata ? 'system_act_id'),'contracted_acts',count(*) FILTER (WHERE contract_status IN ('signed','accepted')),'published_acts',count(*) FILTER (WHERE system_act_id IS NOT NULL)) FROM slots),
+    'finance',public.festival_edition_finance_summary(p_edition_id),
+    'data_health',public.festival_data_health(p_edition_id)
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.festival_edition_operations_summary(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary(uuid) TO authenticated, service_role;

--- a/supabase/seeds/festival_london_test.sql
+++ b/supabase/seeds/festival_london_test.sql
@@ -1,5 +1,12 @@
 -- Development/test-only fixture for the Festival Owner Dashboard.
--- Run manually with: npm run seed:festival:london
+-- Run manually with: npm run seed:festival:london (requires app.allow_test_fixtures=true)
+DO $$
+BEGIN
+  IF current_setting('app.allow_test_fixtures', true) IS DISTINCT FROM 'true' THEN
+    RAISE EXCEPTION 'Test fixture execution not enabled. Set app.allow_test_fixtures=true before running the London fixture.';
+  END IF;
+END $$;
+
 DO $$
 DECLARE
   v_brand uuid := '11111111-1111-4111-8111-111111111111';
@@ -11,7 +18,7 @@ DECLARE
   v_end timestamptz := (current_date + 62 + time '23:00') AT TIME ZONE 'Europe/London';
   v_stage uuid;
   v_slot uuid;
-  v_names text[] := ARRAY['The Thames Lines','Electric Borough','Camden Static','Southbank Riot','Neon Underground','The Night Buses','Soho Feedback','Brixton Echoes','Hackney Signals','Greenwich Static','Islington Relay','Peckham Frequencies','Chelsea Riot','Wembley Afterglow','Shoreditch Arcade'];
+  v_names text[] := ARRAY['The Thames Lines','Electric Borough','Camden Static','Southbank Riot','Neon Underground','The Night Buses','Soho Feedback','Brixton Echoes','Hackney Signals','Greenwich Static','Islington Relay','Peckham Frequencies','Chelsea Riot','Wembley Afterglow','Shoreditch Arcade','Deptford Frequencies','Kensington Voltage','Stratford Signals','Vauxhall Feedback','Canary Static','Clapham Riot'];
   v_idx int := 0;
   v_day int;
   v_hour int;
@@ -34,52 +41,50 @@ BEGIN
   ON CONFLICT (id) DO UPDATE SET title=excluded.title,start_date=excluded.start_date,end_date=excluded.end_date,requirements=excluded.requirements;
 
   INSERT INTO public.festival_editions(id,festival_id,edition_number,edition_year,title,slug,description,city_id,venue_id,start_at,end_at,timezone,time_zone,doors_open_at,curfew_at,expected_attendance,capacity,minimum_ticket_price_cents,maximum_ticket_price_cents,currency_code,budget_cents,status,lifecycle_metadata,public_metadata,legacy_metadata)
-  VALUES (v_edition,v_brand,1,extract(year from v_start)::int,'RockMundo London Test Festival','rockmundo-london-test-festival','Development and QA fixture for validating the complete RockMundo festival workflow.',v_city,v_venue,v_start,v_end,'Europe/London','Europe/London',v_start - interval '2 hours',v_end,7500,10000,5500,24000,'GBP',25000000,'announced',jsonb_build_object('fixture','london-dashboard','is_test_fixture',true,'ticket_summary',jsonb_build_object('capacity',10000,'tickets_sold',3250,'tiers',jsonb_build_array(jsonb_build_object('name','Weekend General Admission','price_cents',12000,'inventory',6000,'sold',2100),jsonb_build_object('name','Day Ticket','price_cents',5500,'inventory',3000,'sold',900),jsonb_build_object('name','VIP Weekend','price_cents',24000,'inventory',1000,'sold',250)))),jsonb_build_object('fixture','london-dashboard','is_test_fixture',true),jsonb_build_object('compatibility_game_event_id',v_legacy))
-  ON CONFLICT (id) DO UPDATE SET start_at=excluded.start_at,end_at=excluded.end_at,edition_year=excluded.edition_year,city_id=excluded.city_id,venue_id=excluded.venue_id,budget_cents=excluded.budget_cents,status=excluded.status,public_metadata=excluded.public_metadata;
+  VALUES (v_edition,v_brand,1,extract(year from v_start)::int,'RockMundo London Test Festival','rockmundo-london-test-festival','Development and QA fixture for validating the complete RockMundo festival workflow.',v_city,v_venue,v_start,v_end,'Europe/London','Europe/London',v_start - interval '2 hours',v_end,7500,10000,5500,24000,'GBP',25000000,'announced',jsonb_build_object('fixture','london-dashboard','is_test_fixture',true,'ticket_summary',jsonb_build_object('capacity',10000,'tickets_sold',3250,'tiers',jsonb_build_array(jsonb_build_object('name','Weekend General Admission','price_cents',12000,'inventory',6000,'sold',2100),jsonb_build_object('name','Day Ticket','price_cents',5500,'inventory',3000,'sold',900),jsonb_build_object('name','VIP Weekend','price_cents',24000,'inventory',1000,'sold',250)))),jsonb_build_object('fixture','london-dashboard','is_test_fixture',true,'alcohol',false,'food_vendors',false,'camping',false,'road_closure',false),jsonb_build_object('compatibility_game_event_id',v_legacy))
+  ON CONFLICT (id) DO UPDATE SET start_at=excluded.start_at,end_at=excluded.end_at,edition_year=excluded.edition_year,city_id=excluded.city_id,venue_id=excluded.venue_id,budget_cents=excluded.budget_cents,status=excluded.status,lifecycle_metadata=excluded.lifecycle_metadata,public_metadata=excluded.public_metadata,legacy_metadata=excluded.legacy_metadata;
 
   INSERT INTO public.festival_legacy_mappings(edition_id,legacy_source,legacy_id,legacy_festival_id,metadata)
   VALUES (v_edition,'game_event',v_legacy,v_brand,jsonb_build_object('fixture','london-dashboard','read_only',true))
   ON CONFLICT (legacy_source, legacy_id) DO UPDATE SET edition_id=excluded.edition_id, legacy_festival_id=excluded.legacy_festival_id, metadata=excluded.metadata;
 
-  DELETE FROM public.festival_stage_slots WHERE edition_id=v_edition;
-  DELETE FROM public.festival_system_acts WHERE edition_id=v_edition;
-  DELETE FROM public.festival_stages WHERE edition_id=v_edition;
+  DELETE FROM public.festival_stage_slots WHERE edition_id=v_edition AND idempotency_key LIKE 'RM-LONDON-TEST-FESTIVAL:%';
+  DELETE FROM public.festival_system_acts WHERE edition_id=v_edition AND internal_seed='RM-LONDON-TEST-FESTIVAL';
+  DELETE FROM public.festival_stages WHERE edition_id=v_edition AND idempotency_key LIKE 'RM-LONDON-TEST-FESTIVAL:%';
 
   FOREACH v_stage_name IN ARRAY ARRAY['Main Stage','River Stage','New Music Stage'] LOOP
     v_stage := CASE v_stage_name WHEN 'Main Stage' THEN '11111111-1111-4111-8111-111111111120'::uuid WHEN 'River Stage' THEN '11111111-1111-4111-8111-111111111121'::uuid ELSE '11111111-1111-4111-8111-111111111122'::uuid END;
     INSERT INTO public.festival_stages(id,festival_id,edition_id,stage_name,stage_number,capacity,genre_focus,stage_type,public_name,technical_metadata,public_metadata,idempotency_key)
-    VALUES (v_stage,v_legacy,v_edition,v_stage_name,CASE v_stage_name WHEN 'Main Stage' THEN 1 WHEN 'River Stage' THEN 2 ELSE 3 END,CASE v_stage_name WHEN 'Main Stage' THEN 7000 WHEN 'River Stage' THEN 3000 ELSE 1500 END,'mixed','outdoor',v_stage_name,jsonb_build_object('fixture','london-dashboard'),jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:'||v_stage_name);
+    VALUES (v_stage,v_brand,v_edition,v_stage_name,CASE v_stage_name WHEN 'Main Stage' THEN 1 WHEN 'River Stage' THEN 2 ELSE 3 END,CASE v_stage_name WHEN 'Main Stage' THEN 7000 WHEN 'River Stage' THEN 3000 ELSE 1500 END,'mixed','outdoor',v_stage_name,jsonb_build_object('fixture','london-dashboard'),jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:'||v_stage_name);
     FOR v_day IN 0..2 LOOP
       FOREACH v_hour IN ARRAY CASE v_stage_name WHEN 'Main Stage' THEN ARRAY[15,17,19,21] WHEN 'River Stage' THEN ARRAY[14,16,18,20] ELSE ARRAY[13,15,17,19] END LOOP
-        IF v_idx < 24 THEN
-          v_slot := ('11111111-1111-4111-8111-' || lpad((111111111200 + v_idx)::text,12,'0'))::uuid;
-          INSERT INTO public.festival_stage_slots(id,stage_id,festival_id,edition_id,day_number,slot_number,slot_type,start_time,end_time,changeover_minutes,status,public_status,slot_template,reservation_metadata,idempotency_key)
-          VALUES (v_slot,v_stage,v_legacy,v_edition,v_day+1,(v_idx%6)+1,CASE WHEN v_hour=21 THEN 'headliner' WHEN v_hour>=19 THEN 'support' ELSE 'opener' END,(v_start::date + v_day + make_interval(hours=>v_hour)) AT TIME ZONE 'Europe/London',(v_start::date + v_day + make_interval(hours=>v_hour+1)) AT TIME ZONE 'Europe/London',30,CASE WHEN v_idx < 15 THEN 'confirmed' ELSE 'open' END,CASE WHEN v_idx < 15 THEN 'announced' ELSE 'draft' END,'london-dashboard',jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:slot:'||v_idx);
-          IF v_idx < 15 THEN
+        v_slot := ('11111111-1111-4111-8111-' || lpad((111111111200 + v_idx)::text,12,'0'))::uuid;
+        INSERT INTO public.festival_stage_slots(id,stage_id,festival_id,edition_id,day_number,slot_number,slot_type,start_time,end_time,changeover_minutes,status,public_status,slot_template,reservation_metadata,idempotency_key)
+        VALUES (v_slot,v_stage,v_brand,v_edition,v_day+1,(v_day*4)+(CASE v_hour WHEN 13 THEN 1 WHEN 14 THEN 1 WHEN 15 THEN 2 WHEN 16 THEN 2 WHEN 17 THEN 3 WHEN 18 THEN 3 ELSE 4 END),CASE WHEN v_hour>=21 THEN 'headliner' WHEN v_hour>=19 THEN 'support' ELSE 'opener' END,(v_start::date + v_day + make_interval(hours=>v_hour)) AT TIME ZONE 'Europe/London',(v_start::date + v_day + make_interval(hours=>v_hour+1)) AT TIME ZONE 'Europe/London',30,CASE WHEN v_idx < 21 THEN 'confirmed' ELSE 'open' END,CASE WHEN v_idx < 21 THEN 'announced' ELSE 'draft' END,'london-dashboard',jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:slot:'||v_idx);
+          IF v_idx < 21 THEN
             INSERT INTO public.festival_system_acts(id,edition_id,slot_id,deterministic_key,display_name,act_type,genre,quality_tier,public_metadata,internal_seed,status)
-            VALUES (('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,v_edition,v_slot,'RM-LONDON-ACT-'||v_idx,v_names[v_idx+1],'fixture_system_act','rock',CASE WHEN v_idx < 3 THEN 'headline' WHEN v_idx < 10 THEN 'strong' ELSE 'local' END,jsonb_build_object('fixture','london-dashboard','published',v_idx < 12),'RM-LONDON-TEST-FESTIVAL','assigned')
+            VALUES (('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,v_edition,v_slot,'RM-LONDON-ACT-'||v_idx,v_names[v_idx+1],'fixture_system_act','rock',CASE WHEN v_idx < 3 THEN 'headline' WHEN v_idx < 10 THEN 'strong' ELSE 'local' END,jsonb_build_object('fixture','london-dashboard','published',v_idx < 15),'RM-LONDON-TEST-FESTIVAL','assigned')
             ON CONFLICT (edition_id, deterministic_key) DO UPDATE SET slot_id=excluded.slot_id, display_name=excluded.display_name, public_metadata=excluded.public_metadata, status=excluded.status;
-            UPDATE public.festival_stage_slots SET reservation_metadata=reservation_metadata || jsonb_build_object('system_act_id',('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,'contract_status',CASE WHEN v_idx < 10 THEN 'signed' WHEN v_idx < 13 THEN 'accepted' ELSE 'published' END), status='confirmed' WHERE id=v_slot;
+            UPDATE public.festival_stage_slots SET reservation_metadata=reservation_metadata || jsonb_build_object('system_act_id',('11111111-1111-4111-8111-' || lpad((111111111300 + v_idx)::text,12,'0'))::uuid,'contract_status',CASE WHEN v_idx < 14 THEN 'signed' WHEN v_idx < 18 THEN 'accepted' ELSE 'published' END), status='confirmed' WHERE id=v_slot;
           END IF;
-          v_idx := v_idx + 1;
-        END IF;
+        v_idx := v_idx + 1;
       END LOOP;
     END LOOP;
   END LOOP;
 
-  DELETE FROM public.festival_staff WHERE edition_id=v_edition;
-  INSERT INTO public.festival_staff(festival_id,edition_id,role,name,skill_level,weekly_wage_cents,status,metadata,idempotency_key)
-  SELECT v_brand,v_edition,role,name,skill,weekly,'active',jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:staff:'||role FROM (VALUES ('promoter','Festival Manager',85,150000),('booker','Production Manager',82,130000),('safety_officer','Security Lead',80,110000),('medic','Medical Lead',78,100000),('stage_manager','Main Stage Manager',75,90000),('stage_manager','River Stage Manager',72,85000),('stage_manager','New Music Stage Manager',70,80000)) v(role,name,skill,weekly);
+  DELETE FROM public.festival_staff WHERE edition_id=v_edition AND idempotency_key LIKE 'RM-LONDON-TEST-FESTIVAL:%';
+  INSERT INTO public.festival_staff(festival_id,edition_id,role,name,skill_level,weekly_wage_cents,status,assignment_scope,metadata,idempotency_key)
+  SELECT v_brand,v_edition,role,name,skill,weekly,'active',scope,jsonb_build_object('fixture','london-dashboard'),'RM-LONDON-TEST-FESTIVAL:staff:'||replace(lower(name),' ','-') FROM (VALUES ('promoter','Festival Manager',85,150000,'{}'::jsonb),('booker','Production Manager',82,130000,'{}'::jsonb),('safety_officer','Security Lead',80,110000,'{}'::jsonb),('medic','Medical Lead',78,100000,'{}'::jsonb),('stage_manager','Main Stage Manager',75,90000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111120')),('stage_manager','River Stage Manager',72,85000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111121')),('stage_manager','New Music Stage Manager',70,80000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111122')),('sound_engineer','Main Stage Sound Engineer',76,95000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111120')),('sound_engineer','River Stage Sound Engineer',74,90000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111121')),('sound_engineer','New Music Stage Sound Engineer',72,85000,jsonb_build_object('stage_id','11111111-1111-4111-8111-111111111122'))) v(role,name,skill,weekly,scope);
 
-  DELETE FROM public.festival_permits WHERE edition_id=v_edition;
+  DELETE FROM public.festival_permits WHERE edition_id=v_edition AND idempotency_key LIKE 'RM-LONDON-TEST-FESTIVAL:%';
   INSERT INTO public.festival_permits(festival_id,edition_id,city_id,permit_type,status,permit_fee_cents,approved_at,expires_on,requirement_code,reason,idempotency_key)
-  SELECT v_brand,v_edition,v_city,kind,'approved',fee,now(),(v_end + interval '30 days')::date,code,'London dashboard fixture approved permit','RM-LONDON-TEST-FESTIVAL:permit:'||code FROM (VALUES ('event','event_licence',150000),('noise','noise_permit',50000),('alcohol','temporary_alcohol_licence',75000),('safety','public_space_permit',25000)) v(kind,code,fee);
+  SELECT v_brand,v_edition,v_city,kind,'approved',fee,now(),(v_end + interval '30 days')::date,code,'London dashboard fixture approved permit','RM-LONDON-TEST-FESTIVAL:permit:'||code FROM (VALUES ('event','public_event',50000),('noise','noise',25000),('event','temporary_structures',90000),('safety','fire_safety',40000),('noise','amplified_music',30000)) v(kind,code,fee);
 
-  DELETE FROM public.festival_insurance_policies WHERE edition_id=v_edition;
+  DELETE FROM public.festival_insurance_policies WHERE edition_id=v_edition AND idempotency_key='RM-LONDON-TEST-FESTIVAL:insurance';
   INSERT INTO public.festival_insurance_policies(festival_id,edition_id,coverage_type,premium_cents,payout_ceiling_cents,weather_rider,active,effective_from,effective_to,policy_status,idempotency_key)
   VALUES (v_brand,v_edition,'standard',250000,100000000,true,true,(v_start - interval '7 days')::date,(v_end + interval '7 days')::date,'pending_payment','RM-LONDON-TEST-FESTIVAL:insurance');
 
-  DELETE FROM public.festival_expense_ledger WHERE edition_id=v_edition;
+  DELETE FROM public.festival_expense_ledger WHERE edition_id=v_edition AND idempotency_key LIKE 'RM-LONDON-TEST-FESTIVAL:%';
   INSERT INTO public.festival_expense_ledger(festival_id,edition_number,edition_id,category,direction,amount_cents,currency_code,status,description,source_type,source_id,due_at,idempotency_key)
   SELECT v_brand,1,v_edition,category,'expense',amount,'GBP','committed',description,'london_dashboard_fixture',v_edition,v_start,'RM-LONDON-TEST-FESTIVAL:ledger:'||category FROM (VALUES ('artist_guarantee',6000000,'Artist commitments'),('stage_rental',2000000,'Venue'),('security',1200000,'Security'),('staff_wages',900000,'Staffing'),('insurance',250000,'Insurance'),('equipment_rental',650000,'Production')) v(category,amount,description);
 
@@ -90,7 +95,11 @@ CREATE OR REPLACE FUNCTION public.assign_london_test_festival_owner(p_profile_id
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
 DECLARE v_brand uuid := '11111111-1111-4111-8111-111111111111'; v_edition uuid := '11111111-1111-4111-8111-111111111112';
 BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.festivals WHERE id=v_brand) OR NOT EXISTS (SELECT 1 FROM public.festival_editions WHERE id=v_edition AND festival_id=v_brand) THEN RAISE EXCEPTION 'London fixture brand or edition not found'; END IF;
   IF NOT EXISTS (SELECT 1 FROM public.profiles WHERE id=p_profile_id) THEN RAISE EXCEPTION 'Profile % not found', p_profile_id; END IF;
   UPDATE public.festivals SET owner_profile_id=p_profile_id, metadata=metadata || jsonb_build_object('fixture_owner_assigned_at',now()) WHERE id=v_brand;
   RETURN jsonb_build_object('festival_id',v_brand,'edition_id',v_edition,'public_url','/festivals/'||v_brand,'owner_url','/festivals/'||v_brand||'/manage/editions/'||v_edition);
 END $$;
+
+REVOKE ALL ON FUNCTION public.assign_london_test_festival_owner(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assign_london_test_festival_owner(uuid) TO service_role;

--- a/supabase/tests/festival_london_test_fixture.sql
+++ b/supabase/tests/festival_london_test_fixture.sql
@@ -1,4 +1,5 @@
 BEGIN;
+SET LOCAL app.allow_test_fixtures = 'true';
 \i supabase/seeds/festival_london_test.sql
 \i supabase/seeds/festival_london_test.sql
 DO $$
@@ -8,22 +9,31 @@ DECLARE
   v_count int;
   v_ops jsonb;
   v_fin jsonb;
+  v_missing text[];
 BEGIN
   IF (SELECT count(*) FROM public.festivals WHERE metadata->>'fixture_key'='RM-LONDON-TEST-FESTIVAL') <> 1 THEN RAISE EXCEPTION 'fixture brand count mismatch'; END IF;
   IF (SELECT count(*) FROM public.festival_editions WHERE id=v_edition AND festival_id=v_brand AND start_at > now()) <> 1 THEN RAISE EXCEPTION 'fixture edition missing or not upcoming'; END IF;
   IF NOT EXISTS (SELECT 1 FROM public.festival_editions e JOIN public.cities c ON c.id=e.city_id WHERE e.id=v_edition AND lower(c.name)='london') THEN RAISE EXCEPTION 'fixture edition does not resolve to London'; END IF;
   IF (SELECT count(*) FROM public.cities WHERE lower(name)='london') < 1 THEN RAISE EXCEPTION 'London city missing'; END IF;
   IF (SELECT count(*) FROM public.festival_stages WHERE edition_id=v_edition AND archived_at IS NULL) <> 3 THEN RAISE EXCEPTION 'stage count mismatch'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_stages st WHERE st.edition_id=v_edition AND NOT EXISTS (SELECT 1 FROM public.festival_stage_slots sl WHERE sl.stage_id=st.id AND sl.archived_at IS NULL)) THEN RAISE EXCEPTION 'stage without slots'; END IF;
   IF EXISTS (SELECT 1 FROM public.festival_stage_slots a JOIN public.festival_stage_slots b ON a.stage_id=b.stage_id AND a.id<b.id WHERE a.edition_id=v_edition AND b.edition_id=v_edition AND tstzrange(a.start_time,a.end_time,'[)') && tstzrange(b.start_time,b.end_time,'[)')) THEN RAISE EXCEPTION 'same-stage slot overlap'; END IF;
-  SELECT count(*) INTO v_count FROM public.festival_stage_slots WHERE edition_id=v_edition; IF v_count <> 24 THEN RAISE EXCEPTION 'slot count mismatch %', v_count; END IF;
-  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='confirmed') <> 15 THEN RAISE EXCEPTION 'occupied slot count mismatch'; END IF;
-  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='open') <> 9 THEN RAISE EXCEPTION 'empty slot count mismatch'; END IF;
-  IF (SELECT count(*) FROM public.festival_system_acts WHERE edition_id=v_edition) <> 15 THEN RAISE EXCEPTION 'system act count mismatch'; END IF;
+  SELECT count(*) INTO v_count FROM public.festival_stage_slots WHERE edition_id=v_edition; IF v_count <> 36 THEN RAISE EXCEPTION 'slot count mismatch %', v_count; END IF;
+  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='confirmed') <> 21 THEN RAISE EXCEPTION 'occupied slot count mismatch'; END IF;
+  IF (SELECT count(*) FROM public.festival_stage_slots WHERE edition_id=v_edition AND status='open') <> 15 THEN RAISE EXCEPTION 'empty slot count mismatch'; END IF;
+  IF (SELECT count(*) FROM public.festival_system_acts WHERE edition_id=v_edition) <> 21 THEN RAISE EXCEPTION 'system act count mismatch'; END IF;
   IF (SELECT capacity FROM public.festival_editions WHERE id=v_edition) <> 10000 THEN RAISE EXCEPTION 'capacity mismatch'; END IF;
+  SELECT array_agg(r->>'permit_type') INTO v_missing FROM jsonb_array_elements(public.festival_edition_permit_requirements(v_edition)) r WHERE r->>'status'='required' AND r->>'blocker'='true';
+  IF coalesce(array_length(v_missing,1),0) <> 0 THEN RAISE EXCEPTION 'required permits missing %', v_missing; END IF;
+  IF jsonb_array_length(coalesce(public.festival_edition_staffing_readiness(v_edition)->'blockers','[]'::jsonb)) <> 0 THEN RAISE EXCEPTION 'canonical staffing blockers %', public.festival_edition_staffing_readiness(v_edition); END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_stages st WHERE st.edition_id=v_edition AND NOT EXISTS (SELECT 1 FROM public.festival_staff sf WHERE sf.edition_id=v_edition AND sf.role='stage_manager' AND sf.assignment_scope->>'stage_id'=st.id::text)) THEN RAISE EXCEPTION 'stage manager missing'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_stages st WHERE st.edition_id=v_edition AND NOT EXISTS (SELECT 1 FROM public.festival_staff sf WHERE sf.edition_id=v_edition AND sf.role='sound_engineer' AND sf.assignment_scope->>'stage_id'=st.id::text)) THEN RAISE EXCEPTION 'sound engineer missing'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.festival_insurance_policies p JOIN public.festival_editions e ON e.id=p.edition_id WHERE p.edition_id=v_edition AND p.active AND p.policy_status='pending_payment' AND p.effective_from <= e.start_at::date AND p.effective_to >= e.end_at::date) THEN RAISE EXCEPTION 'canonical insurance missing'; END IF;
+  v_ops := public.festival_edition_operations_summary(v_edition);
+  IF (v_ops->'ticket_summary'->>'capacity')::int <> 10000 OR (v_ops->'ticket_summary'->>'tickets_sold')::int <> 3250 THEN RAISE EXCEPTION 'operations ticket summary mismatch %', v_ops->'ticket_summary'; END IF;
+  IF (v_ops->'schedule_summary'->>'occupied_slots')::int <> 21 THEN RAISE EXCEPTION 'operations occupied slots mismatch %', v_ops->'schedule_summary'; END IF;
   v_fin := public.festival_edition_finance_summary(v_edition);
   IF (v_fin->>'budget_cents')::bigint <> 25000000 OR (v_fin->>'committed_cost_cents')::bigint <> 11000000 OR v_fin->>'currency' <> 'GBP' THEN RAISE EXCEPTION 'finance summary mismatch %', v_fin; END IF;
-  IF (SELECT count(*) FROM public.festival_permits WHERE edition_id=v_edition AND status='approved') <> 4 THEN RAISE EXCEPTION 'permit approvals mismatch'; END IF;
-  IF NOT EXISTS (SELECT 1 FROM public.festival_insurance_policies p JOIN public.festival_editions e ON e.id=p.edition_id WHERE p.edition_id=v_edition AND p.active AND p.policy_status='pending_payment' AND p.effective_from <= e.start_at::date AND p.effective_to >= e.end_at::date) THEN RAISE EXCEPTION 'canonical insurance missing'; END IF;
   IF EXISTS (SELECT 1 FROM public.festival_participants fp WHERE fp.festival_id=v_brand) THEN RAISE EXCEPTION 'forbidden legacy festival_participants write'; END IF;
   IF NOT EXISTS (SELECT 1 FROM public.public_festival_editions WHERE id=v_edition) THEN RAISE EXCEPTION 'public projection missing'; END IF;
 END $$;

--- a/tests/festivals/london-fixture.spec.ts
+++ b/tests/festivals/london-fixture.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+const brandId = "11111111-1111-4111-8111-111111111111";
+const editionId = "11111111-1111-4111-8111-111111111112";
+
+test.describe("London deterministic festival fixture", () => {
+  test("public page exposes fixture identity and lineup", async ({ page }) => {
+    await page.goto(`/festivals/${brandId}`);
+    await expect(page.getByText(/RockMundo London Test Festival/i)).toBeVisible();
+    await expect(page.getByText(/London/i).first()).toBeVisible();
+    await expect(page.getByText(/Thames|Electric|Camden|lineup/i).first()).toBeVisible();
+    await expect(page.locator("body")).not.toContainText(/undefined|NaN|\[object Object\]/);
+  });
+
+  test("owner dashboard fixture values remain readable without desktop overflow", async ({ page }) => {
+    await page.goto(`/festivals/${brandId}/manage/editions/${editionId}#live`);
+    await expect(page.getByText(/Operations|Planning|Festival management/i).first()).toBeVisible();
+    await expect(page.locator("body")).not.toContainText(/undefined|NaN|\[object Object\]/);
+  });
+
+  test("mobile owner dashboard avoids horizontal overflow", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/festivals/${brandId}/manage/editions/${editionId}#schedule`);
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth);
+    expect(overflow).toBe(false);
+    await expect(page.locator("body")).not.toContainText(/undefined|NaN|\[object Object\]/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the deterministic London festival fixture a trustworthy baseline by repairing data mismatch issues (permits, staffing, slots, ticket visibility, legacy writes and security) so canonical readiness/health functions and the owner dashboard report correct values.
- Prevent accidental production mutation by adding an explicit opt-in guard and hardening the owner-assignment helper.
- Ensure the fixture projects occupancy and ticketing into the canonical operations RPC so the frontend can read expected ticket totals and occupied slots.

### Description
- Added a SQL opt-in guard to the seed and updated the npm seed script to set `app.allow_test_fixtures=true` so the seed refuses to run unless explicitly enabled (`supabase/seeds/festival_london_test.sql` and `package.json`).
- Repaired the seed to use canonical permit `requirement_code`s, scope cleanup to fixture-owned rows via idempotency keys, create 36 slots distributed across all three stages, and add stage-scoped `sound_engineer` staff entries (keeps deterministic IDs) (`supabase/seeds/festival_london_test.sql`).
- Exposed system-act occupancy, contract status and ticket totals to the owner dashboard by adding `public.festival_edition_operations_summary(uuid)` and granting execute to `authenticated` and `service_role` (`supabase/migrations/20260720120000_repair_london_fixture_operations_projection.sql`).
- Hardened `assign_london_test_festival_owner(uuid)` to validate fixture records and restricted execution by revoking `PUBLIC`, `anon`, `authenticated` and granting `service_role` only (`supabase/seeds/festival_london_test.sql`).
- Strengthened the SQL fixture harness with idempotent rerun semantics and expanded assertions that call canonical readiness/summary functions (slots, staffing, permits, insurance, ticket/finance expectations) (`supabase/tests/festival_london_test_fixture.sql`).
- Added a focused Playwright smoke test for the deterministic public and owner routes and updated documentation to record safe seed commands, expected values and the compatibility-event rationale (`tests/festivals/london-fixture.spec.ts` and `docs/festivals/LONDON_TEST_FESTIVAL.md`).

### Testing
- `npm run typecheck` (`tsc --noEmit`) completed successfully in this environment.
- Attempted `npm ci` but dependency installation failed due to registry/permission errors (HTTP 403 fetching `@react-three/fiber`), so browser/test tooling (`vitest`, `vite`, Playwright run) could not be executed in this session.
- `npm run lint` could not complete because `@eslint/js` was not present in the local `node_modules` state produced by the failed install.
- Database integration steps (`supabase db start`, `supabase db reset`, `supabase test db`) and Playwright runs could not be executed here because the Supabase CLI and full node dependencies were not available; SQL harness and migration files were added and a local run with `PGOPTIONS="-c app.allow_test_fixtures=true" psql "$SUPABASE_DB_URL" -f supabase/tests/festival_london_test_fixture.sql` is expected to validate the fixture end-to-end in CI or a developer machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e7890ba748325baa4aa15bf13addf)