### PR TITLE
Add leader-managed band member RPCs and UI for performance role editing

### DIFF
--- a/src/components/band/AddTouringMember.tsx
+++ b/src/components/band/AddTouringMember.tsx
@@ -27,18 +27,13 @@ export function AddTouringMember({ bandId, onAdded }: AddTouringMemberProps) {
     try {
       const memberName = generateTouringMemberName();
       
-      const { error } = await supabase
-        .from('band_members')
-        .insert({
-          band_id: bandId,
-          user_id: null,
-          role: memberName,
-          instrument_role: instrument,
-          is_touring_member: true,
-          touring_member_tier: tier,
-          touring_member_cost: selectedTier.weeklyCost,
-          salary: selectedTier.weeklyCost,
-        });
+      const { error } = await (supabase as any).rpc('hire_band_touring_member', {
+        p_band_id: bandId,
+        p_member_name: memberName,
+        p_instrument_role: instrument,
+        p_tier: tier,
+        p_weekly_cost: selectedTier.weeklyCost,
+      });
 
       if (error) throw error;
 

--- a/src/components/bands/BandRosterTab.tsx
+++ b/src/components/bands/BandRosterTab.tsx
@@ -3,11 +3,13 @@ import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/lib/supabase-types";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Users, Shield, Zap, Activity, Bus, UserCheck, User, UserX } from "lucide-react";
 import { BandMemberDetailDialog } from "./BandMemberDetailDialog";
@@ -22,13 +24,14 @@ type BandMemberRow = Database["public"]["Tables"]["band_members"]["Row"];
 type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
 
 type MemberWithProfile = BandMemberRow & {
-  profiles: { 
-    user_id: string; 
-    display_name: string | null; 
-    username: string; 
-    avatar_url: string | null; 
+  profiles: {
+    id: string;
+    user_id: string;
+    display_name: string | null;
+    username: string;
+    avatar_url: string | null;
     rpm_avatar_url?: string | null;
-    level: number | null; 
+    level: number | null;
   } | null;
 };
 
@@ -55,6 +58,22 @@ const statusColors: Record<string, string> = {
   suspended: "bg-red-500/20 text-red-700",
   probation: "bg-sky-500/20 text-sky-700",
 };
+
+const performanceRoleOptions = [
+  "Vocals",
+  "Lead Vocals",
+  "Backing Vocals",
+  "Guitar",
+  "Lead Guitar",
+  "Rhythm Guitar",
+  "Bass",
+  "Drums",
+  "Keyboard",
+  "DJ",
+  "Producer",
+  "Multi-instrumentalist",
+  "Other",
+];
 
 function getStatusLabel(status?: string | null) {
   if (!status) return "Active";
@@ -156,8 +175,21 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
   const [statusHistory, setStatusHistory] = useState<Record<string, BandMembershipStatusHistory[]>>({});
   const [selectedMember, setSelectedMember] = useState<MemberWithProfile | null>(null);
   const [bandLeaderId, setBandLeaderId] = useState<string | null>(null);
+  const [updatingRoleMemberId, setUpdatingRoleMemberId] = useState<string | null>(null);
+  const [draftPerformanceRoles, setDraftPerformanceRoles] = useState<Record<string, string>>({});
 
-  const isLeader = profile?.user_id === bandLeaderId;
+  const currentMember = useMemo(() => (
+    members.find((member) => (
+      (profile?.id && member.profile_id === profile.id) ||
+      (profile?.user_id && member.user_id === profile.user_id)
+    ))
+  ), [members, profile?.id, profile?.user_id]);
+
+  const isLeader = Boolean(
+    currentMember?.role === "leader" ||
+    (profile?.id && bandLeaderId === profile.id) ||
+    (profile?.user_id && bandLeaderId === profile.user_id),
+  );
 
   useEffect(() => {
     let isMounted = true;
@@ -186,17 +218,39 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
 
         if (memberError) throw memberError;
 
-        // Fetch profiles separately with rpm_avatar_url
+        // Fetch profiles by profile_id first so active characters show the correct name/avatar.
+        // Fall back to user_id for legacy/touring member records that may not have profile_id populated.
+        const profileIds = memberData?.map(m => m.profile_id).filter(Boolean) ?? [];
         const userIds = memberData?.map(m => m.user_id).filter(Boolean) ?? [];
-        const { data: profileData } = await supabase
-          .from("profiles")
-          .select("user_id, display_name, username, avatar_url, rpm_avatar_url, level")
-          .in("user_id", userIds);
+        const profileData: Array<MemberWithProfile["profiles"]> = [];
+
+        if (profileIds.length > 0) {
+          const { data } = await supabase
+            .from("profiles")
+            .select("id, user_id, display_name, username, avatar_url, rpm_avatar_url, level")
+            .in("id", profileIds);
+
+          profileData.push(...(data ?? []));
+        }
+
+        if (userIds.length > 0) {
+          const { data } = await supabase
+            .from("profiles")
+            .select("id, user_id, display_name, username, avatar_url, rpm_avatar_url, level")
+            .in("user_id", userIds);
+
+          profileData.push(...(data ?? []));
+        }
+
+        const profilesById = new Map(profileData.filter(Boolean).map(p => [p!.id, p]));
+        const profilesByUserId = new Map(profileData.filter(Boolean).map(p => [p!.user_id, p]));
 
         // Merge members with profiles
         const membersWithProfiles: MemberWithProfile[] = (memberData ?? []).map(member => ({
           ...member,
-          profiles: profileData?.find(p => p.user_id === member.user_id) ?? null
+          profiles: (member.profile_id ? profilesById.get(member.profile_id) : null)
+            ?? (member.user_id ? profilesByUserId.get(member.user_id) : null)
+            ?? null
         }));
 
         // Fetch status history
@@ -211,6 +265,12 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
         if (!isMounted) return;
 
         setMembers(membersWithProfiles);
+        setDraftPerformanceRoles(
+          membersWithProfiles.reduce((acc, member) => {
+            acc[member.id] = member.instrument_role || "Other";
+            return acc;
+          }, {} as Record<string, string>),
+        );
 
         const historyMap = (historyData as BandMembershipStatusHistory[] | null)?.reduce(
           (acc, entry) => {
@@ -281,6 +341,58 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
         description: "Could not update travel setting",
         variant: "destructive",
       });
+    }
+  };
+
+  const handlePerformanceRoleDraftChange = (memberId: string, nextRole: string) => {
+    setDraftPerformanceRoles((current) => ({ ...current, [memberId]: nextRole }));
+  };
+
+  const handlePerformanceRoleSave = async (memberId: string) => {
+    if (!isLeader) {
+      toast({
+        title: "Permission denied",
+        description: "Only the band leader can change member performance roles",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const member = members.find((candidate) => candidate.id === memberId);
+    const nextRole = draftPerformanceRoles[memberId];
+    if (!member || !nextRole || member.instrument_role === nextRole) return;
+
+    setUpdatingRoleMemberId(memberId);
+    try {
+      const { data, error } = await (supabase as any).rpc("update_band_member_performance_role", {
+        p_member_id: memberId,
+        p_instrument_role: nextRole,
+      });
+
+      if (error) throw error;
+
+      const updatedRole = data?.instrument_role ?? nextRole;
+
+      setMembers(prev =>
+        prev.map(m =>
+          m.id === memberId ? { ...m, instrument_role: updatedRole } : m
+        )
+      );
+      setDraftPerformanceRoles((current) => ({ ...current, [memberId]: updatedRole }));
+
+      toast({
+        title: "Performance role saved",
+        description: `${member.profiles?.display_name ?? member.profiles?.username ?? "Member"} is now assigned to ${updatedRole}.`,
+      });
+    } catch (error) {
+      console.error("Failed to save performance role", error);
+      toast({
+        title: "Save failed",
+        description: "Could not save the member performance role",
+        variant: "destructive",
+      });
+    } finally {
+      setUpdatingRoleMemberId(null);
     }
   };
 
@@ -416,7 +528,7 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
       <Card>
         <CardHeader>
           <CardTitle>Band roster</CardTitle>
-          <CardDescription>Overview of every active member and their contributions.</CardDescription>
+          <CardDescription>Overview of every active member and their contributions. Band leaders can change performance roles, including solo-act lineups.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {members.length === 0 ? (
@@ -440,6 +552,11 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
                   {members.map((member) => {
                     const lastStatus = statusHistory[member.id]?.[0];
                     const statusLabel = getStatusLabel(member.member_status);
+                    const draftRole = draftPerformanceRoles[member.id] ?? member.instrument_role ?? "Other";
+                    const roleOptions = draftRole && !performanceRoleOptions.includes(draftRole)
+                      ? [draftRole, ...performanceRoleOptions]
+                      : performanceRoleOptions;
+                    const hasUnsavedRole = draftRole !== (member.instrument_role || "Other");
                     return (
                       <TableRow key={member.id}>
                         <TableCell>
@@ -475,10 +592,41 @@ export function BandRosterTab({ bandId }: BandRosterTabProps) {
                           </div>
                         </TableCell>
                         <TableCell className="align-middle">
-                          <div className="flex flex-col gap-1">
-                            <span className="text-sm font-medium">{member.role}</span>
-                            {member.can_be_leader && <Badge variant="outline">Leadership pool</Badge>}
-                            {member.is_touring_member && <Badge variant="secondary">Session</Badge>}
+                          <div className="flex flex-col gap-2">
+                            <Select
+                              value={draftRole}
+                              onValueChange={(value) => handlePerformanceRoleDraftChange(member.id, value)}
+                              disabled={!isLeader || updatingRoleMemberId === member.id}
+                            >
+                              <SelectTrigger className="h-8 w-[190px]">
+                                <SelectValue placeholder="Assign performance role" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {roleOptions.map((role) => (
+                                  <SelectItem key={role} value={role}>
+                                    {role}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            {isLeader && (
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant={hasUnsavedRole ? "default" : "outline"}
+                                className="h-8 w-fit"
+                                disabled={!hasUnsavedRole || updatingRoleMemberId === member.id}
+                                onClick={() => handlePerformanceRoleSave(member.id)}
+                              >
+                                {updatingRoleMemberId === member.id ? "Saving…" : "Save role"}
+                              </Button>
+                            )}
+                            <div className="flex flex-wrap gap-1">
+                              {member.role === "leader" && <Badge>Leader</Badge>}
+                              {member.role !== "leader" && <Badge variant="outline">{member.role}</Badge>}
+                              {member.can_be_leader && <Badge variant="outline">Leadership pool</Badge>}
+                              {member.is_touring_member && <Badge variant="secondary">Session</Badge>}
+                            </div>
                           </div>
                         </TableCell>
                         <TableCell className="align-middle">

--- a/src/pages/BandManager.tsx
+++ b/src/pages/BandManager.tsx
@@ -29,6 +29,7 @@ import { ChemistryDisplay } from "@/components/band/ChemistryDisplay";
 import { BandChat } from "@/components/band/BandChat";
 import { BandEarnings } from "@/components/band/BandEarnings";
 import { BandFinancesTab } from "@/components/bands/BandFinancesTab";
+import { BandRosterTab } from "@/components/bands/BandRosterTab";
 import { InviteFriendToBand } from "@/components/band/InviteFriendToBand";
 import { BandSettingsTab } from "@/components/band/BandSettingsTab";
 import { BandStatusBanner } from "@/components/band/BandStatusBanner";
@@ -442,6 +443,8 @@ export default function BandManager() {
               onMemberAdded={() => loadBandMembers(selectedBand.id)}
             />
           )}
+
+          <BandRosterTab bandId={selectedBand.id} />
 
           <Card>
             <CardHeader>

--- a/supabase/migrations/20260722130000_band_member_management_rpcs.sql
+++ b/supabase/migrations/20260722130000_band_member_management_rpcs.sql
@@ -1,0 +1,147 @@
+-- Authoritative band-member management helpers for leader-only roster edits.
+-- These avoid browser writes being blocked by band_members RLS policies that still
+-- depend on historical user_id-based leader checks while the app now uses profiles.
+
+CREATE OR REPLACE FUNCTION public.can_manage_band_members(target_band_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.user_id = auth.uid()
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM public.bands b
+          WHERE b.id = target_band_id
+            AND (b.leader_id = auth.uid() OR b.leader_id = p.id)
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM public.band_members bm
+          WHERE bm.band_id = target_band_id
+            AND COALESCE(bm.member_status, 'active') = 'active'
+            AND (bm.user_id = auth.uid() OR bm.profile_id = p.id)
+            AND lower(COALESCE(bm.role, '')) IN ('leader', 'founder', 'co-leader', 'manager')
+        )
+      )
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_band_member_performance_role(
+  p_member_id uuid,
+  p_instrument_role text
+)
+RETURNS public.band_members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  target_member public.band_members;
+  normalized_role text;
+BEGIN
+  normalized_role := NULLIF(btrim(COALESCE(p_instrument_role, '')), '');
+
+  IF normalized_role IS NULL OR char_length(normalized_role) > 50 THEN
+    RAISE EXCEPTION 'invalid_performance_role';
+  END IF;
+
+  SELECT * INTO target_member
+  FROM public.band_members
+  WHERE id = p_member_id
+  FOR UPDATE;
+
+  IF target_member.id IS NULL THEN
+    RAISE EXCEPTION 'band_member_not_found';
+  END IF;
+
+  IF NOT public.can_manage_band_members(target_member.band_id) THEN
+    RAISE EXCEPTION 'not_band_manager';
+  END IF;
+
+  UPDATE public.band_members
+  SET instrument_role = normalized_role
+  WHERE id = p_member_id
+  RETURNING * INTO target_member;
+
+  RETURN target_member;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.hire_band_touring_member(
+  p_band_id uuid,
+  p_member_name text,
+  p_instrument_role text,
+  p_tier integer,
+  p_weekly_cost integer
+)
+RETURNS public.band_members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_member public.band_members;
+  normalized_name text;
+  normalized_role text;
+BEGIN
+  normalized_name := NULLIF(btrim(COALESCE(p_member_name, '')), '');
+  normalized_role := NULLIF(btrim(COALESCE(p_instrument_role, '')), '');
+
+  IF normalized_name IS NULL OR char_length(normalized_name) > 50 THEN
+    RAISE EXCEPTION 'invalid_touring_member_name';
+  END IF;
+
+  IF normalized_role IS NULL OR char_length(normalized_role) > 50 THEN
+    RAISE EXCEPTION 'invalid_performance_role';
+  END IF;
+
+  IF p_tier IS NULL OR p_tier < 1 OR p_tier > 5 THEN
+    RAISE EXCEPTION 'invalid_touring_member_tier';
+  END IF;
+
+  IF p_weekly_cost IS NULL OR p_weekly_cost < 0 THEN
+    RAISE EXCEPTION 'invalid_touring_member_cost';
+  END IF;
+
+  IF NOT public.can_manage_band_members(p_band_id) THEN
+    RAISE EXCEPTION 'not_band_manager';
+  END IF;
+
+  INSERT INTO public.band_members (
+    band_id,
+    user_id,
+    profile_id,
+    role,
+    instrument_role,
+    is_touring_member,
+    touring_member_tier,
+    touring_member_cost,
+    salary,
+    member_status
+  ) VALUES (
+    p_band_id,
+    NULL,
+    NULL,
+    normalized_name,
+    normalized_role,
+    true,
+    p_tier,
+    p_weekly_cost,
+    p_weekly_cost,
+    'active'
+  )
+  RETURNING * INTO new_member;
+
+  RETURN new_member;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.can_manage_band_members(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.update_band_member_performance_role(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.hire_band_touring_member(uuid, text, text, integer, integer) TO authenticated;


### PR DESCRIPTION
### Motivation

- Provide server-side helpers to allow leader-only roster edits while respecting RLS and the app's move to profile-based identities.
- Allow band leaders to assign and persist member performance roles from the roster UI and hire touring/session members via a single RPC.

### Description

- Added a new Supabase migration that creates `can_manage_band_members`, `update_band_member_performance_role`, and `hire_band_touring_member` RPCs and grants `EXECUTE` to `authenticated` users, moving sensitive roster writes behind security-definer functions.
- Switched touring-member creation in `AddTouringMember.tsx` to call the `hire_band_touring_member` RPC instead of inserting directly into `band_members`.
- Reworked `BandRosterTab.tsx` to prefer `profile_id` when resolving profile data, include the profile `id` in the merged profile shape, and de-duplicate profile fetches by `id` and `user_id`.
- Implemented in-place performance role editing: added UI (`Select` + `Save` button), draft state tracking, leader-checking logic, and `handlePerformanceRoleSave` which calls the `update_band_member_performance_role` RPC and updates local state on success.
- Imported and rendered the new `BandRosterTab` in `BandManager.tsx` and adjusted copy to indicate leaders can change performance roles.

### Testing

- Ran a TypeScript build via `pnpm build` to verify types and compile-time errors, and the build completed successfully.
- Executed the project's test suite via `pnpm test`, and existing tests passed (no new unit tests were added for the RPCs or UI in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6115b657648325b606f36054532233)