### PR TITLE
Fix media interview submission RLS for character memberships

### DIFF
--- a/supabase/migrations/20260728130000_fix_media_submission_profile_membership_rls.sql
+++ b/supabase/migrations/20260728130000_fix_media_submission_profile_membership_rls.sql
@@ -1,0 +1,37 @@
+-- Character-scoped band memberships may not have an auth-level user_id.  Media
+-- submission policies must therefore recognise the authenticated owner of the
+-- membership's profile as well as legacy memberships linked directly by user_id.
+DO $migration$
+DECLARE
+  submission_table text;
+  insert_policy text;
+BEGIN
+  FOR submission_table, insert_policy IN
+    SELECT *
+    FROM (VALUES
+      ('newspaper_submissions', 'Users can create newspaper submissions for their bands'),
+      ('magazine_submissions', 'Users can create magazine submissions for their bands'),
+      ('podcast_submissions', 'Users can create podcast submissions for their bands')
+    ) AS policies(table_name, policy_name)
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', insert_policy, submission_table);
+
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR INSERT TO authenticated WITH CHECK (
+        user_id = auth.uid()
+        AND EXISTS (
+          SELECT 1
+          FROM public.band_members AS bm
+          LEFT JOIN public.profiles AS p ON p.id = bm.profile_id
+          WHERE bm.band_id = %I.band_id
+            AND (bm.user_id = auth.uid() OR p.user_id = auth.uid())
+            AND COALESCE(bm.member_status, ''active'') = ''active''
+        )
+      )',
+      insert_policy,
+      submission_table,
+      submission_table
+    );
+  END LOOP;
+END
+$migration$;


### PR DESCRIPTION
### Motivation

- Submissions were failing with row-level security errors because band membership records can be character-scoped (store `profile_id`) and not have an auth-level `user_id`, so existing INSERT policies rejected valid requests. 
- The database policies must recognise profile-owned memberships while still preventing `user_id` spoofing and requiring an active membership.

### Description

- Add a migration file `supabase/migrations/20260728130000_fix_media_submission_profile_membership_rls.sql` that replaces the INSERT policies for `newspaper_submissions`, `magazine_submissions`, and `podcast_submissions`.
- Each new policy requires `user_id = auth.uid()` and verifies an active membership by checking `band_members.user_id = auth.uid()` or the owning profile via `profiles.user_id = auth.uid()` (joined from `bm.profile_id`), and drops the old policy if present.
- The migration implements the changes in a single `DO $migration$` block that loops over the three submission tables and installs the corrected `WITH CHECK` logic.

### Testing

- Ran `npm run verify:migration-timestamps` and it completed successfully.
- Ran `npm run typecheck` and it completed successfully.
- Ran a preflight diff check (`git diff --cached --check`) which passed, and attempted `npm run lint` which did not complete (stopped after more than two minutes without output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688364a1e08325bcf1989e05042860)