### PR TITLE
Route podcast submissions through secure RPC to fix RLS failures

### DIFF
--- a/src/components/media/MediaSubmissionDialog.tsx
+++ b/src/components/media/MediaSubmissionDialog.tsx
@@ -125,9 +125,16 @@ export function MediaSubmissionDialog({
         ...(linkedReleaseId ? { linked_release_id: linkedReleaseId } : {}),
       };
 
-      const { error } = await supabase
-        .from(config.table as "newspaper_submissions" | "magazine_submissions" | "podcast_submissions" | "website_submissions")
-        .insert(submission as never);
+      const { error } = mediaType === "podcast"
+        ? await supabase.rpc("submit_podcast_appearance", {
+            p_band_id: bandId,
+            p_podcast_id: mediaItem.id,
+            p_episode_topic: selectedType,
+            p_linked_release_id: linkedReleaseId || undefined,
+          })
+        : await supabase
+            .from(config.table as "newspaper_submissions" | "magazine_submissions" | "website_submissions")
+            .insert(submission as never);
 
       if (error) {
         if (error.code === "23505") {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -44570,6 +44570,15 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      submit_podcast_appearance: {
+        Args: {
+          p_band_id: string
+          p_episode_topic: string
+          p_linked_release_id?: string
+          p_podcast_id: string
+        }
+        Returns: string
+      }
       submit_festival_setlist:
         | {
             Args: { p_setlist_id: string }

--- a/supabase/migrations/20260728150000_submit_podcast_appearance_rpc.sql
+++ b/supabase/migrations/20260728150000_submit_podcast_appearance_rpc.sql
@@ -1,0 +1,59 @@
+-- Submit podcast requests through a narrowly scoped, authenticated function.
+-- This avoids relying on client-visible band_members/profile rows while still
+-- enforcing ownership and active membership before the RLS-bypassing insert.
+CREATE OR REPLACE FUNCTION public.submit_podcast_appearance(
+  p_band_id uuid,
+  p_podcast_id uuid,
+  p_episode_topic text,
+  p_linked_release_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  submission_id uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT public.can_submit_media_for_band(p_band_id) THEN
+    RAISE EXCEPTION 'Active band membership required' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_linked_release_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1
+    FROM public.releases AS r
+    WHERE r.id = p_linked_release_id
+      AND r.band_id = p_band_id
+  ) THEN
+    RAISE EXCEPTION 'Linked release must belong to the submitting band'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.podcast_submissions (
+    user_id,
+    band_id,
+    podcast_id,
+    episode_topic,
+    linked_release_id,
+    status
+  )
+  VALUES (
+    auth.uid(),
+    p_band_id,
+    p_podcast_id,
+    p_episode_topic,
+    p_linked_release_id,
+    'pending'
+  )
+  RETURNING id INTO submission_id;
+
+  RETURN submission_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.submit_podcast_appearance(uuid, uuid, text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.submit_podcast_appearance(uuid, uuid, text, uuid) TO authenticated;


### PR DESCRIPTION
### Motivation
- Client-side inserts into `podcast_submissions` were failing with RLS errors because membership checks can involve profile-scoped `band_members` rows that the insertion's WITH CHECK policy could not reliably evaluate. 
- The change ensures membership and linked-release ownership are validated server-side so authenticated players can submit podcast appearance requests without RLS false-negatives. 
- This preserves the existing client UX and duplicate-submission handling while moving the sensitive authorization checks into a narrowly scoped, security-definer RPC.

### Description
- Add a new migration that creates a `SECURITY DEFINER` function `public.submit_podcast_appearance(p_band_id uuid, p_podcast_id uuid, p_episode_topic text, p_linked_release_id uuid)` which checks `auth.uid()`, calls `public.can_submit_media_for_band(...)`, validates linked-release ownership, inserts into `podcast_submissions`, and returns the new submission `id`, then grants `EXECUTE` to `authenticated` (file: `supabase/migrations/20260728150000_submit_podcast_appearance_rpc.sql`).
- Update `MediaSubmissionDialog.tsx` to call `supabase.rpc("submit_podcast_appearance", {...})` for `mediaType === "podcast"` while leaving newspaper/magazine/website submission behavior unchanged and preserving duplicate-submission error handling. 
- Add the new RPC signature to the generated Supabase TypeScript definitions under `submit_podcast_appearance` so client code has correct types (file: `src/integrations/supabase/types.ts`).

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npx eslint src/components/media/MediaSubmissionDialog.tsx` and it reported no errors. 
- Ran `npm run verify:migration-timestamps` and `git diff --check` and both checks passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688e4e56888325985900b862450698)