### PR TITLE
fix(festivals): complete settlement, legacy integrations and cross-phase contracts

### DIFF
--- a/docs/festivals/FESTIVAL_WORKER_OPERATIONS.md
+++ b/docs/festivals/FESTIVAL_WORKER_OPERATIONS.md
@@ -1,0 +1,20 @@
+# Festival performance worker operations
+
+Deploy `festival-performance-worker` with JWT verification disabled only at the
+gateway; the function itself requires `x-worker-secret` to equal the
+`FESTIVAL_WORKER_SECRET` Edge Function secret. `SUPABASE_URL` and
+`SUPABASE_SERVICE_ROLE_KEY` are also required.
+
+Invoke the function once per minute from the trusted scheduler with an HTTP POST.
+Supabase Cron (`pg_cron` plus `pg_net`) is the recommended scheduler; store the
+worker secret in Vault and send it as the `x-worker-secret` header. Do not put the
+secret in migration SQL or source control. Concurrent invocations are safe because
+job claiming uses `FOR UPDATE SKIP LOCKED`; an empty queue performs one cheap claim.
+
+Every invocation is recorded in `festival_simulation_worker_invocations`. The
+worker recovers five-minute stale leases before claiming work. Operators use
+`get_festival_simulation_worker_health()` and
+`get_exhausted_festival_simulation_jobs()`, then the audited
+`requeue_festival_performance_simulation_job(...)` RPC when evidence supports a
+retry. Alert when the last invocation is older than three minutes, any invocation
+fails, exhausted count is non-zero, or the oldest queued job exceeds five minutes.

--- a/scripts/supabase/verify-migration-timestamps.mjs
+++ b/scripts/supabase/verify-migration-timestamps.mjs
@@ -19,6 +19,7 @@ const festivalPhase8OperationsContinuation = "20291217210000_festival_crowds_inc
 const festivalPhase9SettlementContinuation = "20291217220000_festival_financial_settlement.sql";
 const festivalPhase9LegacyContinuation = "20291217230000_festival_historical_legacy.sql";
 const festivalRuntimeWorkerContinuation = "20291218000000_complete_festival_runtime_worker_boundary.sql";
+const festivalCrossPhaseContinuation = "20291218010000_festival_cross_phase_contracts.sql";
 const legacySequenceNames = new Set(["085_jam_sessions_core.sql", "086_band_member_locks.sql", "087_bands_add_chemistry_cohesion.sql"]);
 const today = new Date();
 const reasonableFuture = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 2, 23, 59, 59));
@@ -31,7 +32,7 @@ for (const filename of readdirSync(migrationDirectory).filter((name) => name.end
     failures.push(`${filename}: expected YYYYMMDDHHMMSS_description.sql`); continue;
   }
   const stamp = match[1];
-  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation || filename === festivalRuntimeWorkerContinuation) { exceptions.push(filename); continue; }
+  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation || filename === festivalRuntimeWorkerContinuation || filename === festivalCrossPhaseContinuation) { exceptions.push(filename); continue; }
   const todayStamp = `${today.getUTCFullYear()}${String(today.getUTCMonth() + 1).padStart(2, "0")}${String(today.getUTCDate()).padStart(2, "0")}235959`;
   // Freeze every inherited future sequence through the known anomaly. This includes
   // several historical invalid calendar-day names; accepting the exact bounded

--- a/supabase/functions/_shared/gig-simulation/index.test.ts
+++ b/supabase/functions/_shared/gig-simulation/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "https://deno.land/std@0.224.0/testing/bdd.ts";
+import { simulateCanonicalFestivalPerformance } from "./index.ts";
+import type { FestivalSimulationInput } from "./types.ts";
+
+const input: FestivalSimulationInput = {
+  runtimeSessionId: "runtime", dayId: "day", stageId: "stage", performanceId: "performance", seed: "seed",
+  canonicalEngineVersion: "canonical-gig-v1", festivalAdapterVersion: "festival-gig-adapter-v2",
+  resultSchemaVersion: "festival-performance-result-v1", runtimeFormulaVersion: "festival-runtime-v1",
+  formulaVersions: { runtime: "festival-runtime-v1" },
+  canonicalGigInput: { gigId: "gig", artistId: "artist", performerSkill: 70, stagePresence: 75,
+    readinessScore: 80, setlist: [{ id: "song", title: "Real song", position: 1, quality: 70, popularity: 60, familiarity: 80, rehearsalLevel: 75 }] },
+  festivalModifiers: { stageQuality: 60, soundAndLighting: 60, technicalReadiness: 60, rehearsal: 70,
+    crewEffectiveness: 60, weather: 50, delayMinutes: 0, crowdMood: 70, crowdDensity: 70,
+    equipmentCondition: 70, billingPosition: 100, headlinerExpectation: 80, incidentDisruption: 0, setLengthMinutes: 60 },
+  crowdEvidence: { attendance: 800, stageCapacity: 1000 },
+};
+
+describe("Festival simulation contract", () => {
+  it("is deterministic", () => expect(simulateCanonicalFestivalPerformance(input, "digest")).toEqual(simulateCanonicalFestivalPerformance(input, "digest")));
+  it("rejects missing canonical setlists", () => expect(() => simulateCanonicalFestivalPerformance({ ...input, canonicalGigInput: { ...input.canonicalGigInput, setlist: [] } }, "digest")).toThrow("festival_simulation_canonical_input_missing"));
+});

--- a/supabase/functions/_shared/gig-simulation/index.ts
+++ b/supabase/functions/_shared/gig-simulation/index.ts
@@ -1,0 +1,65 @@
+import type { CanonicalSong, FestivalSimulationInput } from "./types.ts";
+
+export * from "./types.ts";
+export const CANONICAL_ENGINE_VERSION = "canonical-gig-v1";
+export const FESTIVAL_ADAPTER_VERSION = "festival-gig-adapter-v2";
+export const RESULT_SCHEMA_VERSION = "festival-performance-result-v1";
+
+const clamp = (value: number) => Math.max(0, Math.min(100, value));
+const hash = (seed: string) => Array.from(seed).reduce((value, char) =>
+  (Math.imul(31, value) + char.charCodeAt(0)) | 0, 2166136261) >>> 0;
+const variance = (seed: string) => (hash(seed) % 801) / 100 - 4;
+const finite = (value: unknown, code: string) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(code);
+  return value;
+};
+
+function scoreSong(input: FestivalSimulationInput, song: CanonicalSong) {
+  const canonical = input.canonicalGigInput;
+  const technicalScore = clamp(song.quality * .28 + song.familiarity * .2 +
+    song.rehearsalLevel * .17 + canonical.performerSkill * .2 + input.festivalModifiers.technicalReadiness * .15);
+  const base = technicalScore * .4 + song.popularity * .2 + canonical.stagePresence * .2 +
+    canonical.readinessScore * .2 + variance(`${input.seed}:${song.id}`);
+  const m = input.festivalModifiers;
+  const festivalEffect = (m.stageQuality - 50) * .04 + (m.soundAndLighting - 50) * .05 +
+    (m.crewEffectiveness - 50) * .03 + (m.weather - 50) * .03 +
+    (m.crowdMood - 50) * .04 + (m.equipmentCondition - 50) * .04 -
+    Math.min(60, Math.max(0, m.delayMinutes)) * .055 - clamp(m.incidentDisruption) * .045;
+  const score = clamp(base + Math.max(-18, Math.min(18, festivalEffect)));
+  return {
+    setlistItemId: song.id, songId: song.id, title: song.title,
+    score: Number(score.toFixed(3)), technicalScore: Number(technicalScore.toFixed(3)),
+    highlights: score >= 82 ? [`${song.title} became a standout live moment.`] : [],
+  };
+}
+
+/** Pure deterministic adapter. It deliberately refuses to fabricate missing evidence. */
+export function simulateCanonicalFestivalPerformance(input: FestivalSimulationInput, inputDigest: string) {
+  if (input.canonicalEngineVersion !== CANONICAL_ENGINE_VERSION ||
+      input.festivalAdapterVersion !== FESTIVAL_ADAPTER_VERSION ||
+      input.resultSchemaVersion !== RESULT_SCHEMA_VERSION) throw new Error("festival_engine_version_unsupported");
+  const canonical = input.canonicalGigInput;
+  if (!canonical?.artistId || !Array.isArray(canonical.setlist) || canonical.setlist.length === 0 ||
+      canonical.setlist.some(song => !song.id || !song.title)) {
+    throw new Error("festival_simulation_canonical_input_missing");
+  }
+  const songs = [...canonical.setlist].sort((a, b) => a.position - b.position).map(song => scoreSong(input, song));
+  const average = (key: "score" | "technicalScore") => songs.reduce((sum, song) => sum + song[key], 0) / songs.length;
+  const attendance = finite(input.crowdEvidence.attendance, "festival_result_attendance_invalid");
+  const stageCapacity = finite(input.crowdEvidence.stageCapacity, "festival_result_attendance_invalid");
+  if (attendance < 0 || attendance > stageCapacity) throw new Error("festival_result_attendance_invalid");
+  const finalScore = Number(average("score").toFixed(3));
+  return {
+    resultVersion: input.resultSchemaVersion, engineVersion: input.canonicalEngineVersion,
+    canonicalEngineVersion: input.canonicalEngineVersion, festivalAdapterVersion: input.festivalAdapterVersion,
+    runtimeFormulaVersion: input.runtimeFormulaVersion, formulaVersions: input.formulaVersions,
+    seed: input.seed, performanceId: input.performanceId, inputDigest, canonicalGigResultId: null,
+    basePerformanceScore: finalScore, festivalModifiers: input.festivalModifiers,
+    finalScore, technicalScore: Number(average("technicalScore").toFixed(3)),
+    crowdResponse: { score: finalScore, energy: clamp(input.festivalModifiers.crowdMood) },
+    attendance, stageCapacity, delayImpact: -Math.min(60, input.festivalModifiers.delayMinutes) * .055,
+    weatherImpact: (input.festivalModifiers.weather - 50) * .045,
+    incidentImpact: -input.festivalModifiers.incidentDisruption * .045,
+    setlistItemOutcomes: songs, stageActions: [], generatedHighlights: songs.flatMap(song => song.highlights),
+  };
+}

--- a/supabase/functions/_shared/gig-simulation/types.ts
+++ b/supabase/functions/_shared/gig-simulation/types.ts
@@ -1,0 +1,38 @@
+/** Environment-neutral input consumed by the canonical Festival adapter. */
+export interface CanonicalSong {
+  id: string;
+  title: string;
+  position: number;
+  quality: number;
+  popularity: number;
+  familiarity: number;
+  rehearsalLevel: number;
+  durationSeconds?: number;
+}
+
+export interface CanonicalFestivalGigInput {
+  gigId: string;
+  artistId: string;
+  performerSkill: number;
+  stagePresence: number;
+  readinessScore: number;
+  setlist: CanonicalSong[];
+}
+
+export interface FestivalModifiers {
+  stageQuality: number; soundAndLighting: number; technicalReadiness: number;
+  rehearsal: number; crewEffectiveness: number; weather: number;
+  delayMinutes: number; crowdMood: number; crowdDensity: number;
+  equipmentCondition: number; billingPosition: number;
+  headlinerExpectation: number; incidentDisruption: number; setLengthMinutes: number;
+}
+
+export interface FestivalSimulationInput {
+  runtimeSessionId: string; dayId: string; stageId: string; performanceId: string;
+  seed: string; canonicalEngineVersion: string; festivalAdapterVersion: string;
+  resultSchemaVersion: string; runtimeFormulaVersion: string;
+  formulaVersions: Record<string, string>;
+  canonicalGigInput: CanonicalFestivalGigInput;
+  festivalModifiers: FestivalModifiers;
+  crowdEvidence: { attendance: number; stageCapacity: number };
+}

--- a/supabase/functions/festival-performance-worker/index.ts
+++ b/supabase/functions/festival-performance-worker/index.ts
@@ -8,18 +8,29 @@ Deno.serve(async request => {
   if (request.headers.get("x-worker-secret") !== Deno.env.get("FESTIVAL_WORKER_SECRET")) return new Response("Forbidden", { status: 403 });
   const client = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!, { auth: { persistSession: false } });
   const worker = `festival-worker:${crypto.randomUUID()}`;
+  const { data: recovered = 0 } = await client.rpc("recover_stale_festival_performance_simulation_jobs", { p_lease_seconds: 300 });
+  const { data: invocation } = await client.from("festival_simulation_worker_invocations")
+    .insert({ worker_id: worker, status: "running", recovered_leases: recovered }).select("id").single();
   const { data: job, error: claimError } = await client.rpc("claim_festival_performance_simulation_job", { p_worker: worker });
-  if (claimError) return new Response(JSON.stringify({ error: claimError.message }), { status: 503, headers });
-  if (!job) return new Response(JSON.stringify({ processed: false }), { headers });
+  if (claimError) {
+    if (invocation) await client.from("festival_simulation_worker_invocations").update({ status: "failed", error_code: claimError.message, completed_at: new Date().toISOString() }).eq("id", invocation.id);
+    return new Response(JSON.stringify({ error: claimError.message }), { status: 503, headers });
+  }
+  if (!job) {
+    if (invocation) await client.from("festival_simulation_worker_invocations").update({ status: "succeeded", completed_at: new Date().toISOString() }).eq("id", invocation.id);
+    return new Response(JSON.stringify({ processed: false, recoveredLeases: recovered }), { headers });
+  }
   try {
     const { data: valid, error: validationError } = await client.rpc("validate_festival_performance_simulation_input", { p_job: job.id, p_input_digest: job.input_digest });
     if (validationError || valid !== true) throw new Error("festival_simulation_input_digest_mismatch");
     const output = simulateFestivalPerformance(job.input_snapshot as FestivalJobSnapshot, job.input_digest);
     const { data, error } = await client.rpc("complete_festival_performance_simulation_job", { p_job: job.id, p_worker: worker, p_input_digest: job.input_digest, p_output: output });
     if (error) throw error;
+    if (invocation) await client.from("festival_simulation_worker_invocations").update({ status: "succeeded", processed_job_id: job.id, completed_at: new Date().toISOString() }).eq("id", invocation.id);
     return new Response(JSON.stringify({ processed: true, result: data }), { headers });
   } catch (error) {
     const { error: failureError } = await client.rpc("fail_festival_performance_simulation_job", { p_job: job.id, p_worker: worker, p_error: String(error), p_retryable: transient(error) });
+    if (invocation) await client.from("festival_simulation_worker_invocations").update({ status: "failed", processed_job_id: job.id, error_code: String(error).slice(0, 500), completed_at: new Date().toISOString() }).eq("id", invocation.id);
     return new Response(JSON.stringify({ processed: false, error: String(error), failureError: failureError?.message }), { status: transient(error) ? 503 : 422, headers });
   }
 });

--- a/supabase/functions/festival-performance-worker/simulation.ts
+++ b/supabase/functions/festival-performance-worker/simulation.ts
@@ -1,69 +1,43 @@
-import { applySongResultToSession, buildInitialLiveSession, finalizeLiveGig, resolveLiveSong, type FestivalLiveContext, type GigLiveContext, type LiveIncident, type LiveSongResult } from "../../../src/utils/gigLive.ts";
+import {
+  CANONICAL_ENGINE_VERSION, FESTIVAL_ADAPTER_VERSION, RESULT_SCHEMA_VERSION,
+  simulateCanonicalFestivalPerformance,
+} from "../_shared/gig-simulation/index.ts";
+import type { FestivalSimulationInput } from "../_shared/gig-simulation/types.ts";
 
-export const FESTIVAL_RESULT_VERSION = "festival-performance-result-v1";
-export const SUPPORTED_ENGINE_VERSION = "canonical-gig-v1";
-
-export interface FestivalJobSnapshot {
-  runtimeSessionId: string; dayId: string; stageId: string; performanceId: string;
-  seed: string; engineVersion: string; runtimeVersion: number;
-  formulaVersions: Record<string, string>; canonicalGigInput: GigLiveContext;
-  festivalModifiers: FestivalLiveContext; weatherEvidence: unknown; crowdEvidence: { attendance: number; stageCapacity: number };
-  delayEvidence: unknown; incidentEvidence: unknown; crewEquipmentEvidence: unknown;
-}
-
-const finite = (value: unknown, name: string) => {
-  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`festival_result_${name}_invalid`);
-  return value;
+export { RESULT_SCHEMA_VERSION as FESTIVAL_RESULT_VERSION, CANONICAL_ENGINE_VERSION as SUPPORTED_ENGINE_VERSION };
+export type FestivalJobSnapshot = FestivalSimulationInput & {
+  engineVersion?: string;
+  canonicalGigInput: FestivalSimulationInput["canonicalGigInput"] & {
+    bandId?: string;
+    readiness?: { score?: number };
+    setlist: Array<Record<string, unknown>>;
+  };
 };
 
+/** Maps pre-v2 jobs without treating the overloaded legacy name as a hard failure. */
 export function simulateFestivalPerformance(snapshot: FestivalJobSnapshot, inputDigest: string) {
-  if (snapshot.engineVersion !== SUPPORTED_ENGINE_VERSION) throw new Error("festival_engine_version_unsupported");
-  const raw = snapshot.canonicalGigInput as GigLiveContext & { artist?: { bandId?: string }; schedule?: { startsAt?: string; endsAt?: string } };
-  const duration = raw.schedule?.startsAt && raw.schedule?.endsAt ? Math.max(600, (Date.parse(raw.schedule.endsAt) - Date.parse(raw.schedule.startsAt)) / 1000) : snapshot.festivalModifiers.setLengthMinutes * 60;
-  // Phase 8 v1 inputs did not carry a saved setlist. They remain runnable through a
-  // deterministic canonical placeholder set; no Festival-only score is introduced.
-  const canonical = raw.setlist?.length ? raw : {
-    ...raw, gigId: snapshot.performanceId, bandId: raw.artist?.bandId ?? snapshot.performanceId,
-    scheduledAt: raw.schedule?.startsAt ?? "1970-01-01T00:00:00.000Z", capacity: snapshot.crowdEvidence.stageCapacity,
-    ticketsSold: snapshot.crowdEvidence.attendance, performerSkill: 50, stagePresence: 50, bandChemistry: 50,
-    readiness: { score: 50, blockingIssues: [] },
-    setlist: [{ id: `${snapshot.performanceId}:set`, position: 1, song: { id: `${snapshot.performanceId}:song`, title: "Festival set", durationSeconds: duration, quality: 50, popularity: 50, familiarity: 50, rehearsalLevel: snapshot.festivalModifiers.rehearsal } }],
-  } as GigLiveContext;
-  const context = Object.freeze({ ...canonical, festival: Object.freeze({ ...snapshot.festivalModifiers }) });
-  let session = buildInitialLiveSession(context, new Date(context.scheduledAt));
-  const songs: LiveSongResult[] = [];
-  for (const item of [...context.setlist].sort((a, b) => a.position - b.position)) {
-    const result = resolveLiveSong(context, session, item, item.position, snapshot.seed);
-    songs.push(result);
-    session = applySongResultToSession(session, result, item);
-  }
-  const aggregate = finalizeLiveGig(session, songs, [] as LiveIncident[]);
-  const baseScores = songs.map(song => song.breakdown.find(item => item.key === "base_score")?.modifier ?? song.score);
-  const basePerformanceScore = baseScores.length ? baseScores.reduce((sum, score) => sum + score, 0) / baseScores.length : aggregate.finalQuality;
-  const technicalScore = songs.length ? songs.reduce((sum, song) => sum + song.technicalScore, 0) / songs.length : 0;
-  const modifiers = songs[0]?.breakdown.filter(item => item.key.startsWith("festival_")) ?? [];
-  const result = {
-    resultVersion: FESTIVAL_RESULT_VERSION, engineVersion: snapshot.engineVersion, formulaVersions: snapshot.formulaVersions,
-    seed: snapshot.seed, performanceId: snapshot.performanceId, inputDigest, canonicalGigResultId: null,
-    basePerformanceScore: Number(basePerformanceScore.toFixed(3)), festivalModifiers: { values: snapshot.festivalModifiers, effects: modifiers },
-    finalScore: aggregate.finalQuality, technicalScore: Number(technicalScore.toFixed(3)),
-    crowdResponse: { score: aggregate.finalSatisfaction, energy: aggregate.finalCrowdEnergy }, attendance: snapshot.crowdEvidence.attendance,
-    stageCapacity: snapshot.crowdEvidence.stageCapacity, delayImpact: -Math.min(60, snapshot.festivalModifiers.delayMinutes) * .055,
-    weatherImpact: (snapshot.festivalModifiers.weather - 50) * .045, incidentImpact: -snapshot.festivalModifiers.incidentDisruption * .045,
-    setlistItemOutcomes: songs, stageActions: [], generatedHighlights: songs.flatMap(song => song.highlights),
-  };
-  validateFestivalSimulationResult(result, snapshot, inputDigest);
-  return result;
-}
-
-export function validateFestivalSimulationResult(result: Record<string, unknown>, snapshot: FestivalJobSnapshot, digest: string) {
-  if (result.resultVersion !== FESTIVAL_RESULT_VERSION || result.engineVersion !== snapshot.engineVersion) throw new Error("festival_result_version_invalid");
-  if (result.seed !== snapshot.seed || result.performanceId !== snapshot.performanceId || result.inputDigest !== digest) throw new Error("festival_result_identity_invalid");
-  for (const field of ["basePerformanceScore", "finalScore", "technicalScore", "delayImpact", "weatherImpact", "incidentImpact"])
-    finite(result[field], field);
-  const attendance = finite(result.attendance, "attendance");
-  const capacity = finite(result.stageCapacity, "stage_capacity");
-  if (attendance < 0 || capacity < 0 || attendance > capacity) throw new Error("festival_result_attendance_invalid");
-  for (const field of ["crowdResponse", "festivalModifiers"]) if (!result[field] || typeof result[field] !== "object") throw new Error(`festival_result_${field}_missing`);
-  for (const field of ["setlistItemOutcomes", "stageActions", "generatedHighlights"]) if (!Array.isArray(result[field])) throw new Error(`festival_result_${field}_missing`);
+  const raw = snapshot.canonicalGigInput;
+  const setlist = raw?.setlist?.map((item, index) => {
+    const song = (item.song ?? item) as Record<string, unknown>;
+    return {
+      id: String(song.id ?? item.id ?? ""), title: String(song.title ?? ""),
+      position: Number(item.position ?? index + 1), quality: Number(song.quality ?? 0),
+      popularity: Number(song.popularity ?? 0), familiarity: Number(song.familiarity ?? 0),
+      rehearsalLevel: Number(song.rehearsalLevel ?? 0), durationSeconds: Number(song.durationSeconds ?? 0),
+    };
+  }) ?? [];
+  return simulateCanonicalFestivalPerformance({
+    ...snapshot,
+    canonicalEngineVersion: snapshot.canonicalEngineVersion ??
+      (snapshot.engineVersion === "gig-v1" ? CANONICAL_ENGINE_VERSION : snapshot.engineVersion) ?? CANONICAL_ENGINE_VERSION,
+    festivalAdapterVersion: snapshot.festivalAdapterVersion ?? FESTIVAL_ADAPTER_VERSION,
+    resultSchemaVersion: snapshot.resultSchemaVersion ?? RESULT_SCHEMA_VERSION,
+    runtimeFormulaVersion: snapshot.runtimeFormulaVersion ?? snapshot.formulaVersions?.runtime ?? "festival-runtime-v1",
+    canonicalGigInput: {
+      gigId: raw?.gigId ?? snapshot.performanceId,
+      artistId: raw?.artistId ?? raw?.bandId ?? "",
+      performerSkill: Number(raw?.performerSkill ?? 0), stagePresence: Number(raw?.stagePresence ?? 0),
+      readinessScore: Number(raw?.readinessScore ?? raw?.readiness?.score ?? 0), setlist,
+    },
+  }, inputDigest);
 }

--- a/supabase/migrations/20291218010000_festival_cross_phase_contracts.sql
+++ b/supabase/migrations/20291218010000_festival_cross_phase_contracts.sql
@@ -1,0 +1,135 @@
+-- Final cross-phase contract: explicit runtime outcome v2 and observable simulation workers.
+ALTER TABLE public.festival_performance_simulation_jobs
+  ADD COLUMN canonical_engine_version text NOT NULL DEFAULT 'canonical-gig-v1',
+  ADD COLUMN festival_adapter_version text NOT NULL DEFAULT 'festival-gig-adapter-v2',
+  ADD COLUMN runtime_formula_version text NOT NULL DEFAULT 'festival-runtime-v1';
+
+-- Earlier jobs used `gig-v1` and `engine_version` for several different concepts.
+UPDATE public.festival_performance_simulation_jobs
+SET canonical_engine_version = CASE WHEN engine_version IN ('gig-v1','canonical-gig-v1') THEN 'canonical-gig-v1' ELSE engine_version END,
+    engine_version = CASE WHEN engine_version='gig-v1' THEN 'canonical-gig-v1' ELSE engine_version END;
+
+CREATE TABLE public.festival_simulation_worker_invocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), worker_id text NOT NULL,
+  status text NOT NULL CHECK(status IN ('running','succeeded','failed')),
+  recovered_leases integer NOT NULL DEFAULT 0, processed_job_id uuid REFERENCES public.festival_performance_simulation_jobs(id),
+  error_code text, started_at timestamptz NOT NULL DEFAULT now(), completed_at timestamptz
+);
+ALTER TABLE public.festival_simulation_worker_invocations ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.festival_simulation_worker_invocations FROM PUBLIC,anon,authenticated;
+
+CREATE FUNCTION public._festival_runtime_performance_projection(p public.festival_runtime_performances)
+RETURNS jsonb LANGUAGE sql STABLE SET search_path='' AS $$
+ SELECT jsonb_build_object(
+  'id',p.id,'runtimePerformanceId',p.id,'runtimeDayId',p.runtime_day_id,'runtimeStageId',p.runtime_stage_id,
+  'status',p.status,'artistType',CASE WHEN p.band_id IS NOT NULL THEN 'band' WHEN p.solo_artist_profile_id IS NOT NULL THEN 'solo' ELSE 'npc' END,
+  'artistId',coalesce(p.band_id,p.solo_artist_profile_id,p.npc_artist_id),'bandId',p.band_id,
+  'soloArtistProfileId',p.solo_artist_profile_id,'npcArtistId',p.npc_artist_id,'artistName',p.artist_name,
+  'billingPosition',coalesce((p.engine_input_snapshot->>'billingPosition')::integer,0),
+  'isHeadliner',coalesce((p.engine_input_snapshot->>'headlinerExpectation')::numeric,0)>0,
+  'performanceScore',p.performance_score,'technicalScore',p.technical_score,
+  'crowdResponse',coalesce(p.engine_result_snapshot->'crowdResponse','{}'::jsonb),'attendance',coalesce(p.estimated_audience,0),
+  'scheduledStart',p.scheduled_start,'scheduledEnd',p.scheduled_end,'actualStart',p.actual_start,'actualEnd',p.actual_end,
+  'delayMinutes',p.delay_minutes,'canonicalEngineVersion',CASE WHEN p.engine_version='gig-v1' THEN 'canonical-gig-v1' ELSE p.engine_version END,
+  'festivalAdapterVersion','festival-gig-adapter-v2','resultSchemaVersion','festival-performance-result-v1',
+  'runtimeFormulaVersion',p.formula_version,'inputDigest',j.input_digest,'outputDigest',j.output_digest,
+  'setlistItemOutcomes',coalesce(x.setlist_item_outcomes,'[]'::jsonb),'stageActions',coalesce(x.stage_actions,'[]'::jsonb),
+  'highlights',coalesce(x.generated_highlights,'[]'::jsonb),
+  'band_id',p.band_id,'solo_artist_profile_id',p.solo_artist_profile_id,'npc_artist_id',p.npc_artist_id,
+  'artist_name',p.artist_name,'billing_position',coalesce((p.engine_input_snapshot->>'billingPosition')::integer,0),
+  'performance_score',p.performance_score,'technical_score',p.technical_score,'crowd_response',p.crowd_response)
+ FROM public.festival_performance_simulation_jobs j
+ LEFT JOIN public.festival_performance_simulation_results x ON x.runtime_performance_id=p.id
+ WHERE j.runtime_performance_id=p.id
+ UNION ALL
+ SELECT jsonb_build_object(
+  'id',p.id,'runtimePerformanceId',p.id,'runtimeDayId',p.runtime_day_id,'runtimeStageId',p.runtime_stage_id,'status',p.status,
+  'artistType',CASE WHEN p.band_id IS NOT NULL THEN 'band' WHEN p.solo_artist_profile_id IS NOT NULL THEN 'solo' ELSE 'npc' END,
+  'artistId',coalesce(p.band_id,p.solo_artist_profile_id,p.npc_artist_id),'bandId',p.band_id,'soloArtistProfileId',p.solo_artist_profile_id,
+  'npcArtistId',p.npc_artist_id,'artistName',p.artist_name,'billingPosition',coalesce((p.engine_input_snapshot->>'billingPosition')::integer,0),
+  'isHeadliner',coalesce((p.engine_input_snapshot->>'headlinerExpectation')::numeric,0)>0,'performanceScore',p.performance_score,
+  'technicalScore',p.technical_score,'crowdResponse','{}'::jsonb,'attendance',coalesce(p.estimated_audience,0),
+  'scheduledStart',p.scheduled_start,'scheduledEnd',p.scheduled_end,'actualStart',p.actual_start,'actualEnd',p.actual_end,
+  'delayMinutes',p.delay_minutes,'canonicalEngineVersion',CASE WHEN p.engine_version='gig-v1' THEN 'canonical-gig-v1' ELSE p.engine_version END,
+  'festivalAdapterVersion','festival-gig-adapter-v2','resultSchemaVersion','festival-performance-result-v1','runtimeFormulaVersion',p.formula_version,
+  'inputDigest',NULL,'outputDigest',NULL,'setlistItemOutcomes','[]'::jsonb,'stageActions','[]'::jsonb,'highlights','[]'::jsonb,'band_id',p.band_id,'solo_artist_profile_id',p.solo_artist_profile_id,'npc_artist_id',p.npc_artist_id,
+  'artist_name',p.artist_name,'billing_position',coalesce((p.engine_input_snapshot->>'billingPosition')::integer,0),
+  'performance_score',p.performance_score,'technical_score',p.technical_score,'crowd_response',p.crowd_response)
+ WHERE NOT EXISTS(SELECT 1 FROM public.festival_performance_simulation_jobs j WHERE j.runtime_performance_id=p.id)
+ LIMIT 1
+$$;
+
+CREATE FUNCTION public._festival_runtime_outcome_projection(p_session uuid,p_kind text) RETURNS jsonb
+LANGUAGE plpgsql STABLE SET search_path='' AS $$ BEGIN
+ CASE p_kind
+ WHEN 'attendance' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('runtimeDayId',x.runtime_day_id,'admittedCount',x.admitted_count,'exitedCount',x.exited_count,'onsiteCount',x.onsite_count,'capacity',x.capacity,'version',x.version,'updatedAt',x.updated_at) ORDER BY x.runtime_day_id) FROM public.festival_runtime_attendance x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'performances' THEN RETURN coalesce((SELECT jsonb_agg(public._festival_runtime_performance_projection(x) ORDER BY x.scheduled_start,x.id) FROM public.festival_runtime_performances x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'crowds' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('runtimeDayId',x.runtime_day_id,'allocatedCount',x.allocated_count,'unallocatedCount',x.unallocated_count,'satisfaction',x.satisfaction) ORDER BY x.runtime_day_id) FROM public.festival_runtime_crowds x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'stageCrowds' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('runtimeDayId',x.runtime_day_id,'runtimeStageId',x.runtime_stage_id,'currentCrowd',x.current_crowd,'stageCapacity',x.stage_capacity) ORDER BY x.runtime_day_id,x.runtime_stage_id) FROM public.festival_runtime_stage_crowds x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'crowdMovements' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'runtimeDayId',x.runtime_day_id,'fromStageId',x.from_stage_id,'toStageId',x.to_stage_id,'arrivals',x.arrivals,'departures',x.departures,'createdAt',x.created_at) ORDER BY x.created_at,x.id) FROM public.festival_runtime_crowd_movements x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'weather' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('runtimeDayId',x.runtime_day_id,'weatherState',x.weather_state,'temperatureBand',x.temperature_band,'groundCondition',x.ground_condition,'operationalImpact',x.operational_impact) ORDER BY x.runtime_day_id) FROM public.festival_runtime_weather x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'incidents' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'runtimeDayId',x.runtime_day_id,'runtimeStageId',x.runtime_stage_id,'category',x.category,'severity',x.severity,'status',x.status,'detectedAt',x.detected_at,'resolvedAt',x.resolved_at,'resolutionOutcome',x.resolution_outcome) ORDER BY x.detected_at,x.id) FROM public.festival_runtime_incidents x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'staffOutcomes' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'staffCheckinId',x.staff_checkin_id,'shiftCompletion',x.shift_completion,'roleEffectiveness',x.role_effectiveness,'latenessMinutes',x.lateness_minutes,'staff_checkin_id',x.staff_checkin_id,'shift_completion',x.shift_completion,'role_effectiveness',x.role_effectiveness,'lateness_minutes',x.lateness_minutes) ORDER BY x.id) FROM public.festival_runtime_staff_outcomes x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'supplierOutcomes' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'supplierCheckinId',x.supplier_checkin_id,'deliveryCompleteness',x.delivery_completeness,'productQuality',x.product_quality,'contractCompliance',x.contract_compliance,'latenessMinutes',x.lateness_minutes,'supplier_checkin_id',x.supplier_checkin_id,'delivery_completeness',x.delivery_completeness,'product_quality',x.product_quality,'contract_compliance',x.contract_compliance,'lateness_minutes',x.lateness_minutes) ORDER BY x.id) FROM public.festival_runtime_supplier_outcomes x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'sponsorActivations' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'contractDeliverableId',x.contract_deliverable_id,'status',x.status,'deliveryQuality',x.delivery_quality,'audienceExposure',x.audience_exposure,'contract_deliverable_id',x.contract_deliverable_id,'source_activation_id',x.source_activation_id,'delivery_quality',x.delivery_quality,'audience_exposure',x.audience_exposure) ORDER BY x.id) FROM public.festival_runtime_sponsor_activations x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'vendorSales' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'runtimeDayId',x.runtime_day_id,'category',x.category,'status',x.status,'currencyCode',x.currency_code,'grossRevenueMinor',x.gross_revenue_minor::text,'taxLiabilityMinor',x.tax_liability_minor::text,'costBasisMinor',x.cost_basis_minor::text,'unitsSold',x.units_sold) ORDER BY x.runtime_day_id,x.id) FROM public.festival_runtime_vendor_sales x WHERE x.runtime_session_id=p_session),'[]');
+ WHEN 'revenuePostings' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',x.id,'vendorSalesId',x.vendor_sales_id,'amountMinor',x.amount_minor::text,'currencyCode',x.currency_code,'postedAt',x.posted_at) ORDER BY x.posted_at,x.id) FROM public.festival_runtime_revenue_postings x JOIN public.festival_runtime_vendor_sales v ON v.id=x.vendor_sales_id WHERE v.runtime_session_id=p_session),'[]');
+ WHEN 'headliners' THEN RETURN coalesce((SELECT jsonb_agg(public._festival_runtime_performance_projection(x) ORDER BY x.scheduled_start,x.id) FROM public.festival_runtime_performances x WHERE x.runtime_session_id=p_session AND coalesce((x.engine_input_snapshot->>'headlinerExpectation')::numeric,0)>0),'[]');
+ WHEN 'timetable' THEN RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('runtimePerformanceId',x.id,'runtimeDayId',x.runtime_day_id,'runtimeStageId',x.runtime_stage_id,'scheduledStart',x.scheduled_start,'scheduledEnd',x.scheduled_end,'status',x.status) ORDER BY x.scheduled_start,x.id) FROM public.festival_runtime_performances x WHERE x.runtime_session_id=p_session),'[]');
+ ELSE RAISE EXCEPTION 'festival_runtime_projection_unsupported'; END CASE;
+ END $$;
+
+CREATE FUNCTION public.assert_festival_runtime_outcome_v2(p_snapshot jsonb) RETURNS void
+LANGUAGE plpgsql IMMUTABLE SET search_path='' AS $$ BEGIN
+ IF p_snapshot->>'schemaVersion'<>'festival-runtime-outcome-v2' THEN RAISE EXCEPTION 'festival_runtime_outcome_schema_unsupported'; END IF;
+ IF p_snapshot->>'runtimeSessionId' IS NULL OR jsonb_typeof(p_snapshot->'performances')<>'array' THEN RAISE EXCEPTION 'festival_runtime_outcome_contract_invalid'; END IF;
+ END $$;
+
+CREATE OR REPLACE FUNCTION public.finalise_festival_runtime_outcomes(p_runtime_session_id uuid,p_expected_version integer,p_idempotency_key uuid) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE r public.festival_runtime_sessions%ROWTYPE; existing public.festival_runtime_outcome_snapshots%ROWTYPE; payload jsonb;snapshot jsonb;content_digest text;edition uuid;
+BEGIN
+ SELECT * INTO r FROM public.festival_runtime_sessions WHERE id=p_runtime_session_id FOR UPDATE;
+ IF r.id IS NULL THEN RAISE EXCEPTION 'festival_runtime_chain_session'; END IF;
+ IF NOT public._festival_runtime_owner(r.id,public._festival_runtime_actor()) THEN RAISE EXCEPTION 'festival_runtime_forbidden'; END IF;
+ SELECT * INTO existing FROM public.festival_runtime_outcome_snapshots WHERE runtime_session_id=r.id;
+ IF existing.id IS NOT NULL THEN RETURN jsonb_build_object('readyForSettlement',true,'outcomeDigest',existing.content_digest,'schemaVersion',existing.snapshot->>'schemaVersion','idempotent',true); END IF;
+ IF r.version<>p_expected_version THEN RAISE EXCEPTION 'festival_runtime_stale'; END IF;
+ IF r.status NOT IN('public_closed','site_clearance') OR r.gates_open
+   OR EXISTS(SELECT 1 FROM public.festival_performance_simulation_jobs WHERE runtime_session_id=r.id AND status IN('pending','processing','failed','exhausted'))
+   OR EXISTS(SELECT 1 FROM public.festival_runtime_performances WHERE runtime_session_id=r.id AND status NOT IN('completed','cancelled','abandoned'))
+   OR EXISTS(SELECT 1 FROM public.festival_runtime_incidents WHERE runtime_session_id=r.id AND severity IN('major','critical') AND status NOT IN('resolved','handed_over'))
+ THEN RAISE EXCEPTION 'festival_runtime_outcomes_blocked'; END IF;
+ SELECT e.id INTO edition FROM public.festival_public_editions e WHERE e.festival_launch_id=r.festival_launch_id;
+ payload:=jsonb_build_object('schemaVersion','festival-runtime-outcome-v2','engineVersion','canonical-gig-v1',
+  'formulaVersions',jsonb_build_object('runtime',r.formula_version,'performance','festival-performance-result-v1','crowd','festival-crowd-largest-remainder-v2','settlement','festival-settlement-v1'),
+  'runtimeSessionId',r.id,'festivalLaunchId',r.festival_launch_id,'festivalEditionId',edition,'createdAt',now(),
+  'attendance',public._festival_runtime_outcome_projection(r.id,'attendance'),'performances',public._festival_runtime_outcome_projection(r.id,'performances'),
+  'crowds',public._festival_runtime_outcome_projection(r.id,'crowds'),'stageCrowds',public._festival_runtime_outcome_projection(r.id,'stageCrowds'),
+  'crowdMovements',public._festival_runtime_outcome_projection(r.id,'crowdMovements'),'weather',public._festival_runtime_outcome_projection(r.id,'weather'),
+  'incidents',public._festival_runtime_outcome_projection(r.id,'incidents'),'staffOutcomes',public._festival_runtime_outcome_projection(r.id,'staffOutcomes'),
+  'supplierOutcomes',public._festival_runtime_outcome_projection(r.id,'supplierOutcomes'),'sponsorActivations',public._festival_runtime_outcome_projection(r.id,'sponsorActivations'),
+  'vendorSales',public._festival_runtime_outcome_projection(r.id,'vendorSales'),'revenuePostings',public._festival_runtime_outcome_projection(r.id,'revenuePostings'),
+  'headliners',public._festival_runtime_outcome_projection(r.id,'headliners'),'timetable',public._festival_runtime_outcome_projection(r.id,'timetable'));
+ content_digest:=encode(digest(payload::text,'sha256'),'hex'); snapshot:=payload||jsonb_build_object('contentDigest',content_digest);
+ PERFORM public.assert_festival_runtime_outcome_v2(snapshot);
+ INSERT INTO public.festival_runtime_outcome_snapshots(runtime_session_id,snapshot,engine_version,formula_versions,content_digest) VALUES(r.id,snapshot,'canonical-gig-v1',snapshot->'formulaVersions',content_digest);
+ UPDATE public.festival_runtime_sessions SET status='runtime_complete',ready_for_settlement=true,completed_at=now(),gates_open=false,version=version+1,updated_at=now() WHERE id=r.id;
+ RETURN jsonb_build_object('readyForSettlement',true,'outcomeDigest',content_digest,'schemaVersion','festival-runtime-outcome-v2','idempotencyKey',p_idempotency_key,'idempotent',false);
+END $$;
+
+CREATE FUNCTION public._festival_settlement_runtime_contract_guard() RETURNS trigger LANGUAGE plpgsql SET search_path='' AS $$
+DECLARE contract jsonb; BEGIN SELECT snapshot INTO contract FROM public.festival_runtime_outcome_snapshots WHERE runtime_session_id=NEW.runtime_session_id; PERFORM public.assert_festival_runtime_outcome_v2(contract); RETURN NEW; END $$;
+CREATE TRIGGER festival_settlement_runtime_contract_guard BEFORE INSERT ON public.festival_financial_settlements FOR EACH ROW EXECUTE FUNCTION public._festival_settlement_runtime_contract_guard();
+
+CREATE FUNCTION public.get_festival_simulation_worker_health() RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path='' AS $$
+BEGIN IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false) THEN RAISE EXCEPTION 'festival_simulation_admin_required'; END IF;
+ RETURN jsonb_build_object('pendingCount',(SELECT count(*) FROM public.festival_performance_simulation_jobs WHERE status='pending'),
+ 'processingCount',(SELECT count(*) FROM public.festival_performance_simulation_jobs WHERE status='processing'),'failedCount',(SELECT count(*) FROM public.festival_performance_simulation_jobs WHERE status='failed'),
+ 'exhaustedCount',(SELECT count(*) FROM public.festival_performance_simulation_jobs WHERE status='exhausted'),'oldestQueuedJob',(SELECT min(created_at) FROM public.festival_performance_simulation_jobs WHERE status IN('pending','failed')),
+ 'lastSuccessfulCompletion',(SELECT max(completed_at) FROM public.festival_performance_simulation_jobs WHERE status='completed'),'lastWorkerInvocation',(SELECT max(started_at) FROM public.festival_simulation_worker_invocations)); END $$;
+CREATE FUNCTION public.get_exhausted_festival_simulation_jobs() RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path='' AS $$
+BEGIN IF NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false) THEN RAISE EXCEPTION 'festival_simulation_admin_required'; END IF;
+ RETURN coalesce((SELECT jsonb_agg(jsonb_build_object('id',id,'runtimePerformanceId',runtime_performance_id,'attempts',attempts,'lastError',last_error,'createdAt',created_at) ORDER BY created_at) FROM public.festival_performance_simulation_jobs WHERE status='exhausted'),'[]'); END $$;
+GRANT EXECUTE ON FUNCTION public.get_festival_simulation_worker_health(),public.get_exhausted_festival_simulation_jobs() TO authenticated;
+REVOKE ALL ON FUNCTION public._festival_runtime_performance_projection(public.festival_runtime_performances),public._festival_runtime_outcome_projection(uuid,text),public.assert_festival_runtime_outcome_v2(jsonb) FROM PUBLIC,anon,authenticated;
+COMMENT ON FUNCTION public._festival_runtime_outcome_projection(uuid,text) IS 'Explicit projections for every festival-runtime-outcome-v2 collection; raw table rows are never the cross-phase API.';

--- a/supabase/tests/festival_cross_phase_contract_harness.sql
+++ b/supabase/tests/festival_cross_phase_contract_harness.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+BEGIN;
+DO $$ DECLARE sample jsonb:=jsonb_build_object('schemaVersion','festival-runtime-outcome-v2','runtimeSessionId',gen_random_uuid(),'performances','[]'::jsonb); BEGIN
+  PERFORM public.assert_festival_runtime_outcome_v2(sample);
+  BEGIN PERFORM public.assert_festival_runtime_outcome_v2(sample||jsonb_build_object('schemaVersion','festival-runtime-outcome-v1')); RAISE EXCEPTION 'unsupported schema accepted';
+  EXCEPTION WHEN raise_exception THEN IF SQLERRM<>'festival_runtime_outcome_schema_unsupported' THEN RAISE; END IF; END;
+  IF to_regprocedure('public.prepare_festival_settlement(uuid,integer,uuid)') IS NULL OR to_regprocedure('public.generate_festival_result(uuid)') IS NULL THEN RAISE EXCEPTION 'cross-phase consumer missing'; END IF;
+END $$;
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Provide an explicit, versioned Festival runtime outcome contract (`festival-runtime-outcome-v2`) with limited, documented collections to be consumed by settlement and legacy systems.
- Stop fabricating fallback performances and make the simulation result canonical, deterministic and auditable across runtime -> settlement -> legacy phases.
- Standardise engine/adapter/result/formula identities so worker jobs and consumers map legacy `gig-v1` usages safely. 
- Operationalise the simulation worker with health, stale-lease recovery and observable invocations so recurring scheduling and recovery are safe.

### Description

- Add a cross-phase migration `20291218010000_festival_cross_phase_contracts.sql` that: adds `canonical_engine_version`, `festival_adapter_version`, `runtime_formula_version` to simulation jobs, defines the `festival-runtime-outcome-v2` finalisation projection, introduces explicit flat performance projection functions, and creates `festival_simulation_worker_invocations`, health RPCs and a settlement contract guard trigger. 
- Extract a deterministic, environment-neutral simulation core in `supabase/functions/_shared/gig-simulation` with typed inputs (`types.ts`), a pure `simulateCanonicalFestivalPerformance` adapter, and Deno test harness (`index.test.ts`), which rejects missing canonical setlists with `festival_simulation_canonical_input_missing`. 
- Update the Edge worker (`supabase/functions/festival-performance-worker/index.ts`) and its adapter mapping (`simulation.ts`) to use the shared simulation core, map legacy inputs (gracefully handle `gig-v1`), recover stale leases before claiming work, and persist invocation records for observability and recovery. 
- Add an executable SQL contract harness `supabase/tests/festival_cross_phase_contract_harness.sql` that asserts the runtime outcome v2 guard and verifies presence of cross-phase consumers. 
- Add operational documentation `docs/festivals/FESTIVAL_WORKER_OPERATIONS.md` describing secure scheduling, required secrets, invocation recording and alerting guidance. 

### Testing

- Ran `npm run verify:migration-timestamps` and it passed (migration filename checks adjusted to include the new migration). (succeeded)
- Ran `npm run verify:supabase-rpcs` and it passed (Supabase RPC verification against migrations). (succeeded)
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully for the modified TS surface. (succeeded)
- Ran `git diff --check` as part of verification; no repository whitespace errors introduced by this work. (succeeded)
- Attempted `npm ci` but it failed due to registry access returning HTTP 403 while fetching dependencies (this removed the prior node_modules state and prevented subsequent `build`/`test` runs). (blocked)
- `npm run test:unit` / `vitest` could not complete in the workspace because the runtime installation was incomplete and the test environment reported missing module `rrweb-cssom` and many pre-existing repo test/lint issues; no new unit test regressions introduced by these changes were claimed. (blocked / existing baseline failures)
- The SQL harness and an actual worker invocation were not executed against a disposable Supabase/PostgreSQL instance in this environment (no `SUPABASE_DB_URL` / local Supabase available), so runtime job processing and settlement execution were not validated by an end-to-end run here. (not executed)

If you want, the next step is a focused CI run on a disposable Supabase instance and a full `npm ci`/`npm run build` in an environment with npm registry access so the harness and worker can be exercised end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6646568c7083258326dfe3ba8939fa)