### PR TITLE
Fix resilient loading on My Companies

### DIFF
--- a/src/hooks/useCompanies.test.tsx
+++ b/src/hooks/useCompanies.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCompanies, useCompany } from "./useCompanies";
+
+const from = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({ supabase: { from } }));
+vi.mock("@/hooks/useActiveProfile", () => ({
+  useActiveProfile: () => ({ userId: "auth-user-1" }),
+}));
+
+const company = { id: "company-1", owner_id: "auth-user-1", name: "Ordinary Co" };
+
+function wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function companiesQuery(result: { data: unknown; error: unknown }) {
+  const query = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    order: vi.fn().mockResolvedValue(result),
+  };
+  query.select.mockReturnValue(query);
+  query.eq.mockReturnValue(query);
+  return query;
+}
+
+function festivalListQuery(result: { data: unknown; error: unknown }) {
+  const query = { select: vi.fn(), in: vi.fn().mockResolvedValue(result) };
+  query.select.mockReturnValue(query);
+  return query;
+}
+
+describe("useCompanies", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps core companies when the optional festival extension query fails", async () => {
+    const coreQuery = companiesQuery({ data: [company], error: null });
+    const extensionQuery = festivalListQuery({ data: null, error: new Error("schema cache unavailable") });
+    from.mockImplementation((table: string) => table === "companies" ? coreQuery : extensionQuery);
+
+    const { result } = renderHook(() => useCompanies(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ ...company, festival_company_id: null }]);
+    expect(coreQuery.eq).toHaveBeenCalledWith("owner_id", "auth-user-1");
+    expect(extensionQuery.in).toHaveBeenCalledWith("company_id", ["company-1"]);
+  });
+
+  it("merges a festival extension id into its matching company", async () => {
+    const coreQuery = companiesQuery({ data: [company], error: null });
+    const extensionQuery = festivalListQuery({
+      data: [{ id: "festival-1", company_id: "company-1" }],
+      error: null,
+    });
+    from.mockImplementation((table: string) => table === "companies" ? coreQuery : extensionQuery);
+
+    const { result } = renderHook(() => useCompanies(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].festival_company_id).toBe("festival-1");
+  });
+
+  it("treats a core query failure as an error and does not query extensions", async () => {
+    from.mockReturnValue(companiesQuery({ data: null, error: new Error("companies unavailable") }));
+
+    const { result } = renderHook(() => useCompanies(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(from).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useCompany", () => {
+  it("keeps a core company when its optional festival extension query fails", async () => {
+    const coreQuery = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: company, error: null }),
+    };
+    coreQuery.select.mockReturnValue(coreQuery);
+    coreQuery.eq.mockReturnValue(coreQuery);
+    const extensionQuery = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: new Error("optional failure") }),
+    };
+    extensionQuery.select.mockReturnValue(extensionQuery);
+    extensionQuery.eq.mockReturnValue(extensionQuery);
+    from.mockImplementation((table: string) => table === "companies" ? coreQuery : extensionQuery);
+
+    const { result } = renderHook(() => useCompany("company-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ ...company, festival_company_id: null });
+  });
+});

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -18,8 +18,7 @@ export const useCompanies = () => {
         .select(`
           *,
           headquarters_city:cities!headquarters_city_id(id, name, country),
-          parent_company:companies!parent_company_id(id, name),
-          festival_companies(id)
+          parent_company:companies!parent_company_id(id, name)
         `)
         .eq("owner_id", userId)
         .order("created_at", { ascending: false });
@@ -29,10 +28,26 @@ export const useCompanies = () => {
         throw error;
       }
 
-      return (data || []).map((company: any) => ({
+      const companies = (data || []) as Company[];
+      if (companies.length === 0) return companies;
+
+      const { data: festivalCompanies, error: festivalError } = await supabase
+        .from("festival_companies")
+        .select("id, company_id")
+        .in("company_id", companies.map((company) => company.id));
+
+      if (festivalError) {
+        console.error("Error fetching festival company extensions:", festivalError);
+      }
+
+      const festivalIdByCompany = new Map(
+        (festivalCompanies || []).map((festival) => [festival.company_id, festival.id]),
+      );
+
+      return companies.map((company) => ({
         ...company,
-        festival_company_id: Array.isArray(company.festival_companies) ? company.festival_companies[0]?.id ?? null : null,
-      })) as Company[];
+        festival_company_id: festivalIdByCompany.get(company.id) ?? null,
+      }));
     },
     enabled: !!userId,
   });
@@ -49,8 +64,7 @@ export const useCompany = (companyId: string | undefined) => {
         .select(`
           *,
           headquarters_city:cities!headquarters_city_id(id, name, country),
-          parent_company:companies!parent_company_id(id, name),
-          festival_companies(id)
+          parent_company:companies!parent_company_id(id, name)
         `)
         .eq("id", companyId)
         .maybeSingle();
@@ -60,7 +74,22 @@ export const useCompany = (companyId: string | undefined) => {
         throw error;
       }
 
-      return data as Company | null;
+      if (!data) return null;
+
+      const { data: festivalCompany, error: festivalError } = await supabase
+        .from("festival_companies")
+        .select("id")
+        .eq("company_id", data.id)
+        .maybeSingle();
+
+      if (festivalError) {
+        console.error("Error fetching festival company extension:", festivalError);
+      }
+
+      return {
+        ...(data as Company),
+        festival_company_id: festivalCompany?.id ?? null,
+      };
     },
     enabled: !!companyId,
   });

--- a/src/pages/MyCompanies.test.tsx
+++ b/src/pages/MyCompanies.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MyCompanies from "./MyCompanies";
+
+const useCompanies = vi.fn();
+const refetch = vi.fn();
+
+vi.mock("@/hooks/useCompanies", () => ({
+  useCompanies,
+  useCompanyFinancialSummary: () => ({ data: {}, isLoading: false }),
+}));
+vi.mock("@/hooks/useCompanyFinance", () => ({ useAllCompanyTaxRecords: () => ({ data: [] }) }));
+vi.mock("@/hooks/useActiveProfile", () => ({ useActiveProfile: () => ({ isLoading: false }) }));
+vi.mock("@/hooks/use-auth-context", () => ({ useAuth: () => ({ loading: false }) }));
+vi.mock("@/components/company/VipGate", () => ({ VipGate: ({ children }: any) => children }));
+vi.mock("@/components/fm/FMPageScaffold", () => ({ FMPageScaffold: ({ children }: any) => children }));
+vi.mock("@/components/company/CompanyCard", () => ({ CompanyCard: ({ company }: any) => <div>{company.name}</div> }));
+vi.mock("@/components/company/CreateCompanyDialog", () => ({
+  CreateCompanyDialog: ({ trigger }: any) => trigger ?? <button>Create Company</button>,
+}));
+vi.mock("@/components/company/CompanySynergies", () => ({ CompanySynergies: () => null }));
+vi.mock("@/components/company/CompanyTaxOverview", () => ({ CompanyTaxOverview: () => null }));
+vi.mock("@/features/festival-company", () => ({
+  FestivalCompanyCard: () => null,
+  FestivalCompanyEligibilityCard: () => null,
+  useOwnedFestivalCompanies: () => ({ data: [] }),
+}));
+
+describe("My Companies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCompanies.mockReturnValue({
+      data: [], isLoading: false, isError: false, error: null, refetch,
+    });
+  });
+
+  it("renders existing holding companies and subsidiaries", () => {
+    useCompanies.mockReturnValue({
+      data: [
+        { id: "holding-1", name: "Touring Holdings", company_type: "holding" },
+        { id: "label-1", name: "Roadrunner Records", company_type: "record_label", parent_company_id: "holding-1" },
+      ],
+      isLoading: false, isError: false, error: null, refetch,
+    });
+
+    render(<MyCompanies />);
+
+    expect(screen.getByText("Touring Holdings")).toBeInTheDocument();
+    expect(screen.getByText("Roadrunner Records")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Holding (1)" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Subsidiaries (1)" })).toBeInTheDocument();
+  });
+
+  it("shows a core query error instead of the create-first-company empty state", () => {
+    useCompanies.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Please try again later."),
+      refetch,
+    });
+
+    render(<MyCompanies />);
+
+    expect(screen.getByText("Companies could not be loaded")).toBeInTheDocument();
+    expect(screen.getByText("Please try again later.")).toBeInTheDocument();
+    expect(screen.queryByText("Create Your First Company")).not.toBeInTheDocument();
+  });
+
+  it("refetches companies when Retry is clicked", async () => {
+    useCompanies.mockReturnValue({
+      data: undefined, isLoading: false, isError: true, error: new Error("Failed"), refetch,
+    });
+
+    render(<MyCompanies />);
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/MyCompanies.tsx
+++ b/src/pages/MyCompanies.tsx
@@ -11,6 +11,8 @@ import { CompanyTaxOverview } from "@/components/company/CompanyTaxOverview";
 import { CreateCompanyDialog } from "@/components/company/CreateCompanyDialog";
 import { FestivalCompanyCard, FestivalCompanyEligibilityCard, useOwnedFestivalCompanies } from "@/features/festival-company";
 import { useCompanies, useCompanyFinancialSummary } from "@/hooks/useCompanies";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { useAuth } from "@/hooks/use-auth-context";
 import { useAllCompanyTaxRecords } from "@/hooks/useCompanyFinance";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -26,8 +28,16 @@ const formatCurrency = (amount: number) => {
   }).format(amount);
 };
 
-const CompanyDashboardContent = () => {
-  const { data: companies, isLoading: companiesLoading } = useCompanies();
+export const CompanyDashboardContent = () => {
+  const { loading: authLoading } = useAuth();
+  const { isLoading: profileLoading } = useActiveProfile();
+  const {
+    data: companies,
+    isLoading: companiesLoading,
+    isError: companiesError,
+    error,
+    refetch,
+  } = useCompanies();
   const { data: financialSummary, isLoading: summaryLoading } = useCompanyFinancialSummary();
   const { data: festivalCompanies = [] } = useOwnedFestivalCompanies();
   const companyIds = companies?.map(c => c.id) || [];
@@ -42,7 +52,7 @@ const CompanyDashboardContent = () => {
   );
   const overdueTaxCount = pendingTaxes.filter(t => t.status === 'overdue').length;
 
-  if (companiesLoading) {
+  if (authLoading || profileLoading || companiesLoading) {
     return (
       <div className="space-y-6">
         <div className="grid gap-4 md:grid-cols-4">
@@ -51,6 +61,25 @@ const CompanyDashboardContent = () => {
           ))}
         </div>
       </div>
+    );
+  }
+
+  if (companiesError) {
+    return (
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            Companies could not be loaded
+          </CardTitle>
+          <CardDescription>
+            {error instanceof Error ? error.message : "Something went wrong while loading your companies."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" onClick={() => void refetch()}>Retry</Button>
+        </CardContent>
+      </Card>
     );
   }
 


### PR DESCRIPTION
### Motivation

- Prevent a failing optional `festival_companies` relationship query from causing the full owned-company read to fail and hide ordinary companies on `/my-companies`.
- Ensure ownership semantics use `useActiveProfile().userId` (auth-level `auth.users.id`) and do not conflate shareholders with direct ownership.
- Make the UI show a clear error state (with Retry) when the core company query fails and keep the loading skeleton until auth/profile/company resolution completes.

### Description

- Decoupled the core companies query in `useCompanies()` so it selects only `companies` rows where `owner_id` equals the active `userId` and still includes `headquarters_city` and `parent_company`, but no longer embeds `festival_companies` in the primary select. (`src/hooks/useCompanies.ts`)
- Added a separate lookup for `festival_companies` after the core companies query succeeds that selects `id, company_id` for the returned company IDs and merges `festival_company_id` into matching companies; extension query failures are logged but do not block returning core companies. (`src/hooks/useCompanies.ts`)
- Applied the same resilient pattern to `useCompany()` so a missing festival extension cannot hide a single company. (`src/hooks/useCompanies.ts`)
- Improved `/my-companies` (`MyCompanies.tsx`) to wait for authentication and active-profile resolution before hiding the skeleton, and added explicit error handling that reads `isError/error/refetch` from `useCompanies()` to render a “Companies could not be loaded” error card with a `Retry` button (the empty "Create Your First Company" state is not shown when the query has failed). (`src/pages/MyCompanies.tsx`)
- Added unit/regression tests covering the resilient behaviour: `src/hooks/useCompanies.test.tsx` (core vs extension queries, merge behaviour, error semantics) and `src/pages/MyCompanies.test.tsx` (rendering of holdings/subsidiaries, error vs empty-state, retry). (`src/hooks/useCompanies.test.tsx`, `src/pages/MyCompanies.test.tsx`)
- Checked RLS for `festival_companies` and confirmed the existing owner-scoped SELECT policy (`Festival owners can read own festival companies`) restricts access appropriately, so no migration was added.

### Testing

- Ran type checking with `npm run typecheck` and it succeeded.
- Ran lint and build with `npm run lint` and `npm run build` and both succeeded.
- Added unit tests and attempted to run `npm run test:unit -- src/hooks/useCompanies.test.tsx src/pages/MyCompanies.test.tsx`, but the test runner aborted due to the JSDOM dependency tree missing `rrweb-cssom` / `whatwg-url/webidl2js-wrapper` in this environment; attempts to repair were blocked by registry access (HTTP 403), so unit tests could not be completed here (the new tests are present and exercise the described scenarios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a688f4cf00483258926325ae3f6aa20)