### PR TITLE
fix(festivals): complete runtime workers and correct financial settlement

### DIFF
--- a/scripts/supabase/verify-migration-timestamps.mjs
+++ b/scripts/supabase/verify-migration-timestamps.mjs
@@ -18,6 +18,7 @@ const festivalPhase8RuntimeContinuation = "20291217200000_live_festival_runtime_
 const festivalPhase8OperationsContinuation = "20291217210000_festival_crowds_incidents_and_operations.sql";
 const festivalPhase9SettlementContinuation = "20291217220000_festival_financial_settlement.sql";
 const festivalPhase9LegacyContinuation = "20291217230000_festival_historical_legacy.sql";
+const festivalRuntimeWorkerContinuation = "20291218000000_complete_festival_runtime_worker_boundary.sql";
 const legacySequenceNames = new Set(["085_jam_sessions_core.sql", "086_band_member_locks.sql", "087_bands_add_chemistry_cohesion.sql"]);
 const today = new Date();
 const reasonableFuture = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 2, 23, 59, 59));
@@ -30,7 +31,7 @@ for (const filename of readdirSync(migrationDirectory).filter((name) => name.end
     failures.push(`${filename}: expected YYYYMMDDHHMMSS_description.sql`); continue;
   }
   const stamp = match[1];
-  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation) { exceptions.push(filename); continue; }
+  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation || filename === festivalRuntimeWorkerContinuation) { exceptions.push(filename); continue; }
   const todayStamp = `${today.getUTCFullYear()}${String(today.getUTCMonth() + 1).padStart(2, "0")}${String(today.getUTCDate()).padStart(2, "0")}235959`;
   // Freeze every inherited future sequence through the known anomaly. This includes
   // several historical invalid calendar-day names; accepting the exact bounded

--- a/src/utils/__tests__/gigLive.test.ts
+++ b/src/utils/__tests__/gigLive.test.ts
@@ -38,6 +38,18 @@ describe('gig live simulation', () => {
     expect(strong.score).toBeGreaterThan(weak.score);
   });
 
+  it('applies Festival evidence in the canonical score while preserving normal gigs', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const normal = resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'festival-seed');
+    const normalAgain = resolveLiveSong({ ...ctx }, session, ctx.setlist[0], 1, 'festival-seed');
+    const excellentFestival = resolveLiveSong({ ...ctx, festival: { stageQuality: 100, soundAndLighting: 100, technicalReadiness: 100, rehearsal: 100, crewEffectiveness: 100, weather: 100, delayMinutes: 0, crowdMood: 100, crowdDensity: 100, equipmentCondition: 100, billingPosition: 100, headlinerExpectation: 50, incidentDisruption: 0, setLengthMinutes: 60 } }, session, ctx.setlist[0], 1, 'festival-seed');
+    const disruptedFestival = resolveLiveSong({ ...ctx, festival: { stageQuality: 10, soundAndLighting: 10, technicalReadiness: 10, rehearsal: 10, crewEffectiveness: 10, weather: 5, delayMinutes: 60, crowdMood: 10, crowdDensity: 10, equipmentCondition: 10, billingPosition: 10, headlinerExpectation: 100, incidentDisruption: 100, setLengthMinutes: 120 } }, session, ctx.setlist[0], 1, 'festival-seed');
+    expect(normalAgain).toEqual(normal);
+    expect(excellentFestival.score).toBeGreaterThan(disruptedFestival.score);
+    expect(excellentFestival.breakdown.some(item => item.key === 'festival_stage_quality')).toBe(true);
+    expect(normal.breakdown.some(item => item.key.startsWith('festival_'))).toBe(false);
+  });
+
   it('supports tactical decisions, automatic fallbacks, encore checks and immutable completed segments', () => {
     const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
     const incident = maybeGenerateLiveIncident({ ...ctx, equipment: [{ equipmentRole: 'amplifier', quality: 20, condition: 20, isSpare: false }] }, { ...session, bandStamina: 20 }, { ...buildLiveTimeline(ctx)[1], segmentIndex: 1 }, 'likely-incident') ?? { incidentType: 'equipment_fault', category: 'equipment' as const, severity: 'moderate' as const, title: 'Equipment fault', decisionType: 'equipment_response', generationSnapshot: {}, resultSnapshot: {} };

--- a/src/utils/gigLive.ts
+++ b/src/utils/gigLive.ts
@@ -15,7 +15,8 @@ export interface LiveGigSong { id: string; title: string; durationSeconds?: numb
 export interface LiveSetlistItem { id: string; song: LiveGigSong; position: number; isEncore?: boolean; }
 export interface GigLiveSegment { id?: string; segmentIndex: number; segmentType: LiveSegmentType; setlistItemId?: string | null; songId?: string | null; plannedStartAt: string; plannedDurationSeconds: number; status: LiveSegmentStatus; resultSnapshot?: Record<string, unknown>; }
 export interface LiveGigSessionState { gigId: string; bandId: string; status: LiveGigStatus; startedAt: string; expectedEndAt?: string; currentSegmentIndex: number; currentSongItemId?: string | null; crowdEnergy: number; fanSatisfaction: number; performanceQuality: number; bandStamina: number; momentum: number; incidentRisk: number; simulationVersion: number; lastProcessedAt?: string; }
-export interface GigLiveContext { gigId: string; bandId: string; scheduledAt: string | Date; status?: string | null; slotDurationSeconds?: number | null; capacity?: number | null; ticketsSold?: number | null; venueAcoustics?: number | null; venueQuality?: number | null; genreAffinity?: number | null; ticketPrice?: number | null; curfewAt?: string | Date | null; performerSkill?: number | null; stagePresence?: number | null; bandChemistry?: number | null; healthScore?: number | null; fatigueScore?: number | null; readiness: ReadinessResult; crew?: CrewAssignmentInput[]; equipment?: EquipmentLoadoutInput[]; productionQuality?: ProductionQualityResult | null; soundcheckType?: SoundcheckType; preShowConsequences?: PreshowConsequence[]; setlist: LiveSetlistItem[]; }
+export interface FestivalLiveContext { stageQuality: number; soundAndLighting: number; technicalReadiness: number; rehearsal: number; crewEffectiveness: number; weather: number; delayMinutes: number; crowdMood: number; crowdDensity: number; equipmentCondition: number; billingPosition: number; headlinerExpectation: number; incidentDisruption: number; setLengthMinutes: number; }
+export interface GigLiveContext { gigId: string; bandId: string; scheduledAt: string | Date; status?: string | null; slotDurationSeconds?: number | null; capacity?: number | null; ticketsSold?: number | null; venueAcoustics?: number | null; venueQuality?: number | null; genreAffinity?: number | null; ticketPrice?: number | null; curfewAt?: string | Date | null; performerSkill?: number | null; stagePresence?: number | null; bandChemistry?: number | null; healthScore?: number | null; fatigueScore?: number | null; readiness: ReadinessResult; crew?: CrewAssignmentInput[]; equipment?: EquipmentLoadoutInput[]; productionQuality?: ProductionQualityResult | null; soundcheckType?: SoundcheckType; preShowConsequences?: PreshowConsequence[]; setlist: LiveSetlistItem[]; festival?: Readonly<FestivalLiveContext>; }
 export interface LiveBreakdownItem { key: string; label: string; modifier: number; explanation: string; }
 export interface LiveSongResult { score: number; rating: LiveSongRating; technicalScore: number; performanceScore: number; audienceResponse: number; energyChange: number; satisfactionChange: number; staminaCost: number; momentumChange: number; incidents: string[]; highlights: string[]; breakdown: LiveBreakdownItem[]; }
 export interface LiveIncident { incidentType: string; category: LiveIncidentCategory; severity: LiveIncidentSeverity; title: string; decisionType?: string; generationSnapshot: Record<string, unknown>; resultSnapshot: Record<string, unknown>; }
@@ -30,6 +31,29 @@ const signedClamp = (n: number, max: number) => Math.max(-max, Math.min(max, n))
 const hash = (seed: string) => Array.from(seed).reduce((h, ch) => Math.imul(31, h) + ch.charCodeAt(0) | 0, 2166136261) >>> 0;
 export const deterministicRandom = (seed: string) => (hash(seed) % 10000) / 10000;
 const ratingFor = (score: number): LiveSongRating => score < 25 ? 'disaster' : score < 40 ? 'poor' : score < 58 ? 'average' : score < 72 ? 'good' : score < 86 ? 'great' : 'outstanding';
+
+/** A bounded, auditable modifier inside the canonical engine (not a second score). */
+export function calculateFestivalLiveModifier(context?: Readonly<FestivalLiveContext>): LiveBreakdownItem[] {
+  if (!context) return [];
+  const centered = (value: number, weight: number) => (clamp(value) - 50) * weight;
+  const effects: Array<[string, string, number]> = [
+    ['stage_quality', 'Stage quality', centered(context.stageQuality, .055)],
+    ['sound_lighting', 'Sound and lighting', centered(context.soundAndLighting, .06)],
+    ['technical_readiness', 'Technical readiness', centered(context.technicalReadiness, .05)],
+    ['rehearsal', 'Festival rehearsal', centered(context.rehearsal, .045)],
+    ['crew', 'Festival crew', centered(context.crewEffectiveness, .04)],
+    ['weather', 'Weather', centered(context.weather, .045)],
+    ['crowd_mood', 'Crowd mood', centered(context.crowdMood, .055)],
+    ['crowd_density', 'Crowd density', centered(context.crowdDensity, .035)],
+    ['equipment', 'Equipment condition', centered(context.equipmentCondition, .045)],
+    ['billing', 'Billing position', centered(context.billingPosition, .025)],
+    ['headliner', 'Headliner expectation', -Math.max(0, context.headlinerExpectation - 65) * .035],
+    ['delay', 'Delay', -Math.min(60, Math.max(0, context.delayMinutes)) * .055],
+    ['incidents', 'Incident disruption', -clamp(context.incidentDisruption) * .045],
+    ['set_length', 'Set length', -Math.abs(Math.max(10, context.setLengthMinutes) - 60) * .018],
+  ];
+  return effects.map(([key, label, modifier]) => ({ key: `festival_${key}`, label, modifier: Number(modifier.toFixed(3)), explanation: `${label} is supplied by the immutable Festival runtime evidence.` }));
+}
 
 export function canStartLiveGig(ctx: GigLiveContext, now = new Date()) {
   const status = ctx.status ?? 'scheduled';
@@ -85,14 +109,17 @@ export function resolveLiveSong(ctx: GigLiveContext, session: LiveGigSessionStat
   const technicalScore = clamp((song.quality ?? 55) * 0.24 + familiarity * 0.2 + (ctx.performerSkill ?? 55) * 0.17 + reliability.quality * 0.12 + crewAvg * 0.08 + (ctx.venueAcoustics ?? 55) * 0.08 + sound.soundBenefit * 0.11 - staminaPenalty + preshow.soundQualityModifier * 45);
   const performanceScore = clamp(ctx.readiness.score * 0.22 + (ctx.bandChemistry ?? 55) * 0.14 + (ctx.stagePresence ?? ctx.performerSkill ?? 55) * 0.16 + (song.popularity ?? 45) * 0.11 + (ctx.productionQuality?.score ?? 55) * 0.09 + session.bandStamina * 0.08 + 50 * 0.08 + positionMod.modifier + crowdLift + momentumLift + preshow.performanceModifier * 100);
   const audienceResponse = clamp(performanceScore * 0.45 + technicalScore * 0.28 + (song.popularity ?? 45) * 0.17 + session.crowdEnergy * 0.10 + venueFit);
-  const score = Math.round(clamp(technicalScore * 0.38 + performanceScore * 0.39 + audienceResponse * 0.23 + boundedRandom));
+  const festivalEffects = calculateFestivalLiveModifier(ctx.festival);
+  const festivalModifier = signedClamp(festivalEffects.reduce((sum, effect) => sum + effect.modifier, 0), 18);
+  const baseScore = clamp(technicalScore * 0.38 + performanceScore * 0.39 + audienceResponse * 0.23 + boundedRandom);
+  const score = Math.round(clamp(baseScore + festivalModifier));
   const intensity = clamp(((song.tempo ?? 110) - 70) / 90 * 100) / 100;
   const staminaCost = Math.round(clamp(DEFAULT_LIVE_GIG_CONFIG.staminaCostBase + (song.durationSeconds ?? 210) / 90 + (song.difficulty ?? 50) / 22 + intensity * 3 - ((song.tags ?? []).some(t => /ballad|slow/i.test(t)) ? 2 : 0), 1, 18));
   const energyChange = Math.round(signedClamp((audienceResponse - 55) * 0.18 + positionMod.modifier * 0.35 - DEFAULT_LIVE_GIG_CONFIG.energyDecayPerSegment, 16));
   const satisfactionChange = Math.round(signedClamp((score - 58) * 0.12 + (technicalScore - 55) * 0.06 + (item.isEncore ? 3 : 0), 12));
   const momentumChange = Math.round(signedClamp((score - 55) * 0.11 + positionMod.modifier * 0.2, 8));
   const highlights = score >= 82 ? [`${song.title} became a standout live moment.`] : audienceResponse >= 78 ? [`The crowd lifted ${song.title}.`] : [];
-  return { score, rating: ratingFor(score), technicalScore: Math.round(technicalScore), performanceScore: Math.round(performanceScore), audienceResponse: Math.round(audienceResponse), energyChange, satisfactionChange, staminaCost, momentumChange, incidents: [], highlights, breakdown: [ { key: 'readiness', label: 'Final readiness', modifier: Math.round(calculateReadinessPerformanceModifier(ctx.readiness.score) * 100), explanation: `Readiness score ${ctx.readiness.score} anchors the performance.` }, { key: 'familiarity', label: 'Song familiarity', modifier: Math.round(familiarity - 55), explanation: 'Saved setlist familiarity/rehearsal affects accuracy.' }, { key: 'equipment_crew', label: 'Equipment and crew', modifier: Math.round((reliability.score + crewAvg) / 2 - 55), explanation: 'Loadout reliability and crew effectiveness reduce mistakes.' }, { key: 'sound_production', label: 'Soundcheck and production', modifier: Math.round(sound.soundBenefit * 0.6 + ((ctx.productionQuality?.score ?? 55) - 55) * 0.12), explanation: 'Soundcheck and production quality shape technical/audience response.' }, { key: 'position', label: 'Setlist position', modifier: Math.round(positionMod.modifier), explanation: positionMod.notes.join(' ') || 'Neutral setlist position.' }, { key: 'live_state', label: 'Crowd, stamina and momentum', modifier: Math.round(crowdLift + momentumLift - staminaPenalty), explanation: 'Current live state modestly influences this song.' }, { key: 'bounded_randomness', label: 'Bounded live variance', modifier: Math.round(boundedRandom), explanation: 'Deterministic per-song variance prevents refresh rerolls.' } ] };
+  return { score, rating: ratingFor(score), technicalScore: Math.round(technicalScore), performanceScore: Math.round(performanceScore), audienceResponse: Math.round(audienceResponse), energyChange, satisfactionChange, staminaCost, momentumChange, incidents: [], highlights, breakdown: [ { key: 'base_score', label: 'Canonical base score', modifier: Number(baseScore.toFixed(3)), explanation: 'Score before optional Festival effects.' }, { key: 'readiness', label: 'Final readiness', modifier: Math.round(calculateReadinessPerformanceModifier(ctx.readiness.score) * 100), explanation: `Readiness score ${ctx.readiness.score} anchors the performance.` }, { key: 'familiarity', label: 'Song familiarity', modifier: Math.round(familiarity - 55), explanation: 'Saved setlist familiarity/rehearsal affects accuracy.' }, { key: 'equipment_crew', label: 'Equipment and crew', modifier: Math.round((reliability.score + crewAvg) / 2 - 55), explanation: 'Loadout reliability and crew effectiveness reduce mistakes.' }, { key: 'sound_production', label: 'Soundcheck and production', modifier: Math.round(sound.soundBenefit * 0.6 + ((ctx.productionQuality?.score ?? 55) - 55) * 0.12), explanation: 'Soundcheck and production quality shape technical/audience response.' }, { key: 'position', label: 'Setlist position', modifier: Math.round(positionMod.modifier), explanation: positionMod.notes.join(' ') || 'Neutral setlist position.' }, { key: 'live_state', label: 'Crowd, stamina and momentum', modifier: Math.round(crowdLift + momentumLift - staminaPenalty), explanation: 'Current live state modestly influences this song.' }, { key: 'bounded_randomness', label: 'Bounded live variance', modifier: Math.round(boundedRandom), explanation: 'Deterministic per-song variance prevents refresh rerolls.' }, ...festivalEffects ] };
 }
 
 export function applySongResultToSession(session: LiveGigSessionState, result: LiveSongResult, item: LiveSetlistItem): LiveGigSessionState {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -192,6 +192,9 @@ verify_jwt = false
 [functions."auto-start-gigs"]
 verify_jwt = false
 
+[functions.festival-performance-worker]
+verify_jwt = false
+
 [functions.create-slot-checkout]
 verify_jwt = false
 

--- a/supabase/functions/festival-performance-worker/index.ts
+++ b/supabase/functions/festival-performance-worker/index.ts
@@ -1,0 +1,25 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { simulateFestivalPerformance, type FestivalJobSnapshot } from "./simulation.ts";
+
+const headers = { "content-type": "application/json" };
+const transient = (error: unknown) => /timeout|network|fetch|temporar|connection/i.test(String(error));
+
+Deno.serve(async request => {
+  if (request.headers.get("x-worker-secret") !== Deno.env.get("FESTIVAL_WORKER_SECRET")) return new Response("Forbidden", { status: 403 });
+  const client = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!, { auth: { persistSession: false } });
+  const worker = `festival-worker:${crypto.randomUUID()}`;
+  const { data: job, error: claimError } = await client.rpc("claim_festival_performance_simulation_job", { p_worker: worker });
+  if (claimError) return new Response(JSON.stringify({ error: claimError.message }), { status: 503, headers });
+  if (!job) return new Response(JSON.stringify({ processed: false }), { headers });
+  try {
+    const { data: valid, error: validationError } = await client.rpc("validate_festival_performance_simulation_input", { p_job: job.id, p_input_digest: job.input_digest });
+    if (validationError || valid !== true) throw new Error("festival_simulation_input_digest_mismatch");
+    const output = simulateFestivalPerformance(job.input_snapshot as FestivalJobSnapshot, job.input_digest);
+    const { data, error } = await client.rpc("complete_festival_performance_simulation_job", { p_job: job.id, p_worker: worker, p_input_digest: job.input_digest, p_output: output });
+    if (error) throw error;
+    return new Response(JSON.stringify({ processed: true, result: data }), { headers });
+  } catch (error) {
+    const { error: failureError } = await client.rpc("fail_festival_performance_simulation_job", { p_job: job.id, p_worker: worker, p_error: String(error), p_retryable: transient(error) });
+    return new Response(JSON.stringify({ processed: false, error: String(error), failureError: failureError?.message }), { status: transient(error) ? 503 : 422, headers });
+  }
+});

--- a/supabase/functions/festival-performance-worker/simulation.ts
+++ b/supabase/functions/festival-performance-worker/simulation.ts
@@ -1,0 +1,69 @@
+import { applySongResultToSession, buildInitialLiveSession, finalizeLiveGig, resolveLiveSong, type FestivalLiveContext, type GigLiveContext, type LiveIncident, type LiveSongResult } from "../../../src/utils/gigLive.ts";
+
+export const FESTIVAL_RESULT_VERSION = "festival-performance-result-v1";
+export const SUPPORTED_ENGINE_VERSION = "canonical-gig-v1";
+
+export interface FestivalJobSnapshot {
+  runtimeSessionId: string; dayId: string; stageId: string; performanceId: string;
+  seed: string; engineVersion: string; runtimeVersion: number;
+  formulaVersions: Record<string, string>; canonicalGigInput: GigLiveContext;
+  festivalModifiers: FestivalLiveContext; weatherEvidence: unknown; crowdEvidence: { attendance: number; stageCapacity: number };
+  delayEvidence: unknown; incidentEvidence: unknown; crewEquipmentEvidence: unknown;
+}
+
+const finite = (value: unknown, name: string) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`festival_result_${name}_invalid`);
+  return value;
+};
+
+export function simulateFestivalPerformance(snapshot: FestivalJobSnapshot, inputDigest: string) {
+  if (snapshot.engineVersion !== SUPPORTED_ENGINE_VERSION) throw new Error("festival_engine_version_unsupported");
+  const raw = snapshot.canonicalGigInput as GigLiveContext & { artist?: { bandId?: string }; schedule?: { startsAt?: string; endsAt?: string } };
+  const duration = raw.schedule?.startsAt && raw.schedule?.endsAt ? Math.max(600, (Date.parse(raw.schedule.endsAt) - Date.parse(raw.schedule.startsAt)) / 1000) : snapshot.festivalModifiers.setLengthMinutes * 60;
+  // Phase 8 v1 inputs did not carry a saved setlist. They remain runnable through a
+  // deterministic canonical placeholder set; no Festival-only score is introduced.
+  const canonical = raw.setlist?.length ? raw : {
+    ...raw, gigId: snapshot.performanceId, bandId: raw.artist?.bandId ?? snapshot.performanceId,
+    scheduledAt: raw.schedule?.startsAt ?? "1970-01-01T00:00:00.000Z", capacity: snapshot.crowdEvidence.stageCapacity,
+    ticketsSold: snapshot.crowdEvidence.attendance, performerSkill: 50, stagePresence: 50, bandChemistry: 50,
+    readiness: { score: 50, blockingIssues: [] },
+    setlist: [{ id: `${snapshot.performanceId}:set`, position: 1, song: { id: `${snapshot.performanceId}:song`, title: "Festival set", durationSeconds: duration, quality: 50, popularity: 50, familiarity: 50, rehearsalLevel: snapshot.festivalModifiers.rehearsal } }],
+  } as GigLiveContext;
+  const context = Object.freeze({ ...canonical, festival: Object.freeze({ ...snapshot.festivalModifiers }) });
+  let session = buildInitialLiveSession(context, new Date(context.scheduledAt));
+  const songs: LiveSongResult[] = [];
+  for (const item of [...context.setlist].sort((a, b) => a.position - b.position)) {
+    const result = resolveLiveSong(context, session, item, item.position, snapshot.seed);
+    songs.push(result);
+    session = applySongResultToSession(session, result, item);
+  }
+  const aggregate = finalizeLiveGig(session, songs, [] as LiveIncident[]);
+  const baseScores = songs.map(song => song.breakdown.find(item => item.key === "base_score")?.modifier ?? song.score);
+  const basePerformanceScore = baseScores.length ? baseScores.reduce((sum, score) => sum + score, 0) / baseScores.length : aggregate.finalQuality;
+  const technicalScore = songs.length ? songs.reduce((sum, song) => sum + song.technicalScore, 0) / songs.length : 0;
+  const modifiers = songs[0]?.breakdown.filter(item => item.key.startsWith("festival_")) ?? [];
+  const result = {
+    resultVersion: FESTIVAL_RESULT_VERSION, engineVersion: snapshot.engineVersion, formulaVersions: snapshot.formulaVersions,
+    seed: snapshot.seed, performanceId: snapshot.performanceId, inputDigest, canonicalGigResultId: null,
+    basePerformanceScore: Number(basePerformanceScore.toFixed(3)), festivalModifiers: { values: snapshot.festivalModifiers, effects: modifiers },
+    finalScore: aggregate.finalQuality, technicalScore: Number(technicalScore.toFixed(3)),
+    crowdResponse: { score: aggregate.finalSatisfaction, energy: aggregate.finalCrowdEnergy }, attendance: snapshot.crowdEvidence.attendance,
+    stageCapacity: snapshot.crowdEvidence.stageCapacity, delayImpact: -Math.min(60, snapshot.festivalModifiers.delayMinutes) * .055,
+    weatherImpact: (snapshot.festivalModifiers.weather - 50) * .045, incidentImpact: -snapshot.festivalModifiers.incidentDisruption * .045,
+    setlistItemOutcomes: songs, stageActions: [], generatedHighlights: songs.flatMap(song => song.highlights),
+  };
+  validateFestivalSimulationResult(result, snapshot, inputDigest);
+  return result;
+}
+
+export function validateFestivalSimulationResult(result: Record<string, unknown>, snapshot: FestivalJobSnapshot, digest: string) {
+  if (result.resultVersion !== FESTIVAL_RESULT_VERSION || result.engineVersion !== snapshot.engineVersion) throw new Error("festival_result_version_invalid");
+  if (result.seed !== snapshot.seed || result.performanceId !== snapshot.performanceId || result.inputDigest !== digest) throw new Error("festival_result_identity_invalid");
+  for (const field of ["basePerformanceScore", "finalScore", "technicalScore", "delayImpact", "weatherImpact", "incidentImpact"])
+    finite(result[field], field);
+  const attendance = finite(result.attendance, "attendance");
+  const capacity = finite(result.stageCapacity, "stage_capacity");
+  if (attendance < 0 || capacity < 0 || attendance > capacity) throw new Error("festival_result_attendance_invalid");
+  for (const field of ["crowdResponse", "festivalModifiers"]) if (!result[field] || typeof result[field] !== "object") throw new Error(`festival_result_${field}_missing`);
+  for (const field of ["setlistItemOutcomes", "stageActions", "generatedHighlights"]) if (!Array.isArray(result[field])) throw new Error(`festival_result_${field}_missing`);
+}

--- a/supabase/migrations/20291218000000_complete_festival_runtime_worker_boundary.sql
+++ b/supabase/migrations/20291218000000_complete_festival_runtime_worker_boundary.sql
@@ -1,0 +1,145 @@
+-- Phase 8 worker boundary correctness: immutable inputs, leases, idempotency and complete outcomes.
+ALTER TABLE public.festival_performance_simulation_jobs
+  ADD COLUMN input_snapshot jsonb,
+  ADD COLUMN result_version text NOT NULL DEFAULT 'festival-performance-result-v1';
+
+CREATE TABLE public.festival_performance_resolution_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), runtime_performance_id uuid NOT NULL REFERENCES public.festival_runtime_performances(id),
+  idempotency_key uuid NOT NULL, request_digest text NOT NULL, simulation_job_id uuid REFERENCES public.festival_performance_simulation_jobs(id),
+  response jsonb, created_at timestamptz NOT NULL DEFAULT now(), completed_at timestamptz,
+  UNIQUE(runtime_performance_id,idempotency_key), UNIQUE(idempotency_key)
+);
+ALTER TABLE public.festival_performance_resolution_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.festival_performance_resolution_requests FROM PUBLIC,anon,authenticated;
+
+CREATE TABLE public.festival_performance_simulation_requeue_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), job_id uuid NOT NULL REFERENCES public.festival_performance_simulation_jobs(id),
+  actor_profile_id uuid NOT NULL REFERENCES public.profiles(id), previous_attempts integer NOT NULL, reason text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(), idempotency_key uuid NOT NULL UNIQUE
+);
+ALTER TABLE public.festival_performance_simulation_requeue_audit ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.festival_performance_simulation_requeue_audit FROM PUBLIC,anon,authenticated;
+
+CREATE OR REPLACE FUNCTION public.resolve_festival_performance(p_runtime_performance_id uuid,p_expected_version integer,p_idempotency_key uuid) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE p public.festival_runtime_performances%ROWTYPE;j public.festival_performance_simulation_jobs%ROWTYPE;req public.festival_performance_resolution_requests%ROWTYPE;snapshot jsonb;digest_input text;response jsonb;
+BEGIN
+ SELECT * INTO p FROM public.festival_runtime_performances WHERE id=p_runtime_performance_id FOR UPDATE;
+ IF p.id IS NULL THEN RAISE EXCEPTION 'festival_runtime_chain_performance';END IF;
+ PERFORM public._festival_assert_runtime_chain(p.runtime_session_id,p.runtime_day_id,p.runtime_stage_id,p.id);
+ IF NOT public._festival_runtime_owner(p.runtime_session_id,public._festival_runtime_actor()) THEN RAISE EXCEPTION 'festival_runtime_forbidden';END IF;
+ snapshot:=jsonb_build_object(
+   'canonicalGigInput',p.engine_input_snapshot,'festivalModifiers',jsonb_build_object(
+     'stageQuality',coalesce((p.engine_input_snapshot->>'stageQuality')::numeric,50),'soundAndLighting',coalesce((p.engine_input_snapshot->>'soundAndLighting')::numeric,50),
+     'technicalReadiness',coalesce((p.engine_input_snapshot->>'technicalReadiness')::numeric,50),'rehearsal',coalesce((p.engine_input_snapshot->>'rehearsal')::numeric,50),
+     'crewEffectiveness',coalesce((p.engine_input_snapshot->>'crewEffectiveness')::numeric,50),'weather',coalesce(100-(SELECT operational_impact FROM public.festival_runtime_weather WHERE runtime_day_id=p.runtime_day_id),50),
+     'delayMinutes',p.delay_minutes,'crowdMood',coalesce((SELECT satisfaction FROM public.festival_runtime_crowds WHERE runtime_day_id=p.runtime_day_id),50),
+     'crowdDensity',coalesce((SELECT round(current_crowd::numeric/nullif(stage_capacity,0)*100) FROM public.festival_runtime_stage_crowds WHERE runtime_day_id=p.runtime_day_id AND runtime_stage_id=p.runtime_stage_id),50),
+     'equipmentCondition',coalesce((p.engine_input_snapshot->>'equipmentCondition')::numeric,50),'billingPosition',coalesce((p.engine_input_snapshot->>'billingPosition')::numeric,50),
+     'headlinerExpectation',coalesce((p.engine_input_snapshot->>'headlinerExpectation')::numeric,50),'incidentDisruption',coalesce((SELECT sum(CASE severity WHEN 'critical' THEN 40 WHEN 'major' THEN 25 WHEN 'moderate' THEN 12 ELSE 4 END) FROM public.festival_runtime_incidents WHERE runtime_day_id=p.runtime_day_id AND (runtime_stage_id IS NULL OR runtime_stage_id=p.runtime_stage_id)),0),
+     'setLengthMinutes',greatest(10,extract(epoch from(p.scheduled_end-p.scheduled_start))/60)),
+   'runtimeSessionId',p.runtime_session_id,'dayId',p.runtime_day_id,'stageId',p.runtime_stage_id,'performanceId',p.id,'seed',p.performance_seed,
+   'engineVersion',p.engine_version,'formulaVersions',jsonb_build_object('performance',p.formula_version,'runtime',(SELECT formula_version FROM public.festival_runtime_sessions WHERE id=p.runtime_session_id),'crowd','festival-crowd-largest-remainder-v2'),
+   'runtimeVersion',(SELECT version FROM public.festival_runtime_sessions WHERE id=p.runtime_session_id),
+   'weatherEvidence',(SELECT to_jsonb(w) FROM public.festival_runtime_weather w WHERE runtime_day_id=p.runtime_day_id),
+   'crowdEvidence',jsonb_build_object('attendance',least(coalesce((SELECT current_crowd FROM public.festival_runtime_stage_crowds WHERE runtime_day_id=p.runtime_day_id AND runtime_stage_id=p.runtime_stage_id),0),(SELECT capacity FROM public.festival_runtime_stages WHERE id=p.runtime_stage_id)),'stageCapacity',(SELECT capacity FROM public.festival_runtime_stages WHERE id=p.runtime_stage_id)),
+   'delayEvidence',jsonb_build_object('minutes',p.delay_minutes,'actualStart',p.actual_start),'incidentEvidence',coalesce((SELECT jsonb_agg(to_jsonb(i) ORDER BY i.id) FROM public.festival_runtime_incidents i WHERE i.runtime_day_id=p.runtime_day_id AND (i.runtime_stage_id IS NULL OR i.runtime_stage_id=p.runtime_stage_id)),'[]'),
+   'crewEquipmentEvidence',jsonb_build_object('crew',coalesce(p.engine_input_snapshot->'crew','[]'),'equipment',coalesce(p.engine_input_snapshot->'equipment','[]')));
+ digest_input:=encode(digest(snapshot::text,'sha256'),'hex');
+ INSERT INTO public.festival_performance_resolution_requests(runtime_performance_id,idempotency_key,request_digest) VALUES(p.id,p_idempotency_key,digest_input) ON CONFLICT(idempotency_key) DO NOTHING;
+ SELECT * INTO req FROM public.festival_performance_resolution_requests WHERE idempotency_key=p_idempotency_key FOR UPDATE;
+ IF req.runtime_performance_id<>p.id OR req.request_digest<>digest_input THEN RAISE EXCEPTION 'festival_performance_idempotency_conflict';END IF;
+ IF req.response IS NOT NULL THEN RETURN req.response;END IF;
+ IF p.status='completed' THEN response:=jsonb_build_object('runtimePerformanceId',p.id,'simulationStatus','completed','canonicalResult',p.engine_result_snapshot);UPDATE public.festival_performance_resolution_requests SET response=response,completed_at=now() WHERE id=req.id;RETURN response;END IF;
+ IF p.version<>p_expected_version THEN RAISE EXCEPTION 'festival_runtime_stale';END IF;
+ IF p.status<>'live' OR p.engine_input_snapshot IS NULL THEN RAISE EXCEPTION 'festival_performance_resolution_invalid';END IF;
+ INSERT INTO public.festival_performance_simulation_jobs(runtime_session_id,runtime_day_id,runtime_stage_id,runtime_performance_id,seed,engine_version,input_digest,input_snapshot)
+ VALUES(p.runtime_session_id,p.runtime_day_id,p.runtime_stage_id,p.id,p.performance_seed,p.engine_version,digest_input,snapshot) ON CONFLICT(runtime_performance_id) DO NOTHING RETURNING * INTO j;
+ IF j.id IS NULL THEN SELECT * INTO j FROM public.festival_performance_simulation_jobs WHERE runtime_performance_id=p.id;IF j.input_digest<>digest_input THEN RAISE EXCEPTION 'festival_simulation_input_digest_mismatch';END IF;END IF;
+ response:=jsonb_build_object('runtimePerformanceId',p.id,'simulationJobId',j.id,'simulationStatus',j.status,'idempotencyKey',p_idempotency_key);
+ UPDATE public.festival_performance_resolution_requests SET simulation_job_id=j.id,response=response,completed_at=now() WHERE id=req.id;RETURN response;
+END$$;
+
+CREATE FUNCTION public.validate_festival_performance_simulation_input(p_job uuid,p_input_digest text) RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path='' AS $$
+ SELECT EXISTS(SELECT 1 FROM public.festival_performance_simulation_jobs j WHERE j.id=p_job AND j.input_digest=p_input_digest AND j.input_snapshot IS NOT NULL AND encode(digest(j.input_snapshot::text,'sha256'),'hex')=j.input_digest)
+$$;
+
+CREATE FUNCTION public.fail_festival_performance_simulation_job(p_job uuid,p_worker text,p_error text,p_retryable boolean DEFAULT true) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE j public.festival_performance_simulation_jobs%ROWTYPE;terminal boolean;
+BEGIN SELECT * INTO j FROM public.festival_performance_simulation_jobs WHERE id=p_job FOR UPDATE;
+ IF j.id IS NULL OR j.status<>'processing' OR j.locked_by IS DISTINCT FROM p_worker THEN RAISE EXCEPTION 'festival_simulation_job_not_claimed';END IF;
+ terminal:=NOT p_retryable OR j.attempts>=j.max_attempts;
+ UPDATE public.festival_performance_simulation_jobs SET status=CASE WHEN terminal THEN 'exhausted' ELSE 'failed' END,last_error=left(p_error,1000),next_attempt_at=CASE WHEN terminal THEN next_attempt_at ELSE now()+make_interval(secs=>least(3600,power(2,j.attempts)::integer*5)) END,locked_at=NULL,locked_by=NULL WHERE id=j.id RETURNING * INTO j;RETURN to_jsonb(j);
+END$$;
+
+CREATE FUNCTION public.recover_stale_festival_performance_simulation_jobs(p_lease_seconds integer DEFAULT 300) RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE n integer;BEGIN UPDATE public.festival_performance_simulation_jobs SET status=CASE WHEN attempts>=max_attempts THEN 'exhausted' ELSE 'failed' END,last_error='processing_lease_expired',next_attempt_at=now(),locked_at=NULL,locked_by=NULL WHERE status='processing' AND locked_at<now()-make_interval(secs=>greatest(30,p_lease_seconds));GET DIAGNOSTICS n=ROW_COUNT;RETURN n;END$$;
+
+CREATE FUNCTION public.requeue_festival_performance_simulation_job(p_job uuid,p_reason text,p_idempotency_key uuid) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE j public.festival_performance_simulation_jobs%ROWTYPE;a uuid:=public._caller_profile_id();BEGIN IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false) THEN RAISE EXCEPTION 'festival_simulation_admin_required';END IF;SELECT * INTO j FROM public.festival_performance_simulation_jobs WHERE id=p_job FOR UPDATE;IF j.status NOT IN('failed','exhausted') THEN RAISE EXCEPTION 'festival_simulation_job_not_requeueable';END IF;INSERT INTO public.festival_performance_simulation_requeue_audit(job_id,actor_profile_id,previous_attempts,reason,idempotency_key)VALUES(j.id,a,j.attempts,p_reason,p_idempotency_key) ON CONFLICT(idempotency_key) DO NOTHING;UPDATE public.festival_performance_simulation_jobs SET status='pending',attempts=0,next_attempt_at=now(),last_error=NULL,locked_at=NULL,locked_by=NULL WHERE id=j.id RETURNING * INTO j;RETURN to_jsonb(j);END$$;
+
+-- Completion is strict and version-safe; the result trigger makes a successful result immutable.
+CREATE OR REPLACE FUNCTION public.complete_festival_performance_simulation_job(p_job uuid,p_worker text,p_input_digest text,p_output jsonb) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE j public.festival_performance_simulation_jobs%ROWTYPE;p public.festival_runtime_performances%ROWTYPE;rts public.festival_runtime_sessions%ROWTYPE;d text;res public.festival_performance_simulation_results%ROWTYPE;
+BEGIN SELECT * INTO j FROM public.festival_performance_simulation_jobs WHERE id=p_job FOR UPDATE;SELECT * INTO p FROM public.festival_runtime_performances WHERE id=j.runtime_performance_id FOR UPDATE;SELECT * INTO rts FROM public.festival_runtime_sessions WHERE id=j.runtime_session_id FOR UPDATE;
+ IF j.id IS NULL OR j.status<>'processing' OR j.locked_by IS DISTINCT FROM p_worker THEN RAISE EXCEPTION 'festival_simulation_job_not_claimed';END IF;
+ PERFORM public._festival_assert_runtime_chain(j.runtime_session_id,j.runtime_day_id,j.runtime_stage_id,j.runtime_performance_id);
+ IF rts.status IN('runtime_complete','cancelled','failed') OR rts.completed_at IS NOT NULL OR p.status<>'live' THEN RAISE EXCEPTION 'festival_simulation_completion_superseded';END IF;
+ IF j.input_digest<>p_input_digest OR encode(digest(j.input_snapshot::text,'sha256'),'hex')<>j.input_digest THEN RAISE EXCEPTION 'festival_simulation_input_digest_mismatch';END IF;
+ IF p_output->>'resultVersion'<>j.result_version OR p_output->>'engineVersion'<>j.engine_version OR p_output->>'seed'<>j.seed OR p_output->>'performanceId'<>j.runtime_performance_id::text OR p_output->>'inputDigest'<>j.input_digest THEN RAISE EXCEPTION 'festival_simulation_result_identity_invalid';END IF;
+ IF jsonb_typeof(p_output->'basePerformanceScore')<>'number' OR jsonb_typeof(p_output->'finalScore')<>'number' OR jsonb_typeof(p_output->'technicalScore')<>'number' OR jsonb_typeof(p_output->'crowdResponse')<>'object' OR jsonb_typeof(p_output->'setlistItemOutcomes')<>'array' OR jsonb_typeof(p_output->'stageActions')<>'array' OR jsonb_typeof(p_output->'generatedHighlights')<>'array' THEN RAISE EXCEPTION 'festival_simulation_result_schema_invalid';END IF;
+ IF (p_output->>'attendance')::integer<0 OR (p_output->>'attendance')::integer>(p_output->>'stageCapacity')::integer OR (p_output->>'stageCapacity')::integer<>(SELECT capacity FROM public.festival_runtime_stages WHERE id=j.runtime_stage_id) THEN RAISE EXCEPTION 'festival_simulation_result_attendance_invalid';END IF;
+ d:=encode(digest(p_output::text,'sha256'),'hex');
+ INSERT INTO public.festival_performance_simulation_results(runtime_performance_id,canonical_gig_result_id,engine_version,seed,input_digest,output_digest,base_performance_score,festival_modifiers,final_score,technical_score,crowd_response,attendance,delay_impact,weather_impact,incident_impact,setlist_item_outcomes,stage_actions,generated_highlights)
+ VALUES(j.runtime_performance_id,nullif(p_output->>'canonicalGigResultId','')::uuid,j.engine_version,j.seed,j.input_digest,d,(p_output->>'basePerformanceScore')::numeric,p_output->'festivalModifiers',(p_output->>'finalScore')::numeric,(p_output->>'technicalScore')::numeric,p_output->'crowdResponse',(p_output->>'attendance')::integer,(p_output->>'delayImpact')::numeric,(p_output->>'weatherImpact')::numeric,(p_output->>'incidentImpact')::numeric,p_output->'setlistItemOutcomes',p_output->'stageActions',p_output->'generatedHighlights') ON CONFLICT(runtime_performance_id) DO NOTHING RETURNING * INTO res;
+ IF res.id IS NULL THEN SELECT * INTO res FROM public.festival_performance_simulation_results WHERE runtime_performance_id=j.runtime_performance_id;IF res.input_digest<>j.input_digest OR res.output_digest<>d THEN RAISE EXCEPTION 'festival_simulation_result_conflict';END IF;END IF;
+ UPDATE public.festival_runtime_performances SET engine_result_snapshot=p_output,performance_score=res.final_score,technical_score=res.technical_score,crowd_response=res.crowd_response::text,estimated_audience=res.attendance,status='completed',actual_end=coalesce(actual_end,now()),version=version+1 WHERE id=p.id AND status='live' AND engine_result_snapshot IS NULL;
+ IF NOT FOUND THEN RAISE EXCEPTION 'festival_simulation_completion_superseded';END IF;
+ UPDATE public.festival_performance_simulation_jobs SET status='completed',output_digest=d,completed_at=now(),locked_at=NULL,locked_by=NULL WHERE id=j.id;RETURN to_jsonb(res);
+END$$;
+
+REVOKE ALL ON FUNCTION public.validate_festival_performance_simulation_input(uuid,text),public.fail_festival_performance_simulation_job(uuid,text,text,boolean),public.recover_stale_festival_performance_simulation_jobs(integer),public.complete_festival_performance_simulation_job(uuid,text,text,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_festival_performance_simulation_job(text),public.validate_festival_performance_simulation_input(uuid,text),public.fail_festival_performance_simulation_job(uuid,text,text,boolean),public.recover_stale_festival_performance_simulation_jobs(integer),public.complete_festival_performance_simulation_job(uuid,text,text,jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.requeue_festival_performance_simulation_job(uuid,text,uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.finalise_festival_runtime_outcomes(p_runtime_session_id uuid,p_expected_version integer,p_idempotency_key uuid) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE r public.festival_runtime_sessions%ROWTYPE;snapshot jsonb;content_digest text;existing public.festival_runtime_outcome_snapshots%ROWTYPE;
+BEGIN SELECT * INTO r FROM public.festival_runtime_sessions WHERE id=p_runtime_session_id FOR UPDATE;
+ IF r.id IS NULL THEN RAISE EXCEPTION 'festival_runtime_chain_session';END IF;PERFORM public._festival_assert_runtime_chain(r.id,NULL,NULL,NULL);
+ IF NOT public._festival_runtime_owner(r.id,public._festival_runtime_actor()) THEN RAISE EXCEPTION 'festival_runtime_forbidden';END IF;
+ SELECT * INTO existing FROM public.festival_runtime_outcome_snapshots WHERE runtime_session_id=r.id;IF existing.id IS NOT NULL THEN RETURN jsonb_build_object('readyForSettlement',true,'outcomeDigest',existing.content_digest,'idempotent',true);END IF;
+ IF r.version<>p_expected_version THEN RAISE EXCEPTION 'festival_runtime_stale';END IF;
+ IF r.status NOT IN('public_closed','site_clearance') OR r.gates_open
+  OR EXISTS(SELECT 1 FROM public.festival_performance_simulation_jobs WHERE runtime_session_id=r.id AND status IN('pending','processing','failed','exhausted'))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_performances WHERE runtime_session_id=r.id AND status NOT IN('completed','cancelled','abandoned'))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_incidents WHERE runtime_session_id=r.id AND severity IN('major','critical') AND status NOT IN('resolved','handed_over'))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_days d WHERE d.runtime_session_id=r.id AND NOT EXISTS(SELECT 1 FROM public.festival_runtime_weather w WHERE w.runtime_day_id=d.id))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_days d WHERE d.runtime_session_id=r.id AND NOT EXISTS(SELECT 1 FROM public.festival_crowd_recalculation_requests q WHERE q.runtime_day_id=d.id AND q.status='completed'))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_attendance a LEFT JOIN public.festival_runtime_crowds c ON c.runtime_day_id=a.runtime_day_id WHERE a.runtime_session_id=r.id AND (coalesce(c.allocated_count,0)+coalesce(c.unallocated_count,0)<>a.onsite_count OR coalesce((SELECT sum(sc.current_crowd) FROM public.festival_runtime_stage_crowds sc WHERE sc.runtime_day_id=a.runtime_day_id),0)<>coalesce(c.allocated_count,0)))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_staff_checkins c WHERE c.runtime_session_id=r.id AND NOT EXISTS(SELECT 1 FROM public.festival_runtime_staff_outcomes o WHERE o.staff_checkin_id=c.id))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_supplier_checkins c WHERE c.runtime_session_id=r.id AND NOT EXISTS(SELECT 1 FROM public.festival_runtime_supplier_outcomes o WHERE o.supplier_checkin_id=c.id))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_sponsor_activations WHERE runtime_session_id=r.id AND status NOT IN('completed','partially_completed','failed','cancelled'))
+  OR EXISTS(SELECT 1 FROM public.festival_runtime_vendor_sales v WHERE v.runtime_session_id=r.id AND (v.status<>'closed' OR NOT EXISTS(SELECT 1 FROM public.festival_runtime_revenue_postings rp WHERE rp.vendor_sales_id=v.id)))
+ THEN RAISE EXCEPTION 'festival_runtime_outcomes_blocked';END IF;
+ snapshot:=jsonb_build_object(
+  'attendance',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.runtime_day_id) FROM public.festival_runtime_attendance x WHERE x.runtime_session_id=r.id),'[]'),
+  'performances',coalesce((SELECT jsonb_agg(jsonb_build_object('performance',to_jsonb(p),'result',to_jsonb(x)) ORDER BY p.scheduled_start,p.id) FROM public.festival_runtime_performances p LEFT JOIN public.festival_performance_simulation_results x ON x.runtime_performance_id=p.id WHERE p.runtime_session_id=r.id),'[]'),
+  'crowds',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.runtime_day_id) FROM public.festival_runtime_crowds x WHERE x.runtime_session_id=r.id),'[]'),
+  'stageCrowds',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.runtime_day_id,x.runtime_stage_id) FROM public.festival_runtime_stage_crowds x WHERE x.runtime_session_id=r.id),'[]'),
+  'crowdMovements',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.created_at,x.id) FROM public.festival_runtime_crowd_movements x WHERE x.runtime_session_id=r.id),'[]'),
+  'weather',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.runtime_day_id) FROM public.festival_runtime_weather x WHERE x.runtime_session_id=r.id),'[]'),
+  'incidents',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.detected_at,x.id) FROM public.festival_runtime_incidents x WHERE x.runtime_session_id=r.id),'[]'),
+  'incidentOutcomes',coalesce((SELECT jsonb_agg(jsonb_build_object('incidentId',x.id,'status',x.status,'resolutionOutcome',x.resolution_outcome,'resolvedAt',x.resolved_at) ORDER BY x.id) FROM public.festival_runtime_incidents x WHERE x.runtime_session_id=r.id),'[]'),
+  'staffOutcomes',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.id) FROM public.festival_runtime_staff_outcomes x WHERE x.runtime_session_id=r.id),'[]'),
+  'supplierOutcomes',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.id) FROM public.festival_runtime_supplier_outcomes x WHERE x.runtime_session_id=r.id),'[]'),
+  'sponsorActivations',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.id) FROM public.festival_runtime_sponsor_activations x WHERE x.runtime_session_id=r.id),'[]'),
+  'vendorSales',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.runtime_day_id,x.id) FROM public.festival_runtime_vendor_sales x WHERE x.runtime_session_id=r.id),'[]'),
+  'revenuePostings',coalesce((SELECT jsonb_agg(to_jsonb(x) ORDER BY x.posted_at,x.id) FROM public.festival_runtime_revenue_postings x JOIN public.festival_runtime_vendor_sales v ON v.id=x.vendor_sales_id WHERE v.runtime_session_id=r.id),'[]'),
+  'headliners',coalesce((SELECT jsonb_agg(to_jsonb(p) ORDER BY p.scheduled_start,p.id) FROM public.festival_runtime_performances p WHERE p.runtime_session_id=r.id AND coalesce((p.engine_input_snapshot->>'headlinerExpectation')::numeric,0)>0),'[]'),
+  'timetable',coalesce((SELECT jsonb_agg(jsonb_build_object('performanceId',p.id,'dayId',p.runtime_day_id,'stageId',p.runtime_stage_id,'scheduledStart',p.scheduled_start,'scheduledEnd',p.scheduled_end,'status',p.status) ORDER BY p.scheduled_start,p.id) FROM public.festival_runtime_performances p WHERE p.runtime_session_id=r.id),'[]'),
+  'runtimeMetadata',jsonb_build_object('runtimeSessionId',r.id,'runtimeVersion',r.version,'engineVersion',r.engine_version,'finalisedAt',now(),'idempotencyKey',p_idempotency_key),
+  'sourceDigests',jsonb_build_object('performanceInputs',coalesce((SELECT jsonb_agg(input_digest ORDER BY runtime_performance_id) FROM public.festival_performance_simulation_jobs WHERE runtime_session_id=r.id),'[]'),'crowdInputs',coalesce((SELECT jsonb_agg(input_digest ORDER BY runtime_day_id,created_at) FROM public.festival_crowd_recalculation_requests WHERE runtime_session_id=r.id AND status='completed'),'[]')),
+  'formulaVersions',jsonb_build_object('runtime',r.formula_version,'engine',r.engine_version,'performance','festival-performance-result-v1','crowd','festival-crowd-largest-remainder-v2','settlement','festival-settlement-v2'));
+ content_digest:=encode(digest(snapshot::text,'sha256'),'hex');INSERT INTO public.festival_runtime_outcome_snapshots(runtime_session_id,snapshot,engine_version,formula_versions,content_digest)VALUES(r.id,snapshot,r.engine_version,snapshot->'formulaVersions',content_digest);
+ UPDATE public.festival_runtime_sessions SET status='runtime_complete',ready_for_settlement=true,completed_at=now(),gates_open=false,version=version+1,updated_at=now() WHERE id=r.id;
+ RETURN jsonb_build_object('readyForSettlement',true,'outcomeDigest',content_digest,'idempotencyKey',p_idempotency_key,'idempotent',false);
+END$$;


### PR DESCRIPTION
### Motivation
- Close the Phase 8 runtime boundary by providing a trusted server worker that runs canonical gig simulations (never in the browser) and make Phase 9A settlement consumers reliable by hardening runtime snapshots and idempotent resolution semantics.
- Enforce immutable, complete simulation inputs and server-side validation so settlement and finance logic can rely on deterministic, audit-safe evidence.
- Provide robust job leasing, retry/exhaustion, admin requeue and exactly-once completion to prevent duplicate effects and recover from worker crashes.
- Ensure final runtime snapshots contain every Phase 9 consumer section and block settlement until operational evidence reconciles.

### Description
- Added a Supabase Edge/Deno worker and simulation harness under `supabase/functions/festival-performance-worker/` that claims jobs via `claim_festival_performance_simulation_job`, validates the immutable input snapshot digest, calls the canonical engine, validates the result schema, and calls `complete_festival_performance_simulation_job` or `fail_festival_performance_simulation_job` on error.  (files: `index.ts`, `simulation.ts`)
- Extended the canonical live-gig engine contract in `src/utils/gigLive.ts` with an explicit optional Festival context and implemented `calculateFestivalLiveModifier` which is applied to the canonical base score while preserving identical behaviour when context is absent. (file: `src/utils/gigLive.ts`)
- Persisted complete immutable simulation inputs, added a resolution/receipt table and idempotency requests, and added administrative requeue/audit with processing lease recovery and exponential backoff via a new migration `supabase/migrations/20291218000000_complete_festival_runtime_worker_boundary.sql`. (migration: new file)
- Strengthened completion RPCs to be version-safe and idempotent, validated input/output identity and schema on completion, and made simulation results immutable via `festival_performance_simulation_results`. (migration + function updates)
- Hardened `finalise_festival_runtime_outcomes` to include all required runtime sections (attendance, performances, crowds, stageCrowds, crowdMovements, weather, incidents, incidentOutcomes, staffOutcomes, supplierOutcomes, sponsorActivations, vendorSales, revenuePostings, headliners, timetable, runtimeMetadata, sourceDigests, formulaVersions) and added completeness checks so settlement cannot proceed with missing evidence. (migration update)
- Updated repo config and verification helpers to accept the new migration filename and added deterministic unit tests asserting Festival context changes canonical outcomes while normal gigs remain unchanged. (files: `supabase/config.toml`, `scripts/supabase/verify-migration-timestamps.mjs`, `src/utils/__tests__/gigLive.test.ts`)

### Testing
- Ran migrations/contract checks: `npm run verify:migration-timestamps` and `npm run verify:supabase-rpcs`, both succeeded against the repository migrations.  
- Ran static checks: `npm run typecheck` and `npm run lint` both succeeded.  
- Built the project: `npm run build` succeeded.  
- Attempted unit test run via Vitest but the test harness failed to initialise due to a missing transitive dependency (`rrweb-cssom`) required by `jsdom` in the locked tree; `npm ci` initially encountered registry 403 for `jsdom` and the environment recovered node modules from an offline cache but the missing transitive module prevented Vitest from completing (this is an external registry/install issue, not test logic).  
- SQL harnesses (Supabase/Postgres) were not executed because the environment did not provide a Supabase CLI/psql endpoint; therefore the migration SQL changes were verified syntactically by the repository verification scripts but not run against a disposable database.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a664261b2d483258f1a994a0ab2b5ef)