### PR TITLE
Secure and finalise festival operations summary

### DIFF
--- a/docs/festivals/FESTIVAL_OPERATIONS_SUMMARY_FINALISATION.md
+++ b/docs/festivals/FESTIVAL_OPERATIONS_SUMMARY_FINALISATION.md
@@ -1,0 +1,72 @@
+# Festival Operations Summary Finalisation
+
+## Definitions audited
+
+| Migration | Operation | Parameters | Return | Security | Grants | Access check | Clean-reset order impact |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `20260720120000_repair_london_fixture_operations_projection.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `authenticated`, `service_role` | None in function body | Applied before the later 2029 festival domain migrations and before this finalisation migration. Its definition is not authoritative after this PR. |
+| `20291217100000_finalise_festival_operations_summary.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary_internal` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `service_role` only | Internal helper; caller must be pre-authorised | Private builder used by the final wrapper. |
+| `20291217100000_finalise_festival_operations_summary.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `authenticated`, `service_role`; `anon` and `PUBLIC` revoked | `public.can_manage_festival_edition(auth.uid(), p_edition_id)` before aggregation | Final authoritative definition on both clean reset and forward-upgraded databases. |
+
+Repository search found only the 2026 PR definition before this finalisation work. The authoritative festival operations domain is otherwise established later, especially by `20291212090000_complete_festival_edition_operations.sql`, which defines the private source tables and helper functions consumed by the summary. Because migrations run in filename order, a clean reset applies the 2026 summary before later festival operations migrations; this final `20291217100000` migration is now later than the currently relevant festival migrations and wins on clean reset.
+
+## Current authoritative access model
+
+`public.festival_edition_operations_summary(uuid)` is owner-only. It rejects callers unless `public.can_manage_festival_edition(auth.uid(), p_edition_id)` returns true. The helper allows:
+
+- service role;
+- platform administrators;
+- the festival brand owner through `public.can_manage_festival_brand`;
+- active edition management roles: `delegated_manager`, `operations_manager`, `stage_manager`, `talent_booker`, `finance_manager`, and `safety_officer`.
+
+The private builder `public.festival_edition_operations_summary_internal(uuid)` remains callable only by `service_role`. The public wrapper performs the authorisation check before calling finance, staffing and data-health aggregators so nested `SECURITY DEFINER` helpers cannot be used through this RPC by unrelated authenticated players.
+
+## Owner-only response contract
+
+The final wrapper preserves the keys required by current owner console consumers:
+
+| Key | Status | Notes |
+| --- | --- | --- |
+| `edition_id` | retained | Canonical edition identifier. |
+| `festival_id` | retained | Canonical festival brand identifier. |
+| `festival_name` | retained | Owner dashboard display value. |
+| `venue_name` | retained | Owner dashboard display value. |
+| `stages` | retained, always array | Canonical stage rows. |
+| `slots` | retained, always array | Canonical slots, enriched with system-act and contract-status fields. |
+| `staff` | retained, always array | Private staffing rows, including wage/assignment details. |
+| `permit_requirements` | retained, always array | Canonical permit readiness projection. |
+| `staffing_readiness` | retained, explicit object | Canonical staffing readiness projection. |
+| `insurance_policies` | retained, always array | Private policy rows. |
+| `ticket_summary` | retained | Capacity, tickets sold, tiers and internal source. |
+| `ticketing` | retained | Backward-compatible alias of ticket summary. |
+| `tickets_sold` | retained | Numeric shortcut used by dashboards. |
+| `schedule_summary` | retained | Includes total, occupied, open, contracted, published and system-act counts. |
+| `finance` | retained | Private finance summary. |
+| `data_health` | retained, always array | Migration/data-health blockers. |
+| `permissions` | retained | Explicit `can_manage: true` after wrapper authorisation. |
+| `lifecycle` | retained | Status/date/currency owner context. |
+| `candidates` | retained as empty array | Compatibility placeholder for older owner screens. |
+| `insurance_quotes` | retained as empty array | Compatibility placeholder for older owner screens. |
+| `ticket_summary_source` | added | Internal authority marker: `canonical_sales`, `server_projection`, or `test_fixture_metadata`. |
+
+No existing keys from the PR #1259 summary were intentionally removed. Deprecated compatibility placeholders should remain until all owner console consumers stop reading them.
+
+## Frontend consumers audited
+
+- `src/features/festivals/admin/service.ts` calls the RPC from `fetchFestivalEditionOperations` and still falls back to scoped table reads only when the RPC is unavailable.
+- `useFestivalEditionOperations` and the owner dashboard consume the service-layer projection rather than calling public festival projections directly.
+- Schedule, staffing, permit, insurance and live operations pages should continue using owner/admin services for private data. Public festival pages must use `public_festival_editions` and public lineup/schedule/ticket availability projections, not the owner summary.
+
+## Ticket summary authority
+
+The final summary uses this precedence order:
+
+1. Canonical audience/ticket-holder projection from `festival_audience_generations` and `festival_audience_cohorts`.
+2. Server projection defaults based on edition capacity when no canonical sales exist.
+3. `lifecycle_metadata.ticket_summary` only when `lifecycle_metadata.is_test_fixture = true`.
+
+The London fixture may therefore keep using simulated metadata, but ordinary production festivals cannot make arbitrary lifecycle metadata authoritative for owner ticket totals.
+
+## Upgraded environment vs clean reset
+
+Before this PR, an upgraded environment that had just applied PR #1259 could expose the 2026 `SECURITY DEFINER` function with no caller check. A clean reset could also diverge if any later migration redefined the same RPC. After this PR, both upgraded and clean-reset databases end at `20291217100000_finalise_festival_operations_summary.sql`, with the same wrapper, grants, internal helper and contract.

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -108,7 +108,7 @@ export function mapFestivalError(error: {
       "FESTIVAL_CREATE_STAGE_DUPLICATE",
       error,
     );
-  if (/permission|not authorised|not authorized|rls|FESTIVAL_CREATE_PERMISSION_DENIED/i.test(message))
+  if (/permission|permission_denied|not authorised|not authorized|rls|FESTIVAL_CREATE_PERMISSION_DENIED/i.test(message))
     return new FestivalAdminServiceError(
       "You do not have permission to perform this festival operation.",
       "FESTIVAL_PERMISSION_DENIED",
@@ -543,6 +543,8 @@ const callMaybeRpc = async <T>(
   try {
     return await rpc(fn as RpcName, args, jsonRecord as z.ZodType<T>);
   } catch (error) {
+    const mapped = mapFestivalError(error as { message?: string; code?: string });
+    if (mapped.code === "FESTIVAL_PERMISSION_DENIED") throw mapped;
     if (fallback) {
       try {
         return await fallback();
@@ -550,7 +552,7 @@ const callMaybeRpc = async <T>(
         /* graceful */ return {} as T;
       }
     }
-    throw error;
+    throw mapped;
   }
 };
 

--- a/supabase/migrations/20291217100000_finalise_festival_operations_summary.sql
+++ b/supabase/migrations/20291217100000_finalise_festival_operations_summary.sql
@@ -1,0 +1,120 @@
+-- Authoritative final festival owner operations summary.
+-- This migration intentionally runs after all earlier festival operations migrations so
+-- clean resets and upgraded databases finish with the same secured RPC contract.
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_edition(p_actor_user_id uuid, p_edition_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  SELECT coalesce(public.has_role(p_actor_user_id,'admin'::public.app_role), false)
+    OR public.is_service_role()
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_editions e
+      WHERE e.id = p_edition_id
+        AND public.can_manage_festival_brand(e.festival_id)
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_edition_management_roles r
+      WHERE r.edition_id = p_edition_id
+        AND r.profile_id = public.current_profile_id_safe()
+        AND r.status = 'active'
+        AND (r.ends_at IS NULL OR r.ends_at > now())
+        AND r.role IN ('delegated_manager','operations_manager','stage_manager','talent_booker','finance_manager','safety_officer')
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_manage_festival_edition(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition(uuid, uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary_internal(p_edition_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  WITH e AS (
+    SELECT * FROM public.festival_editions WHERE id = p_edition_id
+  ), slots AS (
+    SELECT sl.*, sa.id system_act_id, sa.display_name system_act_name, sa.status system_act_status,
+      coalesce(sl.reservation_metadata->>'contract_status', CASE WHEN sa.id IS NOT NULL THEN 'published' END) contract_status
+    FROM public.festival_stage_slots sl
+    LEFT JOIN public.festival_system_acts sa ON sa.slot_id = sl.id AND sa.edition_id = sl.edition_id
+    WHERE sl.edition_id = p_edition_id AND sl.archived_at IS NULL
+  ), canonical_ticket AS (
+    SELECT sum(c.ticket_holders)::integer tickets_sold, sum(c.estimated_demand)::integer estimated_demand
+    FROM public.festival_audience_generations g
+    JOIN public.festival_audience_cohorts c ON c.generation_id = g.id
+    WHERE g.edition_id = p_edition_id
+  ), ticket AS (
+    SELECT
+      coalesce((SELECT tickets_sold FROM canonical_ticket WHERE tickets_sold IS NOT NULL),
+        CASE WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) THEN (e.lifecycle_metadata->'ticket_summary'->>'tickets_sold')::integer END,
+        0) tickets_sold,
+      coalesce((e.lifecycle_metadata->'ticket_summary'->>'capacity')::integer, e.capacity, 0) capacity,
+      CASE
+        WHEN (SELECT tickets_sold FROM canonical_ticket WHERE tickets_sold IS NOT NULL) IS NOT NULL THEN 'canonical_sales'
+        WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) AND e.lifecycle_metadata ? 'ticket_summary' THEN 'test_fixture_metadata'
+        ELSE 'server_projection'
+      END ticket_summary_source,
+      CASE WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) THEN coalesce(e.lifecycle_metadata->'ticket_summary'->'tiers','[]'::jsonb) ELSE '[]'::jsonb END tiers
+    FROM e
+  )
+  SELECT jsonb_build_object(
+    'edition_id', p_edition_id,
+    'festival_id', (SELECT festival_id FROM e),
+    'festival_name', (SELECT f.name FROM public.festivals f JOIN e ON e.festival_id = f.id),
+    'venue_name', (SELECT v.name FROM public.venues v JOIN e ON e.venue_id = v.id),
+    'stages', (SELECT coalesce(jsonb_agg(to_jsonb(st) ORDER BY st.stage_number), '[]'::jsonb) FROM public.festival_stages st WHERE st.edition_id = p_edition_id AND st.archived_at IS NULL),
+    'slots', (SELECT coalesce(jsonb_agg(to_jsonb(sl) || jsonb_build_object('system_act_id', sl.system_act_id, 'system_act_name', sl.system_act_name, 'system_act_status', sl.system_act_status, 'contract_status', sl.contract_status) ORDER BY sl.day_number, sl.start_time), '[]'::jsonb) FROM slots sl),
+    'staff', (SELECT coalesce(jsonb_agg(to_jsonb(s) ORDER BY s.role, s.name), '[]'::jsonb) FROM public.festival_staff s WHERE s.edition_id = p_edition_id),
+    'permit_requirements', coalesce(public.festival_edition_permit_requirements(p_edition_id), '[]'::jsonb),
+    'staffing_readiness', coalesce(public.festival_edition_staffing_readiness(p_edition_id), '{}'::jsonb),
+    'insurance_policies', (SELECT coalesce(jsonb_agg(to_jsonb(p)), '[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id = p_edition_id),
+    'ticket_summary', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket),
+    'ticketing', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket),
+    'tickets_sold', (SELECT tickets_sold FROM ticket),
+    'ticket_summary_source', (SELECT ticket_summary_source FROM ticket),
+    'schedule_summary', (SELECT jsonb_build_object('total_slots', count(*), 'occupied_slots', count(*) FILTER (WHERE system_act_id IS NOT NULL OR reservation_metadata ? 'system_act_id'), 'open_slots', count(*) FILTER (WHERE system_act_id IS NULL AND NOT (reservation_metadata ? 'system_act_id')), 'contracted_acts', count(*) FILTER (WHERE contract_status IN ('signed','accepted')), 'published_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL), 'system_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL)) FROM slots),
+    'finance', coalesce(public.festival_edition_finance_summary(p_edition_id), '{}'::jsonb),
+    'data_health', coalesce(public.festival_data_health(p_edition_id), '[]'::jsonb),
+    'permissions', jsonb_build_object('can_manage', true),
+    'lifecycle', (SELECT jsonb_build_object('status', status, 'start_at', start_at, 'end_at', end_at, 'currency_code', currency_code) FROM e),
+    'candidates', '[]'::jsonb,
+    'insurance_quotes', '[]'::jsonb
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.festival_edition_operations_summary_internal(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary_internal(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary(p_edition_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.festival_editions WHERE id = p_edition_id) THEN
+    RAISE EXCEPTION 'edition_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.can_manage_festival_edition(auth.uid(), p_edition_id) THEN
+    RAISE EXCEPTION 'permission_denied' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN public.festival_edition_operations_summary_internal(p_edition_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.festival_edition_operations_summary(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary(uuid) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.festival_edition_operations_summary(uuid) IS 'Authoritative owner-only festival operations RPC finalised by 20291217100000. Uses can_manage_festival_edition before calling private aggregators; public festival pages must use public projections.';
+COMMENT ON FUNCTION public.festival_edition_operations_summary_internal(uuid) IS 'Private service-role/internal aggregation helper. Do not grant to anon or authenticated.';

--- a/supabase/tests/festival_london_test_fixture.sql
+++ b/supabase/tests/festival_london_test_fixture.sql
@@ -37,4 +37,70 @@ BEGIN
   IF EXISTS (SELECT 1 FROM public.festival_participants fp WHERE fp.festival_id=v_brand) THEN RAISE EXCEPTION 'forbidden legacy festival_participants write'; END IF;
   IF NOT EXISTS (SELECT 1 FROM public.public_festival_editions WHERE id=v_edition) THEN RAISE EXCEPTION 'public projection missing'; END IF;
 END $$;
+
+DO $$
+DECLARE
+  v_fn text := pg_get_functiondef('public.festival_edition_operations_summary(uuid)'::regprocedure);
+  v_internal_priv boolean;
+BEGIN
+  IF v_fn NOT LIKE '%can_manage_festival_edition(auth.uid(), p_edition_id)%' THEN RAISE EXCEPTION 'operations summary missing authorisation guard'; END IF;
+  IF v_fn NOT LIKE '%permission_denied%' THEN RAISE EXCEPTION 'operations summary missing structured permission denial'; END IF;
+  IF has_function_privilege('anon','public.festival_edition_operations_summary(uuid)','EXECUTE') THEN RAISE EXCEPTION 'anon can execute operations summary'; END IF;
+  IF NOT has_function_privilege('authenticated','public.festival_edition_operations_summary(uuid)','EXECUTE') THEN RAISE EXCEPTION 'authenticated wrapper execute missing'; END IF;
+  SELECT has_function_privilege('authenticated','public.festival_edition_operations_summary_internal(uuid)','EXECUTE') INTO v_internal_priv;
+  IF v_internal_priv THEN RAISE EXCEPTION 'authenticated can execute internal operations summary'; END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_edition uuid := '11111111-1111-4111-8111-111111111112';
+  v_owner_user uuid := '22222222-2222-4222-8222-222222222201';
+  v_unrelated_user uuid := '22222222-2222-4222-8222-222222222202';
+  v_manager_user uuid := '22222222-2222-4222-8222-222222222203';
+  v_admin_user uuid := '22222222-2222-4222-8222-222222222204';
+  v_other_owner_user uuid := '22222222-2222-4222-8222-222222222205';
+  v_owner_profile uuid := '33333333-3333-4333-8333-333333333301';
+  v_unrelated_profile uuid := '33333333-3333-4333-8333-333333333302';
+  v_manager_profile uuid := '33333333-3333-4333-8333-333333333303';
+  v_admin_profile uuid := '33333333-3333-4333-8333-333333333304';
+  v_other_profile uuid := '33333333-3333-4333-8333-333333333305';
+  v_other_brand uuid := '11111111-1111-4111-8111-111111111121';
+  v_other_edition uuid := '11111111-1111-4111-8111-111111111122';
+  v_ops jsonb;
+BEGIN
+  INSERT INTO auth.users(id, email) VALUES
+    (v_owner_user,'fixture-owner@example.test'),(v_unrelated_user,'fixture-unrelated@example.test'),(v_manager_user,'fixture-manager@example.test'),(v_admin_user,'fixture-admin@example.test'),(v_other_owner_user,'fixture-other@example.test')
+  ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.profiles(id,user_id,username,display_name) VALUES
+    (v_owner_profile,v_owner_user,'fixture_owner','Fixture Owner'),(v_unrelated_profile,v_unrelated_user,'fixture_unrelated','Fixture Unrelated'),(v_manager_profile,v_manager_user,'fixture_manager','Fixture Manager'),(v_admin_profile,v_admin_user,'fixture_admin','Fixture Admin'),(v_other_profile,v_other_owner_user,'fixture_other','Fixture Other')
+  ON CONFLICT (id) DO NOTHING;
+  UPDATE public.festivals SET owner_profile_id = v_owner_profile WHERE id = '11111111-1111-4111-8111-111111111111';
+  INSERT INTO public.user_roles(user_id, role) VALUES (v_admin_user, 'admin') ON CONFLICT DO NOTHING;
+  INSERT INTO public.festival_edition_management_roles(edition_id, profile_id, role, status) VALUES (v_edition, v_manager_profile, 'operations_manager', 'active') ON CONFLICT DO NOTHING;
+
+  INSERT INTO public.festivals(id,name,city_id,venue_id,owner_profile_id,status,metadata) SELECT v_other_brand,'Other Fixture Festival',city_id,venue_id,v_other_profile,'planning','{}'::jsonb FROM public.festivals WHERE id='11111111-1111-4111-8111-111111111111' ON CONFLICT DO NOTHING;
+  INSERT INTO public.festival_editions(id,festival_id,edition_number,edition_year,title,city_id,venue_id,start_at,end_at,timezone,time_zone,capacity,currency_code,budget_cents,status,lifecycle_metadata,public_metadata)
+  SELECT v_other_edition,v_other_brand,1,edition_year,'Other Fixture Edition',city_id,venue_id,start_at,end_at,timezone,time_zone,capacity,currency_code,budget_cents,'planning','{}'::jsonb,'{}'::jsonb FROM public.festival_editions WHERE id=v_edition ON CONFLICT DO NOTHING;
+
+  PERFORM set_config('request.jwt.claim.role','authenticated', true);
+
+  PERFORM set_config('request.jwt.claim.sub', v_unrelated_user::text, true);
+  BEGIN PERFORM public.festival_edition_operations_summary(v_edition); RAISE EXCEPTION 'unrelated user unexpectedly read summary'; EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+
+  PERFORM set_config('request.jwt.claim.sub', v_owner_user::text, true);
+  v_ops := public.festival_edition_operations_summary(v_edition);
+  IF (v_ops->'stages') IS NULL THEN RAISE EXCEPTION 'owner summary malformed'; END IF;
+  BEGIN PERFORM public.festival_edition_operations_summary(v_other_edition); RAISE EXCEPTION 'owner read another festival'; EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+
+  PERFORM set_config('request.jwt.claim.sub', v_manager_user::text, true);
+  IF public.festival_edition_operations_summary(v_edition)->>'edition_id' <> v_edition::text THEN RAISE EXCEPTION 'manager denied'; END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', v_admin_user::text, true);
+  IF public.festival_edition_operations_summary(v_edition)->>'edition_id' <> v_edition::text THEN RAISE EXCEPTION 'admin denied'; END IF;
+
+  PERFORM set_config('request.jwt.claim.role','service_role', true);
+  PERFORM set_config('request.jwt.claim.sub', '', true);
+  IF public.festival_edition_operations_summary(v_edition)->>'edition_id' <> v_edition::text THEN RAISE EXCEPTION 'service role denied'; END IF;
+END $$;
+
 ROLLBACK;


### PR DESCRIPTION
### Motivation

- Close a critical data-leak by preventing unauthorised authenticated users from calling the owner operations RPC and reading private festival finance/staff/permit data. 
- Ensure a single authoritative forward migration defines the `festival_edition_operations_summary` RPC so clean resets and upgraded databases converge to the same secure behaviour. 
- Preserve the existing owner RPC contract for frontend consumers while making ticket-summary provenance explicit and limiting fixture metadata fallback to test fixtures. 

### Description

- Add a forward migration `supabase/migrations/20291217100000_finalise_festival_operations_summary.sql` that introduces `can_manage_festival_edition`, a service-role-only internal builder `festival_edition_operations_summary_internal(uuid)`, and an authenticated wrapper `festival_edition_operations_summary(uuid)` which enforces `can_manage_festival_edition(auth.uid(), p_edition_id)` and raises `permission_denied` for unauthorised callers. 
- Limit grants so the internal aggregator is only executable by `service_role` and revoke public/anon execution on the wrapper while granting `authenticated` and `service_role` the wrapper as appropriate. 
- Implement ticket-summary precedence: prefer canonical sales via `festival_audience_generations`/`festival_audience_cohorts`, fall back to server projection, and use `lifecycle_metadata.ticket_summary` only for fixtures with `is_test_fixture = true`, and add `ticket_summary_source` to the response. 
- Add `docs/festivals/FESTIVAL_OPERATIONS_SUMMARY_FINALISATION.md` documenting audited definitions, ordering, access model, response contract and ticket-summary authority. 
- Extend the London fixture SQL harness (`supabase/tests/festival_london_test_fixture.sql`) with checks that assert the function definition contains the authorization guard, that grants are correct, and role-based execution behaviour for anon, authenticated/unrelated, owner, manager, admin and service-role callers. 
- Update the frontend admin service (`src/features/festivals/admin/service.ts`) to map SQL permission errors into `FESTIVAL_PERMISSION_DENIED` and to rethrow permission errors rather than falling back to public table reads that could mask permission failures. 

### Testing

- `npm run typecheck` (TS typecheck) succeeded. 
- `git diff --check` passed before commit. 
- `npm ci` failed in this environment due to a `403` from the npm registry for `@react-three/fiber`, leaving dependencies unavailable and preventing further JS tooling from running. 
- `npm run lint` could not be run because `npm ci` failed and `@eslint/js` was missing. 
- Unit/test runner (`vitest`) and `npm run test` could not run because dependencies were not installed in this environment. 
- `npm run build` could not run because `vite` was not available due to the failed install. 
- Supabase-local commands and DB harnesses (`supabase db start`, `supabase db reset`, `supabase test db`) were not executed because the Supabase CLI is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e7c01752c832581b78411e3fe5c4d)