### PR TITLE
fix(festivals): complete runtime gate and secure founding internals

### DIFF
--- a/src/features/festival-company/__tests__/festivalCompanyParsers.test.ts
+++ b/src/features/festival-company/__tests__/festivalCompanyParsers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCapabilityObject,
+  isFestivalSetupState,
+  isFoundFestivalCompanyRpcResult,
+  isOwnedFestivalCompanySummary,
+} from "../data/festivalCompanyRepository";
+
+const uuid = "81280000-0000-4000-8000-000000000001";
+const uuid2 = "81280000-0000-4000-8000-000000000002";
+
+describe("festival company strict RPC parsers", () => {
+  it("requires complete founding results with a valid finance transaction and canonical cost", () => {
+    expect(isFoundFestivalCompanyRpcResult({
+      companyId: uuid,
+      festivalCompanyId: uuid2,
+      personalFinancialTransactionId: "81280000-0000-4000-8000-000000000003",
+      personalCash: 8_000_000,
+      foundingCost: 2_000_000,
+      idempotent: false,
+    })).toBe(true);
+
+    expect(isFoundFestivalCompanyRpcResult({ companyId: uuid, festivalCompanyId: uuid2, personalCash: 8_000_000, foundingCost: 1, idempotent: false })).toBe(false);
+    expect(isFoundFestivalCompanyRpcResult({ companyId: uuid, festivalCompanyId: uuid2, personalFinancialTransactionId: "not-a-uuid", personalCash: 8_000_000, foundingCost: 2_000_000, idempotent: false })).toBe(false);
+  });
+
+  it("fails closed for partial setup, capabilities and owned-company records", () => {
+    expect(isCapabilityObject({
+      newFestivalSystemEnabled: true,
+      festivalCompanyCreationEnabled: true,
+      festivalCompanyManagementEnabled: true,
+      festivalConfigurationEnabled: true,
+      companyLimit: 3,
+    })).toBe(true);
+    expect(isCapabilityObject({ newFestivalSystemEnabled: true, companyLimit: 3 })).toBe(false);
+
+    expect(isFestivalSetupState({
+      festivalCompanyId: uuid,
+      companyId: uuid2,
+      publicName: "Runtime Fest",
+      legalCompanyName: "Runtime LLC",
+      companyBalance: 0,
+      isBankrupt: false,
+      setupCompleted: false,
+      configurationComplete: false,
+      firstEditionExists: false,
+    })).toBe(true);
+    expect(isFestivalSetupState({ festivalCompanyId: uuid, companyId: uuid2, publicName: "", legalCompanyName: "Runtime LLC" })).toBe(false);
+
+    expect(isOwnedFestivalCompanySummary({
+      festivalCompanyId: uuid,
+      companyId: uuid2,
+      publicName: "Runtime Fest",
+      legalCompanyName: "Runtime LLC",
+      setupStatus: "setup_required",
+      setupCompleted: false,
+      configurationComplete: false,
+      firstEditionExists: false,
+      companyBalance: 0,
+      managementEnabled: true,
+    })).toBe(true);
+    expect(isOwnedFestivalCompanySummary({ festivalCompanyId: uuid, companyId: uuid2, publicName: "Runtime Fest", legalCompanyName: "Runtime LLC" })).toBe(false);
+  });
+});

--- a/src/features/festival-company/data/festivalCompanyRepository.ts
+++ b/src/features/festival-company/data/festivalCompanyRepository.ts
@@ -7,6 +7,8 @@ import { disabledFestivalCompanyEligibility, parseFestivalCompanyEligibility, ty
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const isUuid = (value: unknown) => typeof value === "string" && UUID_RE.test(value);
 const isFiniteNonNegative = (value: unknown) => Number.isFinite(Number(value)) && Number(value) >= 0;
+const isNonNegativeInteger = (value: unknown) => Number.isInteger(Number(value)) && Number(value) >= 0;
+const isNonEmptyString = (value: unknown) => typeof value === "string" && value.trim().length > 0;
 
 interface FoundFestivalCompanyRpcResult {
   companyId: string;
@@ -39,20 +41,22 @@ export const foundFestivalCompany = async (
   };
 };
 
-const isFoundFestivalCompanyRpcResult = (value: unknown): value is FoundFestivalCompanyRpcResult => {
+export const isFoundFestivalCompanyRpcResult = (value: unknown): value is FoundFestivalCompanyRpcResult => {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   return isUuid(candidate.companyId) && isUuid(candidate.festivalCompanyId) && isUuid(candidate.personalFinancialTransactionId)
-    && isFiniteNonNegative(candidate.personalCash) && isFiniteNonNegative(candidate.foundingCost) && typeof candidate.idempotent === "boolean";
+    && isFiniteNonNegative(candidate.personalCash)
+    && Number(candidate.foundingCost) === 2_000_000
+    && typeof candidate.idempotent === "boolean";
 };
 
-const isFestivalSetupState = (value: unknown): value is FestivalCompanySetupState => {
+export const isFestivalSetupState = (value: unknown): value is FestivalCompanySetupState => {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   return isUuid(candidate.festivalCompanyId)
     && isUuid(candidate.companyId)
-    && typeof candidate.publicName === "string"
-    && typeof candidate.legalCompanyName === "string"
+    && isNonEmptyString(candidate.publicName)
+    && isNonEmptyString(candidate.legalCompanyName)
     && isFiniteNonNegative(candidate.companyBalance)
     && typeof candidate.isBankrupt === "boolean"
     && typeof candidate.setupCompleted === "boolean"
@@ -75,19 +79,21 @@ export const getFestivalCompanySetup = async (festivalCompanyId: string): Promis
     setupCompleted: Boolean(data.setupCompleted),
     configurationComplete: Boolean(data.configurationComplete),
     firstEditionExists: Boolean(data.firstEditionExists),
-    capabilities: { ...disabledFestivalCompanyCapabilities, ...(data.capabilities ?? {}) },
+    capabilities: isCapabilityObject(data.capabilities)
+      ? { ...data.capabilities, companyLimit: Number(data.capabilities.companyLimit) }
+      : disabledFestivalCompanyCapabilities,
   };
 };
 
 
-const isCapabilityObject = (value: unknown): value is FestivalCompanyCapabilities => {
+export const isCapabilityObject = (value: unknown): value is FestivalCompanyCapabilities => {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   return typeof candidate.newFestivalSystemEnabled === "boolean"
     && typeof candidate.festivalCompanyCreationEnabled === "boolean"
     && typeof candidate.festivalCompanyManagementEnabled === "boolean"
     && typeof candidate.festivalConfigurationEnabled === "boolean"
-    && Number.isInteger(Number(candidate.companyLimit)) && Number(candidate.companyLimit) >= 0;
+    && isNonNegativeInteger(candidate.companyLimit);
 };
 
 export const getFestivalCompanyCapabilities = async (): Promise<FestivalCompanyCapabilities> => {
@@ -115,16 +121,26 @@ export interface OwnedFestivalCompanySummary {
   managementEnabled: boolean;
 }
 
-const isOwnedFestivalCompanySummary = (value: unknown): value is OwnedFestivalCompanySummary => {
+export const isOwnedFestivalCompanySummary = (value: unknown): value is OwnedFestivalCompanySummary => {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
-  return isUuid(candidate.festivalCompanyId) && isUuid(candidate.companyId) && typeof candidate.publicName === "string" && candidate.publicName.length > 0 && typeof candidate.legalCompanyName === "string" && candidate.legalCompanyName.length > 0 && typeof candidate.setupStatus === "string" && typeof candidate.setupCompleted === "boolean" && typeof candidate.configurationComplete === "boolean" && typeof candidate.firstEditionExists === "boolean" && isFiniteNonNegative(candidate.companyBalance) && typeof candidate.managementEnabled === "boolean";
+  return isUuid(candidate.festivalCompanyId)
+    && isUuid(candidate.companyId)
+    && isNonEmptyString(candidate.publicName)
+    && isNonEmptyString(candidate.legalCompanyName)
+    && typeof candidate.setupStatus === "string"
+    && typeof candidate.setupCompleted === "boolean"
+    && typeof candidate.configurationComplete === "boolean"
+    && typeof candidate.firstEditionExists === "boolean"
+    && isFiniteNonNegative(candidate.companyBalance)
+    && typeof candidate.managementEnabled === "boolean";
 };
 
 export const getOwnedFestivalCompanies = async (): Promise<OwnedFestivalCompanySummary[]> => {
   const { data, error } = await supabase.rpc("get_owned_festival_companies");
   if (error || !Array.isArray(data)) return [];
-  return data.filter(isOwnedFestivalCompanySummary).map((company) => ({
+  if (!data.every(isOwnedFestivalCompanySummary)) return [];
+  return data.map((company) => ({
     ...company,
     setupCompleted: Boolean(company.setupCompleted),
     configurationComplete: Boolean(company.configurationComplete),


### PR DESCRIPTION
### Motivation
- Finish the festival founding runtime/security gate left incomplete after the previous PR by securing internal finance primitives, replacing the placeholder concurrency check with a real overlapping two-session test, and proving rollback and idempotency behaviour against persisted state.
- Prevent clients from calling privileged helpers such as `public.finance_debit_player_personal_cash(...)` directly while preserving `SECURITY DEFINER` invocation from `public.found_festival_company(...)`.
- Harden frontend/runtime integration by strict RPC response parsing, correct React Query invalidation, and ensuring festival cards route only to registered paths.

### Description
- Database/migrations: added/updated a forward-only hardening migration (present at `supabase/migrations/20260723210000_secure_festival_runtime_gate.sql`) which explicitly revokes execution on the internal bridge and helpers with lines like `REVOKE ALL ON FUNCTION public.finance_debit_player_personal_cash(...) FROM PUBLIC;` and similar revokes for `anon` and `authenticated`, while keeping `found_festival_company(...)` executable to authenticated clients via `SECURITY DEFINER` semantics.
- Concurrency and test hooks: replaced the placeholder script with a genuine two-session overlapped concurrency test at `scripts/festivals/run-company-runtime-concurrency.sh` that uses two `psql` sessions calling `found_festival_company(...)` with the same profile/idempotency key and a transaction-local test fixture guard `app.allow_test_fixtures = true`; added test-only guards (`public._festival_test_fixtures_allowed()` plus `app.festival_foundation_fail_after_debit`) that require the fixture setting.
- Runtime harness and rollback: expanded the SQL runtime harness (`supabase/tests/festival_company_financial_correctness_harness.sql`) to exercise anonymous/authenticated/profile/VIP/money/name/idempotency/limit scenarios and to force a post-debit failure proving a full rollback of balances and created rows; documented canonical finance facts: starting authoritative wallet `1,000,000,000` minor units ($10,000,000) -> `800,000,000` minor units ($8,000,000) on success, exactly 1 `festival_company_founding_fee` transaction and exactly 2 balanced ledger entries per successful founding, and a complete rollback on forced post-debit failure.
- Generic helpers: preserved generic wrappers (`company_ownership_limit`, `can_profile_found_company`) but documented/deprecated them and ensured festival code uses festival-specific helpers (`festival_company_ownership_limit`, `can_profile_found_festival_company`); direct execute permission revoked for deprecated helper wrappers.
- Frontend: hardened RPC parsing and fail-closed validators in `src/features/festival-company/data/festivalCompanyRepository.ts` (strict UUID checks, canonical founding cost check, required non-empty names, booleans and non-negative numeric fields), removed unsafe `as never` RPC casts usage sites, and updated React Query invalidation to refresh `companies`, `owned-festival-companies`, `festival-company-founding-eligibility`, `festival-company-capabilities`, `active-profile`, `user-cash-balance` and `festival-company-setup` after a successful founding.
- Routing and UI: ensured festival cards navigate only to the registered route `/companies/festivals/:festivalCompanyId/setup` and use truthful labels `Continue setup` / `View setup summary`.
- Tests & types: added a unit parser test `src/features/festival-company/__tests__/festivalCompanyParsers.test.ts` validating strict parsers; regenerated Supabase RPC types (RPC entries for `festival_company_capabilities`, `get_festival_company_founding_eligibility`, `get_owned_festival_companies`, `found_festival_company`, and `finance_debit_player_personal_cash` are present) and removed `as never` usages in festival RPC callers.

### Testing
- `npm run typecheck` — passed (TypeScript `tsc --noEmit` succeeded).
- `node scripts/supabase/verify-required-rpcs.mjs` (run via `npm run verify:supabase-rpcs`) — passed and verified required frontend RPC contracts against migrations.
- `npm ci` — failed in this environment due to registry 403 errors (package fetch policy), so full install-based tasks (`vitest`, `vite`, ESLint plugins) were unavailable.
- `npm run lint` — failed because required lint packages were not installed after `npm ci` failure (`@eslint/js` could not be resolved).
- `npm run test:unit` / `vitest` — could not run because `vitest` was not installed in this environment; the new parser test file was added and is present but was not executed here.
- `npm run build` — failed because `vite` is not installed after dependency install failed.
- `npm run test:festivals:company-runtime` — not executed here because `psql` / a reachable Supabase DB is not available in this environment; the runtime gate is included and will run the full harness and the genuine two-session concurrency test when run in an environment with `psql` and `SUPABASE_DB_URL`.

Notes and artefacts
- Finance/runtime facts recorded by the harness: success moves authoritative personal wallet `1,000,000,000` -> `800,000,000` minor units; success creates 1 founding transaction and 2 ledger entries; forced post-debit failure leaves the founder at `1,000,000,000` and removes created company/extension/shareholder/request/audit/transaction/ledger rows.
- Two-session concurrency expected result: both overlapping calls return the same company/festival IDs, one full success and one idempotent saved response, exactly one company, one festival extension, one shareholder row, one founding request, one founding financial transaction, two ledger entries, and no deadlocks/unique-constraint escapes.
- Commands actually run in this environment and results: `npm ci` (failed with 403), `npm run typecheck` (passed), `npm run verify:supabase-rpcs` (passed), `npm run lint` (failed due to missing deps), `npm run test:unit` (could not run), `npm run build` (could not run), `npm run test:festivals:company-runtime` (did not run due to missing `psql`).
- Next steps: CI or a local developer should run `npm ci` in an environment with registry access, then run `npm run lint`, `npm run test:unit`, `npm run build`, and run `SUPABASE_DB_URL=... psql`-backed `npm run test:festivals:company-runtime` to prove the full runtime gate and concurrency harness end-to-end; after that, the follow-up PR will implement the festival configuration wizard and create the first annual edition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e784649883259dac874b20a6065c)