### PR TITLE
Fix remaining PostgreSQL 42703 in gig booking

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "test:festivals:certification": "bash scripts/festivals/run-certification-gate.sh",
     "test:festivals:safety-guard": "vitest run scripts/festivals/assert-safe-test-database.test.mjs",
     "verify:dependencies": "npm ls --all",
-    "verify:migration-timestamps": "node scripts/supabase/verify-migration-timestamps.mjs"
+    "verify:migration-timestamps": "node scripts/supabase/verify-migration-timestamps.mjs",
+    "test:gig-booking:db": "bash -lc 'test -n \"$SUPABASE_DB_URL\" || { echo SUPABASE_DB_URL is required; exit 2; }; psql \"$SUPABASE_DB_URL\" -v ON_ERROR_STOP=1 -f supabase/tests/gig_booking_runtime_harness.sql'"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -42273,6 +42273,10 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      active_band_performing_members: {
+        Args: { p_band_id: string }
+        Returns: { profile_id: string }[]
+      }
       book_gig: {
         Args: {
           p_band_id: string

--- a/src/pages/GigBooking.tsx
+++ b/src/pages/GigBooking.tsx
@@ -430,10 +430,19 @@ const GigBooking = () => {
       setBookingVenue(null);
     } catch (error) {
       const supabaseError = error as GigBookingErrorLike;
-      if (import.meta.env.DEV) console.error('Gig booking failed', {
-        stage: failedStage, code: supabaseError.code, message: supabaseError.message,
-        details: supabaseError.details, hint: supabaseError.hint, requestId,
-      });
+      if (import.meta.env.DEV) {
+        console.groupCollapsed('Gig booking database failure');
+        console.error({
+          context: 'book_gig',
+          stage: failedStage,
+          code: supabaseError.code,
+          message: supabaseError.message,
+          details: supabaseError.details,
+          hint: supabaseError.hint,
+          requestId,
+        });
+        console.groupEnd();
+      }
       const playerError = getGigBookingPlayerError(supabaseError);
       toast({
         ...playerError,

--- a/src/utils/__tests__/atomicGigBookingMigration.test.ts
+++ b/src/utils/__tests__/atomicGigBookingMigration.test.ts
@@ -103,3 +103,33 @@ describe('legacy current-travel gig booking blocker', () => {
     expect(travelHotfixSql).toContain("RAISE EXCEPTION 'gig_booking_band_conflict'");
   });
 });
+
+describe('fully audited gig booking runtime repair', () => {
+  const runtimeSql = readFileSync('supabase/migrations/20260728140000_audit_gig_booking_runtime.sql', 'utf8');
+
+  it('removes the confirmed unused song duration dependency', () => {
+    const rpc = runtimeSql.slice(runtimeSql.indexOf('CREATE OR REPLACE FUNCTION public.book_gig'));
+    expect(rpc).not.toContain('song.duration_seconds');
+    expect(rpc).not.toContain('v_setlist_seconds');
+    expect(rpc).toContain('INTO v_song_count');
+  });
+
+  it('uses one canonical performing-member helper for booking and its gig trigger', () => {
+    expect(runtimeSql.match(/active_band_performing_members\(/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(runtimeSql).toContain("COALESCE(bm.member_status, 'active') = 'active'");
+    expect(runtimeSql).toContain("COALESCE(bm.is_touring_member, false) = false");
+    expect(runtimeSql).toContain('leader_profile.user_id = b.leader_id');
+  });
+
+  it('annotates unexpected errors with a named stage while preserving SQLSTATE', () => {
+    for (const stage of ['resolve_actor', 'idempotency_check', 'load_band', 'load_venue', 'validate_slot',
+      'validate_setlist', 'validate_rider', 'conflict_check', 'calculate_finances', 'debit_balance',
+      'insert_gig', 'create_member_activities']) expect(runtimeSql).toContain(`'${stage}'`);
+    expect(runtimeSql).toContain('v_error_state = RETURNED_SQLSTATE');
+    expect(runtimeSql).toContain('ERRCODE = v_error_state');
+  });
+
+  it('reloads the PostgREST schema cache', () => {
+    expect(runtimeSql).toContain("NOTIFY pgrst, 'reload schema'");
+  });
+});

--- a/supabase/migrations/20260728140000_audit_gig_booking_runtime.sql
+++ b/supabase/migrations/20260728140000_audit_gig_booking_runtime.sql
@@ -1,0 +1,228 @@
+-- Runtime gig-booking schema repair.
+-- Confirmed production failure: SQLSTATE 42703, column song.duration_seconds,
+-- raised by public.book_gig during setlist validation. Duration was calculated but
+-- never consumed, so the invalid/legacy dependency is removed rather than papered
+-- over with a compatibility column.
+
+CREATE OR REPLACE FUNCTION public.active_band_performing_members(p_band_id uuid)
+RETURNS TABLE(profile_id uuid)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT DISTINCT resolved.profile_id
+  FROM (
+    SELECT COALESCE(bm.profile_id, member_profile.id) AS profile_id
+    FROM public.band_members bm
+    LEFT JOIN public.profiles member_profile ON member_profile.user_id = bm.user_id
+    WHERE bm.band_id = p_band_id
+      AND COALESCE(bm.member_status, 'active') = 'active'
+      AND COALESCE(bm.is_touring_member, false) = false
+    UNION ALL
+    SELECT leader_profile.id
+    FROM public.bands b
+    JOIN public.profiles leader_profile
+      ON leader_profile.id = b.leader_id OR leader_profile.user_id = b.leader_id
+    WHERE b.id = p_band_id
+  ) resolved
+  WHERE resolved.profile_id IS NOT NULL;
+$$;
+
+REVOKE ALL ON FUNCTION public.active_band_performing_members(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.active_band_performing_members(uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.book_gig(
+  p_band_id uuid,
+  p_venue_id uuid,
+  p_setlist_id uuid,
+  p_local_date date,
+  p_slot text,
+  p_ticket_price integer,
+  p_request_id uuid,
+  p_rider_id uuid DEFAULT NULL,
+  p_ticket_operator_id text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor public.profiles%ROWTYPE; v_band public.bands%ROWTYPE; v_venue public.venues%ROWTYPE;
+  v_gig public.gigs%ROWTYPE; v_timezone text; v_start_time time; v_end_time time;
+  v_start timestamptz; v_end timestamptz; v_multiplier numeric; v_payment_multiplier numeric;
+  v_capacity integer; v_estimated_attendance integer; v_estimated_revenue integer;
+  v_booking_fee integer; v_payment integer; v_rider_cost integer := 0;
+  v_song_count integer;
+  v_stage text := 'resolve_actor';
+  v_error_state text; v_error_message text; v_error_detail text; v_error_hint text;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'gig_booking_unauthenticated' USING ERRCODE='42501'; END IF;
+  SELECT * INTO v_actor FROM public.profiles WHERE user_id = auth.uid() LIMIT 1;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_profile_missing' USING ERRCODE='P0001'; END IF;
+  IF p_request_id IS NULL THEN RAISE EXCEPTION 'gig_booking_request_invalid' USING ERRCODE='22023'; END IF;
+
+  v_stage := 'idempotency_check';
+  SELECT * INTO v_gig FROM public.gigs WHERE booking_request_id = p_request_id;
+  IF FOUND THEN
+    IF v_gig.band_id <> p_band_id OR NOT public.can_manage_band_gigs(v_gig.band_id, auth.uid()) THEN
+      RAISE EXCEPTION 'gig_booking_request_conflict' USING ERRCODE='23505';
+    END IF;
+    RETURN jsonb_build_object('gig', to_jsonb(v_gig), 'already_booked', true,
+      'booking_fee', COALESCE(v_gig.booking_fee, 0), 'scheduled_start', v_gig.scheduled_date);
+  END IF;
+
+  v_stage := 'load_band';
+  IF NOT public.can_manage_band_gigs(p_band_id, auth.uid()) THEN
+    RAISE EXCEPTION 'gig_booking_forbidden' USING ERRCODE='42501';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('gig-band:'||p_band_id::text, 0));
+  PERFORM pg_advisory_xact_lock(hashtextextended('gig-venue:'||p_venue_id::text, 0));
+
+  SELECT * INTO v_band FROM public.bands WHERE id = p_band_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_band_invalid' USING ERRCODE='P0001'; END IF;
+  v_stage := 'load_venue';
+  SELECT * INTO v_venue FROM public.venues WHERE id = p_venue_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_venue_invalid' USING ERRCODE='P0001'; END IF;
+  SELECT COALESCE(c.timezone, 'UTC') INTO v_timezone FROM public.cities c WHERE c.id = v_venue.city_id;
+  v_timezone := COALESCE(v_timezone, 'UTC');
+
+  v_stage := 'validate_slot';
+  SELECT x.start_time, x.end_time, x.attendance_multiplier, x.payment_multiplier
+  INTO v_start_time, v_end_time, v_multiplier, v_payment_multiplier
+  FROM (VALUES ('kids','15:00'::time,'15:30'::time,0.30,0.50),
+               ('opening','19:00','19:30',0.50,0.60),
+               ('support','19:45','20:30',0.75,0.80),
+               ('headline','20:45','22:00',1.00,1.00))
+    AS x(slot,start_time,end_time,attendance_multiplier,payment_multiplier)
+  WHERE x.slot = p_slot;
+  IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_slot_invalid' USING ERRCODE='22023'; END IF;
+
+  v_start := (p_local_date + v_start_time) AT TIME ZONE v_timezone;
+  v_end := (p_local_date + v_end_time
+            + CASE WHEN v_end_time <= v_start_time THEN interval '1 day' ELSE interval '0' END)
+           AT TIME ZONE v_timezone;
+  IF v_start <= now() THEN RAISE EXCEPTION 'gig_booking_past_date' USING ERRCODE='22023'; END IF;
+  IF p_ticket_price IS NULL OR p_ticket_price <= 0 OR p_ticket_price > 100000 THEN
+    RAISE EXCEPTION 'gig_booking_ticket_price_invalid' USING ERRCODE='22023';
+  END IF;
+
+  v_stage := 'validate_setlist';
+  -- Duration is not part of booking validation. Avoid an unused dependency on
+  -- legacy song duration columns; ownership, active state, and six songs suffice.
+  SELECT count(*)
+  INTO v_song_count
+  FROM public.setlist_songs ss
+  JOIN public.setlists s ON s.id = ss.setlist_id
+  WHERE s.id = p_setlist_id AND s.band_id = p_band_id AND COALESCE(s.is_active, true)
+    AND ss.song_id IS NOT NULL;
+  IF COALESCE(v_song_count, 0) < 6 THEN RAISE EXCEPTION 'gig_booking_setlist_invalid' USING ERRCODE='23514'; END IF;
+
+  v_stage := 'validate_rider';
+  IF p_rider_id IS NOT NULL THEN
+    SELECT COALESCE(total_cost_estimate, 0) INTO v_rider_cost
+    FROM public.band_riders WHERE id = p_rider_id AND band_id = p_band_id;
+    IF NOT FOUND THEN RAISE EXCEPTION 'gig_booking_rider_invalid' USING ERRCODE='23503'; END IF;
+  END IF;
+
+  v_stage := 'conflict_check';
+  IF EXISTS (SELECT 1 FROM public.band_activity_lockouts
+             WHERE band_id = p_band_id AND locked_until > now()) THEN
+    RAISE EXCEPTION 'gig_booking_band_lockout' USING ERRCODE='P0001';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.gigs g WHERE g.band_id = p_band_id
+    AND g.status IN ('scheduled','in_progress','ready_for_completion')
+    AND g.scheduled_date < v_end
+    AND COALESCE(g.scheduled_end, g.scheduled_date + interval '3 hours') > v_start) THEN
+    RAISE EXCEPTION 'gig_booking_band_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.gigs g WHERE g.venue_id = p_venue_id
+    AND g.status IN ('scheduled','in_progress','ready_for_completion')
+    AND g.scheduled_date < v_end
+    AND COALESCE(g.scheduled_end, g.scheduled_date + interval '3 hours') > v_start) THEN
+    RAISE EXCEPTION 'gig_booking_venue_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  v_stage := 'calculate_finances';
+  v_capacity := GREATEST(COALESCE(v_venue.capacity, 100), 1);
+  v_estimated_attendance := LEAST(v_capacity, GREATEST(1, round(v_capacity * LEAST(1.0,
+    (0.25 + COALESCE(v_band.popularity,0)/200.0 + COALESCE(v_band.global_fame,0)/10000.0)) * v_multiplier))::integer);
+  v_estimated_revenue := v_estimated_attendance * p_ticket_price;
+  v_booking_fee := GREATEST(50, round(v_estimated_revenue * 0.10)::integer);
+  v_payment := GREATEST(0, round(COALESCE(v_venue.base_payment,0) * v_payment_multiplier)::integer - v_rider_cost);
+
+  IF COALESCE(v_band.band_balance, 0) < v_booking_fee THEN
+    RAISE EXCEPTION 'gig_booking_insufficient_funds' USING ERRCODE='P0001', DETAIL = v_booking_fee::text;
+  END IF;
+
+  v_stage := 'debit_balance';
+  UPDATE public.bands SET band_balance = band_balance - v_booking_fee WHERE id = p_band_id;
+
+  v_stage := 'insert_gig';
+  INSERT INTO public.gigs (band_id,venue_id,setlist_id,rider_id,ticket_operator_id,scheduled_date,scheduled_end,
+    status,show_type,payment,booking_fee,ticket_price,time_slot,slot_start_time,slot_end_time,
+    slot_attendance_multiplier,estimated_attendance,estimated_revenue,attendance,fan_gain,predicted_tickets,
+    tickets_sold,last_ticket_update,booking_request_id)
+  VALUES (p_band_id,p_venue_id,p_setlist_id,p_rider_id,p_ticket_operator_id,v_start,v_end,'scheduled',
+    'concert',v_payment,v_booking_fee,p_ticket_price,p_slot,v_start_time,v_end_time,
+    v_multiplier,v_estimated_attendance,v_estimated_revenue,0,0,v_estimated_attendance,0,now(),p_request_id)
+  RETURNING * INTO v_gig;
+
+  v_stage := 'create_member_activities';
+  INSERT INTO public.player_scheduled_activities (user_id,profile_id,activity_type,scheduled_start,scheduled_end,
+    status,title,location,linked_gig_id,metadata)
+  SELECT p.user_id, p.id, 'gig', v_start, v_end, 'scheduled',
+         'Gig at '||v_venue.name, v_venue.name, v_gig.id,
+         jsonb_build_object('band_id',p_band_id,'venueId',p_venue_id,'slotId',p_slot,
+                            'venue_timezone',v_timezone,'is_band_activity',true)
+  FROM public.active_band_performing_members(p_band_id) member
+  JOIN public.profiles p ON p.id = member.profile_id
+  ON CONFLICT (linked_gig_id, profile_id)
+  WHERE linked_gig_id IS NOT NULL AND status <> 'cancelled' DO NOTHING;
+
+  RETURN jsonb_build_object('gig', to_jsonb(v_gig), 'already_booked', false, 'booking_fee', v_booking_fee,
+    'band_balance', COALESCE(v_band.band_balance,0) - v_booking_fee,
+    'scheduled_start', v_start, 'scheduled_end', v_end, 'venue_timezone', v_timezone);
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS
+    v_error_state = RETURNED_SQLSTATE,
+    v_error_message = MESSAGE_TEXT,
+    v_error_detail = PG_EXCEPTION_DETAIL,
+    v_error_hint = PG_EXCEPTION_HINT;
+  IF v_error_message LIKE 'gig_booking_%' THEN RAISE; END IF;
+  RAISE EXCEPTION USING
+    ERRCODE = v_error_state,
+    MESSAGE = 'gig_booking_database_failure',
+    DETAIL = format('stage=%s; message=%s; detail=%s', v_stage, v_error_message, COALESCE(v_error_detail, '')),
+    HINT = COALESCE(NULLIF(v_error_hint, ''), 'Inspect the named book_gig stage.');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.book_gig(uuid,uuid,uuid,date,text,integer,uuid,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.book_gig(uuid,uuid,uuid,date,text,integer,uuid,uuid,text) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION public.check_gig_member_schedule_conflicts()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_end timestamptz := COALESCE(NEW.scheduled_end, NEW.scheduled_date + interval '3 hours');
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.player_scheduled_activities a
+    JOIN public.active_band_performing_members(NEW.band_id) member ON member.profile_id = a.profile_id
+    WHERE a.status IN ('scheduled', 'in_progress')
+      AND a.scheduled_start < v_end AND a.scheduled_end > NEW.scheduled_date
+  ) THEN
+    RAISE EXCEPTION 'gig_booking_band_conflict' USING ERRCODE = '23P01';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_gig_member_schedule_conflicts() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.check_gig_member_schedule_conflicts() TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/tests/gig_booking_runtime_harness.sql
+++ b/supabase/tests/gig_booking_runtime_harness.sql
@@ -1,0 +1,106 @@
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- This harness must run only after the complete migration chain has been applied.
+DO $$
+DECLARE
+  missing text;
+BEGIN
+  WITH required(table_name, column_name) AS (VALUES
+    ('bands','id'), ('bands','leader_id'), ('bands','global_fame'), ('bands','band_balance'), ('bands','popularity'),
+    ('venues','id'), ('venues','city_id'), ('venues','capacity'), ('venues','base_payment'),
+    ('cities','id'), ('cities','timezone'),
+    ('setlists','id'), ('setlists','band_id'), ('setlists','is_active'),
+    ('setlist_songs','setlist_id'), ('setlist_songs','song_id'),
+    ('band_members','band_id'), ('band_members','profile_id'), ('band_members','user_id'),
+    ('band_members','member_status'), ('band_members','is_touring_member'),
+    ('gigs','band_id'), ('gigs','venue_id'), ('gigs','scheduled_date'), ('gigs','scheduled_end'),
+    ('gigs','booking_request_id'), ('gigs','ticket_operator_id'),
+    ('player_scheduled_activities','linked_gig_id'), ('player_scheduled_activities','profile_id'),
+    ('player_scheduled_activities','user_id'), ('player_scheduled_activities','scheduled_start'),
+    ('player_scheduled_activities','scheduled_end')),
+  absent AS (
+    SELECT r.* FROM required r LEFT JOIN information_schema.columns c
+      ON c.table_schema='public' AND c.table_name=r.table_name AND c.column_name=r.column_name
+    WHERE c.column_name IS NULL
+  )
+  SELECT string_agg(table_name||'.'||column_name, ', ' ORDER BY table_name,column_name) INTO missing FROM absent;
+  IF missing IS NOT NULL THEN RAISE EXCEPTION 'gig booking schema contract missing: %', missing; END IF;
+
+  IF position('duration_seconds' IN pg_get_functiondef('public.book_gig(uuid,uuid,uuid,date,text,integer,uuid,uuid,text)'::regprocedure)) > 0 THEN
+    RAISE EXCEPTION 'book_gig retains unused song duration dependency';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgrelid='public.gigs'::regclass AND NOT tgisinternal) THEN
+    RAISE EXCEPTION 'production-like schema has no gig triggers';
+  END IF;
+END $$;
+
+-- Reuse a fully migrated disposable database's canonical fixtures. The test is
+-- executable (not migration string matching) and calls the real RPC, all triggers,
+-- and its idempotency path. CI/local setup supplies these IDs after seeding.
+DO $$
+DECLARE
+  v_band_id uuid := nullif(current_setting('app.test_gig_band_id', true),'')::uuid;
+  v_venue_id uuid := nullif(current_setting('app.test_gig_venue_id', true),'')::uuid;
+  v_setlist_id uuid := nullif(current_setting('app.test_gig_setlist_id', true),'')::uuid;
+  v_actor_user_id uuid := nullif(current_setting('app.test_gig_actor_user_id', true),'')::uuid;
+  request_id uuid := gen_random_uuid();
+  before_balance bigint; after_balance bigint; fee bigint; first_result jsonb; retry_result jsonb;
+  gig_id uuid; actor_profile_id uuid; conflict_activity_id uuid;
+BEGIN
+  IF v_band_id IS NULL OR v_venue_id IS NULL OR v_setlist_id IS NULL OR v_actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'set app.test_gig_band_id, venue_id, setlist_id, and actor_user_id to migrated disposable fixtures';
+  END IF;
+  IF (SELECT count(*) FROM public.setlist_songs ss WHERE ss.setlist_id=v_setlist_id) <> 6 THEN
+    RAISE EXCEPTION 'fixture must contain exactly six songs';
+  END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', v_actor_user_id::text, true);
+  IF EXISTS (SELECT 1 FROM public.band_members bm WHERE bm.band_id=v_band_id
+             AND COALESCE(bm.member_status,'active')='active'
+             AND COALESCE(bm.is_touring_member,false)=false) THEN
+    RAISE EXCEPTION 'fixture must be leader-only (touring/inactive rows are allowed)';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.active_band_performing_members(v_band_id) performing
+    JOIN public.band_members bm ON bm.profile_id=performing.profile_id
+    WHERE bm.band_id=v_band_id AND (COALESCE(bm.member_status,'active')<>'active' OR COALESCE(bm.is_touring_member,false))
+  ) THEN RAISE EXCEPTION 'touring or inactive member was treated as performing'; END IF;
+  SELECT band_balance INTO before_balance FROM public.bands WHERE id=v_band_id;
+  SELECT id INTO actor_profile_id FROM public.profiles WHERE user_id=v_actor_user_id;
+  INSERT INTO public.player_scheduled_activities
+    (user_id,profile_id,activity_type,scheduled_start,scheduled_end,status,title)
+  VALUES (v_actor_user_id,actor_profile_id,'other',(current_date+29)::timestamptz, (current_date+32)::timestamptz,'scheduled','gig booking rollback test')
+  RETURNING id INTO conflict_activity_id;
+  BEGIN
+    PERFORM public.book_gig(v_band_id,v_venue_id,v_setlist_id,current_date+30,'headline',10,gen_random_uuid(),NULL,NULL);
+    RAISE EXCEPTION 'expected gig INSERT trigger conflict';
+  EXCEPTION WHEN exclusion_violation THEN NULL;
+  END;
+  IF (SELECT band_balance FROM public.bands WHERE id=v_band_id) <> before_balance THEN
+    RAISE EXCEPTION 'trigger failure did not roll back booking deduction';
+  END IF;
+  DELETE FROM public.player_scheduled_activities WHERE id=conflict_activity_id;
+
+  first_result := public.book_gig(v_band_id,v_venue_id,v_setlist_id,current_date+30,'headline',10,request_id,NULL,NULL);
+  IF first_result IS NULL THEN RAISE EXCEPTION 'book_gig returned null'; END IF;
+  gig_id := (first_result->'gig'->>'id')::uuid;
+  fee := (first_result->>'booking_fee')::bigint;
+  SELECT band_balance INTO after_balance FROM public.bands WHERE id=v_band_id;
+  IF after_balance <> before_balance-fee THEN RAISE EXCEPTION 'balance was not deducted exactly once'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.player_scheduled_activities WHERE linked_gig_id=gig_id) THEN
+    RAISE EXCEPTION 'active member activities were not created';
+  END IF;
+
+  retry_result := public.book_gig(v_band_id,v_venue_id,v_setlist_id,current_date+30,'headline',10,request_id,NULL,NULL);
+  IF COALESCE((retry_result->>'already_booked')::boolean,false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'idempotent retry did not return existing booking';
+  END IF;
+  IF (SELECT band_balance FROM public.bands WHERE id=v_band_id) <> after_balance THEN
+    RAISE EXCEPTION 'idempotent retry deducted balance twice';
+  END IF;
+END $$;
+
+-- The surrounding transaction proves every created gig/activity and deduction is
+-- rolled back together, including failures from any INSERT trigger.
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Resolve the remaining SQLSTATE 42703 failure observed when booking gigs by auditing the full booking execution path and removing stale column dependencies. 
- Improve diagnostics so unexpected database failures during booking report a safe stage and captured Supabase error fields while preserving the original SQLSTATE. 
- Consolidate member-resolution logic to avoid duplicated legacy assumptions and ensure triggers and the RPC agree on who counts as an active performing member.

### Description

- Add a forward-only migration `supabase/migrations/20260728140000_audit_gig_booking_runtime.sql` that removes the unused `song.duration_seconds` lookup from `public.book_gig` and replaces the setlist duration accumulation with a simple song count check (six-song minimum). 
- Introduce `public.active_band_performing_members(p_band_id uuid)` to canonicalize resolution of active, non-touring performing members (handles `profile_id` and legacy `user_id` leader cases) and update both `book_gig` activity creation and the BEFORE INSERT conflict trigger to use it. 
- Instrument `public.book_gig` with named diagnostic stages (e.g. `resolve_actor`, `idempotency_check`, `load_band`, `validate_setlist`, `debit_balance`, `insert_gig`, `create_member_activities`) and wrap unexpected errors to return a safe diagnostic including the stage, message/detail/hint while preserving the original SQLSTATE. 
- Ensure transactional semantics are preserved so the band debit, gig INSERT and activity creation occur in the same function transaction and any trigger/insert failure rolls back the deduction. 
- Add a development-only frontend console group “Gig booking database failure” that logs `code`, `message`, `details`, `hint`, `context`, `stage`, and `requestId` when `import.meta.env.DEV` is true without exposing SQL to players. 
- Add an executable, transactionally isolated DB harness `supabase/tests/gig_booking_runtime_harness.sql` which validates the production-like schema contract, calls the real `book_gig` RPC and triggers, verifies leader-only and six-song fixtures, asserts exactly one debit, verifies member activities creation, checks rollback on trigger conflict, and tests idempotent retry. 
- Refresh generated Supabase function types (add `active_band_performing_members` to `src/integrations/supabase/types.ts`) and add an npm script `test:gig-booking:db` to run the harness against a disposable migrated DB. 
- Add unit assertions covering the migration contents in `src/utils/__tests__/atomicGigBookingMigration.test.ts` and include a PostgREST cache refresh (`NOTIFY pgrst, 'reload schema'`) in the migration.

### Testing

- Ran `npm run verify:migration-timestamps` which succeeded. 
- Ran `npm run typecheck` and `npm run lint -- --quiet`, both succeeded. 
- Executed a targeted Vitest run with a temporary node-only config (`npx vitest run --config vitest.db-audit.config.ts`) and the targeted tests passed (34 tests passed). 
- The repository-level unit test runner initially encountered missing optional dev modules in the environment (`rrweb-cssom` / testing-library helpers); the targeted node-only test run above validated the new tests. 
- The new executable DB harness exists and is runnable via `npm run test:gig-booking:db`, but could not be executed in this CI/workspace because no `SUPABASE_DB_URL` / disposable migrated Postgres instance was provided (harness documents the required `app.test_gig_*` fixture settings and rolls back its changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68a10500bc8325b0c401306d004818)