### PR TITLE
test(env): harden festival runtime gate, pin npm, and strengthen DOM smoke test

### DIFF
--- a/.github/workflows/festival-runtime-gate.yml
+++ b/.github/workflows/festival-runtime-gate.yml
@@ -8,6 +8,7 @@ on:
       - 'supabase/tests/**'
       - 'scripts/festivals/**'
       - 'src/features/festival-company/**'
+      - 'src/testing/**'
       - 'src/integrations/supabase/types.ts'
       - 'vitest.setup.ts'
       - 'vitest.config.*'
@@ -40,38 +41,22 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Use repository npm version
+        run: npm install --global npm@10.9.2
       - name: Install dependencies
         run: npm ci
       - name: Verify dependency tree
         run: npm run verify:dependencies
-      - name: Install pinned Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: 2.31.8
-      - name: Print tool versions
+      - name: Print frontend tool versions
         run: |
           node --version
           npm --version
-          supabase --version
-          psql --version
-      - name: Start local Supabase stack
-        run: supabase start
-      - name: Reset migrated test database
-        run: supabase db reset
-      - name: Verify database safety guard
-        run: npm run test:festivals:safety-guard
       - name: Lint
         run: npm run lint
       - name: Typecheck
         run: npm run typecheck
       - name: Run full unit tests
         run: npm run test:unit
-      - name: Verify required Supabase RPCs
-        run: npm run verify:supabase-rpcs
-      - name: Run canonical festival runtime gate
-        run: npm run test:festivals:company-runtime
-      - name: Prove canonical festival runtime gate is rerunnable
-        run: npm run test:festivals:company-runtime
       - name: Run festival frontend unit tests
         run: npx vitest run src/features/festival-company
       - name: Run smoke test suite
@@ -80,6 +65,26 @@ jobs:
         run: npx vitest run src/testing/__tests__/vitestDomEnvironment.test.tsx
       - name: Build
         run: npm run build
+      - name: Install pinned Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.31.8
+      - name: Print database tool versions
+        run: |
+          supabase --version
+          psql --version
+      - name: Start local Supabase stack
+        run: supabase start
+      - name: Reset migrated test database
+        run: supabase db reset
+      - name: Verify required Supabase RPCs
+        run: npm run verify:supabase-rpcs
+      - name: Verify database safety guard
+        run: npm run test:festivals:safety-guard
+      - name: Run canonical festival runtime gate
+        run: npm run test:festivals:company-runtime
+      - name: Prove canonical festival runtime gate is rerunnable
+        run: npm run test:festivals:company-runtime
 
       - name: Capture runtime diagnostics
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
       },
       "engines": {
         "node": "20.x",
-        "npm": "10.x || 11.x"
+        "npm": "10.9.x"
       }
     },
     "local-packages/jsdom": {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   },
   "engines": {
     "node": "20.x",
-    "npm": "10.x || 11.x"
-  }
+    "npm": "10.9.x"
+  },
+  "packageManager": "npm@10.9.2"
 }

--- a/src/testing/__tests__/vitestDomEnvironment.test.tsx
+++ b/src/testing/__tests__/vitestDomEnvironment.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -18,6 +18,10 @@ function EnvironmentSmoke() {
 }
 
 describe('Vitest DOM environment', () => {
+  beforeEach(() => {
+    expect(document.body).toBeEmptyDOMElement();
+  });
+
   it('renders, queries, types, clicks and unmounts React components', async () => {
     const user = userEvent.setup();
     const view = render(<EnvironmentSmoke />);
@@ -25,11 +29,21 @@ describe('Vitest DOM environment', () => {
     expect(screen.getByRole('heading', { name: 'Vitest DOM smoke' })).toBeInTheDocument();
     const input = screen.getByLabelText('Festival name');
     await user.click(input);
+    expect(input).toHaveFocus();
     await user.keyboard('Genesis Fest');
+    expect(input).toHaveValue('Genesis Fest');
     await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     expect(screen.getByRole('status')).toHaveTextContent('Ready: Genesis Fest');
     view.unmount();
     expect(screen.queryByRole('heading', { name: 'Vitest DOM smoke' })).not.toBeInTheDocument();
+    expect(document.body).toBeEmptyDOMElement();
+  });
+
+  it('starts subsequent renders with isolated component state', () => {
+    render(<EnvironmentSmoke />);
+
+    expect(screen.getByLabelText('Festival name')).toHaveValue('');
+    expect(screen.getByRole('status')).toHaveTextContent('Waiting');
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -48,8 +48,12 @@ if (typeof window !== "undefined") {
 }
 
 const testWindow = typeof window === "undefined" ? undefined : window;
-defineMissing(globalThis as typeof globalThis & { ResizeObserver?: unknown }, "ResizeObserver", testWindow?.ResizeObserver);
-defineMissing(globalThis as typeof globalThis & { IntersectionObserver?: unknown }, "IntersectionObserver", testWindow?.IntersectionObserver);
+if (testWindow?.ResizeObserver) {
+  defineMissing(globalThis as typeof globalThis & { ResizeObserver?: unknown }, "ResizeObserver", testWindow.ResizeObserver);
+}
+if (testWindow?.IntersectionObserver) {
+  defineMissing(globalThis as typeof globalThis & { IntersectionObserver?: unknown }, "IntersectionObserver", testWindow.IntersectionObserver);
+}
 if (typeof Element !== "undefined") defineMissing(Element.prototype, "scrollIntoView", vi.fn());
 if (typeof HTMLElement !== "undefined") defineMissing(HTMLElement.prototype, "scrollTo", vi.fn());
 if (typeof HTMLCanvasElement !== "undefined") defineMissing(HTMLCanvasElement.prototype, "getContext", vi.fn(() => null));


### PR DESCRIPTION
### Motivation

- Restore a reproducible Festival Runtime Gate by pinning the repository npm version and ensuring the CI workflow uses the same installer.  
- Replace fragile test-environment assumptions by avoiding undefined observer globals and strengthening the DOM smoke assertions to prove real jsdom/Test Library behaviour.  
- Re-order the runtime gate so frontend checks run before starting the Supabase stack to reduce wasted infrastructure runtime.  

### Description

- Pin repository npm to `10.9.x` and add `packageManager: "npm@10.9.2"` to `package.json`, and update the lockfile root `engines.npm` to `10.9.x`.  
- Update the Festival Runtime Gate (`.github/workflows/festival-runtime-gate.yml`) to include `src/testing/**` path coverage, install the pinned npm version before `npm ci`, move Supabase steps after frontend/build checks, and keep diagnostics + shutdown under `if: always()`.  
- Harden `vitest.setup.ts` to only define `ResizeObserver` and `IntersectionObserver` globals when valid implementations exist to avoid setting globals to `undefined`.  
- Strengthen `src/testing/__tests__/vitestDomEnvironment.test.tsx` with explicit `beforeEach` DOM cleanup assertion, focus and controlled-value checks, unmount teardown assertion, and an additional test proving render isolation.  

### Testing

- `git diff --check` completed successfully with no whitespace errors.  
- Shell syntax checks `bash -n scripts/festivals/*.sh` and JS syntax validators `node --check scripts/festivals/validate-*.mjs` succeeded.  
- Repository and workflow edits were lint/syntax validated and staged changes were committed locally, but full dependency install and runtime tests could not be executed because the execution environment prevented network access to the npm registry and lacked `gh` and Supabase CLI.  
- Attempts to run `npm install`/`npm ci` and regenerate the lockfile failed due to outbound registry proxy returning HTTP 403, so `vitest`, `lint`, `typecheck`, `build`, `verify:dependencies`, and Supabase runtime gates were not executed in this environment and therefore have no result here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65133396c88325a948877b1d2cbc1e)