### PR TITLE
Fix RLS failures when requesting magazine interviews

### DIFF
--- a/src/components/media/MediaSubmissionDialog.tsx
+++ b/src/components/media/MediaSubmissionDialog.tsx
@@ -103,7 +103,7 @@ export function MediaSubmissionDialog({
   bandId,
   bandFame,
 }: MediaSubmissionDialogProps) {
-  const { profileId } = useActiveProfile();
+  const { profileId, userId } = useActiveProfile();
   const queryClient = useQueryClient();
   const config = mediaConfig[mediaType];
   const Icon = config.icon;
@@ -114,9 +114,10 @@ export function MediaSubmissionDialog({
 
   const submitMutation = useMutation({
     mutationFn: async () => {
-      if (!profileId || !bandId) throw new Error("Not authenticated");
+      if (!profileId || !userId || !bandId) throw new Error("Not authenticated");
       
       const submission: Record<string, unknown> = {
+        ...(mediaType !== "website" ? { user_id: userId } : {}),
         band_id: bandId,
         [config.idField]: mediaItem.id,
         [config.typeField]: selectedType,
@@ -148,7 +149,7 @@ export function MediaSubmissionDialog({
             const hypeBoost = Math.floor(8 + Math.random() * 13); // +8 to +20
             await supabase
               .from("releases")
-              .update({ hype_score: ((rel as any).hype_score || 0) + hypeBoost } as any)
+              .update({ hype_score: (rel.hype_score || 0) + hypeBoost })
               .eq("id", linkedReleaseId);
           }
         } catch (e) {

--- a/supabase/migrations/20260728120000_default_media_submission_user_id.sql
+++ b/supabase/migrations/20260728120000_default_media_submission_user_id.sql
@@ -1,0 +1,11 @@
+-- Media submissions belong to the authenticated account, not the active profile.
+-- Supplying this default keeps inserts compatible with RLS even when a client
+-- omits user_id, while the existing WITH CHECK policies still prevent spoofing.
+ALTER TABLE public.newspaper_submissions
+  ALTER COLUMN user_id SET DEFAULT auth.uid();
+
+ALTER TABLE public.magazine_submissions
+  ALTER COLUMN user_id SET DEFAULT auth.uid();
+
+ALTER TABLE public.podcast_submissions
+  ALTER COLUMN user_id SET DEFAULT auth.uid();


### PR DESCRIPTION
### Motivation
- Media submission inserts were failing RLS because the server expected the authenticated `user_id` on newspaper/magazine/podcast rows while the client only sent the active profile id.
- Ensure clients create submissions that satisfy existing row-level security checks without weakening anti‑spoofing protections.

### Description
- Use `useActiveProfile()` to obtain `userId` and include `user_id` when building the submission payload for `newspaper`, `magazine`, and `podcast` (but not `website`) in `src/components/media/MediaSubmissionDialog.tsx`.
- Add a migration `supabase/migrations/20260728120000_default_media_submission_user_id.sql` that sets `user_id` column defaults to `auth.uid()` on `newspaper_submissions`, `magazine_submissions`, and `podcast_submissions` so server-side inserts remain compatible with RLS when clients omit `user_id`.
- Remove unnecessary `any` casts when updating a release's `hype_score` to use the typed `rel.hype_score` value instead of `(rel as any)`.

### Testing
- Ran `npx eslint src/components/media/MediaSubmissionDialog.tsx` which passed without errors after fixes.
- Ran `npm run typecheck` which completed successfully.
- Ran `npm run verify:migration-timestamps` which completed successfully.
- Ran `git diff --check` to ensure no trailing whitespace or diff issues; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6880480bc483258c09bc57bf78594e)