### PR TITLE
Fix podcast appearance submission RLS checks

### DIFF
--- a/supabase/migrations/20260728140000_fix_podcast_submission_membership_check.sql
+++ b/supabase/migrations/20260728140000_fix_podcast_submission_membership_check.sql
@@ -1,0 +1,43 @@
+-- Evaluate media-submission membership outside table RLS.  Checking
+-- band_members/profiles directly inside a submission policy can produce a false
+-- negative when either table hides character-scoped membership rows.
+CREATE OR REPLACE FUNCTION public.can_submit_media_for_band(p_band_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+  SELECT
+    auth.uid() IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.band_members AS bm
+      WHERE bm.band_id = p_band_id
+        AND COALESCE(bm.member_status, 'active') = 'active'
+        AND (
+          bm.user_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.profiles AS p
+            WHERE p.id = bm.profile_id
+              AND p.user_id = auth.uid()
+          )
+        )
+    );
+$function$;
+
+REVOKE ALL ON FUNCTION public.can_submit_media_for_band(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.can_submit_media_for_band(uuid) TO authenticated;
+
+DROP POLICY IF EXISTS "Users can create podcast submissions for their bands"
+  ON public.podcast_submissions;
+
+CREATE POLICY "Users can create podcast submissions for their bands"
+ON public.podcast_submissions
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  user_id = auth.uid()
+  AND public.can_submit_media_for_band(band_id)
+);


### PR DESCRIPTION
### Motivation
- Prevent legitimate podcast submission attempts from being rejected by row-level-security checks that can miss character-scoped band memberships when evaluated inline in a policy.

### Description
- Add a new migration `supabase/migrations/20260728140000_fix_podcast_submission_membership_check.sql` which introduces `public.can_submit_media_for_band(p_band_id uuid)` as a `SECURITY DEFINER` helper that verifies authenticated ownership or profile-linked active membership for a band.
- Restrict the helper to authenticated callers by revoking public access and granting `EXECUTE` to `authenticated` only.
- Replace the existing insert policy on `public.podcast_submissions` so inserts require `user_id = auth.uid()` and call the new `public.can_submit_media_for_band(band_id)` helper in the `WITH CHECK` clause.

### Testing
- Ran `npm run verify:migration-timestamps` which succeeded and accepted the new migration filename.
- Ran `git diff --check` which returned no issues.
- Committed the migration and verified working tree status with `git status --short` showing a clean state after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6885081a1c8325b4a3efc3a7d6f4b1)