### PR TITLE
architecture: isolate legacy festivals and define replacement system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { bandHubNavigation, businessHubNavigation, careerHubNavigation, characte
 import { isHubNavigationItemActive } from "@/components/hub/HubLayout";
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { PageLoadingState } from "@/components/ui/page-state";
+import { LegacyFestivalGate } from "./features/festival-company";
 
 // Redirect component for removed placeholder pages
 const RedirectTo = ({ to }: { to: string }) => {
@@ -649,8 +650,8 @@ function App() {
                     <Route path="world/studios" element={<PreserveQueryRedirect to="/recording-studio" />} />
                     <Route path="world/companies" element={<PreserveQueryRedirect to="/world-companies" />} />
                     <Route path="world/events" element={<PreserveQueryRedirect to="/major-events" />} />
-                    <Route path="world/festivals" element={<PreserveQueryRedirect to="/festivals" />} />
-                    <Route path="world/festivals/:festivalId" element={<FestivalDetail />} />
+                    <Route path="world/festivals" element={<LegacyFestivalGate area="World festival directory"><PreserveQueryRedirect to="/festivals" /></LegacyFestivalGate>} />
+                    <Route path="world/festivals/:festivalId" element={<LegacyFestivalGate area="Festival detail"><FestivalDetail /></LegacyFestivalGate>} />
                     <Route path="world/pulse" element={<PreserveQueryRedirect to="/world-pulse" />} />
                     <Route path="world/leaderboards" element={<PreserveQueryRedirect to="/band-rankings" />} />
                     <Route path="cities" element={<WorldEnvironment />} />
@@ -696,17 +697,17 @@ function App() {
                     <Route path="my-companies" element={<MyCompanies />} />
                     <Route path="venues" element={<VenueManagement />} />
                     {/* <Route path="community/charity" element={<CharityPage />} /> */}
-                    <Route path="festivals" element={<FestivalBrowser />} />
-                    <Route path="festivals/marketplace" element={<FestivalMarketplace />} />
-                    <Route path="festivals/directory" element={<FestivalDirectory />} />
-                    <Route path="festivals/:festivalId" element={<FestivalDetail />} />
-                    <Route path="festivals/simulation" element={<FestivalsNew />} />
-                    <Route path="festivals/perform/:participationId" element={<FestivalPerformance />} />
-                    <Route path="festivals/:festivalId/manage" element={<FestivalOwnerConsole />} />
-                    <Route path="festivals/:festivalId/manage/editions/:editionId" element={<FestivalOwnerConsole />} />
-                    <Route path="festivals/sessions/:sessionId" element={<FestivalSessionPage />} />
-                    <Route path="festivals/:festivalId/calendar" element={<FestivalBookingCalendar />} />
-                    <Route path="festivals/:festivalId/run" element={<FestivalRunWizard />} />
+                    <Route path="festivals" element={<LegacyFestivalGate area="Festival browser"><FestivalBrowser /></LegacyFestivalGate>} />
+                    <Route path="festivals/marketplace" element={<LegacyFestivalGate area="Festival marketplace"><FestivalMarketplace /></LegacyFestivalGate>} />
+                    <Route path="festivals/directory" element={<LegacyFestivalGate area="Festival directory"><FestivalDirectory /></LegacyFestivalGate>} />
+                    <Route path="festivals/:festivalId" element={<LegacyFestivalGate area="Festival detail"><FestivalDetail /></LegacyFestivalGate>} />
+                    <Route path="festivals/simulation" element={<LegacyFestivalGate area="Festival simulation"><FestivalsNew /></LegacyFestivalGate>} />
+                    <Route path="festivals/perform/:participationId" element={<LegacyFestivalGate area="Festival performance"><FestivalPerformance /></LegacyFestivalGate>} />
+                    <Route path="festivals/:festivalId/manage" element={<LegacyFestivalGate area="Festival owner console"><FestivalOwnerConsole /></LegacyFestivalGate>} />
+                    <Route path="festivals/:festivalId/manage/editions/:editionId" element={<LegacyFestivalGate area="Festival owner console"><FestivalOwnerConsole /></LegacyFestivalGate>} />
+                    <Route path="festivals/sessions/:sessionId" element={<LegacyFestivalGate area="Festival live session"><FestivalSessionPage /></LegacyFestivalGate>} />
+                    <Route path="festivals/:festivalId/calendar" element={<LegacyFestivalGate area="Festival calendar"><FestivalBookingCalendar /></LegacyFestivalGate>} />
+                    <Route path="festivals/:festivalId/run" element={<LegacyFestivalGate area="Festival run wizard"><FestivalRunWizard /></LegacyFestivalGate>} />
                     <Route path="awards" element={<Awards />} />
                     <Route path="chemistry" element={<BandChemistry />} />
                     <Route path="bands/finder" element={<BandFinder />} />

--- a/src/features/festival-company/__tests__/appRouteBoundary.test.ts
+++ b/src/features/festival-company/__tests__/appRouteBoundary.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const appSource = readFileSync("src/App.tsx", "utf8");
+
+const legacyFestivalRoutes = [
+  "world/festivals",
+  "world/festivals/:festivalId",
+  "festivals",
+  "festivals/marketplace",
+  "festivals/directory",
+  "festivals/:festivalId",
+  "festivals/simulation",
+  "festivals/perform/:participationId",
+  "festivals/:festivalId/manage",
+  "festivals/:festivalId/manage/editions/:editionId",
+  "festivals/sessions/:sessionId",
+  "festivals/:festivalId/calendar",
+  "festivals/:festivalId/run",
+];
+
+describe("legacy festival route boundary", () => {
+  it("wraps every player-facing legacy festival route in LegacyFestivalGate", () => {
+    for (const route of legacyFestivalRoutes) {
+      const pattern = new RegExp(
+        `<Route\\s+path=\\"${route.replace(/[/:]/g, (match) => `\\${match}`)}\\"\\s+element=\\{<LegacyFestivalGate`,
+      );
+      expect(appSource, `${route} must be feature gated`).toMatch(pattern);
+    }
+  });
+
+  it("leaves the admin diagnostic route reachable while aliases redirect to it", () => {
+    expect(appSource).toContain('path="admin/festivals" element={<FestivalsAdminPage />}');
+    expect(appSource).toContain('path="admin/festival" element={<Navigate to="/admin/festivals" replace />}');
+    expect(appSource).toContain('path="admin/festival-admin" element={<Navigate to="/admin/festivals" replace />}');
+    expect(appSource).toContain('path="admin/city-festivals" element={<Navigate to="/admin/festivals" replace />}');
+  });
+});


### PR DESCRIPTION
### Motivation
- The existing festival domain is fragmented across duplicate public, owner and admin surfaces with partial client-authoritative logic, so we need a safe, feature-flagged boundary before replacing it with a VIP-owned festival-company design. 
- This PR implements a non-destructive first step to prevent accidental usage of legacy festival routes while preserving admin diagnostics and avoiding any immediate destructive DB migrations.

### Description
- Imported the central replacement boundary and wrapped every player-facing legacy festival and World festival alias route in `LegacyFestivalGate` in `src/App.tsx`, so toggling the legacy flag shows a deliberate rebuild state instead of allowing access or redirects. 
- Added a source-level automated safeguard test `src/features/festival-company/__tests__/appRouteBoundary.test.ts` that asserts each known legacy festival route is covered by the gate and that the admin diagnostic route `/admin/festivals` remains reachable. 
- Kept the default behaviour conservative by leaving `legacyFestivalSystemEnabled` defaulted ON while `newFestivalSystemEnabled` and other festival feature flags default OFF in the existing feature-flag system, and avoided dropping or altering any production festival tables or RPCs. 
- Documented the safe replacement direction and retirement plan are available under `docs/festivals/` and the repository already contains ADRs under `docs/architecture/decisions/` describing festival-as-company, server-authoritative booking, immutable history and delayed destructive DB removal.

### Testing
- Added automated safeguards: the new `appRouteBoundary.test.ts` verifies route-level gating and admin route reachability and existing `featureFlags`/`legacyFestivalGate` tests cover flag resolution and UI fallback. 
- Attempted to run unit tests locally with `npm run test:unit -- <tests>`, but execution failed in this environment because `node_modules` is not installed and `vitest` is unavailable (`sh: 1: vitest: not found`), so tests were not executed here. 
- CI should run the added tests and existing festival-related tests (including feature-flag and gate tests) where a full install exists and will validate the gating behaviour and non-destructive safety boundary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61afb345488325971267821dfbdd7d)