### PR TITLE
Fix gig booking failure in fame forecast

### DIFF
--- a/src/utils/__tests__/atomicGigBookingMigration.test.ts
+++ b/src/utils/__tests__/atomicGigBookingMigration.test.ts
@@ -57,3 +57,19 @@ describe('atomic gig booking database contract', () => {
     expect(sql.indexOf('INSERT INTO public.player_scheduled_activities')).toBeLessThan(sql.lastIndexOf('RETURN jsonb_build_object'));
   });
 });
+
+describe('gig booking band fame hotfix', () => {
+  const hotfixSql = readFileSync('supabase/migrations/20260728120000_fix_gig_booking_band_fame.sql', 'utf8');
+
+  it('uses the actual bands fame column in the booking forecast', () => {
+    expect(hotfixSql).toContain('v_band.global_fame');
+    expect(hotfixSql).not.toContain('v_band.fame');
+  });
+
+  it('replaces the complete atomic booking function and preserves its grant', () => {
+    expect(hotfixSql).toContain('CREATE OR REPLACE FUNCTION public.book_gig');
+    expect(hotfixSql).toContain("UPDATE public.bands SET band_balance = band_balance - v_booking_fee");
+    expect(hotfixSql).toContain('INSERT INTO public.player_scheduled_activities');
+    expect(hotfixSql).toContain('GRANT EXECUTE ON FUNCTION public.book_gig');
+  });
+});

--- a/supabase/migrations/20260728120000_fix_gig_booking_band_fame.sql
+++ b/supabase/migrations/20260728120000_fix_gig_booking_band_fame.sql
@@ -1,0 +1,157 @@
+-- Repair book_gig: bands expose global_fame, not a fame column. The invalid
+-- record-field lookup caused every otherwise-valid booking to fail at runtime.
+
+CREATE OR REPLACE FUNCTION public.book_gig(
+  p_band_id uuid,
+  p_venue_id uuid,
+  p_setlist_id uuid,
+  p_local_date date,
+  p_slot text,
+  p_ticket_price integer,
+  p_request_id uuid,
+  p_rider_id uuid DEFAULT NULL,
+  p_ticket_operator_id text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor public.profiles%ROWTYPE; v_band public.bands%ROWTYPE; v_venue public.venues%ROWTYPE;
+  v_gig public.gigs%ROWTYPE; v_timezone text; v_start_time time; v_end_time time;
+  v_start timestamptz; v_end timestamptz; v_multiplier numeric; v_payment_multiplier numeric;
+  v_capacity integer; v_estimated_attendance integer; v_estimated_revenue integer;
+  v_booking_fee integer; v_payment integer; v_rider_cost integer := 0;
+  v_song_count integer; v_setlist_seconds integer;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'gig_booking_unauthenticated' USING ERRCODE='42501'; END IF;
+  SELECT * INTO v_actor FROM public.profiles WHERE user_id = auth.uid() LIMIT 1;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_profile_missing' USING ERRCODE='P0001'; END IF;
+  IF p_request_id IS NULL THEN RAISE EXCEPTION 'gig_booking_request_invalid' USING ERRCODE='22023'; END IF;
+
+  SELECT * INTO v_gig FROM public.gigs WHERE booking_request_id = p_request_id;
+  IF FOUND THEN
+    IF v_gig.band_id <> p_band_id OR NOT public.can_manage_band_gigs(v_gig.band_id, auth.uid()) THEN
+      RAISE EXCEPTION 'gig_booking_request_conflict' USING ERRCODE='23505';
+    END IF;
+    RETURN jsonb_build_object('gig', to_jsonb(v_gig), 'already_booked', true,
+      'booking_fee', COALESCE(v_gig.booking_fee, 0), 'scheduled_start', v_gig.scheduled_date);
+  END IF;
+
+  IF NOT public.can_manage_band_gigs(p_band_id, auth.uid()) THEN
+    RAISE EXCEPTION 'gig_booking_forbidden' USING ERRCODE='42501';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('gig-band:'||p_band_id::text, 0));
+  PERFORM pg_advisory_xact_lock(hashtextextended('gig-venue:'||p_venue_id::text, 0));
+
+  SELECT * INTO v_band FROM public.bands WHERE id = p_band_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_band_invalid' USING ERRCODE='P0001'; END IF;
+  SELECT * INTO v_venue FROM public.venues WHERE id = p_venue_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_venue_invalid' USING ERRCODE='P0001'; END IF;
+  SELECT COALESCE(c.timezone, 'UTC') INTO v_timezone FROM public.cities c WHERE c.id = v_venue.city_id;
+  v_timezone := COALESCE(v_timezone, 'UTC');
+
+  SELECT x.start_time, x.end_time, x.attendance_multiplier, x.payment_multiplier
+  INTO v_start_time, v_end_time, v_multiplier, v_payment_multiplier
+  FROM (VALUES ('kids','15:00'::time,'15:30'::time,0.30,0.50),
+               ('opening','19:00','19:30',0.50,0.60),
+               ('support','19:45','20:30',0.75,0.80),
+               ('headline','20:45','22:00',1.00,1.00))
+    AS x(slot,start_time,end_time,attendance_multiplier,payment_multiplier)
+  WHERE x.slot = p_slot;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_slot_invalid' USING ERRCODE='22023'; END IF;
+
+  v_start := (p_local_date + v_start_time) AT TIME ZONE v_timezone;
+  v_end := (p_local_date + v_end_time
+            + CASE WHEN v_end_time <= v_start_time THEN interval '1 day' ELSE interval '0' END)
+           AT TIME ZONE v_timezone;
+  IF v_start <= now() THEN RAISE EXCEPTION 'gig_booking_past_date' USING ERRCODE='22023'; END IF;
+  IF p_ticket_price IS NULL OR p_ticket_price <= 0 OR p_ticket_price > 100000 THEN
+    RAISE EXCEPTION 'gig_booking_ticket_price_invalid' USING ERRCODE='22023';
+  END IF;
+
+  SELECT count(*), COALESCE(sum(COALESCE(song.duration_seconds, 180)), 0)
+  INTO v_song_count, v_setlist_seconds
+  FROM public.setlist_songs ss
+  JOIN public.setlists s ON s.id = ss.setlist_id
+  LEFT JOIN public.songs song ON song.id = ss.song_id
+  WHERE s.id = p_setlist_id AND s.band_id = p_band_id AND COALESCE(s.is_active, true)
+    AND ss.song_id IS NOT NULL;
+  IF COALESCE(v_song_count, 0) < 6 THEN RAISE EXCEPTION 'gig_booking_setlist_invalid' USING ERRCODE='23514'; END IF;
+
+  IF p_rider_id IS NOT NULL THEN
+    SELECT COALESCE(total_cost_estimate, 0) INTO v_rider_cost
+    FROM public.band_riders WHERE id = p_rider_id AND band_id = p_band_id;
+    IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_rider_invalid' USING ERRCODE='23503'; END IF;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.band_activity_lockouts
+             WHERE band_id = p_band_id AND locked_until > now()) THEN
+    RAISE EXCEPTION 'gig_booking_band_lockout' USING ERRCODE='P0001';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.gigs g WHERE g.band_id = p_band_id
+    AND g.status IN ('scheduled','in_progress','ready_for_completion')
+    AND g.scheduled_date < v_end
+    AND COALESCE(g.scheduled_end, g.scheduled_date + interval '3 hours') > v_start) THEN
+    RAISE EXCEPTION 'gig_booking_band_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.gigs g WHERE g.venue_id = p_venue_id
+    AND g.status IN ('scheduled','in_progress','ready_for_completion')
+    AND g.scheduled_date < v_end
+    AND COALESCE(g.scheduled_end, g.scheduled_date + interval '3 hours') > v_start) THEN
+    RAISE EXCEPTION 'gig_booking_venue_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  v_capacity := GREATEST(COALESCE(v_venue.capacity, 100), 1);
+  v_estimated_attendance := LEAST(v_capacity, GREATEST(1, round(v_capacity * LEAST(1.0,
+    (0.25 + COALESCE(v_band.popularity,0)/200.0 + COALESCE(v_band.global_fame,0)/10000.0)) * v_multiplier))::integer);
+  v_estimated_revenue := v_estimated_attendance * p_ticket_price;
+  v_booking_fee := GREATEST(50, round(v_estimated_revenue * 0.10)::integer);
+  v_payment := GREATEST(0, round(COALESCE(v_venue.base_payment,0) * v_payment_multiplier)::integer - v_rider_cost);
+
+  IF COALESCE(v_band.band_balance, 0) < v_booking_fee THEN
+    RAISE EXCEPTION 'gig_booking_insufficient_funds' USING ERRCODE='P0001', DETAIL = v_booking_fee::text;
+  END IF;
+
+  UPDATE public.bands SET band_balance = band_balance - v_booking_fee WHERE id = p_band_id;
+
+  INSERT INTO public.gigs (band_id,venue_id,setlist_id,rider_id,ticket_operator_id,scheduled_date,scheduled_end,
+    status,show_type,payment,booking_fee,ticket_price,time_slot,slot_start_time,slot_end_time,
+    slot_attendance_multiplier,estimated_attendance,estimated_revenue,attendance,fan_gain,predicted_tickets,
+    tickets_sold,last_ticket_update,booking_request_id)
+  VALUES (p_band_id,p_venue_id,p_setlist_id,p_rider_id,p_ticket_operator_id,v_start,v_end,'scheduled',
+    'concert',v_payment,v_booking_fee,p_ticket_price,p_slot,v_start_time,v_end_time,
+    v_multiplier,v_estimated_attendance,v_estimated_revenue,0,0,v_estimated_attendance,0,now(),p_request_id)
+  RETURNING * INTO v_gig;
+
+  INSERT INTO public.player_scheduled_activities (user_id,profile_id,activity_type,scheduled_start,scheduled_end,
+    status,title,location,linked_gig_id,metadata)
+  SELECT p.user_id, p.id, 'gig', v_start, v_end, 'scheduled',
+         'Gig at '||v_venue.name, v_venue.name, v_gig.id,
+         jsonb_build_object('band_id',p_band_id,'venueId',p_venue_id,'slotId',p_slot,
+                            'venue_timezone',v_timezone,'is_band_activity',true)
+  FROM public.profiles p
+  WHERE p.id IN (
+    SELECT COALESCE(bm.profile_id, mp.id)
+    FROM public.band_members bm
+    LEFT JOIN public.profiles mp ON mp.user_id = bm.user_id
+    WHERE bm.band_id = p_band_id
+      AND COALESCE(bm.member_status,'active') = 'active'
+      AND COALESCE(bm.is_touring_member,false) = false
+      AND COALESCE(bm.profile_id, mp.id) IS NOT NULL
+    UNION
+    SELECT v_band.leader_id WHERE EXISTS (SELECT 1 FROM public.profiles lp WHERE lp.id = v_band.leader_id)
+  )
+  ON CONFLICT (linked_gig_id, profile_id)
+  WHERE linked_gig_id IS NOT NULL AND status <> 'cancelled' DO NOTHING;
+
+  RETURN jsonb_build_object('gig', to_jsonb(v_gig), 'already_booked', false, 'booking_fee', v_booking_fee,
+    'band_balance', COALESCE(v_band.band_balance,0) - v_booking_fee,
+    'scheduled_start', v_start, 'scheduled_end', v_end, 'venue_timezone', v_timezone);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.book_gig(uuid,uuid,uuid,date,text,integer,uuid,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.book_gig(uuid,uuid,uuid,date,text,integer,uuid,uuid,text) TO authenticated, service_role;


### PR DESCRIPTION
### Motivation
- Booking RPCs were failing because the `book_gig` function referenced a nonexistent `bands.fame` column, causing runtime errors for otherwise-valid bookings.
- The change aims to repair the booking path by using the actual band fame data and ensure the booking flow remains atomic and idempotent.

### Description
- Add `supabase/migrations/20260728120000_fix_gig_booking_band_fame.sql` which replaces `public.book_gig` with a corrected implementation that reads `v_band.global_fame` instead of `v_band.fame` and preserves the atomic charge, gig insertion, and member schedule blocking behavior.
- Preserve authorization, conflict checks, idempotent `booking_request_id` handling, advisory locks, balance deduction, gig `INSERT`, and `player_scheduled_activities` creation in the new function.
- Add regression assertions to `src/utils/__tests__/atomicGigBookingMigration.test.ts` to verify the migration uses `v_band.global_fame`, replaces the RPC, and preserves the schedule insertion and grants.

### Testing
- Ran `npm run verify:migration-timestamps` which succeeded and validated migration filename timestamps.
- Executed `npx vitest run src/utils/__tests__/atomicGigBookingMigration.test.ts` but the test run was blocked by missing runtime dependencies in the container (`rrweb-cssom` / jsdom dependency), producing an unresolved module error.
- Invoked `npm run typecheck`; the TypeScript check was started in the environment and no type errors were observed in the captured logs, though the full `tsc` run was slow in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688ae30c20832598f3953834b201f1)