### PR TITLE
fix(finance): preserve Supabase RPC binding on banking dashboard

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -42878,6 +42878,7 @@ export type Database = {
         Args: { p_setlist_id: string }
         Returns: number
       }
+      get_banking_dashboard: { Args: never; Returns: Json }
       get_song_vote_score: { Args: { p_song_id: string }; Returns: number }
       get_songs_on_albums: {
         Args: { p_band_id: string; p_user_id: string }

--- a/src/services/banking/bankingService.test.ts
+++ b/src/services/banking/bankingService.test.ts
@@ -1,13 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const rpc = vi.fn();
+const { rpcCalls, mockSupabase } = vi.hoisted(() => {
+  const rpcCalls: Array<{ name: string; args: unknown[] }> = [];
+  const mockSupabase = {
+    rest: {},
+    rpc(this: { rest?: unknown }, name: string, ...args: unknown[]) {
+      if (!this.rest) throw new Error("rpc lost Supabase client binding");
+      rpcCalls.push({ name, args });
+      return Promise.resolve({ data: { accounts: [], loans: [], recentActivity: [] }, error: null });
+    },
+  };
 
-vi.mock("@/integrations/supabase/client", () => ({ supabase: { rpc } }));
+  return { rpcCalls, mockSupabase };
+});
+
+vi.mock("@/integrations/supabase/client", () => ({ supabase: mockSupabase }));
 
 import { fetchBankingDashboard, formatCurrencyMinor, mapBankingError, summarizeEqualPrincipalOffer } from "./bankingService";
 
 describe("bankingService", () => {
-  beforeEach(() => rpc.mockReset());
+  beforeEach(() => {
+    rpcCalls.length = 0;
+  });
 
   it("formats configured currency minor units", () => {
     expect(formatCurrencyMinor({ amountMinor: 123456, currencyCode: "USD", locale: "en-US" })).toContain("$1,234.56");
@@ -16,12 +30,10 @@ describe("bankingService", () => {
     expect(formatCurrencyMinor({ amountMinor: 123456, currencyCode: "JPY", locale: "ja-JP" })).toContain("￥123,456");
   });
 
-  it("calls the dashboard RPC with the zero-argument signature", async () => {
-    rpc.mockResolvedValue({ data: { accounts: [], loans: [], recentActivity: [] }, error: null });
-
+  it("calls the dashboard RPC as a bound zero-argument Supabase client method", async () => {
     await expect(fetchBankingDashboard()).resolves.toMatchObject({ accounts: [], loans: [], recentActivity: [] });
 
-    expect(rpc).toHaveBeenCalledWith("get_banking_dashboard");
+    expect(rpcCalls).toEqual([{ name: "get_banking_dashboard", args: [] }]);
   });
 
   it("summarizes declining equal-principal schedules without fixed-payment wording", () => {
@@ -40,9 +52,10 @@ describe("bankingService", () => {
     expect(summary.scheduleDescription).not.toContain("fixed");
   });
 
-  it("maps permission, funding, and missing RPC errors", () => {
+  it("maps permission, funding, missing RPC, and unexpected client errors safely", () => {
     expect(mapBankingError({ code: "42501" })).toContain("permission");
     expect(mapBankingError({ message: "insufficient funds" })).toContain("not enough money");
     expect(mapBankingError({ code: "PGRST202", message: "Could not find the function public.get_banking_dashboard without parameters in the schema cache" })).toBe("Banking is temporarily unavailable while the finance service is being updated. Please try again shortly.");
+    expect(mapBankingError({ message: "Cannot read properties of undefined (reading 'rest')" })).toBe("Banking could not be loaded. Please try again.");
   });
 });

--- a/src/services/banking/bankingService.ts
+++ b/src/services/banking/bankingService.ts
@@ -99,17 +99,25 @@ export function summarizeEqualPrincipalOffer(input: {
 }
 
 export async function fetchBankingDashboard(): Promise<BankingDashboard> {
-  const getBankingDashboardRpc = supabase.rpc as unknown as (fn: "get_banking_dashboard") => Promise<{ data: unknown; error: { code?: string; message?: string; details?: string; hint?: string } | null }>;
-  const { data, error } = await getBankingDashboardRpc("get_banking_dashboard");
+  try {
+    const { data, error } = await supabase.rpc("get_banking_dashboard");
 
-  if (error) {
-    if (isMissingSupabaseRpcError(error)) {
-      console.error("[banking] dashboard RPC unavailable", { code: error.code, message: error.message, details: error.details, hint: error.hint });
+    if (error) {
+      if (isMissingSupabaseRpcError(error)) {
+        logBankingDiagnostic("[banking] dashboard RPC unavailable", error);
+      }
+      throw new Error(mapBankingError(error));
     }
-    throw new Error(mapBankingError(error));
-  }
 
-  return (data as BankingDashboard | null) ?? fallbackDashboard;
+    return (data as BankingDashboard | null) ?? fallbackDashboard;
+  } catch (error) {
+    if (error instanceof Error && isPlayerSafeBankingError(error.message)) {
+      throw error;
+    }
+
+    logBankingDiagnostic("[banking] dashboard RPC invocation failed", error);
+    throw new Error("Banking could not be loaded. Please try again.");
+  }
 }
 
 export async function createLoanApplication(input: {
@@ -164,11 +172,28 @@ export async function acceptLoanOffer(input: {
   return String(data);
 }
 
+const PLAYER_SAFE_BANKING_ERRORS = new Set([
+  SUPABASE_RPC_SCHEMA_UNAVAILABLE_MESSAGE,
+  "You do not have permission to perform this banking action.",
+  "There is not enough money in the selected account.",
+  "Banking could not be loaded. Please try again.",
+]);
+
+function isPlayerSafeBankingError(message: string): boolean {
+  return PLAYER_SAFE_BANKING_ERRORS.has(message);
+}
+
+function logBankingDiagnostic(message: string, error: unknown): void {
+  if (import.meta.env.DEV) {
+    console.error(message, error);
+  }
+}
+
 export function mapBankingError(error: { code?: string; message?: string; details?: string; hint?: string }): string {
   if (isMissingSupabaseRpcError(error)) return SUPABASE_RPC_SCHEMA_UNAVAILABLE_MESSAGE;
   if (error.code === "42501") return "You do not have permission to perform this banking action.";
   if (error.message?.toLowerCase().includes("insufficient funds")) return "There is not enough money in the selected account.";
-  return error.message ?? "Banking is temporarily unavailable.";
+  return "Banking could not be loaded. Please try again.";
 }
 
 export type BankingProduct = {


### PR DESCRIPTION
### Motivation
- The Banking page was crashing because `SupabaseClient.rpc` was extracted and invoked without its client receiver, causing `this.rest` to be read from `undefined` rather than a database/migration problem.  
- The intent is to restore the bound RPC invocation, keep the improved missing-RPC/schema-cache handling from the earlier change, and ensure players never see raw JS/Supabase errors.  
- Add a regression test that detects lost method binding so the issue cannot recur and ensure types include the zero-argument RPC signature.

### Description
- Restore the bound RPC call by replacing the extracted function with a direct invocation `await supabase.rpc("get_banking_dashboard")` in `src/services/banking/bankingService.ts`.  
- Improve runtime error mapping and diagnostics by adding `logBankingDiagnostic`, `isPlayerSafeBankingError`, a player-safe error set, and mapping unexpected client invocation errors to the generic message `"Banking could not be loaded. Please try again."` while preserving missing-RPC/schema-cache detection via `isMissingSupabaseRpcError`.  
- Add the zero-argument `get_banking_dashboard` RPC entry to the generated/local Supabase types in `src/integrations/supabase/types.ts` with `Args: never` and `Returns: Json`.  
- Add a regression test in `src/services/banking/bankingService.test.ts` that uses a receiver-dependent `mockSupabase` (with a `rest` field and method `rpc(this: ...)`) to assert the RPC is invoked as a bound method with no arguments and that lost binding would throw the test.

### Testing
- `git diff --check` passed after the changes.  
- Attempted to run `npm run test:unit -- src/services/banking/bankingService.test.ts`, but `vitest` was not available because `node_modules` were not installed in this environment.  
- Attempted `npm ci` to install dependencies and run typecheck/build, but installation failed due to a registry `403 Forbidden` for a dependency, so full typecheck and test execution were blocked.  
- The changes were committed (branch commit recorded) and the PR metadata prepared; the unit test changes are in place to pass when dependencies are available locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fcadb32ec8325b3c402e2c940e365)