### PR TITLE
test(festivals): execute and close the founding release gate

### DIFF
--- a/supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql
+++ b/supabase/migrations/20260723224500_repair_festival_runtime_finance_gates.sql
@@ -17,14 +17,22 @@ DECLARE
   v_related_entity_id uuid := NULLIF(p_metadata->>'festivalCompanyId','')::uuid;
 BEGIN
   IF p_amount_minor <= 0 THEN RAISE EXCEPTION 'amount must be positive'; END IF;
-  SELECT id INTO tx FROM public.financial_transactions WHERE idempotency_key = p_idempotency_key;
+  SELECT * INTO src FROM public.financial_accounts WHERE owner_type='player' AND owner_id=p_profile_id AND is_primary;
+  IF NOT FOUND THEN RAISE EXCEPTION 'finance account not found'; END IF;
+
+  SELECT id INTO tx
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_idempotency_key
+    AND transaction_category = p_category
+    AND source_account_id = src.id
+    AND related_entity_type IS NOT DISTINCT FROM CASE WHEN v_related_entity_id IS NULL THEN NULL ELSE 'festival_company' END
+    AND related_entity_id IS NOT DISTINCT FROM v_related_entity_id;
   IF tx IS NOT NULL THEN
-    SELECT * INTO src FROM public.financial_accounts WHERE owner_type='player' AND owner_id=p_profile_id AND is_primary;
     UPDATE public.profiles SET cash = (src.current_balance_minor / 100.0), updated_at = now() WHERE id=p_profile_id;
     RETURN jsonb_build_object('transactionId', tx, 'availableBalanceMinor', src.available_balance_minor, 'currentBalanceMinor', src.current_balance_minor, 'projectedCash', (src.current_balance_minor / 100.0));
   END IF;
 
-  SELECT * INTO src FROM public.financial_accounts WHERE owner_type='player' AND owner_id=p_profile_id AND is_primary FOR UPDATE;
+  SELECT * INTO src FROM public.financial_accounts WHERE id=src.id FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'finance account not found'; END IF;
   dst := public.get_or_create_primary_financial_account('system', NULL, 'System operating account', src.default_currency_code);
   SELECT * INTO dst FROM public.financial_accounts WHERE id = dst.id FOR UPDATE;

--- a/supabase/tests/festival_company_financial_correctness_harness.sql
+++ b/supabase/tests/festival_company_financial_correctness_harness.sql
@@ -28,7 +28,7 @@ DECLARE
   other_user uuid := '81280000-0000-0000-0000-000000000002'; other_profile uuid := '81280000-0000-0000-0000-000000000202';
   res jsonb; retry jsonb; company uuid; fc uuid; tx uuid; before_requests bigint; before_tx bigint;
   run_id text := 'runtime-' || replace(gen_random_uuid()::text,'-','');
-  expected_assertions constant integer := 34;
+  expected_assertions constant integer := 35;
   rollback_token text := encode(gen_random_bytes(32),'hex'); post_debit_token text := encode(gen_random_bytes(32),'hex'); ran bigint; failures bigint;
 BEGIN
   PERFORM test_festival_runtime.as_service();
@@ -63,7 +63,8 @@ BEGIN
   PERFORM test_festival_runtime.assert_eq('one founder shareholder',(SELECT count(*) FROM public.company_shareholders WHERE company_id=company AND user_id=u),1);
   PERFORM test_festival_runtime.assert_eq('one founding request',(SELECT count(*) FROM public.festival_company_founding_requests)-before_requests,1);
   PERFORM test_festival_runtime.assert_eq('one founding financial event',(SELECT count(*) FROM public.financial_transactions WHERE transaction_category='festival_company_founding_fee')-before_tx,1);
-  PERFORM test_festival_runtime.assert_eq('two balanced ledger entries',(SELECT count(*) FROM public.financial_ledger_entries WHERE transaction_id=tx),2);
+  PERFORM test_festival_runtime.assert_eq('two ledger entries',(SELECT count(*) FROM public.financial_ledger_entries WHERE transaction_id=tx),2);
+  PERFORM test_festival_runtime.assert_eq('signed journal total zero',(SELECT COALESCE(SUM(CASE WHEN entry_direction='credit' THEN amount_minor ELSE -amount_minor END),0) FROM public.financial_ledger_entries WHERE transaction_id=tx),0);
   PERFORM test_festival_runtime.assert_eq('no company operating expense',(SELECT count(*) FROM public.company_transactions WHERE company_id=company),0);
   PERFORM test_festival_runtime.assert_true('audit rows exist',(SELECT count(*) FROM public.festival_company_audit_log WHERE festival_company_id=fc)>=2);
   PERFORM test_festival_runtime.assert_eq('returned balance matches', (res->>'authoritativePersonalBalance')::numeric, 8000000);


### PR DESCRIPTION
### Motivation
- Prevent idempotent-replay returns of unrelated transactions and align the festival founding runtime with the repository-wide finance conventions. 
- Make the festival runtime SQL harness prove balanced ledger accounting using the shared unsigned-ledger convention (entry_direction determines sign). 

### Description
- Scoped `finance_debit_player_personal_cash` idempotency lookup to require `transaction_category = p_category`, `source_account_id = src.id` and matching `related_entity_type`/`related_entity_id` so a different transaction with the same idempotency key cannot be returned. 
- Load the source `financial_accounts` row before the idempotency lookup and then `FOR UPDATE` that same row when performing the actual debit to ensure correct locking and account resolution. 
- Kept ledger rows as unsigned positive `amount_minor` values and added a signed-journal assertion to the harness that computes the signed sum with `CASE WHEN entry_direction='credit' THEN amount_minor ELSE -amount_minor END`. 
- Updated the runtime SQL harness to expect one additional assertion and to assert both exactly two ledger rows and that the signed journal total is zero. 

### Testing
- `git diff --check` passed on the working tree after the changes and the patch was committed. 
- `npm ci` failed due to a registry/network policy `403 Forbidden` for `@react-three/fiber`, so frontend dependency installation did not complete in this environment. 
- `npm ci --legacy-peer-deps` was attempted (matching CI convention) but did not complete in the container and the run was terminated. 
- `gh` CLI inspection commands (`gh run list` / `gh run view`) were not executed because `gh` is not installed in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63072caf548325a3e1d5e1aa3d66ff)