### PR TITLE
test(festivals): execute and prove the founding runtime gate

### DIFF
--- a/.github/workflows/festival-runtime-gate.yml
+++ b/.github/workflows/festival-runtime-gate.yml
@@ -1,0 +1,48 @@
+name: Festival runtime gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/tests/festival_**'
+      - 'scripts/festivals/**'
+      - 'src/features/festival-company/**'
+      - 'src/integrations/supabase/types.ts'
+      - '.github/workflows/festival-runtime-gate.yml'
+
+jobs:
+  festival-runtime-gate:
+    runs-on: ubuntu-latest
+    env:
+      FESTIVAL_TEST_DATABASE_CONFIRMED: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Start Supabase
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Start local Supabase stack
+        run: supabase start
+      - name: Reset migrated test database
+        run: supabase db reset
+      - name: Export local database URL
+        run: echo "SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres" >> "$GITHUB_ENV"
+      - name: Verify Supabase RPC types
+        run: npm run verify:supabase-rpcs
+      - name: Run SQL runtime harness
+        run: psql "$SUPABASE_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/tests/festival_company_financial_correctness_harness.sql
+      - name: Run deterministic concurrency gate
+        run: npm run test:festivals:company-runtime
+      - name: Run festival frontend unit tests
+        run: npm run test:unit -- src/features/festival-company
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Build
+        run: npm run build

--- a/scripts/festivals/run-company-runtime-concurrency.sh
+++ b/scripts/festivals/run-company-runtime-concurrency.sh
@@ -1,77 +1,140 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 if ! command -v psql >/dev/null; then echo "psql is required for concurrency verification" >&2; exit 127; fi
 if [[ -z "${SUPABASE_DB_URL:-}" ]]; then echo "SUPABASE_DB_URL is required after supabase start/db reset" >&2; exit 2; fi
-workdir="${TMPDIR:-/tmp}/festival-company-concurrency-$$"
+if [[ "${FESTIVAL_TEST_DATABASE_CONFIRMED:-}" != "true" ]]; then echo "Refusing to mutate database: set FESTIVAL_TEST_DATABASE_CONFIRMED=true for an isolated test database" >&2; exit 3; fi
+case "$SUPABASE_DB_URL" in *prod*|*production*|*amazonaws.com*|*supabase.co*) echo "Refusing to run festival runtime gate against a possible production database" >&2; exit 4;; esac
+
+run_id="frt-$(date +%s)-$RANDOM-$RANDOM"
+token="$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+)"
+user_id="81280000-0000-0000-0000-000000000010"
+profile_id="81280000-0000-0000-0000-000000000110"
+public_name="$run_id Concurrent Runtime Fest"
+company_name="$run_id Concurrent Runtime LLC"
+idempotency_key="$run_id-concurrent-key"
+description="$run_id deterministic concurrency proof"
+workdir="${TMPDIR:-/tmp}/festival-company-concurrency-$run_id"
 mkdir -p "$workdir"
-trap 'rm -rf "$workdir"' EXIT
-setup="$workdir/setup.sql"
-call1="$workdir/call1.sql"
-call2="$workdir/call2.sql"
-verify="$workdir/verify.sql"
-cat > "$setup" <<'SQL'
-BEGIN;
-SET LOCAL ROLE service_role;
-SET LOCAL app.allow_test_fixtures = 'true';
-DELETE FROM auth.users WHERE id IN ('81280000-0000-0000-0000-000000000010');
-INSERT INTO auth.users(id,email,role) VALUES ('81280000-0000-0000-0000-000000000010','festival-concurrency@example.test','authenticated');
-INSERT INTO public.profiles(id,user_id,username,display_name,cash,is_active,is_vip) VALUES ('81280000-0000-0000-0000-000000000110','81280000-0000-0000-0000-000000000010','festival_concurrency','Festival Concurrency',10000000,true,true);
-INSERT INTO public.vip_subscriptions(user_id,status,subscription_type,starts_at,expires_at) VALUES ('81280000-0000-0000-0000-000000000010','active','test',now()-interval '1 day',now()+interval '30 days');
-PERFORM public.get_or_create_primary_financial_account('player','81280000-0000-0000-0000-000000000110','Concurrency player cash','USD');
-UPDATE public.financial_accounts SET current_balance_minor=1000000000, available_balance_minor=1000000000 WHERE owner_type='player' AND owner_id='81280000-0000-0000-0000-000000000110' AND is_primary;
+
+psql_base=(psql "$SUPABASE_DB_URL" -X -qAt -v ON_ERROR_STOP=1)
+cleanup() {
+  set +e
+  "${psql_base[@]}" -v run_id="$run_id" <<'SQL' >/dev/null
+SET ROLE service_role;
+SELECT festival_test.cleanup_run(:'run_id');
+SQL
+  rm -rf "$workdir"
+}
+trap cleanup EXIT INT TERM
+
+"${psql_base[@]}" -v run_id="$run_id" -v token="$token" -v user_id="$user_id" -v profile_id="$profile_id" <<'SQL'
+SET ROLE service_role;
+SELECT festival_test.cleanup_run(:'run_id');
+SELECT festival_test.create_run(:'run_id', :'token', 'concurrency', true, false, false, interval '15 minutes');
+INSERT INTO auth.users(id,email,role) VALUES (:'user_id', :'run_id' || '@example.test','authenticated');
+INSERT INTO public.profiles(id,user_id,username,display_name,cash,is_active,is_vip)
+VALUES (:'profile_id', :'user_id', 'festival_' || replace(:'run_id','-','_'), :'run_id', 10000000, true, true);
+INSERT INTO public.vip_subscriptions(user_id,status,subscription_type,starts_at,expires_at,metadata)
+VALUES (:'user_id','active','test',now()-interval '1 day',now()+interval '30 days',jsonb_build_object('festival_test_run_id',:'run_id'));
+SELECT public.get_or_create_primary_financial_account('player',:'profile_id','Concurrency player cash','USD');
+UPDATE public.financial_accounts SET current_balance_minor=1000000000, available_balance_minor=1000000000, metadata=coalesce(metadata,'{}'::jsonb)||jsonb_build_object('festival_test_run_id',:'run_id') WHERE owner_type='player' AND owner_id=:'profile_id' AND is_primary;
 UPDATE public.game_config SET config_value = config_value || '{"new_festival_system_enabled":true,"festival_company_creation_enabled":true,"festival_company_management_enabled":true,"company_limit":3}'::jsonb WHERE config_key='festival_company_creation';
-COMMIT;
 SQL
-cat > "$call1" <<'SQL'
+
+make_call_sql() {
+  local file="$1" token_arg="$2"
+  cat > "$file" <<SQL
 SET ROLE authenticated;
-SET request.jwt.claim.sub = '81280000-0000-0000-0000-000000000010';
+SET request.jwt.claim.sub = '$user_id';
 SET request.jwt.claim.role = 'authenticated';
-SET request.jwt.claims = '{"sub":"81280000-0000-0000-0000-000000000010","role":"authenticated"}';
+SET request.jwt.claims = '{"sub":"$user_id","role":"authenticated"}';
 SET app.allow_test_fixtures = 'true';
-SET app.festival_foundation_delay_after_lock = '1.5';
-SELECT public.found_festival_company('Concurrent Runtime Fest','Concurrent Runtime LLC','proof','runtime-concurrent-key') AS result;
+SET app.festival_foundation_delay_after_lock = '5';
+SET app.festival_foundation_fail_after_extension = 'on';
+SET app.festival_foundation_fail_after_debit = 'on';
+SET app.festival_test_run_token = '$token_arg';
+SELECT public.found_festival_company('$public_name','$company_name','$description','$idempotency_key')::text;
 SQL
-cat > "$call2" <<'SQL'
-SET ROLE authenticated;
-SET request.jwt.claim.sub = '81280000-0000-0000-0000-000000000010';
-SET request.jwt.claim.role = 'authenticated';
-SET request.jwt.claims = '{"sub":"81280000-0000-0000-0000-000000000010","role":"authenticated"}';
-SELECT public.found_festival_company('Concurrent Runtime Fest','Concurrent Runtime LLC','proof','runtime-concurrent-key') AS result;
+}
+make_call_sql "$workdir/call1.sql" "$token"
+make_call_sql "$workdir/call2.sql" "ordinary-caller-controlled-token"
+
+("${psql_base[@]}" -f "$workdir/call1.sql" >"$workdir/out1" 2>"$workdir/err1") & p1=$!
+# Deterministically wait until session one has acquired the advisory lock and reached the trusted pause point.
+for _ in $(seq 1 200); do
+  reached=$("${psql_base[@]}" -v run_id="$run_id" -c "SET ROLE service_role; SELECT CASE WHEN reached_pause_at IS NULL THEN 'no' ELSE 'yes' END FROM festival_test.runs WHERE run_id=:'run_id';" | tail -n 1)
+  [[ "$reached" == "yes" ]] && break
+  sleep 0.05
+done
+[[ "${reached:-no}" == "yes" ]] || { echo "session one never reached trusted pause marker" >&2; exit 1; }
+("${psql_base[@]}" -f "$workdir/call2.sql" >"$workdir/out2" 2>"$workdir/err2") & p2=$!
+sleep 0.1
+"${psql_base[@]}" -v run_id="$run_id" <<'SQL' >/dev/null
+SET ROLE service_role;
+UPDATE festival_test.runs SET second_started_at = now() WHERE run_id=:'run_id';
+SELECT festival_test.release_run(:'run_id');
 SQL
-cat > "$verify" <<'SQL'
-DO $$
-DECLARE c bigint; fc bigint; sh bigint; req bigint; tx bigint; led bigint; bal bigint; r1 jsonb; r2 jsonb;
-BEGIN
-  SELECT result::jsonb INTO r1 FROM pg_read_file(current_setting('app.concurrency_result_1')) AS result;
-EXCEPTION WHEN OTHERS THEN NULL;
-END $$;
-SELECT 'companies', count(*) FROM public.companies WHERE name='Concurrent Runtime LLC';
-SELECT 'festival_extensions', count(*) FROM public.festival_companies WHERE public_name='Concurrent Runtime Fest';
-SELECT 'shareholders', count(*) FROM public.company_shareholders s JOIN public.companies c ON c.id=s.company_id WHERE c.name='Concurrent Runtime LLC';
-SELECT 'requests', count(*) FROM public.festival_company_founding_requests WHERE idempotency_key='runtime-concurrent-key';
-SELECT 'transactions', count(*) FROM public.financial_transactions WHERE idempotency_key='festival-company-founding:runtime-concurrent-key';
-SELECT 'ledger_entries', count(*) FROM public.financial_ledger_entries e JOIN public.financial_transactions t ON t.id=e.transaction_id WHERE t.idempotency_key='festival-company-founding:runtime-concurrent-key';
-SELECT 'balance', current_balance_minor FROM public.financial_accounts WHERE owner_type='player' AND owner_id='81280000-0000-0000-0000-000000000110' AND is_primary;
-DO $$
-BEGIN
- IF (SELECT count(*) FROM public.companies WHERE name='Concurrent Runtime LLC') <> 1 THEN RAISE EXCEPTION 'expected one company'; END IF;
- IF (SELECT count(*) FROM public.festival_companies WHERE public_name='Concurrent Runtime Fest') <> 1 THEN RAISE EXCEPTION 'expected one festival extension'; END IF;
- IF (SELECT count(*) FROM public.festival_company_founding_requests WHERE idempotency_key='runtime-concurrent-key') <> 1 THEN RAISE EXCEPTION 'expected one request'; END IF;
- IF (SELECT count(*) FROM public.financial_transactions WHERE idempotency_key='festival-company-founding:runtime-concurrent-key') <> 1 THEN RAISE EXCEPTION 'expected one debit transaction'; END IF;
- IF (SELECT count(*) FROM public.financial_ledger_entries e JOIN public.financial_transactions t ON t.id=e.transaction_id WHERE t.idempotency_key='festival-company-founding:runtime-concurrent-key') <> 2 THEN RAISE EXCEPTION 'expected two ledger entries'; END IF;
- IF (SELECT current_balance_minor FROM public.financial_accounts WHERE owner_type='player' AND owner_id='81280000-0000-0000-0000-000000000110' AND is_primary) <> 800000000 THEN RAISE EXCEPTION 'expected 800000000 balance'; END IF;
-END $$;
-SQL
-psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f "$setup" >/dev/null
-(psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -tA -f "$call1" > "$workdir/out1" 2> "$workdir/err1") & p1=$!
-sleep 0.2
-(psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -tA -f "$call2" > "$workdir/out2" 2> "$workdir/err2") & p2=$!
 wait "$p1" || { cat "$workdir/err1" >&2; exit 1; }
 wait "$p2" || { cat "$workdir/err2" >&2; exit 1; }
-if rg -i "unique|deadlock" "$workdir/err1" "$workdir/err2"; then exit 1; fi
-id1=$(python3 -c 'import json,sys; d=json.loads(open(sys.argv[1]).read().strip()); print(d["festivalCompanyId"])' "$workdir/out1")
-id2=$(python3 -c 'import json,sys; d=json.loads(open(sys.argv[1]).read().strip()); print(d["festivalCompanyId"])' "$workdir/out2")
-[[ "$id1" == "$id2" ]] || { echo "concurrent calls returned different festival companies" >&2; exit 1; }
-if ! rg '"idempotent"\s*:\s*true' "$workdir/out1" "$workdir/out2" >/dev/null; then echo "expected one idempotent response" >&2; exit 1; fi
-psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f "$verify"
-echo "ok - real two-session festival-company concurrency gate passed"
+[[ ! -s "$workdir/err1" ]] || { cat "$workdir/err1" >&2; exit 1; }
+[[ ! -s "$workdir/err2" ]] || { cat "$workdir/err2" >&2; exit 1; }
+
+python3 - "$workdir/out1" "$workdir/out2" <<'PY'
+import json, re, sys
+uuid=re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', re.I)
+rows=[]
+for path in sys.argv[1:]:
+    lines=[l.strip() for l in open(path) if l.strip()]
+    if len(lines)!=1: raise SystemExit(f'{path} must contain exactly one JSON line, got {len(lines)}')
+    data=json.loads(lines[0]); rows.append(data)
+    for key in ('companyId','festivalCompanyId','personalFinancialTransactionId'):
+        if not uuid.match(str(data.get(key,''))): raise SystemExit(f'{path} missing uuid {key}')
+    if data.get('foundingCost') != 2000000: raise SystemExit(f'{path} has wrong foundingCost')
+if rows[0]['companyId'] != rows[1]['companyId'] or rows[0]['festivalCompanyId'] != rows[1]['festivalCompanyId'] or rows[0]['personalFinancialTransactionId'] != rows[1]['personalFinancialTransactionId']:
+    raise SystemExit('responses returned different persisted ids')
+if sorted([rows[0].get('idempotent'), rows[1].get('idempotent')]) != [False, True]:
+    raise SystemExit('expected one original and one idempotent response')
+print(rows[0]['companyId']); print(rows[0]['festivalCompanyId']); print(rows[0]['personalFinancialTransactionId'])
+PY
+readarray -t ids < <(python3 - "$workdir/out1" <<'PY'
+import json,sys
+j=json.load(open(sys.argv[1])); print(j['companyId']); print(j['festivalCompanyId']); print(j['personalFinancialTransactionId'])
+PY
+)
+company_id="${ids[0]}"
+festival_company_id="${ids[1]}"
+tx_id="${ids[2]}"
+
+"${psql_base[@]}" <<SQL
+DO \$\$
+DECLARE failures int := 0; ran int := 0;
+BEGIN
+  CREATE TEMP TABLE IF NOT EXISTS festival_assertions(label text, passed boolean) ON COMMIT DROP;
+  INSERT INTO festival_assertions VALUES
+  ('one generic company', (SELECT count(*)=1 FROM public.companies WHERE id='$company_id'::uuid AND description LIKE '$run_id%')),
+  ('one festival extension', (SELECT count(*)=1 FROM public.festival_companies WHERE id='$festival_company_id'::uuid AND company_id='$company_id'::uuid AND description LIKE '$run_id%')),
+  ('one founder shareholder', (SELECT count(*)=1 FROM public.company_shareholders WHERE company_id='$company_id'::uuid AND user_id='$user_id'::uuid)),
+  ('one successful request', (SELECT count(*)=1 FROM public.festival_company_founding_requests WHERE idempotency_key='$idempotency_key' AND status='succeeded')),
+  ('two audit rows', (SELECT count(*)=2 FROM public.festival_company_audit_log WHERE festival_company_id='$festival_company_id'::uuid AND idempotency_key='$idempotency_key')),
+  ('one founding fee transaction', (SELECT count(*)=1 FROM public.financial_transactions WHERE id='$tx_id'::uuid AND idempotency_key='festival-company-founding:$idempotency_key' AND transaction_category='festival_company_founding_fee')),
+  ('two ledger entries', (SELECT count(*)=2 FROM public.financial_ledger_entries WHERE transaction_id='$tx_id'::uuid)),
+  ('ledger balances to zero', (SELECT coalesce(sum(amount_minor),0)=0 FROM public.financial_ledger_entries WHERE transaction_id='$tx_id'::uuid)),
+  ('zero company operating expenses', (SELECT count(*)=0 FROM public.company_transactions WHERE company_id='$company_id'::uuid)),
+  ('company balance zero', (SELECT balance=0 FROM public.companies WHERE id='$company_id'::uuid)),
+  ('wallet current balance 800000000', (SELECT current_balance_minor=800000000 FROM public.financial_accounts WHERE owner_type='player' AND owner_id='$profile_id'::uuid AND is_primary)),
+  ('wallet available balance 800000000', (SELECT available_balance_minor=800000000 FROM public.financial_accounts WHERE owner_type='player' AND owner_id='$profile_id'::uuid AND is_primary)),
+  ('profile cash 8000000', (SELECT cash=8000000 FROM public.profiles WHERE id='$profile_id'::uuid)),
+  ('stored request has returned ids', (SELECT result->>'companyId'='$company_id' AND result->>'festivalCompanyId'='$festival_company_id' AND result->>'personalFinancialTransactionId'='$tx_id' FROM public.festival_company_founding_requests WHERE idempotency_key='$idempotency_key'));
+  SELECT count(*), count(*) FILTER (WHERE NOT passed) INTO ran, failures FROM festival_assertions;
+  IF failures <> 0 THEN
+    RAISE EXCEPTION 'concurrency assertions failed: %', (SELECT jsonb_agg(label) FROM festival_assertions WHERE NOT passed);
+  END IF;
+  IF ran <> 14 THEN RAISE EXCEPTION 'expected 14 assertions, ran %', ran; END IF;
+END \$\$;
+SQL
+echo "ok - deterministic festival-company concurrency gate passed for $run_id"

--- a/src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts
+++ b/src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts
@@ -9,6 +9,7 @@ const hookSource = readFileSync("src/hooks/useCompanies.ts", "utf8");
 const repositorySource = readFileSync("src/features/festival-company/data/festivalCompanyRepository.ts", "utf8");
 const appSource = readFileSync("src/App.tsx", "utf8");
 const correctiveMigration = readFileSync("supabase/migrations/20260723210000_secure_festival_runtime_gate.sql", "utf8");
+const trustedRuntimeMigration = readFileSync("supabase/migrations/20260723223000_trusted_festival_runtime_gate.sql", "utf8");
 const cardSource = readFileSync("src/features/festival-company/ui/FestivalCompanyCard.tsx", "utf8");
 const mutationSource = readFileSync("src/features/festival-company/application/useFoundFestivalCompany.ts", "utf8");
 const concurrencyScript = readFileSync("scripts/festivals/run-company-runtime-concurrency.sh", "utf8");
@@ -66,11 +67,12 @@ describe("festival company secure founding foundation", () => {
   it("uses genuine concurrency and test-only fixture guards", () => {
     expect(concurrencyScript).toContain("p1=$!");
     expect(concurrencyScript).toContain("p2=$!");
-    expect(concurrencyScript).toContain("app.allow_test_fixtures");
-    expect(concurrencyScript).toContain("festival_foundation_delay_after_lock");
-    expect(concurrencyScript).toContain("expected one debit transaction");
-    expect(correctiveMigration).toContain("_festival_test_fixtures_allowed");
-    expect(correctiveMigration).toContain("festival_foundation_fail_after_debit");
+    expect(concurrencyScript).toContain("festival_test_run_token");
+    expect(concurrencyScript).toContain("reached_pause_at");
+    expect(concurrencyScript).toContain("exactly one JSON line");
+    expect(trustedRuntimeMigration).toContain("CREATE SCHEMA IF NOT EXISTS festival_test");
+    expect(trustedRuntimeMigration).toContain("_festival_test_context");
+    expect(trustedRuntimeMigration).toContain("festival_primary_financial_account_required");
   });
 
   it("invalidates all festival company queries after founding", () => {

--- a/src/features/festival-company/domain/festivalCompany.ts
+++ b/src/features/festival-company/domain/festivalCompany.ts
@@ -17,7 +17,8 @@ export interface FoundFestivalCompanyResult {
 
 export const festivalFoundingErrorMessages: Record<string, string> = {
   festival_vip_required: "An active VIP subscription is required to found a festival company.",
-  insufficient_personal_funds: "You need $2,000,000 in personal cash to found a festival company.",
+  insufficient_personal_funds: "You need $2,000,000 in available personal cash to found a festival company.",
+  festival_primary_financial_account_required: "Your active character needs a personal cash account before founding a festival company.",
   festival_name_taken: "That festival name is already taken. Choose a different public name.",
   company_limit_reached: "You have reached the company ownership limit.",
   festival_request_in_progress: "A matching festival founding request is still processing. Please retry in a moment.",

--- a/supabase/migrations/20260723223000_trusted_festival_runtime_gate.sql
+++ b/supabase/migrations/20260723223000_trusted_festival_runtime_gate.sql
@@ -1,0 +1,165 @@
+-- Trusted, rerunnable festival founding runtime-test context.
+-- Forward-only: replaces caller-controlled app.allow_test_fixtures with a private token table.
+
+CREATE SCHEMA IF NOT EXISTS festival_test;
+REVOKE ALL ON SCHEMA festival_test FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA festival_test TO service_role;
+
+CREATE TABLE IF NOT EXISTS festival_test.runs (
+  run_id text PRIMARY KEY,
+  token_hash text NOT NULL UNIQUE,
+  mode text NOT NULL DEFAULT 'runtime' CHECK (mode IN ('runtime','concurrency','rollback')),
+  pause_after_lock boolean NOT NULL DEFAULT false,
+  fail_after_extension boolean NOT NULL DEFAULT false,
+  fail_after_debit boolean NOT NULL DEFAULT false,
+  reached_pause_at timestamptz,
+  second_started_at timestamptz,
+  release_after_lock boolean NOT NULL DEFAULT false,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+REVOKE ALL ON festival_test.runs FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON festival_test.runs TO service_role;
+
+CREATE OR REPLACE FUNCTION festival_test.token_hash(p_token text)
+RETURNS text LANGUAGE sql IMMUTABLE STRICT SET search_path=public AS $$
+  SELECT encode(digest(p_token, 'sha256'), 'hex')
+$$;
+
+CREATE OR REPLACE FUNCTION festival_test.create_run(
+  p_run_id text,
+  p_token text,
+  p_mode text DEFAULT 'runtime',
+  p_pause_after_lock boolean DEFAULT false,
+  p_fail_after_extension boolean DEFAULT false,
+  p_fail_after_debit boolean DEFAULT false,
+  p_expires_in interval DEFAULT interval '30 minutes'
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public AS $$
+BEGIN
+  IF current_user <> 'service_role' AND session_user <> 'postgres' THEN
+    RAISE EXCEPTION 'festival_test_privileged_context_required' USING ERRCODE='42501';
+  END IF;
+  INSERT INTO festival_test.runs(run_id, token_hash, mode, pause_after_lock, fail_after_extension, fail_after_debit, expires_at)
+  VALUES (p_run_id, festival_test.token_hash(p_token), p_mode, p_pause_after_lock, p_fail_after_extension, p_fail_after_debit, now() + p_expires_in)
+  ON CONFLICT (run_id) DO UPDATE SET
+    token_hash = excluded.token_hash,
+    mode = excluded.mode,
+    pause_after_lock = excluded.pause_after_lock,
+    fail_after_extension = excluded.fail_after_extension,
+    fail_after_debit = excluded.fail_after_debit,
+    reached_pause_at = NULL,
+    second_started_at = NULL,
+    release_after_lock = false,
+    expires_at = excluded.expires_at;
+END $$;
+
+CREATE OR REPLACE FUNCTION festival_test.release_run(p_run_id text)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public AS $$
+BEGIN
+  IF current_user <> 'service_role' AND session_user <> 'postgres' THEN
+    RAISE EXCEPTION 'festival_test_privileged_context_required' USING ERRCODE='42501';
+  END IF;
+  UPDATE festival_test.runs SET release_after_lock = true WHERE run_id = p_run_id;
+END $$;
+
+CREATE OR REPLACE FUNCTION festival_test.cleanup_run(p_run_id text)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public,auth AS $$
+DECLARE v_prefix text := p_run_id || '%';
+BEGIN
+  IF current_user <> 'service_role' AND session_user <> 'postgres' THEN
+    RAISE EXCEPTION 'festival_test_privileged_context_required' USING ERRCODE='42501';
+  END IF;
+  DELETE FROM public.company_transactions ct USING public.companies c WHERE ct.company_id=c.id AND c.description LIKE v_prefix;
+  DELETE FROM public.festival_company_audit_log a USING public.festival_companies fc WHERE a.festival_company_id=fc.id AND fc.description LIKE v_prefix;
+  DELETE FROM public.festival_company_founding_requests WHERE idempotency_key LIKE p_run_id || '-%';
+  DELETE FROM public.company_shareholders s USING public.companies c WHERE s.company_id=c.id AND c.description LIKE v_prefix;
+  DELETE FROM public.festival_companies WHERE description LIKE v_prefix;
+  DELETE FROM public.companies WHERE description LIKE v_prefix;
+  DELETE FROM public.financial_ledger_entries e USING public.financial_transactions t WHERE e.transaction_id=t.id AND t.idempotency_key LIKE 'festival-company-founding:' || p_run_id || '-%';
+  DELETE FROM public.financial_transactions WHERE idempotency_key LIKE 'festival-company-founding:' || p_run_id || '-%';
+  DELETE FROM public.financial_accounts WHERE metadata->>'festival_test_run_id' = p_run_id;
+  DELETE FROM public.vip_subscriptions WHERE metadata->>'festival_test_run_id' = p_run_id;
+  DELETE FROM public.profiles WHERE username LIKE 'festival_' || replace(p_run_id,'-','_') || '%';
+  DELETE FROM auth.users WHERE email LIKE p_run_id || '%@example.test';
+  DELETE FROM festival_test.runs WHERE run_id = p_run_id;
+END $$;
+
+CREATE OR REPLACE FUNCTION public._festival_test_context()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public AS $$
+DECLARE v_token text := current_setting('app.festival_test_run_token', true); v_run festival_test.runs%ROWTYPE;
+BEGIN
+  IF v_token IS NULL OR btrim(v_token) = '' THEN RETURN '{}'::jsonb; END IF;
+  SELECT * INTO v_run FROM festival_test.runs WHERE token_hash = festival_test.token_hash(v_token) AND expires_at > now();
+  IF NOT FOUND THEN RETURN '{}'::jsonb; END IF;
+  RETURN jsonb_build_object('trusted', true, 'runId', v_run.run_id, 'mode', v_run.mode, 'pauseAfterLock', v_run.pause_after_lock, 'failAfterExtension', v_run.fail_after_extension, 'failAfterDebit', v_run.fail_after_debit);
+END $$;
+
+CREATE OR REPLACE FUNCTION public._festival_test_fixtures_allowed()
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path=public AS $$
+  SELECT COALESCE((public._festival_test_context()->>'trusted')::boolean, false)
+$$;
+
+CREATE OR REPLACE FUNCTION public._festival_test_after_lock()
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public AS $$
+DECLARE v_ctx jsonb := public._festival_test_context(); v_run_id text := v_ctx->>'runId';
+BEGIN
+  IF COALESCE((v_ctx->>'pauseAfterLock')::boolean,false) IS NOT TRUE THEN RETURN; END IF;
+  UPDATE festival_test.runs SET reached_pause_at = COALESCE(reached_pause_at, now()) WHERE run_id = v_run_id;
+  WHILE EXISTS (SELECT 1 FROM festival_test.runs WHERE run_id=v_run_id AND release_after_lock IS NOT TRUE AND expires_at > now()) LOOP
+    PERFORM pg_sleep(0.05);
+  END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.found_festival_company(p_public_name text, p_company_name text, p_description text DEFAULT NULL, p_idempotency_key text DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  v_user uuid := auth.uid(); v_profile public.profiles%ROWTYPE; v_profile_id uuid; v_cost numeric := 2000000; v_cost_minor bigint := 200000000; v_public text; v_company text; v_slug text; v_hash text; v_req public.festival_company_founding_requests%ROWTYPE; v_company_id uuid; v_fc_id uuid; v_finance jsonb; v_result jsonb; v_tx uuid; v_balance numeric; v_available_minor bigint; v_test jsonb := public._festival_test_context();
+BEGIN
+  IF v_user IS NULL THEN RAISE EXCEPTION 'not_authenticated' USING ERRCODE='P0001'; END IF;
+  IF NOT public._festival_company_creation_enabled() THEN RAISE EXCEPTION 'festival_creation_disabled' USING ERRCODE='P0001'; END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN RAISE EXCEPTION 'idempotency_key_required' USING ERRCODE='P0001'; END IF;
+  v_public := btrim(coalesce(p_public_name,'')); v_company := btrim(coalesce(p_company_name,''));
+  IF char_length(v_public) < 3 OR char_length(v_public) > 80 OR char_length(v_company) < 3 OR char_length(v_company) > 120 THEN RAISE EXCEPTION 'invalid_festival_name' USING ERRCODE='P0001'; END IF;
+  v_slug := public._festival_slug(v_public); IF v_slug = '' THEN RAISE EXCEPTION 'invalid_festival_name' USING ERRCODE='P0001'; END IF;
+  v_hash := encode(digest(v_public || '|' || v_company || '|' || coalesce(p_description,'') || '|2000000', 'sha256'), 'hex');
+  v_profile_id := public._caller_profile_id(); IF v_profile_id IS NULL THEN RAISE EXCEPTION 'profile_not_eligible' USING ERRCODE='P0001'; END IF;
+  SELECT * INTO v_profile FROM public.profiles WHERE id=v_profile_id AND user_id=v_user AND died_at IS NULL FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'profile_not_eligible' USING ERRCODE='P0001'; END IF;
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_user::text || ':' || p_idempotency_key, 0));
+  PERFORM public._festival_test_after_lock();
+  SELECT * INTO v_req FROM public.festival_company_founding_requests WHERE actor_user_id=v_user AND idempotency_key=p_idempotency_key FOR UPDATE;
+  IF FOUND THEN
+    IF v_req.request_hash <> v_hash THEN RAISE EXCEPTION 'idempotency_conflict' USING ERRCODE='P0001'; END IF;
+    IF v_req.status = 'succeeded' THEN RETURN v_req.result || jsonb_build_object('idempotent', true); END IF;
+    RAISE EXCEPTION 'festival_request_retryable' USING ERRCODE='P0001';
+  END IF;
+  INSERT INTO public.festival_company_founding_requests(actor_user_id, actor_profile_id, idempotency_key, request_hash) VALUES (v_user, v_profile.id, p_idempotency_key, v_hash) RETURNING * INTO v_req;
+  IF NOT public._has_active_vip_entitlement(v_user) THEN RAISE EXCEPTION 'festival_vip_required' USING ERRCODE='P0001'; END IF;
+  IF NOT public.can_profile_found_festival_company(v_profile.id) THEN RAISE EXCEPTION 'company_limit_reached' USING ERRCODE='P0001'; END IF;
+  SELECT COALESCE(available_balance_minor,0) INTO v_available_minor FROM public.financial_accounts WHERE owner_type='player' AND owner_id=v_profile.id AND is_primary FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'festival_primary_financial_account_required' USING ERRCODE='P0001'; END IF;
+  IF COALESCE(v_available_minor,0) < v_cost_minor THEN RAISE EXCEPTION 'insufficient_personal_funds' USING ERRCODE='P0001'; END IF;
+  IF EXISTS (SELECT 1 FROM public.festival_companies WHERE slug = v_slug OR lower(public_name) = lower(v_public)) THEN RAISE EXCEPTION 'festival_name_taken' USING ERRCODE='P0001'; END IF;
+  INSERT INTO public.companies(owner_id,name,company_type,description,balance,weekly_operating_costs) VALUES (v_user,v_company,'festival',p_description,0,0) RETURNING id INTO v_company_id;
+  INSERT INTO public.festival_companies(company_id, owner_profile_id, public_name, slug, description) VALUES (v_company_id, v_profile.id, v_public, v_slug, p_description) RETURNING id INTO v_fc_id;
+  IF COALESCE((v_test->>'failAfterExtension')::boolean,false) THEN RAISE EXCEPTION 'festival_test_late_failure' USING ERRCODE='P0001'; END IF;
+  INSERT INTO public.company_shareholders(company_id,user_id,shares) VALUES (v_company_id,v_user,100);
+  v_finance := public.finance_debit_player_personal_cash(v_profile.id, v_cost_minor, 'festival_company_founding_fee', 'Festival company founding fee', 'festival-company-founding:'||p_idempotency_key, jsonb_build_object('festivalCompanyId',v_fc_id,'companyId',v_company_id,'wholeUsdAmount',v_cost,'currencyUnit','minor'));
+  IF COALESCE((v_test->>'failAfterDebit')::boolean,false) THEN RAISE EXCEPTION 'festival_test_post_debit_failure' USING ERRCODE='P0001'; END IF;
+  v_tx := (v_finance->>'transactionId')::uuid; v_balance := (v_finance->>'projectedCash')::numeric;
+  INSERT INTO public.festival_company_audit_log(festival_company_id,company_id,actor_profile_id,action,idempotency_key,metadata) VALUES
+    (v_fc_id,v_company_id,v_profile.id,'festival_company_founded',p_idempotency_key,jsonb_build_object('founding_cost',v_cost,'founding_cost_minor',v_cost_minor,'personal_financial_transaction_id',v_tx,'accounting','financial_accounts is authoritative; profiles.cash is an atomic compatibility projection')),
+    (v_fc_id,v_company_id,v_profile.id,'founding_fee_charged',p_idempotency_key,jsonb_build_object('authoritative_personal_balance',v_balance));
+  v_result := jsonb_build_object('companyId', v_company_id, 'festivalCompanyId', v_fc_id, 'personalCash', v_balance, 'authoritativePersonalBalance', v_balance, 'foundingCost', v_cost, 'foundingCostMinor', v_cost_minor, 'personalFinancialTransactionId', v_tx, 'idempotent', false);
+  UPDATE public.festival_company_founding_requests SET status='succeeded', company_id=v_company_id, festival_company_id=v_fc_id, resulting_personal_cash=v_balance, result=v_result, completed_at=now(), updated_at=now() WHERE id=v_req.id;
+  RETURN v_result;
+EXCEPTION WHEN unique_violation THEN
+  IF EXISTS (SELECT 1 FROM public.festival_companies WHERE slug = v_slug OR lower(public_name) = lower(v_public)) THEN RAISE EXCEPTION 'festival_name_taken' USING ERRCODE='P0001'; END IF;
+  RAISE;
+END $$;
+
+REVOKE ALL ON FUNCTION public._festival_test_context() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public._festival_test_after_lock() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.found_festival_company(text,text,text,text) TO authenticated;
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Replace the existing caller-controlled test-hook GUCs with a trusted, forward-only test context so unauthorised callers cannot enable artificial pauses or failures during the festival founding RPC.
- Make the two-session concurrency verification deterministic and safely rerunnable so the runtime gate is actually exercised against a migrated database and proves single-debit, balanced ledger, idempotency and rollback behaviour.
- Improve response capture and verification so each RPC result is parsed as an isolated JSON document and used safely in subsequent assertions, and ensure test fixtures are cleaned up after each run.

### Description
- Adds a forward-only migration `supabase/migrations/20260723223000_trusted_festival_runtime_gate.sql` that creates a private `festival_test` schema, a `runs` table, token hashing and privileged `create_run`/`release_run`/`cleanup_run` helpers, plus `public._festival_test_context()` and replaces the caller-controlled `_festival_test_fixtures_allowed()` with a trusted context check used by `found_festival_company`.
- Replaces the runtime hooks in the founding RPC with deterministic instrumentation: an after-lock synchronization hook, trusted fail-after-extension and fail-after-debit hooks, and a stable domain error `festival_primary_financial_account_required` when the caller lacks a primary personal finance account, without changing the RPC signature.
- Reworks `scripts/festivals/run-company-runtime-concurrency.sh` to require explicit isolated-DB confirmation, generate unique run identifiers and tokens, use the trusted pause marker (instead of timing sleeps) to deterministically coordinate the two sessions, capture exactly one JSON document per response, validate UUIDs and founding cost, assert persisted company/finance invariants, and run privileged cleanup on exit.
- Adds a dedicated GitHub Actions workflow `.github/workflows/festival-runtime-gate.yml` to start/reset a local Supabase stack, verify RPC types, run the SQL runtime harness, run the deterministic concurrency gate, run festival frontend unit tests, typecheck and build; and updates frontend error mapping and source tests to expect the new trusted instrumentation.

### Testing
- `npm run typecheck` — passed locally (no TypeScript errors).
- `npm run verify:supabase-rpcs` — passed locally (required frontend RPCs verified against migrations).
- Syntactic checks of the new/modified scripts and harness (`bash -n` / script static checks) — passed in this environment.
- Not executed here: the full SQL runtime harness and deterministic concurrency gate against a migrated database, and the festival unit tests could not be run in this container because `psql`/Supabase and `vitest` were not available; to execute these reliably the PR adds the GitHub Actions workflow `Festival runtime gate` and the prepared commit SHA for this change is `f432a50`, which will run the end-to-end runtime assertions in CI and produce the final evidence required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61eac000088325a01dc8d4dcabd4b7)