### PR TITLE
Fix Battle of the Bands lifecycle, navigation, and daily news

### DIFF
--- a/src/components/news/BattleOfTheBandsNews.test.ts
+++ b/src/components/news/BattleOfTheBandsNews.test.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { getBattleNewsDateRanges } from "./battleNewsDates";
+
+describe("getBattleNewsDateRanges", () => {
+  it("builds complete local-day ranges for today and yesterday", () => {
+    expect(getBattleNewsDateRanges(new Date(2026, 6, 28, 12, 30))).toEqual({
+      today: "2026-07-28", todayStart: "2026-07-28T00:00:00", todayEnd: "2026-07-28T23:59:59.999",
+      yesterdayStart: "2026-07-27T00:00:00", yesterdayEnd: "2026-07-27T23:59:59.999",
+    });
+  });
+
+  it("crosses month boundaries correctly", () => {
+    expect(getBattleNewsDateRanges(new Date(2026, 7, 1, 8)).yesterdayStart).toBe("2026-07-31T00:00:00");
+  });
+});

--- a/src/components/news/BattleOfTheBandsNews.tsx
+++ b/src/components/news/BattleOfTheBandsNews.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { Calendar, MapPin, Swords, Trophy, Users } from "lucide-react";
+import { Link } from "react-router-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { supabase } from "@/integrations/supabase/client";
+import { getBattleNewsDateRanges } from "./battleNewsDates";
+
+const db = supabase;
+
+export function BattleOfTheBandsNews() {
+  const ranges = getBattleNewsDateRanges(new Date());
+  const { data, isLoading } = useQuery({
+    queryKey: ["battle-of-the-bands-news", ranges.today],
+    queryFn: async () => {
+      const [todayResult, yesterdayResult] = await Promise.all([
+        db.from("botb_events")
+          .select("id, scheduled_date, max_entries, city:cities(name, country), botb_entries(id)")
+          .eq("status", "upcoming").gte("scheduled_date", ranges.todayStart)
+          .lte("scheduled_date", ranges.todayEnd).order("scheduled_date", { ascending: true }),
+        db.from("botb_events")
+          .select("id, scheduled_date, winner_rating, city:cities(name, country), winner_band:bands!botb_events_winner_band_id_fkey(name), botb_entries(id)")
+          .eq("status", "completed").gte("scheduled_date", ranges.yesterdayStart)
+          .lte("scheduled_date", ranges.yesterdayEnd).order("winner_rating", { ascending: false }),
+      ]);
+      if (todayResult.error) throw todayResult.error;
+      if (yesterdayResult.error) throw yesterdayResult.error;
+      return { upcoming: todayResult.data ?? [], results: yesterdayResult.data ?? [] };
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!isLoading && !data?.upcoming.length && !data?.results.length) return null;
+
+  return (
+    <Card className="border-primary/30">
+      <CardHeader className="pb-3"><CardTitle className="flex items-center gap-2 text-lg font-serif">
+        <Swords className="h-5 w-5 text-primary" />Battle of the Bands
+      </CardTitle></CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? <p className="text-sm text-muted-foreground">Loading battle news…</p> : <>
+          {data?.upcoming.map((event) => <article key={event.id} className="rounded-lg border bg-muted/30 p-3">
+            <div className="mb-2 flex items-center justify-between gap-2"><h4 className="font-semibold font-serif">Battle today in {event.city?.name}</h4><Badge>Today</Badge></div>
+            <p className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" />{format(new Date(event.scheduled_date), "p")}</span>
+              <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{event.city?.country}</span>
+              <span className="flex items-center gap-1"><Users className="h-3 w-3" />{event.botb_entries?.length ?? 0}/{event.max_entries} bands</span>
+            </p>
+          </article>)}
+          {data?.results.map((event) => <article key={event.id} className="rounded-lg border bg-muted/30 p-3">
+            <div className="mb-2 flex items-center justify-between gap-2"><h4 className="flex items-center gap-1.5 font-semibold font-serif"><Trophy className="h-4 w-4 text-primary" />{event.winner_band?.name} wins in {event.city?.name}</h4><Badge variant="secondary">Yesterday</Badge></div>
+            <p className="text-xs text-muted-foreground">{event.botb_entries?.length ?? 0} bands competed{event.winner_rating != null ? ` · Winning score ${Number(event.winner_rating).toFixed(0)}%` : ""}</p>
+          </article>)}
+        </>}
+        <Button asChild variant="outline" size="sm" className="w-full"><Link to="/battle-of-the-bands">View battles and enter</Link></Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/news/battleNewsDates.ts
+++ b/src/components/news/battleNewsDates.ts
@@ -1,0 +1,16 @@
+import { format } from "date-fns";
+
+export function getBattleNewsDateRanges(now: Date) {
+  const today = format(now, "yyyy-MM-dd");
+  const yesterdayDate = new Date(now);
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  const yesterday = format(yesterdayDate, "yyyy-MM-dd");
+
+  return {
+    today,
+    todayStart: `${today}T00:00:00`,
+    todayEnd: `${today}T23:59:59.999`,
+    yesterdayStart: `${yesterday}T00:00:00`,
+    yesterdayEnd: `${yesterday}T23:59:59.999`,
+  };
+}

--- a/src/config/fmNavigation.ts
+++ b/src/config/fmNavigation.ts
@@ -234,6 +234,7 @@ export const FM_MODULES: FMModule[] = [
           { label: "Book Gigs", path: "/gig-booking", icon: Calendar },
           { label: "My Gigs", path: "/band/gigs", icon: Mic2 },
           { label: "Open Mic", path: "/open-mic", icon: Mic },
+          { label: "Battle of the Bands", path: "/battle-of-the-bands", icon: Trophy },
           { label: "Jam Sessions", path: "/jam-sessions", icon: Music },
           { label: "Busking", path: "/busking", icon: Music },
           { label: "Stage Setup", path: "/stage-setup", icon: Guitar },

--- a/src/hooks/useBattleOfTheBands.ts
+++ b/src/hooks/useBattleOfTheBands.ts
@@ -216,6 +216,7 @@ function cleanError(message: string): string {
   if (message.includes("BOTB_NOT_BAND_MEMBER")) return "You must be a member of this band";
   if (message.includes("BOTB_SONG_NOT_OWNED")) return "Those songs don't belong to your band";
   if (message.includes("BOTB_INVALID_SONGS")) return "Pick two different songs";
+  if (message.includes("BOTB_INVALID_PROFILE")) return "Select your active character before entering";
   if (message.includes("BOTB_UNAUTHENTICATED")) return "You must be signed in";
   return message;
 }

--- a/src/pages/TodaysNews.tsx
+++ b/src/pages/TodaysNews.tsx
@@ -30,6 +30,7 @@ import { EarningsNews } from "@/components/news/EarningsNews";
 import { ElectionCoverage } from "@/components/news/ElectionCoverage";
 import { ParliamentDigest } from "@/components/news/ParliamentDigest";
 import { PartyPowerRankings } from "@/components/news/PartyPowerRankings";
+import { BattleOfTheBandsNews } from "@/components/news/BattleOfTheBandsNews";
 
 export default function TodaysNewsPage() {
   const today = new Date().toISOString().split("T")[0];
@@ -108,6 +109,7 @@ export default function TodaysNewsPage() {
           <SectionDivider title="Entertainment" />
 
           <TopTracksNews />
+          <BattleOfTheBandsNews />
           <LastNightGigs />
           <OtherBandsGigOutcomes />
           <InterviewNews />

--- a/src/pages/hubs/BandLiveHub.tsx
+++ b/src/pages/hubs/BandLiveHub.tsx
@@ -38,6 +38,7 @@ export default function BandLiveHub() {
             { icon: Calendar, labelKey: "Book Gigs", path: "/gig-booking", imagePrompt: "A booking calendar with venue offers, dates, and contract slips" },
             { icon: Mic, labelKey: "My Gigs", path: "/gigs", imagePrompt: "A packed concert venue with a band performing, colorful stage lights" },
             { icon: Mic, labelKey: "nav.openMic", path: "/open-mic", imagePrompt: "An intimate open mic night at a cozy bar with a single microphone, warm lighting" },
+            { icon: Trophy, labelKey: "Battle of the Bands", path: "/battle-of-the-bands", imagePrompt: "Two emerging bands facing off on a concert stage beneath a championship trophy" },
             { icon: Music, labelKey: "nav.jamSessions", path: "/jam-sessions", imagePrompt: "Musicians jamming together in a garage with guitars and amplifiers" },
             { icon: Music, labelKey: "nav.busking", path: "/busking", imagePrompt: "A street musician busking on a busy city corner with a guitar case open" },
             { icon: Wrench, labelKey: "nav.stageEquipment", path: "/stage-equipment", imagePrompt: "Amplifiers, speakers, microphone stands, and cables on a stage" },

--- a/supabase/migrations/20260728090000_harden_battle_of_the_bands.sql
+++ b/supabase/migrations/20260728090000_harden_battle_of_the_bands.sql
@@ -1,0 +1,108 @@
+-- Keep battles progressing automatically and close authorization gaps found in
+-- the initial Battle of the Bands implementation.
+
+CREATE OR REPLACE FUNCTION public.botb_is_active_member(p_band_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.band_members bm
+    LEFT JOIN public.profiles p ON p.id = bm.profile_id
+    WHERE bm.band_id = p_band_id
+      AND COALESCE(bm.member_status, 'active') = 'active'
+      AND (bm.user_id = auth.uid() OR p.user_id = auth.uid())
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.botb_is_active_member(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.botb_is_active_member(UUID) TO authenticated, service_role;
+
+DROP POLICY IF EXISTS "Band members can withdraw their entry" ON public.botb_entries;
+CREATE POLICY "Band members can withdraw their entry" ON public.botb_entries
+  FOR DELETE TO authenticated USING (
+    public.botb_is_active_member(botb_entries.band_id)
+    AND EXISTS (
+      SELECT 1 FROM public.botb_events e
+      WHERE e.id = botb_entries.event_id
+        AND e.status = 'upcoming'
+        AND e.scheduled_date > now()
+    )
+  );
+
+-- Patch the entry RPC rather than allowing legacy membership rows (whose
+-- user_id can be null) to make valid members appear unauthorized.
+CREATE OR REPLACE FUNCTION public.enter_battle_of_the_bands(
+  p_event_id UUID, p_band_id UUID, p_profile_id UUID,
+  p_song_1_id UUID, p_song_2_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_check JSONB;
+  v_entry public.botb_entries;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'BOTB_UNAUTHENTICATED'; END IF;
+  IF NOT public.botb_is_active_member(p_band_id) THEN RAISE EXCEPTION 'BOTB_NOT_BAND_MEMBER'; END IF;
+  IF p_profile_id IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.profiles WHERE id = p_profile_id AND user_id = auth.uid()
+  ) THEN RAISE EXCEPTION 'BOTB_INVALID_PROFILE'; END IF;
+  IF p_song_1_id IS NULL OR p_song_2_id IS NULL OR p_song_1_id = p_song_2_id THEN
+    RAISE EXCEPTION 'BOTB_INVALID_SONGS';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.botb_events
+    WHERE id = p_event_id AND status = 'upcoming' AND scheduled_date > now()
+  ) THEN RAISE EXCEPTION 'BOTB_INELIGIBLE: This battle is no longer open'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.songs WHERE id = p_song_1_id AND band_id = p_band_id AND NOT COALESCE(archived, false))
+     OR NOT EXISTS (SELECT 1 FROM public.songs WHERE id = p_song_2_id AND band_id = p_band_id AND NOT COALESCE(archived, false)) THEN
+    RAISE EXCEPTION 'BOTB_SONG_NOT_OWNED';
+  END IF;
+
+  v_check := public.botb_check_eligibility(p_event_id, p_band_id);
+  IF NOT (v_check->>'eligible')::boolean THEN
+    RAISE EXCEPTION 'BOTB_INELIGIBLE: %', v_check->>'reason';
+  END IF;
+
+  -- Lock the event so simultaneous final-slot entries cannot exceed capacity.
+  PERFORM 1 FROM public.botb_events WHERE id = p_event_id FOR UPDATE;
+  v_check := public.botb_check_eligibility(p_event_id, p_band_id);
+  IF NOT (v_check->>'eligible')::boolean THEN
+    RAISE EXCEPTION 'BOTB_INELIGIBLE: %', v_check->>'reason';
+  END IF;
+
+  INSERT INTO public.botb_entries (event_id, band_id, profile_id, user_id, song_1_id, song_2_id)
+  VALUES (p_event_id, p_band_id, p_profile_id, auth.uid(), p_song_1_id, p_song_2_id)
+  RETURNING * INTO v_entry;
+  RETURN jsonb_build_object('success', true, 'entry_id', v_entry.id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enter_battle_of_the_bands(UUID, UUID, UUID, UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.enter_battle_of_the_bands(UUID, UUID, UUID, UUID, UUID) TO authenticated, service_role;
+
+-- The original migration created a runner but never scheduled it, leaving due
+-- events unresolved and preventing yesterday's winners from reaching the news.
+DO $$
+DECLARE
+  v_job_id BIGINT;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    SELECT jobid INTO v_job_id FROM cron.job WHERE jobname = 'run-battle-of-the-bands-cycle' LIMIT 1;
+    IF v_job_id IS NOT NULL THEN PERFORM cron.unschedule(v_job_id); END IF;
+    PERFORM cron.schedule(
+      'run-battle-of-the-bands-cycle',
+      '*/5 * * * *',
+      'SELECT public.run_botb_cycle()'
+    );
+  END IF;
+END;
+$$;
+
+SELECT public.run_botb_cycle();


### PR DESCRIPTION
### Motivation
- Make the Battle of the Bands feature discoverable under the band "Perform" navigation and surface current battle activity in Today’s News so players can enter and see results.
- Harden server-side battle workflows and authorisation to handle legacy membership rows and prevent over-capacity or late entries.
- Ensure the battle cycle actually runs so due events are resolved and winners appear in news coverage.

### Description
- Exposed Battle of the Bands in the band Perform navigation and Band Live hub by adding links to `/battle-of-the-bands`. (`src/config/fmNavigation.ts`, `src/pages/hubs/BandLiveHub.tsx`)
- Added a news card component `BattleOfTheBandsNews` and integrated it into `TodaysNewsPage` to show battles scheduled today and winners from yesterday, plus a small date helper `battleNewsDates.ts`. (`src/components/news/BattleOfTheBandsNews.tsx`, `src/components/news/battleNewsDates.ts`, `src/pages/TodaysNews.tsx`)
- Hardened database behavior and RPCs with a migration that: validates active membership against both `band_members.user_id` and `profiles.user_id`, enforces profile ownership, rejects entries for started/closed battles, serializes final-slot entries with `FOR UPDATE`, and schedules the `run_botb_cycle()` via `pg_cron` so due events are generated/resolved. (`supabase/migrations/20260728090000_harden_battle_of_the_bands.sql`)
- Improved client-side error messaging for an invalid profile case in `useBattleOfTheBands`. (`src/hooks/useBattleOfTheBands.ts`)
- Added unit tests for date-range logic used by the news card. (`src/components/news/BattleOfTheBandsNews.test.ts`)

### Testing
- Ran `npx eslint` against the new files and the targeted existing hooks and the lint checks for those files passed for the final state of the patch. (passed)
- Built the production bundle with `npm run build` to validate integration with the app and asset pipeline; the build completed successfully with only existing bundle-size and dynamic-import warnings. (passed)
- Attempted to run the targeted unit test with `npm test -- --run src/components/news/BattleOfTheBandsNews.test.ts` but the test run was blocked by missing transitive dev-dependencies from the environment (`redent` via `@testing-library/jest-dom`) and a separate missing module (`rrweb-cssom`) that could not be installed due to a registry `403` in this environment; as a result the test suite did not execute successfully. (blocked)
- Ran `npm run typecheck` in the environment but the full repository typecheck did not complete within the session and was stopped; local/typecheck validation is recommended before merge. (incomplete)
- Verified staged changes passed `git diff --cached --check` and committed the changes as part of this PR. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68925ac48c8325b8cd92990b2a7164)