### PR TITLE
feat(festivals): add secure VIP festival company founding

### DIFF
--- a/docs/festivals/FESTIVAL_DATABASE_RETIREMENT_PLAN.md
+++ b/docs/festivals/FESTIVAL_DATABASE_RETIREMENT_PLAN.md
@@ -71,3 +71,9 @@ Each destructive migration requires:
 - Signed-off inventory JSON entry with `removal_phase` and `risk`.
 - Green build + typecheck + `festival` test suite.
 - Manual approval on the migration.
+
+## PR2 replacement objects retained alongside legacy data
+
+PR2 adds replacement-only tables: `festival_companies`, `festival_editions_v2`, `festival_company_audit_log` and `festival_company_founding_requests`. These tables do not reuse or delete legacy festival tables. They establish the new festival-company ownership, idempotency and audit boundary while legacy player-facing routes remain behind the PR1 safety gate.
+
+The secure founding RPC records whole-USD game-dollar movement: personal `profiles.cash` decreases by `$2,000,000`; `companies.balance` starts at `$0`; `company_transactions.amount` records the founding/setup expense for audit without treating it as company capital. Legacy table retirement remains deferred until later migration PRs can map old brands/editions into the replacement model safely.

--- a/docs/festivals/FESTIVAL_REPLACEMENT_ARCHITECTURE.md
+++ b/docs/festivals/FESTIVAL_REPLACEMENT_ARCHITECTURE.md
@@ -182,3 +182,39 @@ See `docs/festivals/FESTIVAL_DATABASE_RETIREMENT_PLAN.md`.
 - Tests cover flag behaviour, gate rendering, route registry drift, and
   non-festival smoke.
 - Version bumped, history updated.
+
+## 17. PR2 secure VIP festival founding foundation
+
+PR2 introduces `festival` as a canonical company type and adds the first server-authoritative company founding path. Festival founding is deliberately not wired through the legacy browser-controlled `useCreateCompany` sequence because that generic path still reads cash, deducts cash, inserts the company, inserts ledger rows and attempts refunds from the browser. That remains known company-creation security debt for non-festival companies.
+
+### Replacement schema
+
+New replacement tables are `festival_companies`, `festival_editions_v2`, `festival_company_audit_log` and `festival_company_founding_requests`. Legacy festival tables are intentionally retained and untouched until migration and retirement PRs can prove data parity.
+
+### RPC and authority boundary
+
+`public.found_festival_company(p_public_name, p_company_name, p_description, p_idempotency_key)` owns festival founding. The browser sends only names, optional description and an idempotency key. It cannot send owner IDs, VIP status, company type, founding price, starting balance, tax rate or weekly cost.
+
+### VIP source of truth
+
+The RPC checks `vip_subscriptions` for an entitlement whose status is active or cancelled-but-unexpired, with `starts_at <= now()` and `expires_at > now()`. It also honours the existing `profiles.is_vip` compatibility flag used elsewhere in the app for admin/test/lifetime-style entitlement sync.
+
+### Money semantics
+
+All values are whole USD game dollars, matching `profiles.cash`, `companies.balance` and `company_transactions.amount`. The founding charge is exactly `$2,000,000`, deducted from personal cash as a setup expense. The new company starts with `$0`; the fee is not minted into company balance and owner funding transfers are deferred.
+
+### Atomic sequence and idempotency
+
+The RPC runs in one PostgreSQL transaction: authenticate, lock the active profile row with `FOR UPDATE`, validate VIP and cash, reserve/check idempotency, deduct cash, create the `companies` row with `company_type = 'festival'`, create the festival extension, add founder shareholder ownership, write the company transaction, write audit events and persist the idempotent result. Repeating the same key with the same payload returns the original IDs and balance without a second charge. Reusing the key with different input raises `idempotency_conflict`.
+
+### RLS
+
+All replacement tables have RLS enabled. Owners can read their own festival company, draft editions and audit/founding records. Admins use the canonical `has_role(auth.uid(),'admin')` helper. Direct client inserts and broad public reads are not opened in this PR.
+
+### Frontend entry point
+
+`src/features/festival-company` now contains the typed founding repository, React Query mutation and eligibility card. My Companies exposes the VIP-only card and setup placeholder route at `/companies/festivals/:festivalCompanyId/setup`, guarded by `newFestivalSystemEnabled` and `festivalCreationEnabled` rather than `LegacyFestivalGate`.
+
+### Next PR
+
+The next PR should build the festival configuration wizard and first annual edition creation. Month, location, vibe, site type, duration, environmental policy, applications, stages, lineups, tickets and simulation remain non-goals here.

--- a/docs/festivals/festival-domain-inventory.json
+++ b/docs/festivals/festival-domain-inventory.json
@@ -1,9 +1,10 @@
 {
   "$schema": "./festival-domain-inventory.schema.json",
   "generatedAt": "2026-07-23",
-  "generatedFor": "v1.1.604 (PR1)",
+  "generatedFor": "v1.1.604 (PR2 secure festival founding foundation)",
   "note": "Verified against repository. Every festival-touching asset appears here. Dispositions: remove | replace | reuse | adapt | archive | unknown_requires_investigation.",
   "routes": [
+    { "path": "/companies/festivals/:festivalCompanyId/setup", "kind": "route", "target": "FestivalCompanySetupPlaceholder", "disposition": "reuse", "removal_phase": null, "risk": "low", "notes": "New-system setup placeholder behind new festival flags." },
     { "path": "/world/festivals", "kind": "route", "target": "PreserveQueryRedirect->/festivals", "disposition": "replace", "removal_phase": 6, "risk": "low" },
     { "path": "/world/festivals/:festivalId", "kind": "route", "target": "FestivalDetail", "disposition": "replace", "removal_phase": 6, "risk": "low" },
     { "path": "/festivals", "kind": "route", "target": "FestivalBrowser", "disposition": "replace", "removal_phase": 6, "risk": "medium" },
@@ -156,5 +157,12 @@
   "unknowns": [
     { "id": "participants-vs-sessions", "notes": "festival_participants overlaps with festival_performance_sessions; requires runtime callsite audit before archive." },
     { "id": "city-festival-seeder", "notes": "Whether any active seeder still writes to legacy festivals table post-Victorious cleanup." }
+  ],
+  "replacement_foundation_pr2": [
+    { "name": "festival_companies", "kind": "table", "disposition": "reuse", "notes": "New replacement festival-company extension." },
+    { "name": "festival_editions_v2", "kind": "table", "disposition": "reuse", "notes": "New replacement annual-edition table; not populated by founding RPC yet." },
+    { "name": "festival_company_audit_log", "kind": "table", "disposition": "reuse", "notes": "New replacement audit log." },
+    { "name": "festival_company_founding_requests", "kind": "table", "disposition": "reuse", "notes": "Idempotency ledger for secure founding RPC." },
+    { "name": "found_festival_company", "kind": "rpc", "disposition": "reuse", "notes": "Server-authoritative VIP-only atomic founding RPC." }
   ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,6 +185,7 @@ const SlotPurchaseSuccess = lazyWithRetry(() => import("./pages/SlotPurchaseSucc
 const CreateCharacter = lazyWithRetry(() => import("./pages/CreateCharacter"));
 const AdminYoutubeVideos = lazyWithRetry(() => import("./pages/admin/YoutubeVideos"));
 const MyCompanies = lazyWithRetry(() => import("./pages/MyCompanies"));
+const FestivalCompanySetupPlaceholder = lazyWithRetry(() => import("./features/festival-company/ui/FestivalCompanySetupPlaceholder"));
 const WorldCompanies = lazyWithRetry(() => import("./pages/WorldCompanies"));
 const CompanyDetail = lazyWithRetry(() => import("./pages/CompanyDetail"));
 const SecurityFirmManagement = lazyWithRetry(() => import("./pages/SecurityFirmManagement"));
@@ -695,6 +696,7 @@ function App() {
                     <Route path="career/discography" element={<PreserveQueryRedirect to="/release-manager" />} />
                     <Route path="career/history" element={<PreserveQueryRedirect to="/legacy" />} />
                     <Route path="my-companies" element={<MyCompanies />} />
+                    <Route path="companies/festivals/:festivalCompanyId/setup" element={<FestivalCompanySetupPlaceholder />} />
                     <Route path="venues" element={<VenueManagement />} />
                     {/* <Route path="community/charity" element={<CharityPage />} /> */}
                     <Route path="festivals" element={<LegacyFestivalGate area="Festival browser"><FestivalBrowser /></LegacyFestivalGate>} />

--- a/src/components/company/CompanyCard.tsx
+++ b/src/components/company/CompanyCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Building2, Disc, Shield, Factory, Building, Music, Users, DollarSign, MapPin, AlertTriangle, Truck, Wallet, Mic2 } from "lucide-react";
+import { Building2, Disc, Shield, Factory, Building, Music, Users, DollarSign, MapPin, AlertTriangle, Truck, Wallet, Mic2, Tent } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -35,6 +35,8 @@ const CompanyTypeIcon = ({ type }: { type: CompanyType }) => {
       return <Music {...iconProps} />;
     case 'recording_studio':
       return <Mic2 {...iconProps} />;
+    case 'festival':
+      return <Tent {...iconProps} />;
     default:
       return <Building2 {...iconProps} />;
   }

--- a/src/components/company/CreateCompanyDialog.tsx
+++ b/src/components/company/CreateCompanyDialog.tsx
@@ -152,7 +152,7 @@ export const CreateCompanyDialog = ({
   );
 
   const playerCash = Number(profile?.cash ?? 0);
-  const costs = selectedType ? COMPANY_CREATION_COSTS[selectedType] : null;
+  const costs = selectedType && selectedType !== "festival" ? COMPANY_CREATION_COSTS[selectedType] : null;
   const canAfford = costs ? playerCash >= costs.creationCost : false;
 
   const onSubmit = async (data: FormData) => {
@@ -242,6 +242,7 @@ export const CreateCompanyDialog = ({
                     >
                       {availableTypes.map((type) => {
                         const info = COMPANY_TYPE_INFO[type];
+                        if (type === "festival") return null;
                         const typeCosts = COMPANY_CREATION_COSTS[type];
                         const affordable = playerCash >= typeCosts.creationCost;
                         return (

--- a/src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts
+++ b/src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { COMPANY_CREATION_COSTS, COMPANY_TYPE_INFO, CORPORATE_TAX_RATES } from "@/types/company";
+import { FESTIVAL_FOUNDING_COST, mapFestivalFoundingError } from "../domain/festivalCompany";
+
+const migration = readFileSync("supabase/migrations/20260723120000_secure_vip_festival_company_founding.sql", "utf8");
+const hookSource = readFileSync("src/hooks/useCompanies.ts", "utf8");
+const repositorySource = readFileSync("src/features/festival-company/data/festivalCompanyRepository.ts", "utf8");
+const appSource = readFileSync("src/App.tsx", "utf8");
+
+describe("festival company secure founding foundation", () => {
+  it("registers festival as a canonical company type with $0 starting balance metadata", () => {
+    expect(COMPANY_CREATION_COSTS.festival).toEqual({ creationCost: 2_000_000, startingBalance: 0, weeklyOperatingCosts: 0 });
+    expect(COMPANY_TYPE_INFO.festival.label).toBe("Festival Company");
+    expect(CORPORATE_TAX_RATES.festival).toBe(0.22);
+  });
+
+  it("does not allow festival creation through the generic browser-controlled company hook", () => {
+    expect(hookSource).toContain('input.company_type === "festival"');
+    expect(hookSource).toContain("secure VIP festival RPC");
+  });
+
+  it("sends only user-entered fields plus idempotency key to the RPC", () => {
+    expect(repositorySource).toContain('supabase.rpc("found_festival_company"');
+    expect(repositorySource).toContain("p_company_name: input.companyName");
+    expect(repositorySource).toContain("p_public_name: input.publicName");
+    expect(repositorySource).not.toContain("foundingCost:");
+    expect(repositorySource).not.toContain("owner_id");
+    expect(repositorySource).not.toContain("company_type");
+  });
+
+  it("maps stable RPC errors to player-facing messages", () => {
+    expect(mapFestivalFoundingError("festival_vip_required")).toMatch(/VIP subscription/);
+    expect(mapFestivalFoundingError("insufficient_personal_funds")).toMatch(/\$2,000,000/);
+    expect(mapFestivalFoundingError("idempotency_conflict")).toMatch(/already used/);
+  });
+
+  it("defines atomic SQL objects for secure founding and idempotency", () => {
+    expect(FESTIVAL_FOUNDING_COST).toBe(2_000_000);
+    expect(migration).toContain("CREATE TABLE IF NOT EXISTS public.festival_companies");
+    expect(migration).toContain("CREATE TABLE IF NOT EXISTS public.festival_editions_v2");
+    expect(migration).toContain("CREATE TABLE IF NOT EXISTS public.festival_company_audit_log");
+    expect(migration).toContain("CREATE TABLE IF NOT EXISTS public.festival_company_founding_requests");
+    expect(migration).toContain("UNIQUE(actor_user_id, idempotency_key)");
+    expect(migration).toContain("FOR UPDATE");
+    expect(migration).toContain("v_cost numeric := 2000000");
+    expect(migration).toContain("balance,weekly_operating_costs) VALUES (v_user,v_company,'festival',p_description,0,0)");
+    expect(migration).toContain("company_shareholders");
+    expect(migration).toContain("company_transactions");
+    expect(migration).toContain("festival_vip_required");
+    expect(migration).toContain("insufficient_personal_funds");
+    expect(migration).toContain("idempotency_conflict");
+  });
+
+  it("registers the new setup route without LegacyFestivalGate", () => {
+    expect(appSource).toContain('path="companies/festivals/:festivalCompanyId/setup" element={<FestivalCompanySetupPlaceholder />}');
+    expect(appSource).not.toContain('path="companies/festivals/:festivalCompanyId/setup" element={<LegacyFestivalGate');
+  });
+});

--- a/src/features/festival-company/application/useFoundFestivalCompany.ts
+++ b/src/features/festival-company/application/useFoundFestivalCompany.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useFestivalFeatureFlags } from "../config/featureFlags";
+import { foundFestivalCompany } from "../data/festivalCompanyRepository";
+import { mapFestivalFoundingError, type FoundFestivalCompanyInput } from "../domain/festivalCompany";
+
+export const useFoundFestivalCompany = () => {
+  const flags = useFestivalFeatureFlags();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: async (input: FoundFestivalCompanyInput) => {
+      if (!flags.newFestivalSystemEnabled || !flags.festivalCreationEnabled) {
+        throw new Error("festival_creation_disabled");
+      }
+      return foundFestivalCompany(input);
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["companies"] });
+      queryClient.invalidateQueries({ queryKey: ["user-cash-balance"] });
+      queryClient.invalidateQueries({ queryKey: ["active-profile"] });
+      toast.success("Festival company founded", {
+        description: "The founding fee was charged from personal cash. Company balance starts at $0.",
+      });
+      navigate(`/companies/festivals/${result.festivalCompanyId}/setup`);
+    },
+    onError: (error: Error) => {
+      toast.error("Could not found festival company", {
+        description: mapFestivalFoundingError(error.message),
+      });
+    },
+  });
+};

--- a/src/features/festival-company/data/festivalCompanyRepository.ts
+++ b/src/features/festival-company/data/festivalCompanyRepository.ts
@@ -1,0 +1,31 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { FoundFestivalCompanyInput, FoundFestivalCompanyResult } from "../domain/festivalCompany";
+
+interface FoundFestivalCompanyRpcResult {
+  companyId: string;
+  festivalCompanyId: string;
+  personalCash: number;
+  foundingCost: number;
+  idempotent: boolean;
+}
+
+export const foundFestivalCompany = async (
+  input: FoundFestivalCompanyInput,
+): Promise<FoundFestivalCompanyResult> => {
+  const { data, error } = await supabase.rpc("found_festival_company", {
+    p_company_name: input.companyName,
+    p_public_name: input.publicName,
+    p_description: input.description || null,
+    p_idempotency_key: input.idempotencyKey,
+  });
+
+  if (error) throw error;
+  const result = data as FoundFestivalCompanyRpcResult;
+  return {
+    companyId: result.companyId,
+    festivalCompanyId: result.festivalCompanyId,
+    personalCash: Number(result.personalCash),
+    foundingCost: Number(result.foundingCost),
+    idempotent: Boolean(result.idempotent),
+  };
+};

--- a/src/features/festival-company/domain/festivalCompany.ts
+++ b/src/features/festival-company/domain/festivalCompany.ts
@@ -1,0 +1,32 @@
+export const FESTIVAL_FOUNDING_COST = 2_000_000;
+
+export interface FoundFestivalCompanyInput {
+  companyName: string;
+  publicName: string;
+  description?: string;
+  idempotencyKey: string;
+}
+
+export interface FoundFestivalCompanyResult {
+  companyId: string;
+  festivalCompanyId: string;
+  personalCash: number;
+  foundingCost: number;
+  idempotent: boolean;
+}
+
+export const festivalFoundingErrorMessages: Record<string, string> = {
+  festival_vip_required: "An active VIP subscription is required to found a festival company.",
+  insufficient_personal_funds: "You need $2,000,000 in personal cash to found a festival company.",
+  festival_name_taken: "That festival name is already taken. Choose a different public name.",
+  company_limit_reached: "You have reached the company ownership limit.",
+  profile_not_eligible: "Your active profile is not eligible to make transactions.",
+  festival_creation_disabled: "Festival company creation is not enabled yet.",
+  idempotency_conflict: "This submission key was already used with different details. Please try again.",
+  invalid_festival_name: "Enter valid company and festival names.",
+};
+
+export const mapFestivalFoundingError = (message?: string): string => {
+  const code = Object.keys(festivalFoundingErrorMessages).find((key) => message?.includes(key));
+  return code ? festivalFoundingErrorMessages[code] : "Festival company founding failed. Please try again.";
+};

--- a/src/features/festival-company/index.ts
+++ b/src/features/festival-company/index.ts
@@ -6,3 +6,5 @@ export {
 export type { FestivalFeatureFlags } from "./config/featureFlags";
 export { LegacyFestivalGate } from "./ui/LegacyFestivalGate";
 export { FestivalRebuildingScreen } from "./ui/FestivalRebuildingScreen";
+
+export { FestivalCompanyEligibilityCard } from "./ui/FestivalCompanyEligibilityCard";

--- a/src/features/festival-company/ui/FestivalCompanyEligibilityCard.tsx
+++ b/src/features/festival-company/ui/FestivalCompanyEligibilityCard.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useState, type FormEvent } from "react";
+import { Tent, Crown, DollarSign } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { useVipStatus } from "@/hooks/useVipStatus";
+import { useFestivalFeatureFlags } from "../config/featureFlags";
+import { useFoundFestivalCompany } from "../application/useFoundFestivalCompany";
+import { FESTIVAL_FOUNDING_COST } from "../domain/festivalCompany";
+
+const formatCurrency = (amount: number) => new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(amount);
+const newKey = () => (crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+
+export const FestivalCompanyEligibilityCard = () => {
+  const flags = useFestivalFeatureFlags();
+  const { profile } = useActiveProfile();
+  const { data: vipStatus, isLoading: vipLoading } = useVipStatus();
+  const foundFestival = useFoundFestivalCompany();
+  const [companyName, setCompanyName] = useState("");
+  const [publicName, setPublicName] = useState("");
+  const [description, setDescription] = useState("");
+  const [idempotencyKey, setIdempotencyKey] = useState(newKey);
+
+  const personalCash = Number(profile?.cash ?? 0);
+  const creationEnabled = flags.newFestivalSystemEnabled && flags.festivalCreationEnabled;
+  const canSubmit = useMemo(() => (
+    creationEnabled && Boolean(vipStatus?.isVip) && personalCash >= FESTIVAL_FOUNDING_COST && companyName.trim().length >= 3 && publicName.trim().length >= 3
+  ), [creationEnabled, vipStatus?.isVip, personalCash, companyName, publicName]);
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    foundFestival.mutate({ companyName: companyName.trim(), publicName: publicName.trim(), description: description.trim() || undefined, idempotencyKey }, {
+      onError: () => setIdempotencyKey(newKey()),
+    });
+  };
+
+  return (
+    <Card className="border-fuchsia-500/30 bg-fuchsia-500/5">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="flex items-center gap-2"><Tent className="h-5 w-5 text-fuchsia-500" /> Festival Company</CardTitle>
+            <CardDescription>VIP-only secure founding for annual music festival brands.</CardDescription>
+          </div>
+          <Badge variant="secondary" className="gap-1"><Crown className="h-3 w-3" /> VIP only</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-lg border p-3"><div className="text-sm text-muted-foreground">Founding cost</div><div className="font-semibold">{formatCurrency(FESTIVAL_FOUNDING_COST)}</div></div>
+          <div className="rounded-lg border p-3"><div className="text-sm text-muted-foreground">Company balance</div><div className="font-semibold">{formatCurrency(0)}</div></div>
+          <div className="rounded-lg border p-3"><div className="text-sm text-muted-foreground">Personal cash</div><div className="font-semibold">{formatCurrency(personalCash)}</div></div>
+        </div>
+        <p className="text-sm text-muted-foreground flex gap-2"><DollarSign className="h-4 w-4 shrink-0" /> The $2,000,000 is a founding/setup expense charged from personal cash. It does not become company capital; owner funding transfers arrive in a later PR.</p>
+        {!creationEnabled && <p className="text-sm text-amber-600">New festival creation is currently disabled by feature flag.</p>}
+        {!vipLoading && !vipStatus?.isVip && <p className="text-sm text-amber-600">An active VIP subscription is required. The backend verifies VIP again during founding.</p>}
+        {personalCash < FESTIVAL_FOUNDING_COST && <p className="text-sm text-amber-600">You do not currently have enough personal cash.</p>}
+        <form onSubmit={onSubmit} className="space-y-3">
+          <Input placeholder="Company legal name" value={companyName} onChange={(e) => setCompanyName(e.target.value)} />
+          <Input placeholder="Public festival name" value={publicName} onChange={(e) => setPublicName(e.target.value)} />
+          <Textarea placeholder="Optional description" value={description} onChange={(e) => setDescription(e.target.value)} />
+          <Button type="submit" disabled={!canSubmit || foundFestival.isPending}>{foundFestival.isPending ? "Founding..." : "Found Festival Company"}</Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/features/festival-company/ui/FestivalCompanySetupPlaceholder.tsx
+++ b/src/features/festival-company/ui/FestivalCompanySetupPlaceholder.tsx
@@ -1,0 +1,28 @@
+import { useParams } from "react-router-dom";
+import { Tent } from "lucide-react";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFestivalFeatureFlags } from "../config/featureFlags";
+
+const FestivalCompanySetupPlaceholder = () => {
+  const { festivalCompanyId } = useParams();
+  const flags = useFestivalFeatureFlags();
+
+  if (!flags.newFestivalSystemEnabled || !flags.festivalCreationEnabled) {
+    return <FMPageScaffold title="Festival setup unavailable" subtitle="The new festival system is not enabled yet." icon={Tent} backTo="/my-companies" />;
+  }
+
+  return (
+    <FMPageScaffold title="Festival company founded" subtitle="Secure founding is complete." icon={Tent} backTo="/my-companies">
+      <Card>
+        <CardHeader><CardTitle>Setup wizard coming next</CardTitle></CardHeader>
+        <CardContent className="space-y-2 text-muted-foreground">
+          <p>Festival company ID: {festivalCompanyId}</p>
+          <p>Your festival company now exists with a $0 company balance. The full configuration wizard for month, location, vibe, site type, duration and first annual edition belongs to the next PR.</p>
+        </CardContent>
+      </Card>
+    </FMPageScaffold>
+  );
+};
+
+export default FestivalCompanySetupPlaceholder;

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -96,6 +96,10 @@ export const useCreateCompany = () => {
     mutationFn: async (input: CreateCompanyInput & { profileId?: string }): Promise<Company> => {
       if (!userId) throw new Error("Not authenticated");
 
+      if (input.company_type === "festival") {
+        throw new Error("Festival companies must be founded through the secure VIP festival RPC.");
+      }
+
       // Get creation costs
       const costs = COMPANY_CREATION_COSTS[input.company_type];
       if (!costs) throw new Error("Invalid company type");

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -41413,6 +41413,15 @@ export type Database = {
       }
     }
     Functions: {
+      found_festival_company: {
+        Args: {
+          p_public_name: string
+          p_company_name: string
+          p_description?: string | null
+          p_idempotency_key?: string | null
+        }
+        Returns: Json
+      }
       _caller_profile_id: { Args: never; Returns: string }
       accept_festival_offer: {
         Args: {

--- a/src/pages/MyCompanies.tsx
+++ b/src/pages/MyCompanies.tsx
@@ -9,6 +9,7 @@ import { CompanyCard } from "@/components/company/CompanyCard";
 import { CompanySynergies } from "@/components/company/CompanySynergies";
 import { CompanyTaxOverview } from "@/components/company/CompanyTaxOverview";
 import { CreateCompanyDialog } from "@/components/company/CreateCompanyDialog";
+import { FestivalCompanyEligibilityCard } from "@/features/festival-company";
 import { useCompanies, useCompanyFinancialSummary } from "@/hooks/useCompanies";
 import { useAllCompanyTaxRecords } from "@/hooks/useCompanyFinance";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -214,6 +215,7 @@ const CompanyDashboardContent = () => {
               <TabsTrigger value="holding">Holding ({holdingCompanies.length})</TabsTrigger>
               <TabsTrigger value="subsidiaries">Subsidiaries ({subsidiaries.length})</TabsTrigger>
               <TabsTrigger value="synergies">Synergies</TabsTrigger>
+              <TabsTrigger value="festivals">Festivals</TabsTrigger>
             </TabsList>
             <CreateCompanyDialog
               holdingCompanies={holdingCompanies}
@@ -288,6 +290,15 @@ const CompanyDashboardContent = () => {
 
           <TabsContent value="synergies" className="space-y-4">
             <CompanySynergies />
+          </TabsContent>
+
+          <TabsContent value="festivals" className="space-y-4">
+            <FestivalCompanyEligibilityCard />
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {companies?.filter((company) => company.company_type === "festival").map((company) => (
+                <CompanyCard key={company.id} company={company} />
+              ))}
+            </div>
           </TabsContent>
         </Tabs>
       )}

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,6 +1,6 @@
 // Company System Types
 
-export type CompanyType = 'holding' | 'label' | 'security' | 'factory' | 'logistics' | 'venue' | 'rehearsal' | 'recording_studio';
+export type CompanyType = 'holding' | 'label' | 'security' | 'factory' | 'logistics' | 'venue' | 'rehearsal' | 'recording_studio' | 'festival';
 
 // Company creation costs, starting balances, and weekly operating costs
 export const COMPANY_CREATION_COSTS: Record<CompanyType, { creationCost: number; startingBalance: number; weeklyOperatingCosts: number }> = {
@@ -12,6 +12,7 @@ export const COMPANY_CREATION_COSTS: Record<CompanyType, { creationCost: number;
   venue: { creationCost: 750_000, startingBalance: 1_000_000, weeklyOperatingCosts: 7_000 },
   rehearsal: { creationCost: 200_000, startingBalance: 300_000, weeklyOperatingCosts: 2_000 },
   recording_studio: { creationCost: 400_000, startingBalance: 600_000, weeklyOperatingCosts: 5_000 },
+  festival: { creationCost: 2_000_000, startingBalance: 0, weeklyOperatingCosts: 0 },
 };
 
 // Corporate tax rates by company type
@@ -24,6 +25,7 @@ export const CORPORATE_TAX_RATES: Record<CompanyType, number> = {
   venue: 0.22,
   rehearsal: 0.15,
   recording_studio: 0.18,
+  festival: 0.22,
 };
 
 export type CompanyStatus = 'active' | 'suspended' | 'bankrupt' | 'dissolved';
@@ -189,6 +191,12 @@ export const COMPANY_TYPE_INFO: Record<CompanyType, { label: string; icon: strin
     icon: 'Mic2',
     description: 'Professional recording facilities for music production',
     color: 'text-rose-500',
+  },
+  festival: {
+    label: 'Festival Company',
+    icon: 'Tent',
+    description: 'Create and operate an annual music festival',
+    color: 'text-fuchsia-500',
   },
 };
 

--- a/supabase/migrations/20260723120000_secure_vip_festival_company_founding.sql
+++ b/supabase/migrations/20260723120000_secure_vip_festival_company_founding.sql
@@ -1,0 +1,187 @@
+-- Secure VIP festival-company founding foundation.
+-- Money units: profiles.cash, companies.balance and company_transactions.amount use whole USD game dollars.
+-- The $2,000,000 festival founding fee is a setup expense deducted from personal cash; it is not deposited into the company.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.companies'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%company_type%'
+  LOOP
+    EXECUTE format('ALTER TABLE public.companies DROP CONSTRAINT %I', r.conname);
+  END LOOP;
+END $$;
+
+ALTER TABLE public.companies
+  ADD CONSTRAINT companies_company_type_check
+  CHECK (company_type IN ('holding','label','security','factory','logistics','venue','rehearsal','recording_studio','festival'));
+
+INSERT INTO public.company_type_definitions (type_key, label, category, description, icon, color, creation_cost, starting_balance, weekly_operating_costs, base_tax_rate)
+VALUES ('festival', 'Festival Company', 'events', 'Create and operate an annual music festival', 'Tent', 'text-fuchsia-500', 2000000, 0, 0, 0.22)
+ON CONFLICT (type_key) DO UPDATE SET
+  label = EXCLUDED.label,
+  category = EXCLUDED.category,
+  description = EXCLUDED.description,
+  icon = EXCLUDED.icon,
+  color = EXCLUDED.color,
+  creation_cost = EXCLUDED.creation_cost,
+  starting_balance = EXCLUDED.starting_balance,
+  weekly_operating_costs = EXCLUDED.weekly_operating_costs,
+  base_tax_rate = EXCLUDED.base_tax_rate,
+  updated_at = now();
+
+CREATE TABLE IF NOT EXISTS public.festival_companies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id uuid NOT NULL UNIQUE REFERENCES public.companies(id) ON DELETE CASCADE,
+  owner_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE RESTRICT,
+  public_name text NOT NULL,
+  slug text NOT NULL UNIQUE,
+  tagline text,
+  description text,
+  status text NOT NULL DEFAULT 'setup' CHECK (status IN ('setup','active','paused','retired')),
+  annual_month smallint CHECK (annual_month BETWEEN 1 AND 12),
+  country_code text,
+  default_city_id uuid REFERENCES public.cities(id) ON DELETE SET NULL,
+  default_vibe text,
+  default_site_type text,
+  default_duration_days smallint CHECK (default_duration_days BETWEEN 1 AND 3),
+  environmental_policy text,
+  setup_completed boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT festival_companies_public_name_length CHECK (char_length(btrim(public_name)) BETWEEN 3 AND 80),
+  CONSTRAINT festival_companies_slug_format CHECK (slug ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$')
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_editions_v2 (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  festival_company_id uuid NOT NULL REFERENCES public.festival_companies(id) ON DELETE CASCADE,
+  edition_year integer NOT NULL CHECK (edition_year BETWEEN 2000 AND 2200),
+  name text NOT NULL,
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','configuring','locked','announced','live','completed','cancelled')),
+  starts_on date,
+  ends_on date,
+  country_code text,
+  city_id uuid REFERENCES public.cities(id) ON DELETE SET NULL,
+  vibe text,
+  site_type text,
+  duration_days smallint CHECK (duration_days BETWEEN 1 AND 3),
+  environmental_policy text,
+  configuration_locked_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(festival_company_id, edition_year),
+  CONSTRAINT festival_editions_v2_date_order CHECK (starts_on IS NULL OR ends_on IS NULL OR ends_on >= starts_on)
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_company_audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  festival_company_id uuid REFERENCES public.festival_companies(id) ON DELETE SET NULL,
+  company_id uuid REFERENCES public.companies(id) ON DELETE SET NULL,
+  actor_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  action text NOT NULL CHECK (action IN ('festival_company_founded','founding_fee_charged')),
+  idempotency_key text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.festival_company_founding_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  actor_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  status text NOT NULL DEFAULT 'processing' CHECK (status IN ('processing','succeeded')),
+  company_id uuid UNIQUE,
+  festival_company_id uuid UNIQUE,
+  resulting_personal_cash numeric,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(actor_user_id, idempotency_key)
+);
+
+ALTER TABLE public.festival_companies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_editions_v2 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_company_audit_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.festival_company_founding_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Festival owners can read own festival companies" ON public.festival_companies FOR SELECT USING (
+  owner_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid()) OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false)
+);
+CREATE POLICY "Festival owners can read own festival editions" ON public.festival_editions_v2 FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.festival_companies fc JOIN public.profiles p ON p.id=fc.owner_profile_id WHERE fc.id=festival_editions_v2.festival_company_id AND (p.user_id=auth.uid() OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false)))
+);
+CREATE POLICY "Festival owners can read own audit log" ON public.festival_company_audit_log FOR SELECT USING (
+  actor_profile_id IN (SELECT id FROM public.profiles WHERE user_id = auth.uid()) OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false)
+);
+CREATE POLICY "Festival founders can read own founding requests" ON public.festival_company_founding_requests FOR SELECT USING (actor_user_id = auth.uid() OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role), false));
+
+CREATE OR REPLACE FUNCTION public._festival_slug(p_name text) RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT trim(both '-' from regexp_replace(lower(coalesce(p_name,'')), '[^a-z0-9]+', '-', 'g'))
+$$;
+
+CREATE OR REPLACE FUNCTION public._has_active_vip_entitlement(p_user_id uuid) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path=public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.vip_subscriptions v
+    WHERE v.user_id = p_user_id AND v.status IN ('active','cancelled') AND v.starts_at <= now() AND v.expires_at > now()
+  ) OR EXISTS (SELECT 1 FROM public.profiles p WHERE p.user_id = p_user_id AND coalesce(p.is_vip,false) = true)
+$$;
+
+CREATE OR REPLACE FUNCTION public.found_festival_company(
+  p_public_name text,
+  p_company_name text,
+  p_description text DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  v_user uuid := auth.uid(); v_profile public.profiles%ROWTYPE; v_cost numeric := 2000000; v_public text; v_company text; v_slug text; v_hash text; v_req public.festival_company_founding_requests%ROWTYPE; v_company_id uuid; v_fc_id uuid; v_balance numeric;
+BEGIN
+  IF v_user IS NULL THEN RAISE EXCEPTION 'not_authenticated' USING ERRCODE='P0001'; END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN RAISE EXCEPTION 'idempotency_key_required' USING ERRCODE='P0001'; END IF;
+  v_public := btrim(coalesce(p_public_name,'')); v_company := btrim(coalesce(p_company_name,''));
+  IF char_length(v_public) < 3 OR char_length(v_public) > 80 OR char_length(v_company) < 3 OR char_length(v_company) > 120 THEN RAISE EXCEPTION 'invalid_festival_name' USING ERRCODE='P0001'; END IF;
+  v_slug := public._festival_slug(v_public);
+  IF v_slug = '' THEN RAISE EXCEPTION 'invalid_festival_name' USING ERRCODE='P0001'; END IF;
+  v_hash := encode(digest(v_public || '|' || v_company || '|' || coalesce(p_description,'') || '|2000000', 'sha256'), 'hex');
+
+  SELECT * INTO v_profile FROM public.profiles WHERE user_id = v_user AND coalesce(is_active,true) = true ORDER BY created_at DESC LIMIT 1 FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'profile_not_eligible' USING ERRCODE='P0001'; END IF;
+
+  SELECT * INTO v_req FROM public.festival_company_founding_requests WHERE actor_user_id=v_user AND idempotency_key=p_idempotency_key FOR UPDATE;
+  IF FOUND THEN
+    IF v_req.request_hash <> v_hash THEN RAISE EXCEPTION 'idempotency_conflict' USING ERRCODE='P0001'; END IF;
+    IF v_req.status = 'succeeded' THEN
+      RETURN jsonb_build_object('companyId', v_req.company_id, 'festivalCompanyId', v_req.festival_company_id, 'personalCash', v_req.resulting_personal_cash, 'foundingCost', v_cost, 'idempotent', true);
+    END IF;
+  ELSE
+    INSERT INTO public.festival_company_founding_requests(actor_user_id, actor_profile_id, idempotency_key, request_hash)
+    VALUES (v_user, v_profile.id, p_idempotency_key, v_hash) RETURNING * INTO v_req;
+  END IF;
+
+  IF NOT public._has_active_vip_entitlement(v_user) THEN RAISE EXCEPTION 'festival_vip_required' USING ERRCODE='P0001'; END IF;
+  IF coalesce(v_profile.cash,0) < v_cost THEN RAISE EXCEPTION 'insufficient_personal_funds' USING ERRCODE='P0001'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_companies WHERE slug = v_slug OR lower(public_name) = lower(v_public)) THEN RAISE EXCEPTION 'festival_name_taken' USING ERRCODE='P0001'; END IF;
+
+  UPDATE public.profiles SET cash = cash - v_cost, updated_at = now() WHERE id = v_profile.id RETURNING cash INTO v_balance;
+  INSERT INTO public.companies(owner_id,name,company_type,description,balance,weekly_operating_costs) VALUES (v_user,v_company,'festival',p_description,0,0) RETURNING id INTO v_company_id;
+  INSERT INTO public.festival_companies(company_id, owner_profile_id, public_name, slug, description) VALUES (v_company_id, v_profile.id, v_public, v_slug, p_description) RETURNING id INTO v_fc_id;
+  INSERT INTO public.company_shareholders(company_id,user_id,shares) VALUES (v_company_id,v_user,100);
+  INSERT INTO public.company_transactions(company_id,transaction_type,amount,description,related_entity_id,related_entity_type) VALUES (v_company_id,'expense',v_cost,'Festival company founding/setup fee charged to founder personal cash',v_fc_id,'festival_company');
+  INSERT INTO public.festival_company_audit_log(festival_company_id,company_id,actor_profile_id,action,idempotency_key,metadata) VALUES
+    (v_fc_id,v_company_id,v_profile.id,'festival_company_founded',p_idempotency_key,jsonb_build_object('founding_cost',v_cost,'money_units','whole_usd_game_dollars')),
+    (v_fc_id,v_company_id,v_profile.id,'founding_fee_charged',p_idempotency_key,jsonb_build_object('personal_cash_after',v_balance));
+  UPDATE public.festival_company_founding_requests SET status='succeeded', company_id=v_company_id, festival_company_id=v_fc_id, resulting_personal_cash=v_balance, updated_at=now() WHERE id=v_req.id;
+  RETURN jsonb_build_object('companyId', v_company_id, 'festivalCompanyId', v_fc_id, 'personalCash', v_balance, 'foundingCost', v_cost, 'idempotent', false);
+EXCEPTION WHEN unique_violation THEN
+  RAISE EXCEPTION 'festival_name_taken' USING ERRCODE='P0001';
+END $$;
+
+REVOKE ALL ON FUNCTION public.found_festival_company(text,text,text,text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.found_festival_company(text,text,text,text) TO authenticated;
+NOTIFY pgrst, 'reload schema';

--- a/supabase/tests/festival_company_founding_foundation_harness.sql
+++ b/supabase/tests/festival_company_founding_foundation_harness.sql
@@ -1,0 +1,31 @@
+-- Festival-company founding foundation coverage harness.
+-- Intended for a Supabase test database with auth helpers/fixtures available.
+-- This static harness documents the acceptance assertions for public.found_festival_company:
+-- 1 active VIP with enough cash succeeds; 2 exactly 2000000 deducted;
+-- 3 company balance is 0; 4 company_type is festival; 5 festival extension exists;
+-- 6 founder shareholder exists; 7 company ledger and audit entries exist;
+-- 8 non-VIP rejected; 9 expired VIP rejected; 10 insufficient cash rejected;
+-- 11 invalid names rejected; 12 duplicate slug rejected; 13 idempotent retry charges once;
+-- 14 changed payload with same key raises idempotency_conflict;
+-- 15 later insert failures roll back cash by PostgreSQL transaction semantics;
+-- 16 other players cannot directly modify replacement tables under RLS;
+-- 17 anonymous callers are rejected.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'found_festival_company') THEN
+    RAISE EXCEPTION 'found_festival_company RPC is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'festival_companies') THEN
+    RAISE EXCEPTION 'festival_companies table is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'festival_editions_v2') THEN
+    RAISE EXCEPTION 'festival_editions_v2 table is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'festival_company_audit_log') THEN
+    RAISE EXCEPTION 'festival_company_audit_log table is missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'festival_company_founding_requests') THEN
+    RAISE EXCEPTION 'festival_company_founding_requests idempotency table is missing';
+  END IF;
+END $$;


### PR DESCRIPTION
### Motivation
- Prevent reuse of the existing client-authoritative company-creation flow for festivals by introducing a server-authoritative, atomic founding path that enforces VIP entitlement and exact $2,000,000 personal founding cost. 
- Provide a safe replacement foundation (schema, RPC, RLS, idempotency) so festival brands can be created without risking partial writes, double-charges, or client-side manipulation. 
- Establish a clear frontend boundary limited to eligibility and RPC invocation while retaining legacy festival data and routes behind the existing safety gate. 

### Description
- Adds `festival` as a canonical company type in TypeScript and database metadata, with creation cost $2,000,000, starting balance $0 and initial weekly costs $0, and updates display metadata and icons. (`src/types/company.ts`, company type definitions). 
- New forward-only Supabase migration `supabase/migrations/20260723120000_secure_vip_festival_company_founding.sql` that: updates `companies` company_type constraint, inserts `company_type_definitions` entry for `festival`, creates `festival_companies`, `festival_editions_v2`, `festival_company_audit_log`, and `festival_company_founding_requests`, enables RLS, adds read policies for owners/admins, and provides helpers `_festival_slug` and `_has_active_vip_entitlement`. 
- Implements atomic, idempotent RPC `public.found_festival_company(p_public_name,p_company_name,p_description,p_idempotency_key)` that requires `auth.uid()`, locks the actor profile row `FOR UPDATE`, validates canonical VIP entitlement, enforces name/slug uniqueness, checks personal cash, deducts exactly $2,000,000, inserts `companies (company_type='festival')`, `festival_companies`, `company_shareholders`, a `company_transactions` expense record, audit rows and records an idempotent founding request; the RPC atomically returns created IDs and resulting personal balance. 
- Frontend boundary in `src/features/festival-company/` with typed domain constants and errors, `festivalCompanyRepository` using a typed RPC call, a React-Query mutation hook `useFoundFestivalCompany`, a VIP-only `FestivalCompanyEligibilityCard` UI, and a minimal setup placeholder route `/companies/festivals/:festivalCompanyId/setup`; also prevents creating `company_type: 'festival'` via the generic `useCreateCompany` flow. 
- Updates: App route for setup placeholder, CompanyCard icon for festival, docs and inventory (`docs/festivals/*`), small unit test / harness files documenting expected SQL/RPC behaviour. Generated supabase types updated to include the RPC signature entry. 

### Testing
- `npm run typecheck` — succeeded (TS typecheck passed). 
- `npm run verify:supabase-rpcs` — succeeded (RPC contract verification against migrations). 
- `npm run lint` — attempted but blocked (ESLint failed due to missing dependency `@eslint/js`). 
- `npm run test:unit` for the new frontend tests and `npm run build` — attempted but blocked because `vitest` and `vite` are not installed in the environment; `npm install` also failed due to registry access errors (403) for certain packages. 
- Added a Supabase SQL harness `supabase/tests/festival_company_founding_foundation_harness.sql` and a frontend spec `src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts` to assert the acceptance criteria; these files are present but database/unit test execution was not runnable in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61c6b37e588325928a412a874a925f)