### PR TITLE
Repair admin festival catalogue failures

### DIFF
--- a/src/features/festivals/admin/__tests__/adminFestivalCatalogueErrors.test.ts
+++ b/src/features/festivals/admin/__tests__/adminFestivalCatalogueErrors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { FestivalAdminServiceError, mapFestivalError } from "../service";
+
+describe("admin festival catalogue error mapping", () => {
+  it("maps missing RPC errors separately from permissions", () => {
+    const error = mapFestivalError(
+      { code: "PGRST202", message: "Could not find the function public.admin_festival_catalogue" },
+      "admin_festival_catalogue",
+    );
+
+    expect(error).toBeInstanceOf(FestivalAdminServiceError);
+    expect(error.code).toBe("FESTIVAL_RPC_NOT_DEPLOYED");
+  });
+
+  it("maps relation and column failures to migration mismatch", () => {
+    expect(mapFestivalError({ code: "42P01", message: "relation does not exist" }).code).toBe("FESTIVAL_SCHEMA_MISMATCH");
+    expect(mapFestivalError({ code: "42703", message: "column does not exist" }).code).toBe("FESTIVAL_SCHEMA_MISMATCH");
+  });
+
+  it("preserves real authorization failures", () => {
+    expect(mapFestivalError({ code: "42501", message: "permission denied" }).code).toBe("FESTIVAL_PERMISSION_DENIED");
+  });
+});

--- a/src/features/festivals/admin/service.ts
+++ b/src/features/festivals/admin/service.ts
@@ -21,7 +21,12 @@ import type {
 type RpcName =
   keyof import("@/integrations/supabase/types").Database["public"]["Functions"];
 
-type DomainErrorCode =
+export type DomainErrorCode =
+  | "FESTIVAL_NOT_SIGNED_IN"
+  | "FESTIVAL_NOT_ADMIN"
+  | "FESTIVAL_RPC_NOT_DEPLOYED"
+  | "FESTIVAL_SCHEMA_MISMATCH"
+  | "FESTIVAL_NETWORK_FAILED"
   | "FESTIVAL_RPC_FAILED"
   | "FESTIVAL_RESPONSE_INVALID"
   | "FESTIVAL_PERMISSION_DENIED"
@@ -47,13 +52,16 @@ export class FestivalAdminServiceError extends Error {
   }
 }
 
+const isNetworkFailure = (error: { message?: string; code?: string }) =>
+  !error.code || /failed to fetch|network|load failed|abort/i.test(error.message ?? "");
+
 const rpc = async <T>(
   fn: RpcName,
   args?: Record<string, unknown>,
   schema?: z.ZodType<T>,
 ): Promise<T> => {
   const { data, error } = await supabase.rpc(fn as never, args as never);
-  if (error) throw mapFestivalError(error);
+  if (error) throw mapFestivalError(error, fn as string);
   if (!schema) return data as T;
   const parsed = schema.safeParse(data);
   if (!parsed.success)
@@ -70,13 +78,32 @@ export function mapFestivalError(error: {
   code?: string;
   details?: string;
   hint?: string;
-}) {
+}, rpcName?: string) {
   const message = error.message ?? "Festival operation failed.";
+  const diagnostic = { ...error, rpcName };
+  if (error.code === "PGRST202" || /could not find the function|schema cache/i.test(message))
+    return new FestivalAdminServiceError(
+      "Festival administration services have not been deployed.",
+      "FESTIVAL_RPC_NOT_DEPLOYED",
+      diagnostic,
+    );
+  if (["42P01", "42703", "42883"].includes(error.code ?? ""))
+    return new FestivalAdminServiceError(
+      "The festival database needs migration before this page can load.",
+      "FESTIVAL_SCHEMA_MISMATCH",
+      diagnostic,
+    );
+  if (isNetworkFailure(error))
+    return new FestivalAdminServiceError(
+      "Festival administration could not be loaded due to a network failure.",
+      "FESTIVAL_NETWORK_FAILED",
+      diagnostic,
+    );
   if (/FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT/i.test(message))
     return new FestivalAdminServiceError(
       "This retry key was already used for different festival creation details.",
       "FESTIVAL_CREATE_IDEMPOTENCY_CONFLICT",
-      error,
+      diagnostic,
     );
   if (/FESTIVAL_CREATE_INVALID_DATE|date/i.test(message))
     return new FestivalAdminServiceError(
@@ -295,9 +322,38 @@ const nonNullJson = z
     "RPC returned no result",
   );
 
+
+export async function fetchCurrentUserIsPlatformAdmin(): Promise<boolean> {
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError)
+    throw new FestivalAdminServiceError(
+      "Sign in before opening festival administration.",
+      "FESTIVAL_NOT_SIGNED_IN",
+      userError,
+    );
+  if (!userData.user)
+    throw new FestivalAdminServiceError(
+      "Sign in before opening festival administration.",
+      "FESTIVAL_NOT_SIGNED_IN",
+    );
+
+  const data = await rpc(
+    "current_user_is_platform_admin" as RpcName,
+    undefined,
+    z.boolean(),
+  );
+  if (!data)
+    throw new FestivalAdminServiceError(
+      "You do not have festival administration access.",
+      "FESTIVAL_NOT_ADMIN",
+    );
+  return data;
+}
+
 export async function fetchAdminFestivalCatalogue(): Promise<
   AdminFestivalCatalogueRow[]
 > {
+  await fetchCurrentUserIsPlatformAdmin();
   const data = await rpc(
     "admin_festival_catalogue" as RpcName,
     undefined,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -41342,6 +41342,10 @@ export type Database = {
           stage_count: number
         }[]
       }
+      current_user_is_platform_admin: {
+        Args: never
+        Returns: boolean
+      }
       admin_force_complete_release: {
         Args: { p_release_id: string }
         Returns: undefined

--- a/src/pages/admin/FestivalsAdmin.tsx
+++ b/src/pages/admin/FestivalsAdmin.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
 import { CheckCircle, ExternalLink, XCircle } from "lucide-react";
 import { AdminFestivalCatalogue } from "@/features/festivals/admin/components/AdminFestivalCatalogue";
@@ -19,6 +20,8 @@ import {
   useAdminFestivalCatalogue,
   useOwnerFestivalEditions,
 } from "@/features/festivals/admin/hooks";
+import { FestivalAdminServiceError } from "@/features/festivals/admin/service";
+import { festivalAdminQueryKeys } from "@/features/festivals/admin/queryKeys";
 import type {
   AdminFestivalCatalogueRow,
   OwnerEditionOption,
@@ -50,6 +53,46 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+
+
+const getCatalogueErrorMessage = (error: unknown) => {
+  if (!(error instanceof FestivalAdminServiceError))
+    return "Festival administration could not be loaded. Retry or inspect the error details.";
+
+  switch (error.code) {
+    case "FESTIVAL_NOT_SIGNED_IN":
+      return "Sign in before opening festival administration.";
+    case "FESTIVAL_NOT_ADMIN":
+    case "FESTIVAL_PERMISSION_DENIED":
+      return "You do not have festival administration access.";
+    case "FESTIVAL_RPC_NOT_DEPLOYED":
+      return "Festival administration services have not been deployed.";
+    case "FESTIVAL_SCHEMA_MISMATCH":
+    case "FESTIVAL_MIGRATION_REQUIRED":
+      return "The festival database needs migration before this page can load.";
+    case "FESTIVAL_RESPONSE_INVALID":
+      return "Festival administration returned an unexpected response. Retry or inspect the error details.";
+    case "FESTIVAL_NETWORK_FAILED":
+      return "Festival administration could not be loaded because the network request failed.";
+    default:
+      return "Festival administration could not be loaded. Retry or inspect the error details.";
+  }
+};
+
+const getCatalogueDiagnostic = (error: unknown) => {
+  if (!(error instanceof FestivalAdminServiceError)) return null;
+  const cause = error.cause as
+    | { code?: string; message?: string; details?: string; hint?: string; rpcName?: string }
+    | undefined;
+  return {
+    domainCode: error.code,
+    postgresCode: cause?.code,
+    message: cause?.message ?? error.message,
+    details: cause?.details,
+    hint: cause?.hint,
+    rpcName: cause?.rpcName ?? "admin_festival_catalogue",
+  };
+};
 
 function EditionRequired({
   editionId,
@@ -431,6 +474,7 @@ function Applications({
 
 export default function FestivalsAdminPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const catalogue = useAdminFestivalCatalogue();
   const rows = catalogue.data ?? [];
   const [selectedFestivalId, setSelectedFestivalId] = useState("");
@@ -474,6 +518,7 @@ export default function FestivalsAdminPage() {
           </p>
         </div>
         <Button
+          disabled={catalogue.isLoading || Boolean(catalogue.error)}
           onClick={() => setWizard({ open: true, mode: "create_festival" })}
         >
           Create Festival
@@ -506,9 +551,23 @@ export default function FestivalsAdminPage() {
       )}
       {catalogue.error && (
         <Card>
-          <CardContent className="p-6 text-destructive">
-            Festivals could not be loaded. You may not have permission to manage
-            festivals.
+          <CardContent className="space-y-3 p-6 text-destructive">
+            <p>{getCatalogueErrorMessage(catalogue.error)}</p>
+            {import.meta.env.DEV && getCatalogueDiagnostic(catalogue.error) && (
+              <pre className="overflow-auto rounded bg-muted p-3 text-xs text-muted-foreground">
+                {JSON.stringify(getCatalogueDiagnostic(catalogue.error), null, 2)}
+              </pre>
+            )}
+            <Button
+              variant="outline"
+              onClick={() =>
+                queryClient.invalidateQueries({
+                  queryKey: festivalAdminQueryKeys.catalogue,
+                })
+              }
+            >
+              Retry
+            </Button>
           </CardContent>
         </Card>
       )}
@@ -521,6 +580,7 @@ export default function FestivalsAdminPage() {
           setSelectedEditionId={setSelectedEditionId}
         />
       )}
+      {!catalogue.isLoading && !catalogue.error && (
       <Tabs defaultValue="overview" className="space-y-4">
         <TabsList className="flex h-auto flex-wrap">
           <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -640,6 +700,7 @@ export default function FestivalsAdminPage() {
           <FestivalAuditLog />
         </TabsContent>
       </Tabs>
+      )}
       <FestivalCreationWizard
         open={wizard.open}
         mode={wizard.mode}

--- a/supabase/migrations/20291217120000_repair_admin_festival_catalogue.sql
+++ b/supabase/migrations/20291217120000_repair_admin_festival_catalogue.sql
@@ -1,0 +1,133 @@
+-- Repair festival admin catalogue authorization and resilient projection.
+
+CREATE OR REPLACE FUNCTION public.current_user_is_platform_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT coalesce(public.has_role(auth.uid(), 'admin'::public.app_role), false)
+$$;
+
+GRANT EXECUTE ON FUNCTION public.current_user_is_platform_admin() TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.current_user_is_platform_admin() FROM anon;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_catalogue()
+RETURNS TABLE (
+  festival_id uuid,
+  brand_name text,
+  owner_name text,
+  city_name text,
+  current_edition_id uuid,
+  current_edition_title text,
+  next_edition_id uuid,
+  completed_edition_id uuid,
+  edition_count bigint,
+  lifecycle_state public.festival_edition_status,
+  stage_count bigint,
+  active_contract_count bigint,
+  performance_session_count bigint,
+  outcome_count bigint,
+  attendance integer,
+  currency_code text,
+  projected_finance_cents bigint,
+  actual_finance_cents bigint,
+  legacy_mappings bigint,
+  operational_readiness text,
+  data_health_warnings jsonb
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH admin_authority AS (
+    SELECT public.current_user_is_platform_admin() AS allowed
+  ), edition_rollup AS (
+    SELECT
+      e.festival_id,
+      count(*)::bigint AS edition_count,
+      (array_agg(e.id ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS current_edition_id,
+      (array_agg(e.title ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS current_edition_title,
+      (array_agg(e.id ORDER BY e.start_at NULLS LAST, e.created_at DESC) FILTER (WHERE e.start_at >= now() AND e.status NOT IN ('cancelled','abandoned')))[1] AS next_edition_id,
+      (array_agg(e.id ORDER BY e.completed_at DESC NULLS LAST, e.end_at DESC NULLS LAST, e.created_at DESC) FILTER (WHERE e.status = 'completed'))[1] AS completed_edition_id,
+      (array_agg(e.status ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS lifecycle_state,
+      (array_agg(e.expected_attendance ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS attendance,
+      (array_agg(e.currency_code ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS currency_code,
+      (array_agg(coalesce(e.budget_cents, e.treasury_allocation_cents, 0) ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS projected_finance_cents
+    FROM public.festival_editions e
+    GROUP BY e.festival_id
+  ), counts AS (
+    SELECT
+      f.id AS festival_id,
+      count(DISTINCT st.id) FILTER (WHERE st.archived_at IS NULL)::bigint AS stage_count,
+      count(DISTINCT fc.id) FILTER (WHERE fc.status IN ('awaiting_signatures','awaiting_band_signature','awaiting_organiser_signature','active','amendment_required'))::bigint AS active_contract_count,
+      count(DISTINCT fps.id)::bigint AS performance_session_count,
+      count(DISTINCT fpo.id)::bigint AS outcome_count,
+      count(DISTINCT flm.id)::bigint AS legacy_mappings
+    FROM public.festivals f
+    LEFT JOIN public.festival_editions e ON e.festival_id = f.id
+    LEFT JOIN public.festival_stages st ON st.edition_id = e.id
+    LEFT JOIN public.festival_contracts fc ON fc.edition_id = e.id
+    LEFT JOIN public.festival_performance_sessions fps ON fps.edition_id = e.id
+    LEFT JOIN public.festival_performance_outcomes fpo ON fpo.edition_id = e.id
+    LEFT JOIN public.festival_legacy_mappings flm ON flm.edition_id = e.id
+    GROUP BY f.id
+  ), warnings AS (
+    SELECT
+      f.id AS festival_id,
+      coalesce(jsonb_agg(w.warning) FILTER (WHERE w.warning IS NOT NULL), '[]'::jsonb) AS data_health_warnings
+    FROM public.festivals f
+    LEFT JOIN edition_rollup er ON er.festival_id = f.id
+    LEFT JOIN counts ct ON ct.festival_id = f.id
+    LEFT JOIN public.profiles p ON p.id = f.owner_profile_id
+    LEFT JOIN public.cities c ON c.id = f.city_id
+    CROSS JOIN LATERAL (VALUES
+      (CASE WHEN coalesce(er.edition_count, 0) = 0 THEN jsonb_build_object('code','brand_without_edition','severity','blocker','message','Brand has no canonical edition') END),
+      (CASE WHEN er.current_edition_id IS NOT NULL AND coalesce(ct.stage_count, 0) = 0 THEN jsonb_build_object('code','edition_without_stages','severity','warning','message','Selected edition has no active edition-scoped stages') END),
+      (CASE WHEN coalesce(ct.legacy_mappings, 0) > 1 THEN jsonb_build_object('code','duplicate_legacy_mapping','severity','warning','message','Multiple legacy mappings need review') END),
+      (CASE WHEN f.owner_profile_id IS NOT NULL AND p.id IS NULL THEN jsonb_build_object('code','missing_owner_profile','severity','warning','message','Owner profile is missing') END),
+      (CASE WHEN f.city_id IS NOT NULL AND c.id IS NULL THEN jsonb_build_object('code','missing_city','severity','warning','message','Festival city is missing') END)
+    ) AS w(warning)
+    GROUP BY f.id
+  )
+  SELECT
+    f.id,
+    f.name,
+    p.display_name,
+    c.name,
+    er.current_edition_id,
+    er.current_edition_title,
+    er.next_edition_id,
+    er.completed_edition_id,
+    coalesce(er.edition_count, 0),
+    er.lifecycle_state,
+    coalesce(ct.stage_count, 0),
+    coalesce(ct.active_contract_count, 0),
+    coalesce(ct.performance_session_count, 0),
+    coalesce(ct.outcome_count, 0),
+    er.attendance,
+    coalesce(er.currency_code, 'USD'),
+    coalesce(er.projected_finance_cents, 0),
+    0::bigint,
+    coalesce(ct.legacy_mappings, 0),
+    CASE
+      WHEN coalesce(er.edition_count, 0) = 0 THEN 'missing_edition'
+      WHEN coalesce(ct.stage_count, 0) = 0 THEN 'needs_stages'
+      WHEN coalesce(ct.active_contract_count, 0) = 0 THEN 'needs_contracts'
+      ELSE 'ready'
+    END,
+    coalesce(w.data_health_warnings, '[]'::jsonb)
+  FROM public.festivals f
+  CROSS JOIN admin_authority aa
+  LEFT JOIN public.profiles p ON p.id = f.owner_profile_id
+  LEFT JOIN public.cities c ON c.id = f.city_id
+  LEFT JOIN edition_rollup er ON er.festival_id = f.id
+  LEFT JOIN counts ct ON ct.festival_id = f.id
+  LEFT JOIN warnings w ON w.festival_id = f.id
+  WHERE aa.allowed
+  ORDER BY f.name, f.id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_festival_catalogue() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.admin_festival_catalogue() FROM anon;


### PR DESCRIPTION
### Motivation
- The admin Festivals page showed a generic permission error when `admin_festival_catalogue()` failed, hiding the real Postgres/Supabase failure and blocking effective diagnosis.  
- The RPC projection could fail on missing tables/columns, malformed rows or enum differences and a single broken record must not break the entire admin catalogue.  
- Fixes must be deployable as a forward migration (not editing already-applied migrations) and surface useful diagnostics in development while preserving production safety.

### Description
- Added a forward migration `supabase/migrations/20291217120000_repair_admin_festival_catalogue.sql` which creates `public.current_user_is_platform_admin()` and `CREATE OR REPLACE FUNCTION public.admin_festival_catalogue()` with a resilient, edition-aware projection using safe joins, archived-stage exclusion, guarded aggregation and consistent `data_health_warnings` JSON output; grants are set for `authenticated` and `service_role` and `anon` execute is revoked.  
- Improved backend service at `src/features/festivals/admin/service.ts` by introducing richer `DomainErrorCode`s, passing the RPC name into error mapping, detecting and mapping `PGRST202` (RPC missing/schema cache), `42P01`/`42703`/`42883` (schema mismatch), network failures, and adding `fetchCurrentUserIsPlatformAdmin()` which verifies sign-in and admin authority before calling the catalogue RPC.  
- Updated the admin page `src/pages/admin/FestivalsAdmin.tsx` to distinguish error types with user-friendly messages, show development-only diagnostics (domain code, Postgres code, message, details, hint, RPC name), add a `Retry` button that invalidates `festivalAdminQueryKeys.catalogue`, disable the Create button until authority is confirmed, and hide main admin tabs while catalogue authority/loading has not succeeded.  
- Updated generated Supabase function types in `src/integrations/supabase/types.ts` to include `current_user_is_platform_admin`, and added a focused unit test `src/features/festivals/admin/__tests__/adminFestivalCatalogueErrors.test.ts` that asserts mapping of `PGRST202`, column/relation errors to schema-mismatch and preserving permission failures.

### Testing
- Ran `npm run typecheck`, which succeeded.  
- Attempted package installation with `npm ci`, which failed due to environment/registry restrictions (`403 Forbidden` for `@react-three/fiber`).  
- Attempted to run unit tests (`vitest`) for the new mapping test, but `vitest` could not be executed in this environment (`vitest: not found`), so the test file was added but could not be executed here.  
- `npm run lint` and `npm run build` could not be executed because required tooling was not available in the environment (`@eslint/js` and `vite` missing).  
- Supabase verification steps (`supabase db start`, `supabase db reset`, `supabase db lint`, `supabase test db`) could not be run because the Supabase CLI is not installed in this environment.  

Note: I could not reach the deployed Supabase instance from this environment, so the actual runtime SQLSTATE from `admin_festival_catalogue()` could not be captured here; the changes explicitly preserve and expose the Postgres/Supabase error code and diagnostics in development so the next failing call will reveal the concrete SQLSTATE rather than a generic permission message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e8a0583ec8325a37f63923dea75ca)