### PR TITLE
fix(festivals): execute settlement v2 and complete legacy world effects

### DIFF
--- a/scripts/supabase/verify-migration-timestamps.mjs
+++ b/scripts/supabase/verify-migration-timestamps.mjs
@@ -22,6 +22,7 @@ const festivalRuntimeWorkerContinuation = "20291218000000_complete_festival_runt
 const festivalCrossPhaseContinuation = "20291218010000_festival_cross_phase_contracts.sql";
 const festivalRuntimeV2HardeningContinuation = "20291218020000_festival_runtime_v2_hardening.sql";
 const festivalSettlementV2Continuation = "20291218030000_festival_settlement_v2.sql";
+const festivalSettlementV2ExecutionContinuation = "20291218040000_execute_festival_settlement_v2.sql";
 const legacySequenceNames = new Set(["085_jam_sessions_core.sql", "086_band_member_locks.sql", "087_bands_add_chemistry_cohesion.sql"]);
 const today = new Date();
 const reasonableFuture = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 2, 23, 59, 59));
@@ -34,7 +35,7 @@ for (const filename of readdirSync(migrationDirectory).filter((name) => name.end
     failures.push(`${filename}: expected YYYYMMDDHHMMSS_description.sql`); continue;
   }
   const stamp = match[1];
-  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation || filename === festivalRuntimeWorkerContinuation || filename === festivalCrossPhaseContinuation || filename === festivalRuntimeV2HardeningContinuation || filename === festivalSettlementV2Continuation) { exceptions.push(filename); continue; }
+  if (filename === festivalPhase2Continuation || filename === festivalPhase3Continuation || filename === festivalPhase4Continuation || filename === festivalPhase4WorkflowContinuation || filename === festivalPhase5Continuation || filename === festivalPhase5WorkflowContinuation || filename === festivalPhase6Continuation || filename === festivalPhase6WorkflowContinuation || filename === festivalPhase7Continuation || filename === festivalPhase7LaunchContinuation || filename === festivalPhase8RuntimeContinuation || filename === festivalPhase8OperationsContinuation || filename === festivalPhase9SettlementContinuation || filename === festivalPhase9LegacyContinuation || filename === festivalRuntimeWorkerContinuation || filename === festivalCrossPhaseContinuation || filename === festivalRuntimeV2HardeningContinuation || filename === festivalSettlementV2Continuation || filename === festivalSettlementV2ExecutionContinuation) { exceptions.push(filename); continue; }
   const todayStamp = `${today.getUTCFullYear()}${String(today.getUTCMonth() + 1).padStart(2, "0")}${String(today.getUTCDate()).padStart(2, "0")}235959`;
   // Freeze every inherited future sequence through the known anomaly. This includes
   // several historical invalid calendar-day names; accepting the exact bounded

--- a/src/utils/__tests__/gigLive.test.ts
+++ b/src/utils/__tests__/gigLive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applySongResultToSession, buildInitialLiveSession, buildLiveTimeline, buildTacticalDecision, canApplyLiveSetlistChange, canStartLiveGig, evaluateEncore, finalizeLiveGig, maybeGenerateLiveIncident, resolveLiveSong, type GigLiveContext } from '../gigLive';
+import { applySongResultToSession, buildInitialLiveSession, buildLiveTimeline, buildTacticalDecision, canApplyLiveSetlistChange, canStartLiveGig, evaluateEncore, FESTIVAL_FACTOR_TARGETS, finalizeLiveGig, mapFestivalFactors, maybeGenerateLiveIncident, resolveLiveSong, type GigLiveContext } from '../gigLive';
 import { calculateGigReadiness } from '../gigReadiness';
 
 const readiness = calculateGigReadiness({ setlistSongs: [{ id: 'song-1', durationSeconds: 180, rehearsalLevel: 85 }, { id: 'song-2', durationSeconds: 210, rehearsalLevel: 90 }], bandChemistry: 78, fatigueScore: 80, healthScore: 82, assignedPerformers: 4, requiredPerformers: 4 });
@@ -48,6 +48,20 @@ describe('gig live simulation', () => {
     expect(excellentFestival.score).toBeGreaterThan(disruptedFestival.score);
     expect(excellentFestival.breakdown.some(item => item.key === 'festival_stage_quality')).toBe(true);
     expect(normal.breakdown.some(item => item.key.startsWith('festival_'))).toBe(false);
+  });
+
+  it('keeps neutral Festival evidence at parity and audits every factor once', () => {
+    const session = buildInitialLiveSession(ctx, new Date('2026-07-11T12:00:00Z'));
+    const neutral = { stageQuality: 50, soundAndLighting: 50, technicalReadiness: 50, rehearsal: 50,
+      crewEffectiveness: 50, weather: 50, delayMinutes: 0, crowdMood: 50, crowdDensity: 50,
+      equipmentCondition: 50, billingPosition: 50, headlinerExpectation: 50, incidentDisruption: 0, setLengthMinutes: 60 };
+    expect(resolveLiveSong({ ...ctx, festival: neutral }, session, ctx.setlist[0], 1, 'parity').score)
+      .toBe(resolveLiveSong(ctx, session, ctx.setlist[0], 1, 'parity').score);
+    const mapping = mapFestivalFactors(neutral);
+    expect(mapping.finalModifier).toBe(0);
+    expect(mapping.breakdown).toHaveLength(Object.keys(FESTIVAL_FACTOR_TARGETS).length);
+    expect(new Set(mapping.breakdown.map(item => item.key)).size).toBe(mapping.breakdown.length);
+    expect(mapping.breakdown.every(item => item.inputValue !== undefined && item.targetCanonicalField && item.application)).toBe(true);
   });
 
   it('supports tactical decisions, automatic fallbacks, encore checks and immutable completed segments', () => {

--- a/src/utils/gigLive.ts
+++ b/src/utils/gigLive.ts
@@ -2,7 +2,7 @@ import { calculateCrewEffectiveness, calculateEquipmentReliability, type CrewAss
 import { calculateReadinessPerformanceModifier, type ReadinessResult } from './gigReadiness';
 import { SOUNDCHECK_TYPES, type ProductionQualityResult, type SoundcheckType } from './gigStageProduction';
 import { summarizePreshowPerformanceModifiers, type PreshowConsequence } from './gigPreshow';
-import { calculateCanonicalSongScore, deterministicGigRandom } from '@/domain/gig-simulation';
+import { calculateCanonicalSongOutcome, deterministicGigRandom, type CanonicalSongCalculationInput } from '@/domain/gig-simulation';
 
 export type LiveGigStatus = 'scheduled' | 'preshow' | 'ready_to_start' | 'live' | 'paused_for_decision' | 'resolving' | 'completed' | 'cancelled' | 'failed';
 export type LiveSegmentType = 'intro' | 'song' | 'transition' | 'crowd_interaction' | 'incident' | 'decision' | 'encore_break' | 'encore_song' | 'outro';
@@ -18,7 +18,7 @@ export interface GigLiveSegment { id?: string; segmentIndex: number; segmentType
 export interface LiveGigSessionState { gigId: string; bandId: string; status: LiveGigStatus; startedAt: string; expectedEndAt?: string; currentSegmentIndex: number; currentSongItemId?: string | null; crowdEnergy: number; fanSatisfaction: number; performanceQuality: number; bandStamina: number; momentum: number; incidentRisk: number; simulationVersion: number; lastProcessedAt?: string; }
 export interface FestivalLiveContext { stageQuality: number; soundAndLighting: number; technicalReadiness: number; rehearsal: number; crewEffectiveness: number; weather: number; delayMinutes: number; crowdMood: number; crowdDensity: number; equipmentCondition: number; billingPosition: number; headlinerExpectation: number; incidentDisruption: number; setLengthMinutes: number; }
 export interface GigLiveContext { gigId: string; bandId: string; scheduledAt: string | Date; status?: string | null; slotDurationSeconds?: number | null; capacity?: number | null; ticketsSold?: number | null; venueAcoustics?: number | null; venueQuality?: number | null; genreAffinity?: number | null; ticketPrice?: number | null; curfewAt?: string | Date | null; performerSkill?: number | null; stagePresence?: number | null; bandChemistry?: number | null; healthScore?: number | null; fatigueScore?: number | null; readiness: ReadinessResult; crew?: CrewAssignmentInput[]; equipment?: EquipmentLoadoutInput[]; productionQuality?: ProductionQualityResult | null; soundcheckType?: SoundcheckType; preShowConsequences?: PreshowConsequence[]; setlist: LiveSetlistItem[]; festival?: Readonly<FestivalLiveContext>; }
-export interface LiveBreakdownItem { key: string; label: string; modifier: number; explanation: string; }
+export interface LiveBreakdownItem { key: string; label: string; modifier: number; explanation: string; inputValue?: number; targetCanonicalField?: keyof CanonicalSongCalculationInput | 'finalScore'; application?: 'intermediate' | 'final'; }
 export interface LiveSongResult { score: number; rating: LiveSongRating; technicalScore: number; performanceScore: number; audienceResponse: number; energyChange: number; satisfactionChange: number; staminaCost: number; momentumChange: number; incidents: string[]; highlights: string[]; breakdown: LiveBreakdownItem[]; }
 export interface LiveIncident { incidentType: string; category: LiveIncidentCategory; severity: LiveIncidentSeverity; title: string; decisionType?: string; generationSnapshot: Record<string, unknown>; resultSnapshot: Record<string, unknown>; }
 export interface TacticalDecisionOption { key: string; label: string; consequence: { crowdEnergy?: number; fanSatisfaction?: number; momentum?: number; bandStamina?: number; incidentRisk?: number; durationSeconds?: number }; safeFallback?: boolean; }
@@ -32,28 +32,52 @@ const signedClamp = (n: number, max: number) => Math.max(-max, Math.min(max, n))
 export const deterministicRandom = deterministicGigRandom;
 const ratingFor = (score: number): LiveSongRating => score < 25 ? 'disaster' : score < 40 ? 'poor' : score < 58 ? 'average' : score < 72 ? 'good' : score < 86 ? 'great' : 'outstanding';
 
-/** A bounded, auditable modifier inside the canonical engine (not a second score). */
-export function calculateFestivalLiveModifier(context?: Readonly<FestivalLiveContext>): LiveBreakdownItem[] {
-  if (!context) return [];
+/**
+ * Single-application map for Festival evidence. Factors mapped to a canonical
+ * input MUST NOT also occur in `finalModifier`; disruption-only factors are
+ * applied after the canonical intermediate scores.
+ */
+export const FESTIVAL_FACTOR_TARGETS = {
+  stageQuality: 'stageEffect', soundAndLighting: 'production', technicalReadiness: 'readinessScore',
+  rehearsal: 'rehearsalLevel', crewEffectiveness: 'crewEffectiveness', equipmentCondition: 'equipmentReliability',
+  crowdMood: 'crowdState', crowdDensity: 'crowdState', billingPosition: 'setlistPosition',
+  headlinerExpectation: 'setlistPosition', setLengthMinutes: 'stamina', weather: 'finalScore',
+  delayMinutes: 'finalScore', incidentDisruption: 'finalScore',
+} as const satisfies Record<keyof FestivalLiveContext, keyof CanonicalSongCalculationInput | 'finalScore'>;
+
+export function mapFestivalFactors(context?: Readonly<FestivalLiveContext>) {
+  if (!context) return { canonical: {}, finalModifier: 0, breakdown: [] as LiveBreakdownItem[] };
   const centered = (value: number, weight: number) => (clamp(value) - 50) * weight;
-  const effects: Array<[string, string, number]> = [
-    ['stage_quality', 'Stage quality', centered(context.stageQuality, .055)],
-    ['sound_lighting', 'Sound and lighting', centered(context.soundAndLighting, .06)],
-    ['technical_readiness', 'Technical readiness', centered(context.technicalReadiness, .05)],
-    ['rehearsal', 'Festival rehearsal', centered(context.rehearsal, .045)],
-    ['crew', 'Festival crew', centered(context.crewEffectiveness, .04)],
-    ['weather', 'Weather', centered(context.weather, .045)],
-    ['crowd_mood', 'Crowd mood', centered(context.crowdMood, .055)],
-    ['crowd_density', 'Crowd density', centered(context.crowdDensity, .035)],
-    ['equipment', 'Equipment condition', centered(context.equipmentCondition, .045)],
-    ['billing', 'Billing position', centered(context.billingPosition, .025)],
-    ['headliner', 'Headliner expectation', -Math.max(0, context.headlinerExpectation - 65) * .035],
-    ['delay', 'Delay', -Math.min(60, Math.max(0, context.delayMinutes)) * .055],
-    ['incidents', 'Incident disruption', -clamp(context.incidentDisruption) * .045],
-    ['set_length', 'Set length', -Math.abs(Math.max(10, context.setLengthMinutes) - 60) * .018],
+  const crowdState = clamp(context.crowdMood * .65 + context.crowdDensity * .35);
+  const setlistPosition = clamp(context.billingPosition - Math.max(0, context.headlinerExpectation - 65) * .25);
+  const stamina = clamp(50 - Math.abs(Math.max(10, context.setLengthMinutes) - 60) * .35);
+  const canonical: Partial<CanonicalSongCalculationInput> = { stageEffect: context.stageQuality, production: context.soundAndLighting,
+    readinessScore: context.technicalReadiness, rehearsalLevel: context.rehearsal, crewEffectiveness: context.crewEffectiveness,
+    equipmentReliability: context.equipmentCondition, crowdState, setlistPosition, stamina };
+  const effects: Array<[keyof FestivalLiveContext, string, number, number]> = [
+    ['stageQuality', 'Stage quality', centered(context.stageQuality, .055), context.stageQuality],
+    ['soundAndLighting', 'Sound and lighting', centered(context.soundAndLighting, .06), context.soundAndLighting],
+    ['technicalReadiness', 'Technical readiness', centered(context.technicalReadiness, .05), context.technicalReadiness],
+    ['rehearsal', 'Festival rehearsal', centered(context.rehearsal, .045), context.rehearsal],
+    ['crewEffectiveness', 'Festival crew', centered(context.crewEffectiveness, .04), context.crewEffectiveness],
+    ['crowdMood', 'Crowd mood', centered(context.crowdMood, .055), context.crowdMood],
+    ['crowdDensity', 'Crowd density', centered(context.crowdDensity, .035), context.crowdDensity],
+    ['equipmentCondition', 'Equipment condition', centered(context.equipmentCondition, .045), context.equipmentCondition],
+    ['billingPosition', 'Billing position', centered(context.billingPosition, .025), context.billingPosition],
+    ['headlinerExpectation', 'Headliner expectation', -Math.max(0, context.headlinerExpectation - 65) * .035, context.headlinerExpectation],
+    ['setLengthMinutes', 'Set length', -Math.abs(Math.max(10, context.setLengthMinutes) - 60) * .018, context.setLengthMinutes],
+    ['weather', 'Weather', centered(context.weather, .045), context.weather],
+    ['delayMinutes', 'Delay', -Math.min(60, Math.max(0, context.delayMinutes)) * .055, context.delayMinutes],
+    ['incidentDisruption', 'Incident disruption', -clamp(context.incidentDisruption) * .045, context.incidentDisruption],
   ];
-  return effects.map(([key, label, modifier]) => ({ key: `festival_${key}`, label, modifier: Number(modifier.toFixed(3)), explanation: `${label} is supplied by the immutable Festival runtime evidence.` }));
+  const breakdown = effects.map(([key, label, modifier, inputValue]) => ({ key: `festival_${key}`, label, inputValue,
+    targetCanonicalField: FESTIVAL_FACTOR_TARGETS[key], application: FESTIVAL_FACTOR_TARGETS[key] === 'finalScore' ? 'final' as const : 'intermediate' as const,
+    modifier: Number(modifier.toFixed(3)), explanation: `${label} is supplied by immutable Festival evidence and applied once to ${FESTIVAL_FACTOR_TARGETS[key]}.` }));
+  const finalModifier = signedClamp(breakdown.filter(effect => effect.application === 'final').reduce((sum, effect) => sum + effect.modifier, 0), 18);
+  return { canonical, finalModifier, breakdown };
 }
+
+export const calculateFestivalLiveModifier = (context?: Readonly<FestivalLiveContext>) => mapFestivalFactors(context).breakdown;
 
 export function canStartLiveGig(ctx: GigLiveContext, now = new Date()) {
   const status = ctx.status ?? 'scheduled';
@@ -100,25 +124,28 @@ export function resolveLiveSong(ctx: GigLiveContext, session: LiveGigSessionStat
   const preshow = summarizePreshowPerformanceModifiers(ctx.preShowConsequences ?? []);
   const song = item.song, total = ctx.setlist.length, previous = ctx.setlist.find(s => s.position === item.position - 1);
   const positionMod = setlistPositionModifier(item, total, previous);
-  const staminaPenalty = Math.max(0, 55 - session.bandStamina) * 0.28;
-  const crowdLift = signedClamp((session.crowdEnergy - 55) * 0.08, 4);
-  const momentumLift = signedClamp(session.momentum * 0.18, 4);
-  const venueFit = ((ctx.venueAcoustics ?? 55) - 55) * 0.07 + ((ctx.genreAffinity ?? 55) - 55) * 0.06;
   const familiarity = song.familiarity ?? song.rehearsalLevel ?? 45;
-  const technicalScore = clamp((song.quality ?? 55) * 0.24 + familiarity * 0.2 + (ctx.performerSkill ?? 55) * 0.17 + reliability.quality * 0.12 + crewAvg * 0.08 + (ctx.venueAcoustics ?? 55) * 0.08 + sound.soundBenefit * 0.11 - staminaPenalty + preshow.soundQualityModifier * 45);
-  const performanceScore = clamp(ctx.readiness.score * 0.22 + (ctx.bandChemistry ?? 55) * 0.14 + (ctx.stagePresence ?? ctx.performerSkill ?? 55) * 0.16 + (song.popularity ?? 45) * 0.11 + (ctx.productionQuality?.score ?? 55) * 0.09 + session.bandStamina * 0.08 + 50 * 0.08 + positionMod.modifier + crowdLift + momentumLift + preshow.performanceModifier * 100);
-  const audienceResponse = clamp(performanceScore * 0.45 + technicalScore * 0.28 + (song.popularity ?? 45) * 0.17 + session.crowdEnergy * 0.10 + venueFit);
-  const festivalEffects = calculateFestivalLiveModifier(ctx.festival);
-  const festivalModifier = signedClamp(festivalEffects.reduce((sum, effect) => sum + effect.modifier, 0), 18);
-  const canonicalScore = calculateCanonicalSongScore({ technicalScore, performanceScore, audienceResponse, seed, songId: item.id, festivalModifier });
-  const { baseScore, variance: boundedRandom, score } = canonicalScore;
+  const festival = mapFestivalFactors(ctx.festival);
+  const canonicalInput: CanonicalSongCalculationInput = { quality: song.quality ?? 55, popularity: song.popularity ?? 45,
+    familiarity, rehearsalLevel: song.rehearsalLevel ?? familiarity, performerSkill: ctx.performerSkill ?? 55,
+    stagePresence: ctx.stagePresence ?? ctx.performerSkill ?? 55, readinessScore: ctx.readiness.score,
+    equipmentReliability: reliability.quality, crewEffectiveness: crewAvg, venueEffect: clamp((ctx.venueAcoustics ?? 55) + ((ctx.genreAffinity ?? 55) - 55) * .5),
+    stageEffect: 50, production: clamp((ctx.productionQuality?.score ?? 55) + sound.soundBenefit + preshow.soundQualityModifier * 20),
+    setlistPosition: clamp(50 + positionMod.modifier * 4), stamina: session.bandStamina,
+    momentum: clamp(50 + session.momentum * 3), crowdState: session.crowdEnergy,
+    seed, songId: item.id, festivalModifier: festival.finalModifier };
+  for (const [field, mappedValue] of Object.entries(festival.canonical) as [keyof CanonicalSongCalculationInput, number][]) {
+    if (typeof canonicalInput[field] === 'number') (canonicalInput[field] as number) = clamp((canonicalInput[field] as number) + mappedValue - 50);
+  }
+  const canonicalScore = calculateCanonicalSongOutcome(canonicalInput);
+  const { baseScore, variance: boundedRandom, score, technicalScore, performanceScore, audienceResponse } = canonicalScore;
   const intensity = clamp(((song.tempo ?? 110) - 70) / 90 * 100) / 100;
   const staminaCost = Math.round(clamp(DEFAULT_LIVE_GIG_CONFIG.staminaCostBase + (song.durationSeconds ?? 210) / 90 + (song.difficulty ?? 50) / 22 + intensity * 3 - ((song.tags ?? []).some(t => /ballad|slow/i.test(t)) ? 2 : 0), 1, 18));
   const energyChange = Math.round(signedClamp((audienceResponse - 55) * 0.18 + positionMod.modifier * 0.35 - DEFAULT_LIVE_GIG_CONFIG.energyDecayPerSegment, 16));
   const satisfactionChange = Math.round(signedClamp((score - 58) * 0.12 + (technicalScore - 55) * 0.06 + (item.isEncore ? 3 : 0), 12));
   const momentumChange = Math.round(signedClamp((score - 55) * 0.11 + positionMod.modifier * 0.2, 8));
   const highlights = score >= 82 ? [`${song.title} became a standout live moment.`] : audienceResponse >= 78 ? [`The crowd lifted ${song.title}.`] : [];
-  return { score, rating: ratingFor(score), technicalScore: Math.round(technicalScore), performanceScore: Math.round(performanceScore), audienceResponse: Math.round(audienceResponse), energyChange, satisfactionChange, staminaCost, momentumChange, incidents: [], highlights, breakdown: [ { key: 'base_score', label: 'Canonical base score', modifier: Number(baseScore.toFixed(3)), explanation: 'Score before optional Festival effects.' }, { key: 'readiness', label: 'Final readiness', modifier: Math.round(calculateReadinessPerformanceModifier(ctx.readiness.score) * 100), explanation: `Readiness score ${ctx.readiness.score} anchors the performance.` }, { key: 'familiarity', label: 'Song familiarity', modifier: Math.round(familiarity - 55), explanation: 'Saved setlist familiarity/rehearsal affects accuracy.' }, { key: 'equipment_crew', label: 'Equipment and crew', modifier: Math.round((reliability.score + crewAvg) / 2 - 55), explanation: 'Loadout reliability and crew effectiveness reduce mistakes.' }, { key: 'sound_production', label: 'Soundcheck and production', modifier: Math.round(sound.soundBenefit * 0.6 + ((ctx.productionQuality?.score ?? 55) - 55) * 0.12), explanation: 'Soundcheck and production quality shape technical/audience response.' }, { key: 'position', label: 'Setlist position', modifier: Math.round(positionMod.modifier), explanation: positionMod.notes.join(' ') || 'Neutral setlist position.' }, { key: 'live_state', label: 'Crowd, stamina and momentum', modifier: Math.round(crowdLift + momentumLift - staminaPenalty), explanation: 'Current live state modestly influences this song.' }, { key: 'bounded_randomness', label: 'Bounded live variance', modifier: Math.round(boundedRandom), explanation: 'Deterministic per-song variance prevents refresh rerolls.' }, ...festivalEffects ] };
+  return { score, rating: ratingFor(score), technicalScore: Math.round(technicalScore), performanceScore: Math.round(performanceScore), audienceResponse: Math.round(audienceResponse), energyChange, satisfactionChange, staminaCost, momentumChange, incidents: [], highlights, breakdown: [ { key: 'base_score', label: 'Canonical base score', modifier: Number(baseScore.toFixed(3)), explanation: 'Score before disruption-only Festival effects.' }, { key: 'readiness', label: 'Final readiness', modifier: Math.round(calculateReadinessPerformanceModifier(ctx.readiness.score) * 100), explanation: `Readiness score ${ctx.readiness.score} anchors the performance.` }, { key: 'familiarity', label: 'Song familiarity', modifier: Math.round(familiarity - 55), explanation: 'Saved setlist familiarity/rehearsal affects accuracy.' }, { key: 'equipment_crew', label: 'Equipment and crew', modifier: Math.round((reliability.score + crewAvg) / 2 - 55), explanation: 'Loadout reliability and crew effectiveness reduce mistakes.' }, { key: 'sound_production', label: 'Soundcheck and production', modifier: Math.round(sound.soundBenefit * 0.6 + ((ctx.productionQuality?.score ?? 55) - 55) * 0.12), explanation: 'Soundcheck and production quality shape technical/audience response.' }, { key: 'position', label: 'Setlist position', modifier: Math.round(positionMod.modifier), explanation: positionMod.notes.join(' ') || 'Neutral setlist position.' }, { key: 'bounded_randomness', label: 'Bounded live variance', modifier: Math.round(boundedRandom), explanation: 'Deterministic per-song variance prevents refresh rerolls.' }, ...festival.breakdown ] };
 }
 
 export function applySongResultToSession(session: LiveGigSessionState, result: LiveSongResult, item: LiveSetlistItem): LiveGigSessionState {

--- a/supabase/migrations/20291218040000_execute_festival_settlement_v2.sql
+++ b/supabase/migrations/20291218040000_execute_festival_settlement_v2.sql
@@ -1,0 +1,105 @@
+-- Correct the v2 foundation's default-based provenance and make v2 preparation
+-- evidence-bound. Existing final snapshots and receipts are deliberately untouched.
+ALTER TABLE public.festival_financial_settlements
+  ADD COLUMN prepared_at timestamptz;
+
+-- Every settlement present at this forward-only boundary was prepared by the v1
+-- function. The presence of columns added in 20291218030000 is not v2 evidence.
+UPDATE public.festival_financial_settlements
+SET runtime_schema_version = CASE
+      WHEN EXISTS (SELECT 1 FROM public.festival_runtime_outcome_snapshots o
+                   WHERE o.runtime_session_id=festival_financial_settlements.runtime_session_id
+                     AND o.snapshot->>'schemaVersion'='festival-runtime-outcome-v2')
+        THEN 'festival-runtime-outcome-v2'
+      ELSE 'festival-runtime-outcome-v1'
+    END,
+    settlement_formula_version='festival-settlement-v1',
+    formula_version='festival-settlement-v1',
+    tax_rule_version=coalesce((SELECT o.formula_versions->>'tax'
+                               FROM public.festival_runtime_outcome_snapshots o
+                               WHERE o.runtime_session_id=festival_financial_settlements.runtime_session_id),
+                              'festival-tax-v1'),
+    prepared_at=created_at;
+
+-- Defaults are conservative. Only the executable v2 preparation function may
+-- label evidence as v2.
+ALTER TABLE public.festival_financial_settlements
+  ALTER COLUMN runtime_schema_version SET DEFAULT 'festival-runtime-outcome-v1',
+  ALTER COLUMN settlement_formula_version SET DEFAULT 'festival-settlement-v1';
+
+ALTER FUNCTION public.prepare_festival_settlement(uuid,integer,uuid)
+  RENAME TO _prepare_festival_settlement_v1;
+
+CREATE FUNCTION public.prepare_festival_settlement(
+  p_runtime_session_id uuid,
+  p_expected_runtime_version integer,
+  p_idempotency_key uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path=''
+AS $$
+DECLARE
+  outcome public.festival_runtime_outcome_snapshots%ROWTYPE;
+  settlement public.festival_financial_settlements%ROWTYPE;
+  result jsonb;
+  contracts_digest text;
+  calculation_digest text;
+BEGIN
+  -- Serialise preparation with finalisation and settlement processing.
+  SELECT * INTO outcome
+  FROM public.festival_runtime_outcome_snapshots
+  WHERE runtime_session_id=p_runtime_session_id
+  FOR SHARE;
+  IF outcome.id IS NULL THEN RAISE EXCEPTION 'festival_settlement_not_ready'; END IF;
+  PERFORM public.assert_festival_runtime_outcome_v2(outcome.snapshot);
+  IF outcome.content_digest IS DISTINCT FROM encode(digest(outcome.snapshot::text,'sha256'),'hex')
+  THEN RAISE EXCEPTION 'festival_settlement_snapshot_digest_invalid'; END IF;
+
+  SELECT * INTO settlement FROM public.festival_financial_settlements
+  WHERE runtime_session_id=p_runtime_session_id FOR UPDATE;
+  IF settlement.id IS NOT NULL THEN
+    IF settlement.runtime_snapshot_digest IS DISTINCT FROM outcome.content_digest
+       OR settlement.runtime_schema_version<>'festival-runtime-outcome-v2'
+       OR settlement.settlement_formula_version<>'festival-settlement-v2'
+    THEN RAISE EXCEPTION 'festival_settlement_idempotency_conflict'; END IF;
+    RETURN public._festival_settlement_json(settlement);
+  END IF;
+
+  -- The v1 implementation builds from accepted booking/assignment/contract
+  -- snapshots and remains the line generator while v2 binds and fingerprints it.
+  result:=public._prepare_festival_settlement_v1(
+    p_runtime_session_id,p_expected_runtime_version,p_idempotency_key);
+  SELECT * INTO settlement FROM public.festival_financial_settlements
+  WHERE runtime_session_id=p_runtime_session_id FOR UPDATE;
+
+  SELECT encode(digest(coalesce(jsonb_agg(e ORDER BY kind,id)::text,'[]'),'sha256'),'hex')
+  INTO contracts_digest FROM (
+    SELECT 'line-evidence' kind,l.id,
+           jsonb_build_object('sourceType',l.source_type,'sourceId',l.source_id,
+             'formula',l.formula_version,'evidence',l.calculation_metadata) e
+    FROM public.festival_settlement_lines l WHERE l.settlement_id=settlement.id
+  ) immutable_contract_evidence;
+  SELECT encode(digest(coalesce(jsonb_agg(to_jsonb(l) ORDER BY l.priority,l.id)::text,'[]'),'sha256'),'hex')
+  INTO calculation_digest FROM public.festival_settlement_lines l
+  WHERE l.settlement_id=settlement.id;
+
+  UPDATE public.festival_financial_settlements SET
+    runtime_schema_version='festival-runtime-outcome-v2',
+    settlement_formula_version='festival-settlement-v2',
+    formula_version='festival-settlement-v2', tax_rule_version='festival-tax-v1',
+    payment_priority_version='festival-priority-v1',
+    runtime_snapshot_digest=outcome.content_digest,
+    contract_snapshot_digest=contracts_digest,
+    calculation_digest=calculation_digest, prepared_at=now()
+  WHERE id=settlement.id RETURNING * INTO settlement;
+  UPDATE public.festival_settlement_lines SET formula_version='festival-settlement-v2'
+  WHERE settlement_id=settlement.id;
+  RETURN public._festival_settlement_json(settlement);
+END $$;
+
+REVOKE ALL ON FUNCTION public._prepare_festival_settlement_v1(uuid,integer,uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.prepare_festival_settlement(uuid,integer,uuid) TO authenticated;
+
+COMMENT ON COLUMN public.festival_financial_settlements.prepared_at IS
+  'Preparation boundary timestamp; created_at is retained as historical evidence and column presence never implies v2.';
+COMMENT ON FUNCTION public.prepare_festival_settlement(uuid,integer,uuid) IS
+  'Validates and locks runtime-outcome-v2, verifies its digest, generates immutable lines once, and binds v2 provenance digests.';


### PR DESCRIPTION
### Motivation
- Preserve historical settlement provenance after the v2 schema landed and ensure only validated runtime-v2 evidence can reclassify a settlement as v2. 
- Share a single canonical song calculation between normal gigs and Festival performances and ensure Festival factors are applied exactly once and auditable.
- Provide a v2-bound, idempotent prepare path that fingerprints contract/calculation evidence before labelling settlements as v2.

### Description
- Add a forward-only migration and executable binding `20291218040000_execute_festival_settlement_v2.sql` that: adds `prepared_at`, restores conservative v1 defaults for historical rows, corrects provenance for pre-v2 settlements, and implements a v2-aware `prepare_festival_settlement` that validates `festival-runtime-outcome-v2`, verifies snapshot digests, fingerprints contract & calculation evidence, and sets v2 metadata only when evidence matches. 
- Replace the previous public `prepare_festival_settlement` with a wrapper that delegates line generation to the preserved v1 generator and then binds v2 provenance only after digest checks and idempotency checks are satisfied. 
- Refactor live gig scoring so `resolveLiveSong` builds a single `CanonicalSongCalculationInput` and calls `calculateCanonicalSongOutcome` for full canonical parity between normal gigs and Festival performances. 
- Introduce a documented single-application Festival factor mapping (`FESTIVAL_FACTOR_TARGETS` and `mapFestivalFactors`) that records input, target canonical field, modifier and whether it is applied to an intermediate canonical input or as a final disruption modifier, and expose `calculateFestivalLiveModifier` as the compatibility boundary. 
- Add unit parity coverage asserting neutral Festival context yields canonical parity and that every Festival factor is mapped and audited exactly once (tests updated under `src/utils/__tests__/gigLive.test.ts`). 
- Update the migration timestamp verifier to recognise the new forward-only migration so CI timestamp checks remain deterministic.

### Testing
- Ran `npm run typecheck` successfully (TypeScript checks passed). 
- Ran `npm run verify:migration-timestamps` successfully after registering the new migration in the verifier exceptions. 
- Ran `npm run verify:supabase-rpcs` successfully to confirm required RPCs remain present. 
- Performed `git diff --check` (no whitespace/timestamp issues). 
- Attempted `npm ci` / Vitest runs and in-repo unit tests, but `npm ci` failed to fetch registry packages (HTTP 403) in this environment so `vitest` test execution and full `npm ci`-based verification were blocked. 

Note: database-backed fixtures, Supabase/psql migration execution and full lifecycle integration fixtures were not executed in this environment and remain to be run in CI or a developer environment with access to the package registry and a disposable PostgreSQL instance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66531529388325b9abbe678758685c)