### PR TITLE
Apply festival operations hardening as a forward migration and tighten operations contract

### DIFF
--- a/docs/festivals/operations-summary-contract.md
+++ b/docs/festivals/operations-summary-contract.md
@@ -1,0 +1,25 @@
+# Festival operations summary contract
+
+The secured `festival_edition_operations_summary` RPC intentionally projects slot data field-by-field rather than returning `to_jsonb(festival_stage_slots)` wholesale. The retained non-sensitive slot keys support these current consumers:
+
+| Field | Consumers | Purpose |
+| --- | --- | --- |
+| `id` | Dashboard, schedule editor, lineup manager, stage management, live operations | Stable React keys and slot action targets. |
+| `stage_id` | `FestivalStageManagement`, schedule editor | Groups slots under each stage. |
+| `day_number` | Schedule editor, live operations | Day grouping and ordering. |
+| `start_time`, `end_time` | `FestivalStageSchedule`, live operations | Timeline display. |
+| `slot_type` | `FestivalStageSchedule`, lineup manager | Slot badges and booking type. |
+| `status` | Dashboard, readiness, schedule editor | Confirmed/open/completed operational state. |
+| `public_status` | Lineup manager, public-announcement tooling | Draft versus announced state. |
+| `slot_number` | Schedule editor, drag-and-drop ordering | Stable order within a day/stage. |
+| `changeover_minutes`, `changeover_duration_minutes` | `FestivalStageSchedule`, readiness | Changeover warnings and generation defaults. |
+| `slot_template` | Schedule editor | Template provenance without exposing private metadata. |
+| `reservation_id`, `reservation_status`, `reservation_hold_expires_at` | Schedule editor, stage management | Minimal reservation state for edit/archive affordances. |
+| `soundcheck_at` | `FestivalStageSchedule`, stage management | Soundcheck timeline display. |
+| `performance_session_status` | Live operations | Session readiness state. |
+| `conflict_state`, `conflict_summary` | Schedule editor, readiness | Conflict warnings. |
+| `stage_position` | Stage management, live operations | Non-sensitive placement metadata needed by stage tooling. |
+| `system_act_id`, `system_act_name`, `system_act_status` | Dashboard, readiness, lineup manager | Occupancy and lineup display. |
+| `contract_status` | Dashboard, readiness, stage management | Contracted-act counts and warnings. |
+
+Do not expose `reservation_metadata` wholesale. New consumers must request explicit additions to this projection and document why the field is operational rather than private/commercial.

--- a/src/features/festivals/admin/__tests__/operationsSummarySchema.test.ts
+++ b/src/features/festivals/admin/__tests__/operationsSummarySchema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { operationsSummarySchema } from "../service";
+
+const requiredSlot = {
+  id: "slot-1",
+  stage_id: "stage-1",
+  day_number: 1,
+  start_time: "2027-06-01T18:00:00Z",
+  end_time: "2027-06-01T18:45:00Z",
+  slot_type: "opener",
+  status: "open",
+  public_status: "draft",
+  slot_number: 1,
+  changeover_minutes: 30,
+  changeover_duration_minutes: 30,
+  system_act_id: null,
+  system_act_name: null,
+  system_act_status: null,
+  contract_status: null,
+};
+
+describe("operationsSummarySchema", () => {
+  it("requires the slot contract fields used by dashboard and schedule consumers", () => {
+    const parsed = operationsSummarySchema.parse({
+      stages: [],
+      slots: [requiredSlot],
+      staff: [],
+      permit_requirements: [],
+      insurance_policies: [],
+      schedule_summary: {
+        total_slots: 1,
+        occupied_slots: 0,
+        open_slots: 1,
+        contracted_acts: 0,
+        published_acts: 0,
+        system_acts: 0,
+      },
+      permissions: { can_manage: true, finance_access: false, full_access: false },
+      lifecycle: { status: "draft", start_at: null, end_at: null, currency_code: "GBP" },
+    });
+
+    expect(parsed.slots[0]).toMatchObject({
+      status: "open",
+      public_status: "draft",
+      slot_number: 1,
+      changeover_minutes: 30,
+    });
+  });
+
+  it("rejects slot regressions that remove required operational state", () => {
+    const { status: _status, public_status: _publicStatus, ...missingState } = requiredSlot;
+
+    expect(() => operationsSummarySchema.parse({ slots: [missingState] })).toThrow();
+  });
+});

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -169,50 +169,123 @@ const ownerEditionSchema = z
   })
   .passthrough();
 const jsonRecord = z.record(z.unknown());
+const uuidLike = z.string().min(1);
+const nullableDateString = z.string().datetime({ offset: true }).or(z.string().date()).nullable().optional();
+const nonnegativeInteger = z.coerce.number().int().nonnegative();
+const accessSchema = z.enum(["granted", "limited", "denied"]);
+const financeAccessSchema = z.enum(["granted", "denied"]);
+const festivalStageSummarySchema = z
+  .object({
+    id: uuidLike,
+    stage_name: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    stage_number: nonnegativeInteger.nullable().optional(),
+    stage_type: z.string().nullable().optional(),
+    capacity: nonnegativeInteger.nullable().optional(),
+    genre_focus: z.string().nullable().optional(),
+  })
+  .passthrough();
+const festivalSlotSummarySchema = z
+  .object({
+    id: uuidLike,
+    stage_id: uuidLike,
+    day_number: nonnegativeInteger,
+    start_time: z.string().nullable().optional(),
+    end_time: z.string().nullable().optional(),
+    slot_type: z.string(),
+    status: z.string(),
+    public_status: z.string(),
+    slot_number: nonnegativeInteger,
+    changeover_minutes: nonnegativeInteger.nullable().optional(),
+    changeover_duration_minutes: nonnegativeInteger.nullable().optional(),
+    system_act_id: z.string().nullable().optional(),
+    system_act_name: z.string().nullable().optional(),
+    system_act_status: z.string().nullable().optional(),
+    contract_status: z.string().nullable().optional(),
+  })
+  .passthrough();
+const festivalStaffSummarySchema = z
+  .object({
+    id: uuidLike,
+    role: z.string(),
+    name: z.string().nullable().optional(),
+    skill_level: nonnegativeInteger.nullable().optional(),
+    status: z.string().nullable().optional(),
+    weekly_wage_cents: nonnegativeInteger.nullable().optional(),
+  })
+  .passthrough();
+const festivalScheduleSummarySchema = z
+  .object({
+    total_slots: nonnegativeInteger,
+    occupied_slots: nonnegativeInteger,
+    open_slots: nonnegativeInteger,
+    contracted_acts: nonnegativeInteger,
+    published_acts: nonnegativeInteger,
+    system_acts: nonnegativeInteger,
+  })
+  .passthrough();
+const festivalPermissionsSchema = z
+  .object({
+    can_manage: z.boolean(),
+    finance_access: z.boolean(),
+    full_access: z.boolean(),
+  })
+  .passthrough();
+const festivalLifecycleSchema = z
+  .object({
+    status: z.string().nullable().optional(),
+    start_at: nullableDateString,
+    end_at: nullableDateString,
+    currency_code: z.string().nullable().optional(),
+  })
+  .passthrough();
 const ticketSourceSchema = z.enum([
   "test_fixture_metadata",
   "audience_simulation",
   "canonical_sales",
   "unavailable",
 ]);
-const operationsSummarySchema = z
+const ticketSummarySchema = z
+  .object({
+    capacity: nonnegativeInteger.nullable().optional(),
+    tickets_sold: nonnegativeInteger.nullable().optional(),
+    tiers: z.array(z.unknown()).default([]),
+    source: ticketSourceSchema,
+  })
+  .passthrough();
+const insurancePolicySchema = z
+  .object({
+    coverage_type: z.string().nullable().optional(),
+    policy_status: z.string().nullable().optional(),
+    active: z.boolean().nullable().optional(),
+    effective_from: nullableDateString,
+    effective_to: nullableDateString,
+    premium_cents: nonnegativeInteger.nullable().optional(),
+    payout_ceiling_cents: nonnegativeInteger.nullable().optional(),
+  })
+  .passthrough();
+export const operationsSummarySchema = z
   .object({
     edition_id: z.string().optional(),
     festival_id: z.string().optional(),
-    stages: z.array(z.record(z.unknown())).default([]),
-    slots: z.array(z.record(z.unknown())).default([]),
-    staff: z.array(z.record(z.unknown())).default([]),
+    stages: z.array(festivalStageSummarySchema).default([]),
+    slots: z.array(festivalSlotSummarySchema).default([]),
+    staff: z.array(festivalStaffSummarySchema).default([]),
     permit_requirements: z.array(z.unknown()).default([]),
-    insurance_policies: z.array(z.record(z.unknown())).default([]),
-    ticket_summary: z
-      .object({
-        capacity: z.number().int().nonnegative().nullable().optional(),
-        tickets_sold: z.number().int().nonnegative().nullable().optional(),
-        tiers: z.array(z.unknown()).default([]),
-        source: ticketSourceSchema,
-      })
-      .passthrough()
-      .optional(),
-    ticketing: z
-      .object({
-        capacity: z.number().int().nonnegative().nullable().optional(),
-        tickets_sold: z.number().int().nonnegative().nullable().optional(),
-        tiers: z.array(z.unknown()).default([]),
-        source: ticketSourceSchema,
-      })
-      .passthrough()
-      .optional(),
-    tickets_sold: z.number().int().nonnegative().nullable().optional(),
+    insurance_policies: z.array(insurancePolicySchema).default([]),
+    ticket_summary: ticketSummarySchema.optional(),
+    ticketing: ticketSummarySchema.optional(),
+    tickets_sold: nonnegativeInteger.nullable().optional(),
     ticket_summary_source: ticketSourceSchema.optional(),
-    schedule_summary: z.record(z.unknown()).optional(),
+    schedule_summary: festivalScheduleSummarySchema.optional(),
     finance: z.record(z.unknown()).nullable().optional(),
-    finance_access: z.enum(["granted", "denied"]).optional(),
-    staff_wages_access: z.enum(["granted", "denied"]).optional(),
-    insurance_access: z.enum(["granted", "limited", "denied"]).optional(),
+    finance_access: financeAccessSchema.optional(),
+    staff_wages_access: financeAccessSchema.optional(),
+    insurance_access: accessSchema.optional(),
     data_health: z.array(z.unknown()).optional(),
-    data_health_access: z.enum(["granted", "denied"]).optional(),
-    permissions: z.record(z.unknown()).optional(),
-    lifecycle: z.record(z.unknown()).optional(),
+    data_health_access: financeAccessSchema.optional(),
+    permissions: festivalPermissionsSchema.optional(),
+    lifecycle: festivalLifecycleSchema.optional(),
   })
   .passthrough();
 const nonNullJson = z
@@ -594,8 +667,23 @@ const callMaybeRpc = async <T>(
     if (mapped.code === "FESTIVAL_PERMISSION_DENIED") throw mapped;
     if (fallback) {
       try {
-        return await fallback();
+        const fallbackResult = await fallback();
+        const parsedFallback = schema.safeParse(fallbackResult);
+        if (!parsedFallback.success) {
+          throw new FestivalAdminServiceError(
+            `The ${fn} fallback returned a malformed response.`,
+            "FESTIVAL_RESPONSE_INVALID",
+            parsedFallback.error,
+          );
+        }
+        return parsedFallback.data;
       } catch (fallbackError) {
+        if (
+          fallbackError instanceof FestivalAdminServiceError &&
+          fallbackError.code === "FESTIVAL_RESPONSE_INVALID"
+        ) {
+          throw fallbackError;
+        }
         throw new FestivalAdminServiceError(
           `The ${fn} RPC failed and its fallback also failed.`,
           "FESTIVAL_RPC_FAILED",

--- a/supabase/migrations/20291217110000_apply_festival_operations_hardening.sql
+++ b/supabase/migrations/20291217110000_apply_festival_operations_hardening.sql
@@ -1,0 +1,152 @@
+-- Forward hardening for festival owner operations summary.
+-- Replays the final secure implementation for databases that already recorded
+-- 20291217100000 before PR #1261 edits landed.
+
+DROP FUNCTION IF EXISTS public.festival_edition_operations_summary(uuid);
+DROP FUNCTION IF EXISTS public.can_manage_festival_edition(uuid, uuid);
+DROP FUNCTION IF EXISTS public.can_manage_festival_edition(uuid);
+DROP FUNCTION IF EXISTS public.can_manage_festival_edition_internal(uuid, uuid, uuid);
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_edition_internal(p_actor_user_id uuid, p_profile_id uuid, p_edition_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  SELECT coalesce(public.has_role(p_actor_user_id,'admin'::public.app_role), false)
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_editions e
+      JOIN public.festivals f ON f.id = e.festival_id
+      WHERE e.id = p_edition_id
+        AND f.owner_profile_id = p_profile_id
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.festival_edition_management_roles r
+      WHERE r.edition_id = p_edition_id
+        AND r.profile_id = p_profile_id
+        AND r.status = 'active'
+        AND (r.ends_at IS NULL OR r.ends_at > now())
+        AND r.role IN ('delegated_manager','operations_manager','stage_manager','talent_booker','finance_manager','safety_officer')
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_manage_festival_edition_internal(uuid, uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition_internal(uuid, uuid, uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.can_manage_festival_edition(p_edition_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  SELECT public.is_service_role() OR public.can_manage_festival_edition_internal(auth.uid(), public.current_profile_id_safe(), p_edition_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.can_manage_festival_edition(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_manage_festival_edition(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_safe_jsonb_nonnegative_integer(p_json jsonb, p_key text)
+RETURNS integer LANGUAGE sql IMMUTABLE SET search_path=public AS $$
+  SELECT CASE WHEN p_json ? p_key AND p_json->>p_key ~ '^[0-9]{1,10}$' AND (p_json->>p_key)::bigint <= 2147483647 THEN (p_json->>p_key)::integer END;
+$$;
+REVOKE ALL ON FUNCTION public.festival_safe_jsonb_nonnegative_integer(jsonb,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.festival_safe_jsonb_nonnegative_integer(jsonb,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary_internal(p_edition_id uuid)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+  WITH e AS (
+    SELECT * FROM public.festival_editions WHERE id = p_edition_id
+  ), access AS (
+    SELECT
+      public.is_service_role() OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false) OR EXISTS (SELECT 1 FROM e JOIN public.festivals f ON f.id=e.festival_id WHERE f.owner_profile_id=public.current_profile_id_safe()) AS full_access,
+      EXISTS (SELECT 1 FROM public.festival_edition_management_roles r WHERE r.edition_id=p_edition_id AND r.profile_id=public.current_profile_id_safe() AND r.status='active' AND (r.ends_at IS NULL OR r.ends_at>now()) AND r.role IN ('delegated_manager','operations_manager','finance_manager')) AS finance_access,
+      EXISTS (SELECT 1 FROM public.festival_edition_management_roles r WHERE r.edition_id=p_edition_id AND r.profile_id=public.current_profile_id_safe() AND r.status='active' AND (r.ends_at IS NULL OR r.ends_at>now()) AND r.role IN ('safety_officer')) AS safety_access
+  ), slots AS (
+    SELECT sl.*, sa.id system_act_id, sa.display_name system_act_name, sa.status system_act_status,
+      coalesce(sl.reservation_metadata->>'contract_status', CASE WHEN sa.id IS NOT NULL THEN 'published' END) contract_status
+    FROM public.festival_stage_slots sl
+    LEFT JOIN public.festival_system_acts sa ON sa.slot_id = sl.id AND sa.edition_id = sl.edition_id
+    WHERE sl.edition_id = p_edition_id AND sl.archived_at IS NULL
+  ), ticket AS (
+    SELECT
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN public.festival_safe_jsonb_nonnegative_integer(e.lifecycle_metadata->'ticket_summary','tickets_sold') END fixture_sold,
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN public.festival_safe_jsonb_nonnegative_integer(e.lifecycle_metadata->'ticket_summary','capacity') END fixture_capacity,
+      coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' is_fixture,
+      e.capacity edition_capacity,
+      CASE WHEN coalesce(e.lifecycle_metadata->>'is_test_fixture','false') = 'true' THEN coalesce(e.lifecycle_metadata->'ticket_summary'->'tiers','[]'::jsonb) ELSE '[]'::jsonb END tiers
+    FROM e
+  ), ticket_final AS (
+    SELECT coalesce(edition_capacity, fixture_capacity) capacity,
+      fixture_sold tickets_sold,
+      CASE WHEN is_fixture AND fixture_sold IS NOT NULL THEN 'test_fixture_metadata' ELSE 'unavailable' END ticket_summary_source,
+      tiers
+    FROM ticket
+  )
+  SELECT jsonb_build_object(
+    'edition_id', p_edition_id,
+    'festival_id', (SELECT festival_id FROM e),
+    'festival_name', (SELECT f.name FROM public.festivals f JOIN e ON e.festival_id = f.id),
+    'venue_name', (SELECT v.name FROM public.venues v JOIN e ON e.venue_id = v.id),
+    'stages', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',st.id,'stage_name',st.stage_name,'stage_number',st.stage_number,'stage_type',st.stage_type,'capacity',st.capacity,'genre_focus',st.genre_focus) ORDER BY st.stage_number), '[]'::jsonb) FROM public.festival_stages st WHERE st.edition_id = p_edition_id AND st.archived_at IS NULL),
+    'slots', (SELECT coalesce(jsonb_agg(jsonb_build_object('id',sl.id,'stage_id',sl.stage_id,'day_number',sl.day_number,'start_time',sl.start_time,'end_time',sl.end_time,'slot_type',sl.slot_type,'status',sl.status,'public_status',sl.public_status,'slot_number',sl.slot_number,'changeover_minutes',sl.changeover_minutes,'changeover_duration_minutes',sl.changeover_minutes,'slot_template',sl.slot_template,'reservation_id',sl.reservation_metadata->>'reservation_id','reservation_status',coalesce(sl.reservation_metadata->>'reservation_status', CASE WHEN sl.system_act_id IS NULL THEN 'open' ELSE 'assigned' END),'reservation_hold_expires_at',sl.reservation_metadata->>'reservation_hold_expires_at','soundcheck_at',sl.soundcheck_at,'performance_session_status',sl.reservation_metadata->>'performance_session_status','conflict_state',sl.reservation_metadata->>'conflict_state','conflict_summary',sl.reservation_metadata->>'conflict_summary','stage_position',sl.reservation_metadata->'stage_position','system_act_id',sl.system_act_id,'system_act_name',sl.system_act_name,'system_act_status',sl.system_act_status,'contract_status',sl.contract_status) ORDER BY sl.day_number, sl.start_time, sl.slot_number), '[]'::jsonb) FROM slots sl),
+    'staff', (SELECT coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object('id',s.id,'role',s.role,'name',s.name,'skill_level',s.skill_level,'assignment_scope',s.assignment_scope,'shift_start_at',s.shift_start_at,'shift_end_at',s.shift_end_at,'status',s.status,'weekly_wage_cents',CASE WHEN (SELECT full_access OR finance_access FROM access) THEN s.weekly_wage_cents END)) ORDER BY s.role, s.name), '[]'::jsonb) FROM public.festival_staff s WHERE s.edition_id = p_edition_id),
+    'staff_wages_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
+    'permit_requirements', coalesce(public.festival_edition_permit_requirements(p_edition_id), '[]'::jsonb),
+    'staffing_readiness', coalesce(public.festival_edition_staffing_readiness(p_edition_id), '{}'::jsonb),
+    'insurance_policies', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN (SELECT coalesce(jsonb_agg(jsonb_build_object('id',p.id,'coverage_type',p.coverage_type,'policy_status',p.policy_status,'active',p.active,'premium_cents',p.premium_cents,'payout_ceiling_cents',p.payout_ceiling_cents,'effective_from',p.effective_from,'effective_to',p.effective_to)), '[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id = p_edition_id) WHEN (SELECT safety_access FROM access) THEN (SELECT coalesce(jsonb_agg(jsonb_build_object('coverage_type',p.coverage_type,'policy_status',p.policy_status,'active',p.active,'effective_from',p.effective_from,'effective_to',p.effective_to)), '[]'::jsonb) FROM public.festival_insurance_policies p WHERE p.edition_id = p_edition_id) ELSE '[]'::jsonb END,
+    'insurance_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' WHEN (SELECT safety_access FROM access) THEN 'limited' ELSE 'denied' END,
+    'ticket_summary', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket_final),
+    'ticketing', (SELECT jsonb_build_object('capacity', capacity, 'tickets_sold', tickets_sold, 'tiers', tiers, 'source', ticket_summary_source) FROM ticket_final),
+    'tickets_sold', (SELECT tickets_sold FROM ticket_final),
+    'ticket_summary_source', (SELECT ticket_summary_source FROM ticket_final),
+    'schedule_summary', (SELECT jsonb_build_object('total_slots', count(*), 'occupied_slots', count(*) FILTER (WHERE system_act_id IS NOT NULL OR reservation_metadata ? 'system_act_id'), 'open_slots', count(*) FILTER (WHERE system_act_id IS NULL AND NOT (reservation_metadata ? 'system_act_id')), 'contracted_acts', count(*) FILTER (WHERE contract_status IN ('signed','accepted')), 'published_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL), 'system_acts', count(*) FILTER (WHERE system_act_id IS NOT NULL)) FROM slots),
+    'finance', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN coalesce(public.festival_edition_finance_summary(p_edition_id), '{}'::jsonb) END,
+    'finance_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
+    'data_health', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN coalesce(public.festival_data_health(p_edition_id), '[]'::jsonb) ELSE '[]'::jsonb END,
+    'data_health_access', CASE WHEN (SELECT full_access OR finance_access FROM access) THEN 'granted' ELSE 'denied' END,
+    'permissions', jsonb_build_object('can_manage', true, 'finance_access', (SELECT full_access OR finance_access FROM access), 'full_access', (SELECT full_access FROM access)),
+    'lifecycle', (SELECT jsonb_build_object('status', status, 'start_at', start_at, 'end_at', end_at, 'currency_code', currency_code) FROM e),
+    'candidates', '[]'::jsonb,
+    'insurance_quotes', '[]'::jsonb
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.festival_edition_operations_summary_internal(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary_internal(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.festival_edition_operations_summary(p_edition_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path=public
+AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.festival_editions WHERE id = p_edition_id) THEN
+    RAISE EXCEPTION 'edition_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.can_manage_festival_edition(p_edition_id) THEN
+    RAISE EXCEPTION 'permission_denied' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN public.festival_edition_operations_summary_internal(p_edition_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.festival_edition_operations_summary(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.festival_edition_operations_summary(uuid) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.festival_edition_operations_summary(uuid) IS 'Authoritative owner-only festival operations RPC finalised by 20291217110000. Uses can_manage_festival_edition(p_edition_id) before calling private aggregators; public festival pages must use public projections.';
+COMMENT ON FUNCTION public.festival_edition_operations_summary_internal(uuid) IS 'Private service-role/internal aggregation helper. Do not grant to anon or authenticated.';
+COMMENT ON FUNCTION public.can_manage_festival_edition(uuid) IS 'Authenticated authorisation helper that derives actor identity from auth.uid() and current_profile_id_safe().';
+COMMENT ON FUNCTION public.can_manage_festival_edition_internal(uuid,uuid,uuid) IS 'Service-role-only internal helper that evaluates the supplied actor/profile pair without caller-based service-role bypass; use can_manage_festival_edition(uuid) for trusted caller bypass.';

--- a/supabase/tests/festival_operations_hardening_upgrade_path.sql
+++ b/supabase/tests/festival_operations_hardening_upgrade_path.sql
@@ -1,0 +1,60 @@
+-- Regression harness for upgrading a database that had already applied
+-- 20291217100000 before the hardening was moved into a forward migration.
+-- Run after migrations are applied with: psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f this_file
+
+DO $$
+DECLARE
+  v_internal_comment text;
+  v_rpc_comment text;
+  v_helper_sql text;
+  v_summary_sql text;
+BEGIN
+  IF to_regprocedure('public.can_manage_festival_edition(uuid,uuid)') IS NOT NULL THEN
+    RAISE EXCEPTION 'legacy two-argument can_manage_festival_edition helper still exists after hardening migration';
+  END IF;
+
+  IF to_regprocedure('public.can_manage_festival_edition(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'single-argument can_manage_festival_edition helper missing after hardening migration';
+  END IF;
+
+  IF to_regprocedure('public.can_manage_festival_edition_internal(uuid,uuid,uuid)') IS NULL THEN
+    RAISE EXCEPTION 'explicit actor internal helper missing after hardening migration';
+  END IF;
+
+  IF has_function_privilege('authenticated','public.can_manage_festival_edition_internal(uuid,uuid,uuid)','EXECUTE') THEN
+    RAISE EXCEPTION 'authenticated role can execute explicit actor internal helper';
+  END IF;
+
+  IF NOT has_function_privilege('service_role','public.can_manage_festival_edition_internal(uuid,uuid,uuid)','EXECUTE') THEN
+    RAISE EXCEPTION 'service_role cannot execute explicit actor internal helper';
+  END IF;
+
+  SELECT obj_description('public.festival_edition_operations_summary(uuid)'::regprocedure, 'pg_proc') INTO v_rpc_comment;
+  IF v_rpc_comment NOT LIKE '%20291217110000%' THEN
+    RAISE EXCEPTION 'latest forward migration is not documented as authoritative: %', v_rpc_comment;
+  END IF;
+
+  SELECT obj_description('public.can_manage_festival_edition_internal(uuid,uuid,uuid)'::regprocedure, 'pg_proc') INTO v_internal_comment;
+  IF v_internal_comment NOT LIKE '%without caller-based service-role bypass%' THEN
+    RAISE EXCEPTION 'internal helper semantics are not documented accurately: %', v_internal_comment;
+  END IF;
+
+  SELECT pg_get_functiondef('public.can_manage_festival_edition_internal(uuid,uuid,uuid)'::regprocedure) INTO v_helper_sql;
+  IF v_helper_sql LIKE '%is_service_role%' THEN
+    RAISE EXCEPTION 'internal helper still bypasses actor evaluation for service role callers';
+  END IF;
+
+  SELECT pg_get_functiondef('public.festival_edition_operations_summary_internal(uuid)'::regprocedure) INTO v_summary_sql;
+  IF v_summary_sql LIKE '%simulated_ticket%' THEN
+    RAISE EXCEPTION 'unused simulated_ticket CTE remains in authoritative summary';
+  END IF;
+  IF v_summary_sql NOT LIKE '%ELSE ''[]''::jsonb END%' THEN
+    RAISE EXCEPTION 'insurance denied branch does not return an empty policy array';
+  END IF;
+  IF v_summary_sql NOT LIKE '%''status'',sl.status%' OR v_summary_sql NOT LIKE '%''public_status'',sl.public_status%' OR v_summary_sql NOT LIKE '%''slot_number'',sl.slot_number%' OR v_summary_sql NOT LIKE '%''changeover_minutes'',sl.changeover_minutes%' THEN
+    RAISE EXCEPTION 'slot projection is missing required operational contract fields';
+  END IF;
+  IF v_summary_sql NOT LIKE '%^[0-9]{1,10}$%' OR v_summary_sql NOT LIKE '%2147483647%' THEN
+    RAISE EXCEPTION 'safe integer parser is not bounded against overflow';
+  END IF;
+END $$;


### PR DESCRIPTION
### Motivation
- Ensure upgraded databases receive the hardened festival operations RPC without relying on edited historical migrations, and to close several contract and security gaps introduced by the previous change.  
- Prevent caller-spoofing, stop leaking insurance details to unauthorized roles, and restore required operational slot fields so frontend consumers continue to work.  
- Harden metadata parsing to avoid integer overflow crashes and make RPC/fallback responses uniformly validated.  
- Add explicit upgrade-path and contract regression checks so future edits cannot reintroduce divergence between clean resets and upgraded databases.

### Description
- Add a forward migration `supabase/migrations/20291217110000_apply_festival_operations_hardening.sql` that drops legacy signatures and recreates the authoritative functions (including `festival_edition_operations_summary`, `can_manage_festival_edition`, and `can_manage_festival_edition_internal`) so already-upgraded DBs receive the hardened implementation.  
- Adjust the SQL authoritative projection to restore required non-sensitive slot fields (status, public_status, slot_number, changeover durations, reservation state snippets, stage position, system_act fields), implement three-branch insurance redaction (`granted` / `limited` / `denied`), remove the unused `simulated_ticket` CTE from the authoritative flow, and replace the unsafe integer parser with bounded bigint validation.  
- Split service-role bypass semantics from the explicit-actor helper so `can_manage_festival_edition_internal(actor, profile, edition)` evaluates the supplied identity and `can_manage_festival_edition(edition)` performs the trusted caller/service-role bypass.  
- Strengthen the frontend runtime contract by adding concrete Zod schemas in `src/features/festivals/admin/service.ts`, validate fallback results using the same schema (map failures to `FESTIVAL_RESPONSE_INVALID`), and add a contract doc `docs/festivals/operations-summary-contract.md`.  
- Add automated regression artifacts: `supabase/tests/festival_operations_hardening_upgrade_path.sql` (upgrade-path harness) and `src/features/festivals/admin/__tests__/operationsSummarySchema.test.ts` (schema contract unit test) to catch future regressions.

### Testing
- `npm run typecheck` completed successfully.  
- `git diff --check` completed successfully (no whitespace errors).  
- `npm ci` failed due to registry access errors (`403 Forbidden` for several packages), so dependency installation and downstream steps were blocked.  
- `npx vitest`/unit test execution, `npm run lint`, and `npm run build` were not completed because dependencies and tools (`vitest`, `vite`, `@eslint/js`) were unavailable in the environment, and the Supabase CLI was not present so DB migrations / SQL harnesses were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e81b3539483259970a1aab46609b3)