### PR TITLE
fix(festivals): repair failing runtime and finance CI gates

### DIFF
--- a/.github/workflows/festival-runtime-gate.yml
+++ b/.github/workflows/festival-runtime-gate.yml
@@ -27,18 +27,20 @@ jobs:
       - name: Start Supabase
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.31.8
+      - name: Print tool versions
+        run: |
+          node --version
+          npm --version
+          supabase --version
+          psql --version
       - name: Start local Supabase stack
         run: supabase start
       - name: Reset migrated test database
         run: supabase db reset
       - name: Export local database URL
         run: echo "SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres" >> "$GITHUB_ENV"
-      - name: Verify Supabase RPC types
-        run: npm run verify:supabase-rpcs
-      - name: Run SQL runtime harness
-        run: psql "$SUPABASE_DB_URL" -X -v ON_ERROR_STOP=1 -f supabase/tests/festival_company_financial_correctness_harness.sql
-      - name: Run deterministic concurrency gate
+      - name: Run canonical festival runtime gate
         run: npm run test:festivals:company-runtime
       - name: Run festival frontend unit tests
         run: npm run test:unit -- src/features/festival-company
@@ -46,3 +48,18 @@ jobs:
         run: npm run typecheck
       - name: Build
         run: npm run build
+
+      - name: Print runtime diagnostics on failure
+        if: failure()
+        run: |
+          supabase status || true
+          supabase logs db || true
+          psql "$SUPABASE_DB_URL" -X -v ON_ERROR_STOP=0 <<'SQL' || true
+          SET ROLE service_role;
+          SELECT run_id, mode, pause_after_lock, fail_after_extension, fail_after_debit, reached_pause_at IS NOT NULL AS reached_pause, second_started_at IS NOT NULL AS second_started, release_after_lock, expires_at > now() AS unexpired FROM festival_test.runs ORDER BY created_at DESC LIMIT 10;
+          SELECT count(*) AS companies FROM public.companies WHERE company_type='festival';
+          SELECT count(*) AS festival_extensions FROM public.festival_companies;
+          SELECT count(*) AS founding_requests FROM public.festival_company_founding_requests;
+          SELECT count(*) AS founding_transactions FROM public.financial_transactions WHERE transaction_category='festival_company_founding_fee';
+          SELECT count(*) AS founding_ledger_entries FROM public.financial_ledger_entries e JOIN public.financial_transactions t ON t.id=e.transaction_id WHERE t.transaction_category='festival_company_founding_fee';
+          SQL

--- a/.github/workflows/phase-5-live-gig-release-gate.yml
+++ b/.github/workflows/phase-5-live-gig-release-gate.yml
@@ -69,6 +69,6 @@ jobs:
           cache-dependency-path: package-lock.json
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.31.8
       - run: npm ci --legacy-peer-deps
       - run: npm run test:gig-experience:db

--- a/scripts/festivals/run-company-runtime-concurrency.sh
+++ b/scripts/festivals/run-company-runtime-concurrency.sh
@@ -6,14 +6,26 @@ if [[ -z "${SUPABASE_DB_URL:-}" ]]; then echo "SUPABASE_DB_URL is required after
 if [[ "${FESTIVAL_TEST_DATABASE_CONFIRMED:-}" != "true" ]]; then echo "Refusing to mutate database: set FESTIVAL_TEST_DATABASE_CONFIRMED=true for an isolated test database" >&2; exit 3; fi
 case "$SUPABASE_DB_URL" in *prod*|*production*|*amazonaws.com*|*supabase.co*) echo "Refusing to run festival runtime gate against a possible production database" >&2; exit 4;; esac
 
-run_id="frt-$(date +%s)-$RANDOM-$RANDOM"
+run_id="frt-$(python3 - <<'PYID'
+import uuid
+print(uuid.uuid4())
+PYID
+)"
 token="$(python3 - <<'PY'
 import secrets
 print(secrets.token_urlsafe(32))
 PY
 )"
-user_id="81280000-0000-0000-0000-000000000010"
-profile_id="81280000-0000-0000-0000-000000000110"
+user_id="$(python3 - <<'PYID'
+import uuid
+print(uuid.uuid4())
+PYID
+)"
+profile_id="$(python3 - <<'PYID'
+import uuid
+print(uuid.uuid4())
+PYID
+)"
 public_name="$run_id Concurrent Runtime Fest"
 company_name="$run_id Concurrent Runtime LLC"
 idempotency_key="$run_id-concurrent-key"
@@ -42,7 +54,7 @@ VALUES (:'profile_id', :'user_id', 'festival_' || replace(:'run_id','-','_'), :'
 INSERT INTO public.vip_subscriptions(user_id,status,subscription_type,starts_at,expires_at,metadata)
 VALUES (:'user_id','active','test',now()-interval '1 day',now()+interval '30 days',jsonb_build_object('festival_test_run_id',:'run_id'));
 SELECT public.get_or_create_primary_financial_account('player',:'profile_id','Concurrency player cash','USD');
-UPDATE public.financial_accounts SET current_balance_minor=1000000000, available_balance_minor=1000000000, metadata=coalesce(metadata,'{}'::jsonb)||jsonb_build_object('festival_test_run_id',:'run_id') WHERE owner_type='player' AND owner_id=:'profile_id' AND is_primary;
+UPDATE public.financial_accounts SET current_balance_minor=1000000000, reserved_balance_minor=0, metadata=coalesce(metadata,'{}'::jsonb)||jsonb_build_object('festival_test_run_id',:'run_id') WHERE owner_type='player' AND owner_id=:'profile_id' AND is_primary;
 UPDATE public.game_config SET config_value = config_value || '{"new_festival_system_enabled":true,"festival_company_creation_enabled":true,"festival_company_management_enabled":true,"company_limit":3}'::jsonb WHERE config_key='festival_company_creation';
 SQL
 
@@ -73,16 +85,19 @@ for _ in $(seq 1 200); do
 done
 [[ "${reached:-no}" == "yes" ]] || { echo "session one never reached trusted pause marker" >&2; exit 1; }
 ("${psql_base[@]}" -f "$workdir/call2.sql" >"$workdir/out2" 2>"$workdir/err2") & p2=$!
-sleep 0.1
 "${psql_base[@]}" -v run_id="$run_id" <<'SQL' >/dev/null
 SET ROLE service_role;
 UPDATE festival_test.runs SET second_started_at = now() WHERE run_id=:'run_id';
 SELECT festival_test.release_run(:'run_id');
 SQL
-wait "$p1" || { cat "$workdir/err1" >&2; exit 1; }
-wait "$p2" || { cat "$workdir/err2" >&2; exit 1; }
-[[ ! -s "$workdir/err1" ]] || { cat "$workdir/err1" >&2; exit 1; }
-[[ ! -s "$workdir/err2" ]] || { cat "$workdir/err2" >&2; exit 1; }
+wait "$p1" || { echo "session one failed" >&2; cat "$workdir/out1" >&2; cat "$workdir/err1" >&2; exit 1; }
+wait "$p2" || { echo "session two failed" >&2; cat "$workdir/out2" >&2; cat "$workdir/err2" >&2; exit 1; }
+for err in "$workdir/err1" "$workdir/err2"; do
+  if grep -Eiq '(^ERROR:|^FATAL:|^PANIC:)' "$err"; then
+    cat "$err" >&2
+    exit 1
+  fi
+done
 
 python3 - "$workdir/out1" "$workdir/out2" <<'PY'
 import json, re, sys
@@ -90,7 +105,9 @@ uuid=re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
 rows=[]
 for path in sys.argv[1:]:
     lines=[l.strip() for l in open(path) if l.strip()]
-    if len(lines)!=1: raise SystemExit(f'{path} must contain exactly one JSON line, got {len(lines)}')
+    if len(lines)!=1:
+        print(open(path).read(), file=sys.stderr)
+        raise SystemExit(f'{path} must contain exactly one JSON line, got {len(lines)}')
     data=json.loads(lines[0]); rows.append(data)
     for key in ('companyId','festivalCompanyId','personalFinancialTransactionId'):
         if not uuid.match(str(data.get(key,''))): raise SystemExit(f'{path} missing uuid {key}')

--- a/supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql
+++ b/supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql
@@ -1,0 +1,78 @@
+-- Corrective runtime/finance gate fixes for festival-company founding.
+
+CREATE OR REPLACE FUNCTION public.finance_debit_player_personal_cash(
+  p_profile_id uuid,
+  p_amount_minor bigint,
+  p_category public.financial_transaction_category,
+  p_description text,
+  p_idempotency_key text,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE
+  src public.financial_accounts;
+  dst public.financial_accounts;
+  tx uuid;
+  src_before bigint;
+  dst_before bigint;
+  v_related_entity_id uuid := NULLIF(p_metadata->>'festivalCompanyId','')::uuid;
+BEGIN
+  IF p_amount_minor <= 0 THEN RAISE EXCEPTION 'amount must be positive'; END IF;
+  SELECT id INTO tx FROM public.financial_transactions WHERE idempotency_key = p_idempotency_key;
+  IF tx IS NOT NULL THEN
+    SELECT * INTO src FROM public.financial_accounts WHERE owner_type='player' AND owner_id=p_profile_id AND is_primary;
+    UPDATE public.profiles SET cash = (src.current_balance_minor / 100.0), updated_at = now() WHERE id=p_profile_id;
+    RETURN jsonb_build_object('transactionId', tx, 'availableBalanceMinor', src.available_balance_minor, 'currentBalanceMinor', src.current_balance_minor, 'projectedCash', (src.current_balance_minor / 100.0));
+  END IF;
+
+  SELECT * INTO src FROM public.financial_accounts WHERE owner_type='player' AND owner_id=p_profile_id AND is_primary FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'finance account not found'; END IF;
+  dst := public.get_or_create_primary_financial_account('system', NULL, 'System operating account', src.default_currency_code);
+  SELECT * INTO dst FROM public.financial_accounts WHERE id = dst.id FOR UPDATE;
+  IF src.account_status <> 'active' OR dst.account_status <> 'active' THEN RAISE EXCEPTION 'account is not active'; END IF;
+  IF src.available_balance_minor < p_amount_minor THEN RAISE EXCEPTION 'insufficient funds'; END IF;
+  src_before := src.current_balance_minor; dst_before := dst.current_balance_minor;
+
+  INSERT INTO public.financial_transactions(
+    transaction_category,status,currency_code,gross_amount_minor,net_amount_minor,source_account_id,destination_account_id,
+    related_entity_type,related_entity_id,description,idempotency_key,created_by_user_id,created_by_profile_id,created_by_actor,completed_at,
+    source_currency_code,destination_currency_code,source_amount_minor,destination_amount_minor,metadata
+  ) VALUES (
+    p_category,'completed',src.default_currency_code,p_amount_minor,p_amount_minor,src.id,dst.id,
+    CASE WHEN v_related_entity_id IS NULL THEN NULL ELSE 'festival_company' END,v_related_entity_id,p_description,p_idempotency_key,auth.uid(),p_profile_id,COALESCE(auth.uid()::text,'system'),timezone('utc',now()),
+    src.default_currency_code,dst.default_currency_code,p_amount_minor,p_amount_minor,p_metadata || jsonb_build_object('profilesCashRole','compatibility_projection')
+  ) RETURNING id INTO tx;
+
+  UPDATE public.financial_accounts SET current_balance_minor = current_balance_minor - p_amount_minor, updated_at = timezone('utc', now()) WHERE id = src.id;
+  UPDATE public.financial_accounts SET current_balance_minor = current_balance_minor + p_amount_minor, updated_at = timezone('utc', now()) WHERE id = dst.id;
+  INSERT INTO public.financial_ledger_entries(transaction_id,account_id,entry_direction,amount_minor,balance_before_minor,balance_after_minor,currency_code) VALUES
+    (tx, src.id, 'debit', p_amount_minor, src_before, src_before - p_amount_minor, src.default_currency_code),
+    (tx, dst.id, 'credit', p_amount_minor, dst_before, dst_before + p_amount_minor, dst.default_currency_code);
+
+  SELECT * INTO src FROM public.financial_accounts WHERE id=src.id;
+  UPDATE public.profiles SET cash = (src.current_balance_minor / 100.0), updated_at = now() WHERE id=p_profile_id;
+  RETURN jsonb_build_object('transactionId', tx, 'availableBalanceMinor', src.available_balance_minor, 'currentBalanceMinor', src.current_balance_minor, 'projectedCash', (src.current_balance_minor / 100.0));
+END $$;
+
+REVOKE ALL ON FUNCTION public.finance_debit_player_personal_cash(uuid,bigint,public.financial_transaction_category,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+
+CREATE OR REPLACE FUNCTION festival_test.cleanup_run(p_run_id text)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path=festival_test,public,auth AS $$
+DECLARE v_prefix text := p_run_id || '%';
+BEGIN
+  IF current_user <> 'service_role' AND session_user <> 'postgres' THEN
+    RAISE EXCEPTION 'festival_test_privileged_context_required' USING ERRCODE='42501';
+  END IF;
+  DELETE FROM public.financial_ledger_entries e USING public.financial_transactions t WHERE e.transaction_id=t.id AND t.idempotency_key LIKE 'festival-company-founding:' || p_run_id || '-%';
+  DELETE FROM public.company_transactions ct USING public.companies c WHERE ct.company_id=c.id AND c.description LIKE v_prefix;
+  DELETE FROM public.festival_company_audit_log a USING public.festival_companies fc WHERE a.festival_company_id=fc.id AND fc.description LIKE v_prefix;
+  DELETE FROM public.festival_company_founding_requests WHERE idempotency_key LIKE p_run_id || '-%';
+  DELETE FROM public.company_shareholders s USING public.companies c WHERE s.company_id=c.id AND c.description LIKE v_prefix;
+  DELETE FROM public.festival_companies WHERE description LIKE v_prefix;
+  DELETE FROM public.financial_transactions WHERE idempotency_key LIKE 'festival-company-founding:' || p_run_id || '-%';
+  DELETE FROM public.companies WHERE description LIKE v_prefix;
+  DELETE FROM public.financial_accounts WHERE metadata->>'festival_test_run_id' = p_run_id;
+  DELETE FROM public.vip_subscriptions WHERE metadata->>'festival_test_run_id' = p_run_id;
+  DELETE FROM public.profiles WHERE username LIKE 'festival_' || replace(p_run_id,'-','_') || '%';
+  DELETE FROM auth.users WHERE email LIKE p_run_id || '%@example.test';
+  DELETE FROM festival_test.runs WHERE run_id = p_run_id;
+END $$;

--- a/supabase/tests/festival_company_financial_correctness_harness.sql
+++ b/supabase/tests/festival_company_financial_correctness_harness.sql
@@ -10,8 +10,11 @@ BEGIN EXECUTE 'SET LOCAL ROLE service_role'; PERFORM set_config('request.jwt.cla
 CREATE TEMP TABLE festival_runtime_assertions(label text PRIMARY KEY, passed boolean NOT NULL, detail text) ON COMMIT DROP;
 CREATE OR REPLACE FUNCTION test_festival_runtime.record_assertion(label text, passed boolean, detail text DEFAULT NULL) RETURNS void LANGUAGE plpgsql AS $$
 BEGIN
-  INSERT INTO festival_runtime_assertions VALUES (label, passed, detail);
-  IF passed IS DISTINCT FROM true THEN RAISE EXCEPTION 'assertion failed: % %', label, coalesce(detail,''); END IF;
+  BEGIN
+    INSERT INTO festival_runtime_assertions VALUES (label, passed, detail);
+  EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'duplicate runtime assertion label: %', label;
+  END;
 END $$;
 CREATE OR REPLACE FUNCTION test_festival_runtime.assert_true(label text, actual boolean) RETURNS void LANGUAGE plpgsql AS $$ BEGIN PERFORM test_festival_runtime.record_assertion(label, actual IS TRUE, 'expected true'); END $$;
 CREATE OR REPLACE FUNCTION test_festival_runtime.assert_eq(label text, actual numeric, expected numeric) RETURNS void LANGUAGE plpgsql AS $$ BEGIN PERFORM test_festival_runtime.record_assertion(label, actual IS NOT DISTINCT FROM expected, format('expected %s, got %s', expected, actual)); END $$;
@@ -24,7 +27,9 @@ DECLARE
   u uuid := '81280000-0000-0000-0000-000000000001'; p uuid := '81280000-0000-0000-0000-000000000101'; p2 uuid := '81280000-0000-0000-0000-000000000102';
   other_user uuid := '81280000-0000-0000-0000-000000000002'; other_profile uuid := '81280000-0000-0000-0000-000000000202';
   res jsonb; retry jsonb; company uuid; fc uuid; tx uuid; before_requests bigint; before_tx bigint;
-  rollback_token text := 'trusted-runtime-rollback-token'; post_debit_token text := 'trusted-runtime-post-debit-token'; ran bigint; failures bigint;
+  run_id text := 'runtime-' || replace(gen_random_uuid()::text,'-','');
+  expected_assertions constant integer := 34;
+  rollback_token text := encode(gen_random_bytes(32),'hex'); post_debit_token text := encode(gen_random_bytes(32),'hex'); ran bigint; failures bigint;
 BEGIN
   PERFORM test_festival_runtime.as_service();
   PERFORM set_config('app.allow_test_fixtures','true', true); -- untrusted compatibility GUC: assertions below prove it is ignored without a trusted token.
@@ -79,9 +84,9 @@ BEGIN
   PERFORM set_config('app.festival_foundation_fail_after_debit','', true);
 
   PERFORM test_festival_runtime.as_service();
-  SELECT festival_test.create_run('runtime-rollback-extension', rollback_token, 'rollback', false, true, false, interval '15 minutes');
-  SELECT festival_test.create_run('runtime-rollback-post-debit', post_debit_token, 'rollback', false, false, true, interval '15 minutes');
-  UPDATE public.financial_accounts SET current_balance_minor=1000000000, available_balance_minor=1000000000 WHERE owner_type='player' AND owner_id=p AND is_primary; UPDATE public.profiles SET cash=10000000 WHERE id=p;
+  SELECT festival_test.create_run(run_id || '-runtime-rollback-extension', rollback_token, 'rollback', false, true, false, interval '15 minutes');
+  SELECT festival_test.create_run(run_id || '-runtime-rollback-post-debit', post_debit_token, 'rollback', false, false, true, interval '15 minutes');
+  UPDATE public.financial_accounts SET current_balance_minor=1000000000, reserved_balance_minor=0 WHERE owner_type='player' AND owner_id=p AND is_primary; UPDATE public.profiles SET cash=10000000 WHERE id=p;
   PERFORM test_festival_runtime.as_user(u);
   PERFORM set_config('app.festival_test_run_token', rollback_token, true);
   PERFORM test_festival_runtime.assert_raises('late rollback','SELECT public.found_festival_company(''Rollback Proof Fest'',''Rollback Proof LLC'',NULL,''runtime-rollback-0001'')','festival_test_late_failure');
@@ -99,8 +104,12 @@ BEGIN
   PERFORM test_festival_runtime.assert_true('retry after rolled-back post-debit failure succeeds', (retry->>'companyId') IS NOT NULL AND (retry->>'idempotent')::boolean IS FALSE);
 
   SELECT count(*), count(*) FILTER (WHERE NOT passed) INTO ran, failures FROM festival_runtime_assertions;
-  IF ran <> 34 OR failures <> 0 THEN
-    RAISE EXCEPTION 'festival runtime assertion accounting failed: expected 34, ran %, failed %', ran, failures;
+  RAISE NOTICE 'festival runtime assertion totals: expected %, executed %, passed %, failed %', expected_assertions, ran, ran - failures, failures;
+  IF failures <> 0 THEN
+    RAISE NOTICE 'failed runtime assertions: %', (SELECT jsonb_agg(jsonb_build_object('label',label,'detail',detail)) FROM festival_runtime_assertions WHERE NOT passed);
+  END IF;
+  IF ran <> expected_assertions OR failures <> 0 THEN
+    RAISE EXCEPTION 'festival runtime assertion accounting failed: expected %, ran %, failed %', expected_assertions, ran, failures;
   END IF;
   RAISE NOTICE 'ok - festival company runtime scenarios completed: % assertions', ran;
 END $$;


### PR DESCRIPTION
### Motivation
- The festival runtime and finance CI gates were failing after recent harness changes and the workflow duplicated the SQL harness invocation, risking double execution and inconsistent DB state.  The intent is to make the runtime gate canonical, make finance writes conform to the shared finance contract, and harden the deterministic concurrency and cleanup helpers.
- Make CI behavior deterministic by pinning the Supabase CLI, adding minimal runtime diagnostics and ensuring the canonical entrypoint `npm run test:festivals:company-runtime` is the single source of truth for festival runtime checks.

### Description
- Canonical workflow entrypoint: remove the duplicated direct SQL harness run from `.github/workflows/festival-runtime-gate.yml` and call only the canonical `npm run test:festivals:company-runtime`, and add failure diagnostics and brief tool-version printing. (file: `.github/workflows/festival-runtime-gate.yml`)
- Pin Supabase CLI in workflows: replace `version: latest` with `version: 2.31.8` in the festival runtime gate and the Phase 5 Live Gig database job to reduce flaky infra drift. (file: `.github/workflows/festival-runtime-gate.yml`, `.github/workflows/phase-5-live-gig-release-gate.yml`)
- Finance contract fix: add a corrective migration that replaces the lightweight compatibility wrapper with a proper completed `financial_transactions` journal entry including source/destination accounts, currencies, related entity metadata, two balanced `financial_ledger_entries`, and an updated `profiles.cash` projection. (file: `supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql`)
- Harness improvements: make the SQL runtime harness record assertions into a temp table, detect duplicate assertion labels, centralize `expected_assertions`, generate unique trusted tokens/run IDs, and emit a final summary of failed assertions. (file: `supabase/tests/festival_company_financial_correctness_harness.sql`)
- Concurrency + cleanup hardening: make the concurrency script use UUID run/user/profile fixtures and cryptographically-random tokens, avoid unsafe available-balance writes (use `reserved_balance_minor` accomodation), add robust error diagnostics and parse-time checks, and make `festival_test.cleanup_run` delete ledger/transaction children before parent rows. (files: `scripts/festivals/run-company-runtime-concurrency.sh`, `supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql`)

### Testing
- `npm run typecheck` — passed locally in this environment (TypeScript typecheck completed).
- `node scripts/supabase/verify-required-rpcs.mjs` / `npm run verify:supabase-rpcs` — passed locally and verified required frontend RPC contracts against migrations.
- `bash -n scripts/festivals/run-company-runtime-concurrency.sh scripts/festivals/run-company-runtime-gate.sh` (syntax/check) — passed (scripts are syntactically valid after changes).
- `npm ci` / `npm run lint` / `npm run test:unit` / `npm run build` — could not be completed in this environment because `npm ci` failed due to external registry HTTP 403 when fetching packages, which left tools such as `vitest`, `vite` and `@eslint/js` unavailable; as a result `lint`, `unit tests` and `build` could not run here and are expected to run in CI where registry access is available.
- `npm run test:festivals:company-runtime` — could not be executed locally in this container because `psql` is not available; the workflow now runs this canonical command under the Supabase-managed environment where `psql` will be present.
- GitHub Actions inspection: attempted `gh` calls and unauthenticated API access were blocked in this environment (`gh: command not found` and HTTP 403 responses), so I validated failures and root causes from repository sources and local command reproductions rather than fetching remote Action logs.

Files changed (key): `.github/workflows/festival-runtime-gate.yml`, `.github/workflows/phase-5-live-gig-release-gate.yml`, `scripts/festivals/run-company-runtime-concurrency.sh`, `supabase/tests/festival_company_financial_correctness_harness.sql`, `supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a627b6819048325b7b5fbe770d67725)