### PR TITLE
Harden admin catalogue warnings and prevent nulls from `admin_festival_catalogue()`

### DIFF
--- a/src/features/festivals/admin/__tests__/adminFestivalWarnings.test.ts
+++ b/src/features/festivals/admin/__tests__/adminFestivalWarnings.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { issueFromUnknown, mapCatalogueRow } from "../mappers";
+
+describe("festival admin data health warning mapping", () => {
+  it.each([
+    [null, []],
+    [[null], []],
+    [[{}, null], []],
+    [[5, "abc", [], true], []],
+  ])("ignores malformed warning payload %#", (input, expected) => {
+    expect(issueFromUnknown(input)).toEqual(expected);
+  });
+
+  it("preserves valid warning objects while ignoring null placeholders", () => {
+    expect(
+      issueFromUnknown([
+        null,
+        { code: "x", message: "y", severity: "warning" },
+        null,
+      ]),
+    ).toEqual([{ code: "x", message: "y", severity: "warning" }]);
+  });
+
+  it("maps the legacy RPC payload without throwing or dropping valid warnings", () => {
+    expect(() =>
+      mapCatalogueRow({
+        festival_id: "006da810-3fca-4c5c-a895-b0e73b60c9e4",
+        data_health_warnings: [
+          null,
+          {
+            code: "edition_without_stages",
+            message: "Selected edition has no edition-scoped stages",
+            severity: "warning",
+          },
+          null,
+        ],
+      }),
+    ).not.toThrow();
+
+    const row = mapCatalogueRow({
+      festival_id: "006da810-3fca-4c5c-a895-b0e73b60c9e4",
+      data_health_warnings: [
+        null,
+        {
+          code: "edition_without_stages",
+          message: "Selected edition has no edition-scoped stages",
+          severity: "warning",
+        },
+        null,
+      ],
+    });
+
+    expect(row.dataHealthWarnings).toEqual([
+      {
+        code: "edition_without_stages",
+        message: "Selected edition has no edition-scoped stages",
+        severity: "warning",
+      },
+    ]);
+  });
+});

--- a/src/features/festivals/admin/mappers.ts
+++ b/src/features/festivals/admin/mappers.ts
@@ -1,10 +1,18 @@
 import type { AdminFestivalCatalogueRow, FestivalDataHealthIssue, OwnerEditionOption, OwnerManagementBootstrap } from "./types";
 
-const issueFromUnknown = (value: unknown): FestivalDataHealthIssue[] => {
+export const issueFromUnknown = (value: unknown): FestivalDataHealthIssue[] => {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is FestivalDataHealthIssue => {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      return false;
+    }
+
     const candidate = item as Partial<FestivalDataHealthIssue>;
-    return typeof candidate.code === "string" && typeof candidate.message === "string" && (candidate.severity === "warning" || candidate.severity === "blocker");
+    return (
+      typeof candidate.code === "string" &&
+      typeof candidate.message === "string" &&
+      (candidate.severity === "warning" || candidate.severity === "blocker")
+    );
   });
 };
 

--- a/supabase/migrations/20291217121000_repair_admin_festival_catalogue_warning_arrays.sql
+++ b/supabase/migrations/20291217121000_repair_admin_festival_catalogue_warning_arrays.sql
@@ -1,0 +1,136 @@
+-- Repair festival admin catalogue warning arrays so they never contain null elements.
+
+CREATE OR REPLACE FUNCTION public.current_user_is_platform_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT coalesce(public.has_role(auth.uid(), 'admin'::public.app_role), false)
+$$;
+
+GRANT EXECUTE ON FUNCTION public.current_user_is_platform_admin() TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.current_user_is_platform_admin() FROM anon;
+
+CREATE OR REPLACE FUNCTION public.admin_festival_catalogue()
+RETURNS TABLE (
+  festival_id uuid,
+  brand_name text,
+  owner_name text,
+  city_name text,
+  current_edition_id uuid,
+  current_edition_title text,
+  next_edition_id uuid,
+  completed_edition_id uuid,
+  edition_count bigint,
+  lifecycle_state public.festival_edition_status,
+  stage_count bigint,
+  active_contract_count bigint,
+  performance_session_count bigint,
+  outcome_count bigint,
+  attendance integer,
+  currency_code text,
+  projected_finance_cents bigint,
+  actual_finance_cents bigint,
+  legacy_mappings bigint,
+  operational_readiness text,
+  data_health_warnings jsonb
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH admin_authority AS (
+    SELECT public.current_user_is_platform_admin() AS allowed
+  ), edition_rollup AS (
+    SELECT
+      e.festival_id,
+      count(*)::bigint AS edition_count,
+      (array_agg(e.id ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS current_edition_id,
+      (array_agg(e.title ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS current_edition_title,
+      (array_agg(e.id ORDER BY e.start_at NULLS LAST, e.created_at DESC) FILTER (WHERE e.start_at >= now() AND e.status NOT IN ('cancelled','abandoned')))[1] AS next_edition_id,
+      (array_agg(e.id ORDER BY e.completed_at DESC NULLS LAST, e.end_at DESC NULLS LAST, e.created_at DESC) FILTER (WHERE e.status = 'completed'))[1] AS completed_edition_id,
+      (array_agg(e.status ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS lifecycle_state,
+      (array_agg(e.expected_attendance ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS attendance,
+      (array_agg(e.currency_code ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS currency_code,
+      (array_agg(coalesce(e.budget_cents, e.treasury_allocation_cents, 0) ORDER BY CASE WHEN e.status IN ('live','setup','on_sale','announced','booking','applications_open','planning','concept') THEN 0 ELSE 1 END, e.start_at NULLS LAST, e.created_at DESC))[1] AS projected_finance_cents
+    FROM public.festival_editions e
+    GROUP BY e.festival_id
+  ), counts AS (
+    SELECT
+      f.id AS festival_id,
+      count(DISTINCT st.id) FILTER (WHERE st.archived_at IS NULL)::bigint AS stage_count,
+      count(DISTINCT fc.id) FILTER (WHERE fc.status IN ('awaiting_signatures','awaiting_band_signature','awaiting_organiser_signature','active','amendment_required'))::bigint AS active_contract_count,
+      count(DISTINCT fps.id)::bigint AS performance_session_count,
+      count(DISTINCT fpo.id)::bigint AS outcome_count,
+      count(DISTINCT flm.id)::bigint AS legacy_mappings
+    FROM public.festivals f
+    LEFT JOIN public.festival_editions e ON e.festival_id = f.id
+    LEFT JOIN public.festival_stages st ON st.edition_id = e.id
+    LEFT JOIN public.festival_contracts fc ON fc.edition_id = e.id
+    LEFT JOIN public.festival_performance_sessions fps ON fps.edition_id = e.id
+    LEFT JOIN public.festival_performance_outcomes fpo ON fpo.edition_id = e.id
+    LEFT JOIN public.festival_legacy_mappings flm ON flm.edition_id = e.id
+    GROUP BY f.id
+  ), warnings AS (
+    SELECT
+      f.id AS festival_id,
+      warning_rows.data_health_warnings
+    FROM public.festivals f
+    LEFT JOIN edition_rollup er ON er.festival_id = f.id
+    LEFT JOIN counts ct ON ct.festival_id = f.id
+    LEFT JOIN public.profiles p ON p.id = f.owner_profile_id
+    LEFT JOIN public.cities c ON c.id = f.city_id
+    CROSS JOIN LATERAL (
+      SELECT coalesce(jsonb_agg(w.warning), '[]'::jsonb) AS data_health_warnings
+      FROM (VALUES
+        (CASE WHEN coalesce(er.edition_count, 0) = 0 THEN jsonb_build_object('code','brand_without_edition','severity','blocker','message','Brand has no canonical edition') END),
+        (CASE WHEN er.current_edition_id IS NOT NULL AND coalesce(ct.stage_count, 0) = 0 THEN jsonb_build_object('code','edition_without_stages','severity','warning','message','Selected edition has no edition-scoped stages') END),
+        (CASE WHEN coalesce(ct.legacy_mappings, 0) > 1 THEN jsonb_build_object('code','duplicate_legacy_mapping','severity','warning','message','Multiple legacy mappings need review') END),
+        (CASE WHEN f.owner_profile_id IS NOT NULL AND p.id IS NULL THEN jsonb_build_object('code','missing_owner_profile','severity','warning','message','Owner profile is missing') END),
+        (CASE WHEN f.city_id IS NOT NULL AND c.id IS NULL THEN jsonb_build_object('code','missing_city','severity','warning','message','Festival city is missing') END)
+      ) AS w(warning)
+      WHERE w.warning IS NOT NULL
+    ) AS warning_rows
+  )
+  SELECT
+    f.id,
+    f.name,
+    p.display_name,
+    c.name,
+    er.current_edition_id,
+    er.current_edition_title,
+    er.next_edition_id,
+    er.completed_edition_id,
+    coalesce(er.edition_count, 0),
+    er.lifecycle_state,
+    coalesce(ct.stage_count, 0),
+    coalesce(ct.active_contract_count, 0),
+    coalesce(ct.performance_session_count, 0),
+    coalesce(ct.outcome_count, 0),
+    er.attendance,
+    coalesce(er.currency_code, 'USD'),
+    coalesce(er.projected_finance_cents, 0),
+    0::bigint,
+    coalesce(ct.legacy_mappings, 0),
+    CASE
+      WHEN coalesce(er.edition_count, 0) = 0 THEN 'missing_edition'
+      WHEN coalesce(ct.stage_count, 0) = 0 THEN 'needs_stages'
+      WHEN coalesce(ct.active_contract_count, 0) = 0 THEN 'needs_contracts'
+      ELSE 'ready'
+    END,
+    coalesce(w.data_health_warnings, '[]'::jsonb)
+  FROM public.festivals f
+  CROSS JOIN admin_authority aa
+  LEFT JOIN public.profiles p ON p.id = f.owner_profile_id
+  LEFT JOIN public.cities c ON c.id = f.city_id
+  LEFT JOIN edition_rollup er ON er.festival_id = f.id
+  LEFT JOIN counts ct ON ct.festival_id = f.id
+  LEFT JOIN warnings w ON w.festival_id = f.id
+  WHERE aa.allowed
+  ORDER BY f.name, f.id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_festival_catalogue() TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.admin_festival_catalogue() FROM anon;

--- a/supabase/tests/festival_admin_catalogue_warning_arrays_harness.sql
+++ b/supabase/tests/festival_admin_catalogue_warning_arrays_harness.sql
@@ -1,0 +1,58 @@
+-- Festival admin catalogue warning-array contract harness.
+-- Run with: supabase db reset && psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/festival_admin_catalogue_warning_arrays_harness.sql
+-- Verifies the SQL construction used by admin_festival_catalogue() returns dense arrays.
+
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS test_festival_admin_catalogue_warnings;
+CREATE OR REPLACE FUNCTION test_festival_admin_catalogue_warnings.assert_jsonb_eq(label text, actual jsonb, expected jsonb) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF actual IS DISTINCT FROM expected THEN
+    RAISE EXCEPTION 'assertion failed: %, expected %, got %', label, expected, actual;
+  END IF;
+END $$;
+CREATE OR REPLACE FUNCTION test_festival_admin_catalogue_warnings.assert_true(label text, actual boolean) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF actual IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'assertion failed: %', label;
+  END IF;
+END $$;
+CREATE OR REPLACE FUNCTION test_festival_admin_catalogue_warnings.warning_array(has_edition boolean, has_stage boolean, legacy_mappings integer)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT coalesce(jsonb_agg(w.warning), '[]'::jsonb)
+  FROM (VALUES
+    (CASE WHEN NOT has_edition THEN jsonb_build_object('code','brand_without_edition','severity','blocker','message','Brand has no canonical edition') END),
+    (CASE WHEN has_edition AND NOT has_stage THEN jsonb_build_object('code','edition_without_stages','severity','warning','message','Selected edition has no edition-scoped stages') END),
+    (CASE WHEN legacy_mappings > 1 THEN jsonb_build_object('code','duplicate_legacy_mapping','severity','warning','message','Multiple legacy mappings need review') END)
+  ) AS w(warning)
+  WHERE w.warning IS NOT NULL
+$$;
+
+DO $$
+DECLARE
+  no_warnings jsonb;
+  one_warning jsonb;
+  multiple_warnings jsonb;
+  function_sql text;
+BEGIN
+  no_warnings := test_festival_admin_catalogue_warnings.warning_array(true, true, 0);
+  one_warning := test_festival_admin_catalogue_warnings.warning_array(true, false, 0);
+  multiple_warnings := test_festival_admin_catalogue_warnings.warning_array(true, false, 2);
+
+  PERFORM test_festival_admin_catalogue_warnings.assert_jsonb_eq('no warnings returns empty array', no_warnings, '[]'::jsonb);
+  PERFORM test_festival_admin_catalogue_warnings.assert_jsonb_eq('one warning returns one dense object', one_warning, jsonb_build_array(jsonb_build_object('code','edition_without_stages','severity','warning','message','Selected edition has no edition-scoped stages')));
+  PERFORM test_festival_admin_catalogue_warnings.assert_jsonb_eq('multiple warnings returns dense objects', multiple_warnings, jsonb_build_array(jsonb_build_object('code','edition_without_stages','severity','warning','message','Selected edition has no edition-scoped stages'), jsonb_build_object('code','duplicate_legacy_mapping','severity','warning','message','Multiple legacy mappings need review')));
+
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('no warnings result is not null', no_warnings IS NOT NULL);
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('one warning has no null elements', NOT one_warning @> '[null]'::jsonb);
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('multiple warnings has no null elements', NOT multiple_warnings @> '[null]'::jsonb);
+
+  SELECT pg_get_functiondef('public.admin_festival_catalogue()'::regprocedure) INTO function_sql;
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('catalogue filters null warning rows', position('WHERE w.warning IS NOT NULL' in function_sql) > 0 OR position('FILTER (WHERE w.warning IS NOT NULL)' in function_sql) > 0);
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('catalogue uses jsonb_agg for warning rows', position('jsonb_agg(w.warning)' in function_sql) > 0);
+  PERFORM test_festival_admin_catalogue_warnings.assert_true('catalogue defaults empty warning collections to []', position('''[]''::jsonb' in function_sql) > 0);
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
### Motivation
- Festival Administration crashed when `admin_festival_catalogue()` emitted `null` placeholders inside `data_health_warnings`, because the frontend assumed each element was an object with a `code` property. 
- The database contract must never emit `null` array elements and the frontend must defensively handle malformed/legacy RPC payloads to avoid runtime exceptions.

### Description
- Add a defensive warning mapper in `src/features/festivals/admin/mappers.ts` by exporting `issueFromUnknown` and rejecting `null`, non-object and array values before accessing `code`, `message`, and `severity` (only `"warning"` or `"blocker"` accepted). 
- Add frontend unit tests `src/features/festivals/admin/__tests__/adminFestivalWarnings.test.ts` covering malformed inputs, legacy `[null, {...}, null]` payloads, and primitive/array values to ensure the mapper returns only valid warnings. 
- Add a forward SQL migration `supabase/migrations/20291217121000_repair_admin_festival_catalogue_warning_arrays.sql` that rebuilds `data_health_warnings` via a `VALUES` table, filters out `NULL` rows (`WHERE w.warning IS NOT NULL`), aggregates with `jsonb_agg(w.warning)` and defaults to `'[]'::jsonb` so the RPC never emits `null` elements. 
- Add a SQL harness `supabase/tests/festival_admin_catalogue_warning_arrays_harness.sql` that asserts empty, single-warning, and multi-warning results are dense arrays and that the RPC uses the filtered aggregate contract.

### Testing
- Ran TypeScript typecheck with `npm run typecheck`, which succeeded. 
- Ran repository checks with `git diff --check`, which succeeded. 
- Added unit tests and attempted `npm run test:unit`, but running the `vitest` binary in this environment was blocked because dependencies are not fully installed. 
- Added the SQL harness and attempted to run it against a local DB, but execution is blocked in this environment because `SUPABASE_DB_URL` is not configured; `npm ci` also failed here due to a peer-dependency conflict when installing dev dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e9cd1cb108325926646b29a20233a)