### PR TITLE
Harden festival operations authorization and ticket summary handling

### DIFF
--- a/docs/festivals/FESTIVAL_MANAGEMENT_PERMISSIONS.md
+++ b/docs/festivals/FESTIVAL_MANAGEMENT_PERMISSIONS.md
@@ -1,0 +1,20 @@
+# Festival management permissions
+
+This matrix documents the least-privilege contract for the owner operations dashboard. The complete commercial summary is limited to the festival owner, delegated managers, operations managers, finance managers, administrators, and service-role workflows.
+
+| Capability | Owner/Admin | Delegated manager | Operations manager | Stage manager | Talent booker | Finance manager | Safety officer |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Overview | Full | Full | Full | Limited | Limited | Full | Limited |
+| Schedule | Full | Full | Full | Full | View slots | View | Safety view |
+| Lineup | Full | Full | Full | View | Full | View costs | Safety view |
+| Contracts | Full | Full | Full | Status only | Booking status | Financial terms | Safety status only |
+| Staff identities | Full | Full | Full | Stage staff only | No | Full | Safety staff only |
+| Staff wages | Full | Full | Full | No | No | Full | No |
+| Finance | Full | Full | Full | No | No | Full | No |
+| Tickets | Full | Full | Full | Capacity/status | Sales status only | Full | Capacity/status |
+| Permits | Full | Full | Full | Stage-related | Event status | Cost view | Full safety view |
+| Insurance | Full | Full | Full | Status only | Status only | Full commercial details | Status and dates only |
+| Data health | Full | Full | Full | No | No | Full | No |
+| Settlement | Full | Full | Full | No | No | Full | No |
+
+Sensitive database rows must be projected into explicit JSON objects. The operations RPC must not expose whole staff, finance, insurance, contract, or data-health rows to limited roles. Ticket sales remain unavailable for real festivals until a canonical sales ledger exists; current audience generation tables are simulation inputs, not commercial sales authority.

--- a/docs/festivals/FESTIVAL_OPERATIONS_SUMMARY_FINALISATION.md
+++ b/docs/festivals/FESTIVAL_OPERATIONS_SUMMARY_FINALISATION.md
@@ -6,13 +6,13 @@
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `20260720120000_repair_london_fixture_operations_projection.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `authenticated`, `service_role` | None in function body | Applied before the later 2029 festival domain migrations and before this finalisation migration. Its definition is not authoritative after this PR. |
 | `20291217100000_finalise_festival_operations_summary.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary_internal` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `service_role` only | Internal helper; caller must be pre-authorised | Private builder used by the final wrapper. |
-| `20291217100000_finalise_festival_operations_summary.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `authenticated`, `service_role`; `anon` and `PUBLIC` revoked | `public.can_manage_festival_edition(auth.uid(), p_edition_id)` before aggregation | Final authoritative definition on both clean reset and forward-upgraded databases. |
+| `20291217100000_finalise_festival_operations_summary.sql` | `CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary` | `p_edition_id uuid` | `jsonb` | `SECURITY DEFINER` | `authenticated`, `service_role`; `anon` and `PUBLIC` revoked | `public.can_manage_festival_edition(p_edition_id)` before aggregation | Final authoritative definition on both clean reset and forward-upgraded databases. |
 
 Repository search found only the 2026 PR definition before this finalisation work. The authoritative festival operations domain is otherwise established later, especially by `20291212090000_complete_festival_edition_operations.sql`, which defines the private source tables and helper functions consumed by the summary. Because migrations run in filename order, a clean reset applies the 2026 summary before later festival operations migrations; this final `20291217100000` migration is now later than the currently relevant festival migrations and wins on clean reset.
 
 ## Current authoritative access model
 
-`public.festival_edition_operations_summary(uuid)` is owner-only. It rejects callers unless `public.can_manage_festival_edition(auth.uid(), p_edition_id)` returns true. The helper allows:
+`public.festival_edition_operations_summary(uuid)` is owner-only. It rejects callers unless `public.can_manage_festival_edition(p_edition_id)` returns true. The helper allows:
 
 - service role;
 - platform administrators;
@@ -47,7 +47,7 @@ The final wrapper preserves the keys required by current owner console consumers
 | `lifecycle` | retained | Status/date/currency owner context. |
 | `candidates` | retained as empty array | Compatibility placeholder for older owner screens. |
 | `insurance_quotes` | retained as empty array | Compatibility placeholder for older owner screens. |
-| `ticket_summary_source` | added | Internal authority marker: `canonical_sales`, `server_projection`, or `test_fixture_metadata`. |
+| `ticket_summary_source` | added | Internal authority marker: `test_fixture_metadata` or `unavailable` until a canonical commercial ticket ledger exists. |
 
 No existing keys from the PR #1259 summary were intentionally removed. Deprecated compatibility placeholders should remain until all owner console consumers stop reading them.
 
@@ -59,13 +59,9 @@ No existing keys from the PR #1259 summary were intentionally removed. Deprecate
 
 ## Ticket summary authority
 
-The final summary uses this precedence order:
+The final summary uses edition capacity as the normal capacity authority. It does not treat `festival_audience_generations` or `festival_audience_cohorts.ticket_holders` as completed commercial sales, because those tables model audience simulation rather than a paid ticket ledger. Ticket totals therefore remain unavailable for real festivals until the later Ticket Sales PR introduces canonical ticket inventory, order, purchase, refund, complimentary-ticket, and box-office settlement structures.
 
-1. Canonical audience/ticket-holder projection from `festival_audience_generations` and `festival_audience_cohorts`.
-2. Server projection defaults based on edition capacity when no canonical sales exist.
-3. `lifecycle_metadata.ticket_summary` only when `lifecycle_metadata.is_test_fixture = true`.
-
-The London fixture may therefore keep using simulated metadata, but ordinary production festivals cannot make arbitrary lifecycle metadata authoritative for owner ticket totals.
+Fixture metadata is only considered when `lifecycle_metadata.is_test_fixture = true`; production metadata cannot override edition capacity or supply sales totals. The London fixture may keep using guarded fixture metadata so QA continues to show 3,250 / 10,000.
 
 ## Upgraded environment vs clean reset
 

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -169,6 +169,52 @@ const ownerEditionSchema = z
   })
   .passthrough();
 const jsonRecord = z.record(z.unknown());
+const ticketSourceSchema = z.enum([
+  "test_fixture_metadata",
+  "audience_simulation",
+  "canonical_sales",
+  "unavailable",
+]);
+const operationsSummarySchema = z
+  .object({
+    edition_id: z.string().optional(),
+    festival_id: z.string().optional(),
+    stages: z.array(z.record(z.unknown())).default([]),
+    slots: z.array(z.record(z.unknown())).default([]),
+    staff: z.array(z.record(z.unknown())).default([]),
+    permit_requirements: z.array(z.unknown()).default([]),
+    insurance_policies: z.array(z.record(z.unknown())).default([]),
+    ticket_summary: z
+      .object({
+        capacity: z.number().int().nonnegative().nullable().optional(),
+        tickets_sold: z.number().int().nonnegative().nullable().optional(),
+        tiers: z.array(z.unknown()).default([]),
+        source: ticketSourceSchema,
+      })
+      .passthrough()
+      .optional(),
+    ticketing: z
+      .object({
+        capacity: z.number().int().nonnegative().nullable().optional(),
+        tickets_sold: z.number().int().nonnegative().nullable().optional(),
+        tiers: z.array(z.unknown()).default([]),
+        source: ticketSourceSchema,
+      })
+      .passthrough()
+      .optional(),
+    tickets_sold: z.number().int().nonnegative().nullable().optional(),
+    ticket_summary_source: ticketSourceSchema.optional(),
+    schedule_summary: z.record(z.unknown()).optional(),
+    finance: z.record(z.unknown()).nullable().optional(),
+    finance_access: z.enum(["granted", "denied"]).optional(),
+    staff_wages_access: z.enum(["granted", "denied"]).optional(),
+    insurance_access: z.enum(["granted", "limited", "denied"]).optional(),
+    data_health: z.array(z.unknown()).optional(),
+    data_health_access: z.enum(["granted", "denied"]).optional(),
+    permissions: z.record(z.unknown()).optional(),
+    lifecycle: z.record(z.unknown()).optional(),
+  })
+  .passthrough();
 const nonNullJson = z
   .unknown()
   .refine(
@@ -539,17 +585,22 @@ const callMaybeRpc = async <T>(
   fn: string,
   args?: Record<string, unknown>,
   fallback?: () => Promise<T>,
+  schema: z.ZodType<T> = jsonRecord as z.ZodType<T>,
 ): Promise<T> => {
   try {
-    return await rpc(fn as RpcName, args, jsonRecord as z.ZodType<T>);
+    return await rpc(fn as RpcName, args, schema);
   } catch (error) {
     const mapped = mapFestivalError(error as { message?: string; code?: string });
     if (mapped.code === "FESTIVAL_PERMISSION_DENIED") throw mapped;
     if (fallback) {
       try {
         return await fallback();
-      } catch {
-        /* graceful */ return {} as T;
+      } catch (fallbackError) {
+        throw new FestivalAdminServiceError(
+          `The ${fn} RPC failed and its fallback also failed.`,
+          "FESTIVAL_RPC_FAILED",
+          { rpcError: mapped, fallbackError },
+        );
       }
     }
     throw mapped;
@@ -591,6 +642,7 @@ export async function fetchFestivalEditionOperations(editionId: string) {
         lifecycle: {},
       };
     },
+    operationsSummarySchema,
   );
 }
 

--- a/supabase/migrations/20291217100000_finalise_festival_operations_summary.sql
+++ b/supabase/migrations/20291217100000_finalise_festival_operations_summary.sql
@@ -2,7 +2,9 @@
 -- This migration intentionally runs after all earlier festival operations migrations so
 -- clean resets and upgraded databases finish with the same secured RPC contract.
 
-CREATE OR REPLACE FUNCTION public.can_manage_festival_edition(p_actor_user_id uuid, p_edition_id uuid)
+DROP FUNCTION IF EXISTS public.can_manage_festival_edition(uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_edition_internal(p_actor_user_id uuid, p_profile_id uuid, p_edition_id uuid)
 RETURNS boolean
 LANGUAGE sql
 STABLE
@@ -14,22 +16,43 @@ AS $$
     OR EXISTS (
       SELECT 1
       FROM public.festival_editions e
+      JOIN public.festivals f ON f.id = e.festival_id
       WHERE e.id = p_edition_id
-        AND public.can_manage_festival_brand(e.festival_id)
+        AND f.owner_profile_id = p_profile_id
     )
     OR EXISTS (
       SELECT 1
       FROM public.festival_edition_management_roles r
       WHERE r.edition_id = p_edition_id
-        AND r.profile_id = public.current_profile_id_safe()
+        AND r.profile_id = p_profile_id
         AND r.status = 'active'
         AND (r.ends_at IS NULL OR r.ends_at > now())
         AND r.role IN ('delegated_manager','operations_manager','stage_manager','talent_booker','finance_manager','safety_officer')
     );
 $$;
 
-REVOKE ALL ON FUNCTION public.can_manage_festival_edition(uuid, uuid) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition(uuid, uuid) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.can_manage_festival_edition_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition_internal(uuid, uuid, uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_edition(p_edition_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  SELECT public.can_manage_festival_edition_internal(auth.uid(), public.current_profile_id_safe(), p_edition_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.can_manage_festival_edition(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_safe_jsonb_nonnegative_integer(p_json jsonb, p_key text)
+RETURNS integer LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT CASE WHEN p_json ? p_key AND p_json->>p_key ~ '^[0-9]+$' THEN (p_json->>p_key)::integer END;
+$$;
+REVOKE ALL ON FUNCTION public.festival_safe_jsonb_nonnegative_integer(jsonb,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.festival_safe_jsonb_nonnegative_integer(jsonb,text) TO service_role;
 
 CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary_internal(p_edition_id uuid)
 RETURNS jsonb
@@ -40,50 +63,57 @@ SET search_path=public
 AS $$
   WITH e AS (
     SELECT * FROM public.festival_editions WHERE id = p_edition_id
+  ), access AS (
+    SELECT
+      public.is_service_role() OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) OR EXISTS (SELECT 1 FROM e JOIN public.festivals f ON f.id=e.festival_id WHERE f.owner_profile_id=public.current_profile_id_safe()) AS full_access,
+      EXISTS (SELECT 1 FROM public.festival_edition_management_roles r WHERE r.edition_id=p_edition_id AND r.profile_id=public.current_profile_id_safe() AND r.status='active' AND (r.ends_at IS NULL OR r.ends_at>now()) AND r.role IN ('delegated_manager','operations_manager','finance_manager')) AS finance_access,
+      EXISTS (SELECT 1 FROM public.festival_edition_management_roles r WHERE r.edition_id=p_edition_id AND r.profile_id=public.current_profile_id_safe() AND r.status='active' AND (r.ends_at IS NULL OR r.ends_at>now()) AND r.role IN ('safety_officer')) AS safety_access
   ), slots AS (
     SELECT sl.*, sa.id system_act_id, sa.display_name system_act_name, sa.status system_act_status,
       coalesce(sl.reservation_metadata->>'contract_status', CASE WHEN sa.id IS NOT NULL THEN 'published' END) contract_status
     FROM public.festival_stage_slots sl
     LEFT JOIN public.festival_system_acts sa ON sa.slot_id = sl.id AND sa.edition_id = sl.edition_id
     WHERE sl.edition_id = p_edition_id AND sl.archived_at IS NULL
-  ), canonical_ticket AS (
-    SELECT sum(c.ticket_holders)::integer tickets_sold, sum(c.estimated_demand)::integer estimated_demand
-    FROM public.festival_audience_generations g
-    JOIN public.festival_audience_cohorts c ON c.generation_id = g.id
-    WHERE g.edition_id = p_edition_id
+  ), simulated_ticket AS (
+    SELECT sum(c.ticket_holders)::integer tickets_sold FROM public.festival_audience_generations g JOIN public.festival_audience_cohorts c ON c.generation_id = g.id WHERE g.edition_id = p_edition_id
   ), ticket AS (
     SELECT
-      coalesce((SELECT tickets_sold FROM canonical_ticket WHERE tickets_sold IS NOT NULL),
-        CASE WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) THEN (e.lifecycle_metadata->'ticket_summary'->>'tickets_sold')::integer END,
-        0) tickets_sold,
-      coalesce((e.lifecycle_metadata->'ticket_summary'->>'capacity')::integer, e.capacity, 0) capacity,
-      CASE
-        WHEN (SELECT tickets_sold FROM canonical_ticket WHERE tickets_sold IS NOT NULL) IS NOT NULL THEN 'canonical_sales'
-        WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) AND e.lifecycle_metadata ? 'ticket_summary' THEN 'test_fixture_metadata'
-        ELSE 'server_projection'
-      END ticket_summary_source,
-      CASE WHEN coalesce((e.lifecycle_metadata->>'is_test_fixture')::boolean,false) THEN coalesce(e.lifecycle_metadata->'ticket_summary'->'tiers','[]'::jsonb) ELSE '[]'::jsonb END tiers
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN public.festival_safe_jsonb_nonnegative_integer(e.lifecycle_metadata->'ticket_summary','tickets_sold') END fixture_sold,
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN public.festival_safe_jsonb_nonnegative_integer(e.lifecycle_metadata->'ticket_summary','capacity') END fixture_capacity,
+      coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' is_fixture,
+      e.capacity edition_capacity,
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN coalesce(e.lifecycle_metadata->'ticket_summary'->'tiers','[]'::jsonb) ELSE '[]'::jsonb END tiers
     FROM e
+  ), ticket_final AS (
+    SELECT coalesce(edition_capacity, fixture_capacity) capacity,
+      fixture_sold tickets_sold,
+      CASE WHEN is_fixture AND fixture_sold IS NOT NULL THEN 'test_fixture_metadata' ELSE 'unavailable' END ticket_summary_source,
+      tiers
+    FROM ticket
   )
   SELECT jsonb_build_object(
     'edition_id', p_edition_id,
     'festival_id', (SELECT festival_id FROM e),
     'festival_name', (SELECT f.name FROM public.festivals f JOIN e ON e.festival_id = f.id),
     'venue_name', (SELECT v.name FROM public.venues v JOIN e ON e.venue_id = v.id),
-    'stages', (SELECT coalesce(jsonb_agg(to_jsonb(st) ORDER BY st.stage_number), '[]'::jsonb) FROM public.festival_stages st WHERE st.edition_id = p_edition_id AND st.archived_at IS NULL),
-    'slots', (SELECT coalesce(jsonb_agg(to_jsonb(sl) || jsonb_build_object('system_act_id', sl.system_act_id, 'system_act_name', sl.system_act_name, 'system_act_status', sl.system_act_status, 'contract_status', sl.contract_status) ORDER BY sl.day_number, sl.start_time), '[]'::jsonb) FROM slots sl),
-    'staff', (SELECT coalesce(jsonb_agg(to_jsonb(s) ORDER BY s.role, s.name), '[]'::jsonb) FROM public.festival_staff s WHERE s.edition_id = p_edition_id),
+    'stages', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',st.id,'stage_name',st.stage_name,'stage_number',st.stage_number,'stage_type',st.stage_type,'capacity',st.capacity,'genre_focus',st.genre_focus) ORDER BY st.stage_number), '[]'::jsonb) FROM public.festival_stages st WHERE st.edition_id = p_edition_id AND st.archived_at IS NULL),
+    'slots', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',sl.id,'stage_id',sl.stage_id,'day_number',sl.day_number,'start_time',sl.start_time,'end_time',sl.end_time,'slot_type',sl.slot_type,'system_act_id',sl.system_act_id,'system_act_name',sl.system_act_name,'system_act_status',sl.system_act_status,'contract_status',sl.contract_status) ORDER BY sl.day_number, sl.start_time), '[]'::jsonb) FROM slots sl),
+    'staff', (SELECT coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object('id',s.id,'role',s.role,'name',s.name,'skill_level',s.skill_level,'assignment_scope',s.assignment_scope,'shift_start_at',s.shift_start_at,'shift_end_at',s.shift_end_at,'status',s.status,'weekly_wage_cents',CASE WHEN (SELECT full_access OR finance_access FROM access) THEN s.weekly_wage_cents END)) ORDER BY s.role, s.name), '[]'::jsonb) FROM public.festival_staff s WHERE s.edition_id = p_edition_id),
+    'staff_wages_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
     'permit_requirements', coalesce(public.festival_edition_permit_requirements(p_edition_id), '[]'::jsonb),
     'staffing_readiness', coalesce(public.festival_edition_staffing_readiness(p_edition_id), '{}'::jsonb),
-    'insurance_policies', (SELECT coalesce(jsonb_agg(to_jsonb(p)), '[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id = p_edition_id),
-    'ticket_summary', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket),
-    'ticketing', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket),
-    'tickets_sold', (SELECT tickets_sold FROM ticket),
-    'ticket_summary_source', (SELECT ticket_summary_source FROM ticket),
+    'insurance_policies', (SELECT coalesce(jsonb_agg(CASE WHEN (SELECT full_access OR finance_access FROM access) THEN jsonb_build_object('id',p.id,'coverage_type',p.coverage_type,'policy_status',p.policy_status,'active',p.active,'premium_cents',p.premium_cents,'payout_ceiling_cents',p.payout_ceiling_cents,'effective_from',p.effective_from,'effective_to',p.effective_to) ELSE jsonb_build_object('id',p.id,'coverage_type',p.coverage_type,'policy_status',p.policy_status,'active',p.active,'effective_from',p.effective_from,'effective_to',p.effective_to) END), '[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id = p_edition_id),
+    'insurance_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' WHEN (SELECT safety_access FROM access) THEN 'limited' ELSE 'denied' END,
+    'ticket_summary', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket_final),
+    'ticketing', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket_final),
+    'tickets_sold', (SELECT tickets_sold FROM ticket_final),
+    'ticket_summary_source', (SELECT ticket_summary_source FROM ticket_final),
     'schedule_summary', (SELECT jsonb_build_object('total_slots', count(*), 'occupied_slots', count(*) FILTER (WHERE system_act_id IS NOT NULL OR reservation_metadata ? 'system_act_id'), 'open_slots', count(*) FILTER (WHERE system_act_id IS NULL AND NOT (reservation_metadata ? 'system_act_id')), 'contracted_acts', count(*) FILTER (WHERE contract_status IN ('signed','accepted')), 'published_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL), 'system_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL)) FROM slots),
-    'finance', coalesce(public.festival_edition_finance_summary(p_edition_id), '{}'::jsonb),
-    'data_health', coalesce(public.festival_data_health(p_edition_id), '[]'::jsonb),
-    'permissions', jsonb_build_object('can_manage', true),
+    'finance', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN coalesce(public.festival_edition_finance_summary(p_edition_id), '{}'::jsonb) END,
+    'finance_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
+    'data_health', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN coalesce(public.festival_data_health(p_edition_id), '[]'::jsonb) ELSE '[]'::jsonb END,
+    'data_health_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
+    'permissions', jsonb_build_object('can_manage', true, 'finance_access', (SELECT full_access OR finance_access FROM access), 'full_access', (SELECT full_access FROM access)),
     'lifecycle', (SELECT jsonb_build_object('status', status, 'start_at', start_at, 'end_at', end_at, 'currency_code', currency_code) FROM e),
     'candidates', '[]'::jsonb,
     'insurance_quotes', '[]'::jsonb
@@ -105,7 +135,7 @@ BEGIN
     RAISE EXCEPTION 'edition_not_found' USING ERRCODE = 'P0002';
   END IF;
 
-  IF NOT public.can_manage_festival_edition(auth.uid(), p_edition_id) THEN
+  IF NOT public.can_manage_festival_edition(p_edition_id) THEN
     RAISE EXCEPTION 'permission_denied' USING ERRCODE = '42501';
   END IF;
 
@@ -116,5 +146,7 @@ $$;
 REVOKE ALL ON FUNCTION public.festival_edition_operations_summary(uuid) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary(uuid) TO authenticated, service_role;
 
-COMMENT ON FUNCTION public.festival_edition_operations_summary(uuid) IS 'Authoritative owner-only festival operations RPC finalised by 20291217100000. Uses can_manage_festival_edition before calling private aggregators; public festival pages must use public projections.';
+COMMENT ON FUNCTION public.festival_edition_operations_summary(uuid) IS 'Authoritative owner-only festival operations RPC finalised by 20291217100000. Uses can_manage_festival_edition(p_edition_id) before calling private aggregators; public festival pages must use public projections.';
 COMMENT ON FUNCTION public.festival_edition_operations_summary_internal(uuid) IS 'Private service-role/internal aggregation helper. Do not grant to anon or authenticated.';
+COMMENT ON FUNCTION public.can_manage_festival_edition(uuid) IS 'Authenticated authorisation helper that derives actor identity from auth.uid() and current_profile_id_safe().';
+COMMENT ON FUNCTION public.can_manage_festival_edition_internal(uuid,uuid,uuid) IS 'Service-role-only internal helper for trusted workflows that must evaluate an explicit actor/profile pair.';

--- a/supabase/tests/festival_london_test_fixture.sql
+++ b/supabase/tests/festival_london_test_fixture.sql
@@ -43,8 +43,11 @@ DECLARE
   v_fn text := pg_get_functiondef('public.festival_edition_operations_summary(uuid)'::regprocedure);
   v_internal_priv boolean;
 BEGIN
-  IF v_fn NOT LIKE '%can_manage_festival_edition(auth.uid(), p_edition_id)%' THEN RAISE EXCEPTION 'operations summary missing authorisation guard'; END IF;
+  IF v_fn NOT LIKE '%can_manage_festival_edition(p_edition_id)%' THEN RAISE EXCEPTION 'operations summary missing authorisation guard'; END IF;
   IF v_fn NOT LIKE '%permission_denied%' THEN RAISE EXCEPTION 'operations summary missing structured permission denial'; END IF;
+  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname='can_manage_festival_edition' AND oidvectortypes(proargtypes)='uuid, uuid') THEN RAISE EXCEPTION 'legacy caller-selectable helper still exists'; END IF;
+  IF pg_get_function_arguments('public.can_manage_festival_edition(uuid)'::regprocedure) <> 'p_edition_id uuid' THEN RAISE EXCEPTION 'authenticated helper exposes unexpected arguments'; END IF;
+  IF has_function_privilege('authenticated','public.can_manage_festival_edition_internal(uuid,uuid,uuid)','EXECUTE') THEN RAISE EXCEPTION 'authenticated can execute explicit-identity helper'; END IF;
   IF has_function_privilege('anon','public.festival_edition_operations_summary(uuid)','EXECUTE') THEN RAISE EXCEPTION 'anon can execute operations summary'; END IF;
   IF NOT has_function_privilege('authenticated','public.festival_edition_operations_summary(uuid)','EXECUTE') THEN RAISE EXCEPTION 'authenticated wrapper execute missing'; END IF;
   SELECT has_function_privilege('authenticated','public.festival_edition_operations_summary_internal(uuid)','EXECUTE') INTO v_internal_priv;
@@ -86,6 +89,9 @@ BEGIN
 
   PERFORM set_config('request.jwt.claim.sub', v_unrelated_user::text, true);
   BEGIN PERFORM public.festival_edition_operations_summary(v_edition); RAISE EXCEPTION 'unrelated user unexpectedly read summary'; EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+  IF public.can_manage_festival_edition(v_edition) THEN RAISE EXCEPTION 'unrelated user can manage edition'; END IF;
+  IF EXISTS (SELECT 1 FROM pg_proc WHERE proname='can_manage_festival_edition' AND oidvectortypes(proargtypes)='uuid, uuid') THEN RAISE EXCEPTION 'ordinary user could target removed actor-id helper'; END IF;
+  IF has_function_privilege('authenticated','public.can_manage_festival_edition_internal(uuid,uuid,uuid)','EXECUTE') THEN RAISE EXCEPTION 'ordinary user can execute internal spoof helper'; END IF;
 
   PERFORM set_config('request.jwt.claim.sub', v_owner_user::text, true);
   v_ops := public.festival_edition_operations_summary(v_edition);
@@ -101,6 +107,17 @@ BEGIN
   PERFORM set_config('request.jwt.claim.role','service_role', true);
   PERFORM set_config('request.jwt.claim.sub', '', true);
   IF public.festival_edition_operations_summary(v_edition)->>'edition_id' <> v_edition::text THEN RAISE EXCEPTION 'service role denied'; END IF;
+
+  PERFORM set_config('request.jwt.claim.role','authenticated', true);
+  UPDATE public.festival_editions SET capacity=7777, lifecycle_metadata=jsonb_build_object('is_test_fixture','yes','ticket_summary',jsonb_build_object('capacity','','tickets_sold','unknown')) WHERE id=v_other_edition;
+  PERFORM set_config('request.jwt.claim.sub', v_other_owner_user::text, true);
+  v_ops := public.festival_edition_operations_summary(v_other_edition);
+  IF (v_ops->'ticket_summary'->>'capacity')::int <> 7777 THEN RAISE EXCEPTION 'production metadata overrode capacity %', v_ops->'ticket_summary'; END IF;
+  IF v_ops->'ticket_summary'->>'tickets_sold' IS NOT NULL THEN RAISE EXCEPTION 'missing ticket source should be null %', v_ops->'ticket_summary'; END IF;
+  IF v_ops->'ticket_summary'->>'source' <> 'unavailable' THEN RAISE EXCEPTION 'missing ticket source should be unavailable %', v_ops->'ticket_summary'; END IF;
+  UPDATE public.festival_editions SET lifecycle_metadata=jsonb_build_object('is_test_fixture',true,'ticket_summary',jsonb_build_object('capacity',10000,'tickets_sold',-1)) WHERE id=v_other_edition;
+  v_ops := public.festival_edition_operations_summary(v_other_edition);
+  IF v_ops->'ticket_summary'->>'tickets_sold' IS NOT NULL THEN RAISE EXCEPTION 'negative fixture tickets should be rejected %', v_ops->'ticket_summary'; END IF;
 END $$;
 
 ROLLBACK;


### PR DESCRIPTION
### Motivation

- Prevent authenticated callers from spoofing the identity used for edition authorisation and remove a dangerous actor-id parameter from public helpers.
- Enforce least-privilege visibility for management roles so managers only receive the sensitive fields they are allowed to see.
- Make ticket summary semantics explicit so production lifecycle metadata cannot override canonical edition capacity and missing sales data is reported as unavailable.
- Avoid runtime failures from unguarded JSON casts and stop silently returning `{}` when both RPC and fallback fail in the frontend.

### Description

- Replace the two-argument `can_manage_festival_edition(p_actor_user_id uuid, p_edition_id uuid)` with a single-argument `can_manage_festival_edition(p_edition_id uuid)` that derives `auth.uid()` and `current_profile_id_safe()` internally, and add `can_manage_festival_edition_internal(p_actor_user_id, p_profile_id, p_edition_id)` restricted to `service_role` only; update the wrapper to call the new form. (`supabase/migrations/20291217100000_finalise_festival_operations_summary.sql`)
- Redact and explicitly project sensitive rows instead of serialising full table rows (staff, wages, insurance, finance/data-health) and add capability flags (`finance_access`, `staff_wages_access`, `insurance_access`, etc.) in the operations aggregation. (`supabase/migrations/20291217100000_finalise_festival_operations_summary.sql`)
- Make ticket metadata parsing safe by adding `festival_safe_jsonb_nonnegative_integer(jsonb, text)`, change capacity precedence to prefer edition capacity over fixture metadata, and return `tickets_sold: null` with `source: 'unavailable'` when no authoritative source exists; keep guarded test-fixture behaviour for the London fixture. (`supabase/migrations/20291217100000_finalise_festival_operations_summary.sql`, `supabase/tests/festival_london_test_fixture.sql`)
- Harden SQL assertions and add regression checks that ensure the authenticated helper signature has no actor-id parameter, that the internal explicit-identity helper is service-role-only, spoofing attempts fail, production metadata cannot override capacity, and invalid/negative metadata does not crash the summary. (`supabase/tests/festival_london_test_fixture.sql`)
- Add a documented capability matrix for management roles and least-privilege contracts. (`docs/festivals/FESTIVAL_MANAGEMENT_PERMISSIONS.md`)
- Strengthen the frontend: add an `operationsSummarySchema` to validate the RPC response, allow nullable ticket totals, and change `callMaybeRpc` so it accepts a schema and throws a mapped error when both RPC and fallback fail instead of returning `{}`. (`src/features/festivals/admin/service.ts`)

### Testing

- Ran `npm run typecheck`, which completed successfully. 
- Ran `git diff --check` (style/merge checks) which passed with no whitespace errors. 
- Attempted `npm ci`, `npm run lint` and `npm run build`, but these could not complete in this environment because dependency installation failed (`npm ci` returned registry `403` for `@react-three/fiber`) and tooling (`@eslint/js`, `vite`) were not available. 
- Did not run Supabase DB checks in this environment because the Supabase CLI is not installed; the SQL regression assertions were added to `supabase/tests/festival_london_test_fixture.sql` but database tests were not executed here. 

If you want, I can prepare a follow-up checklist for CI configuration and the commands to run the full DB and frontend test matrix in a CI environment with the Supabase CLI and npm registry access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e7ed9500483259106a505a8731b38)