### PR TITLE
fix(deps): generate the official lockfile in GitHub Actions and unblock CI

### DIFF
--- a/.github/workflows/generate-package-lock.yml
+++ b/.github/workflows/generate-package-lock.yml
@@ -1,0 +1,58 @@
+name: Generate package lock
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-lockfile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install repository npm version
+        run: npm install --global npm@10.9.2
+
+      - name: Print tool versions
+        run: |
+          node --version
+          npm --version
+
+      - name: Remove existing generated state
+        run: |
+          rm -rf node_modules
+          rm -f package-lock.json
+
+      - name: Generate package lock
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Validate generated lock
+        run: |
+          npm ci --ignore-scripts
+          npm run verify:dependencies
+
+      - name: Inspect official test dependencies
+        run: |
+          npm ls jsdom
+          npm ls @testing-library/react
+          npm ls @testing-library/user-event
+          npm ls @testing-library/jest-dom
+
+      - name: Upload generated lockfile
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-package-lock
+          path: package-lock.json
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
### Motivation

- Add a temporary, manually-dispatchable GitHub Actions job to generate a canonical npm 10.9.2 `package-lock.json` from `https://registry.npmjs.org` so CI and the release gates can install the official `jsdom` and Testing Library artifacts and stop failing due to lockfile metadata drift.

### Description

- Add `.github/workflows/generate-package-lock.yml`, a `workflow_dispatch` job that uses `actions/setup-node@v4` (Node 20) and installs `npm@10.9.2`, wipes generated state, runs `npm install --package-lock-only --ignore-scripts`, validates with `npm ci --ignore-scripts` and `npm run verify:dependencies`, inspects `jsdom` and Testing Library packages, and uploads the generated `package-lock.json` as artifact `generated-package-lock`, and commit created on branch `codex/generate-official-lockfile-in-actions` (commit `4682ffa`).

### Testing

- Automated checks performed: `git show --check --oneline HEAD`, `git diff --exit-code package-lock.json`, and `git status --short --branch` succeeded, while `git push` failed with a `CONNECT tunnel failed, response 403` preventing dispatch of the workflow, and an attempted offline `npm install --package-lock-only --ignore-scripts --offline` failed with `ENOTCACHED` for `@testing-library/jest-dom`, so the Actions run could not be executed and no generated artifact or downstream CI/release-gate results are yet available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65afcabd10832580e77bddbd13e9f1)