### PR TITLE
Fix remaining gig booking 42703 execution path

### DIFF
--- a/src/utils/__tests__/atomicGigBookingMigration.test.ts
+++ b/src/utils/__tests__/atomicGigBookingMigration.test.ts
@@ -133,3 +133,18 @@ describe('fully audited gig booking runtime repair', () => {
     expect(runtimeSql).toContain("NOTIFY pgrst, 'reload schema'");
   });
 });
+
+describe('gig lineup trigger membership alignment', () => {
+  const lineupSql = readFileSync('supabase/migrations/20260728150000_align_gig_lineup_trigger_members.sql', 'utf8');
+
+  it('uses the canonical performing-member helper instead of duplicating membership fields', () => {
+    expect(lineupSql).toContain('public.active_band_performing_members(v_gig.band_id)');
+    expect(lineupSql).not.toContain('bm.member_status');
+    expect(lineupSql).not.toContain('bm.is_touring_member');
+  });
+
+  it('keeps the existing INSERT trigger helper idempotent and refreshes PostgREST', () => {
+    expect(lineupSql).toContain('ON CONFLICT ON CONSTRAINT gig_performers_unique DO NOTHING');
+    expect(lineupSql).toContain("NOTIFY pgrst, 'reload schema'");
+  });
+});

--- a/supabase/migrations/20260728150000_align_gig_lineup_trigger_members.sql
+++ b/supabase/migrations/20260728150000_align_gig_lineup_trigger_members.sql
@@ -1,0 +1,46 @@
+-- Keep the AFTER INSERT gig-lineup trigger on the same canonical membership
+-- contract as book_gig and its schedule-conflict trigger.  In particular this
+-- includes a row-less leader and excludes inactive/touring members.
+CREATE OR REPLACE FUNCTION public.seed_gig_performers(p_gig_id uuid)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_gig public.gigs%ROWTYPE;
+  v_count integer := 0;
+BEGIN
+  SELECT * INTO v_gig FROM public.gigs WHERE id = p_gig_id;
+  IF NOT FOUND OR COALESCE(v_gig.status, '') IN ('cancelled', 'failed') THEN
+    RETURN 0;
+  END IF;
+
+  INSERT INTO public.gig_performers
+    (gig_id, band_id, profile_id, role_or_instrument, lineup_status, selected_at)
+  SELECT v_gig.id,
+         v_gig.band_id,
+         member.profile_id,
+         NULLIF(COALESCE(bm.instrument_role, bm.role), ''),
+         'selected',
+         now()
+  FROM public.active_band_performing_members(v_gig.band_id) member
+  LEFT JOIN LATERAL (
+    SELECT candidate.instrument_role, candidate.role, candidate.joined_at
+    FROM public.band_members candidate
+    WHERE candidate.band_id = v_gig.band_id
+      AND candidate.profile_id = member.profile_id
+    ORDER BY candidate.joined_at NULLS LAST, candidate.id
+    LIMIT 1
+  ) bm ON true
+  WHERE bm.joined_at IS NULL OR bm.joined_at <= v_gig.scheduled_date
+  ON CONFLICT ON CONSTRAINT gig_performers_unique DO NOTHING;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.seed_gig_performers(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.seed_gig_performers(uuid) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/tests/gig_booking_runtime_harness.sql
+++ b/supabase/tests/gig_booking_runtime_harness.sql
@@ -18,7 +18,9 @@ BEGIN
     ('gigs','booking_request_id'), ('gigs','ticket_operator_id'),
     ('player_scheduled_activities','linked_gig_id'), ('player_scheduled_activities','profile_id'),
     ('player_scheduled_activities','user_id'), ('player_scheduled_activities','scheduled_start'),
-    ('player_scheduled_activities','scheduled_end')),
+    ('player_scheduled_activities','scheduled_end'),
+    ('gig_performers','gig_id'), ('gig_performers','band_id'), ('gig_performers','profile_id'),
+    ('gig_performers','role_or_instrument'), ('gig_performers','lineup_status'), ('gig_performers','selected_at')),
   absent AS (
     SELECT r.* FROM required r LEFT JOIN information_schema.columns c
       ON c.table_schema='public' AND c.table_name=r.table_name AND c.column_name=r.column_name
@@ -32,6 +34,9 @@ BEGIN
   END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgrelid='public.gigs'::regclass AND NOT tgisinternal) THEN
     RAISE EXCEPTION 'production-like schema has no gig triggers';
+  END IF;
+  IF position('active_band_performing_members' IN pg_get_functiondef('public.seed_gig_performers(uuid)'::regprocedure)) = 0 THEN
+    RAISE EXCEPTION 'gig INSERT lineup trigger bypasses canonical performing members';
   END IF;
 END $$;
 
@@ -90,6 +95,9 @@ BEGIN
   IF after_balance <> before_balance-fee THEN RAISE EXCEPTION 'balance was not deducted exactly once'; END IF;
   IF NOT EXISTS (SELECT 1 FROM public.player_scheduled_activities WHERE linked_gig_id=gig_id) THEN
     RAISE EXCEPTION 'active member activities were not created';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.gig_performers WHERE gig_id=gig_id AND profile_id=actor_profile_id) THEN
+    RAISE EXCEPTION 'gig INSERT lineup trigger did not include the row-less leader';
   END IF;
 
   retry_result := public.book_gig(v_band_id,v_venue_id,v_setlist_id,current_date+30,'headline',10,request_id,NULL,NULL);


### PR DESCRIPTION
### Motivation
- A production PostgreSQL SQLSTATE 42703 during gig booking traced to an unresolved legacy column `song.duration_seconds` referenced in the `validate_setlist` stage of `public.book_gig`.  The duration value was computed but unused, so the dependency must be removed to avoid runtime resolution errors.
- The `gigs` AFTER INSERT lineup path independently duplicated optional membership predicates, risking trigger failures and excluding a leader stored as either a profile ID or legacy auth user ID.
- Provide stronger, executable diagnostics and a disposable-database harness that exercises the full booking execution path (RPC, triggers, idempotency and rollback) so future schema/runtime mismatches are caught at CI time.

### Description
- Remove the unused `song.duration_seconds` dependency from `public.book_gig` and validate setlists using ownership, `is_active`, and a six-song minimum instead of reading legacy duration columns (see `supabase/migrations/20260728140000_audit_gig_booking_runtime.sql`).
- Add a canonical performing-member helper and align the gig-lineup trigger to use it by creating `public.seed_gig_performers` that selects from `public.active_band_performing_members` and a `LEFT JOIN LATERAL` to resolve `band_members` metadata, then expose the forward-only migration `supabase/migrations/20260728150000_align_gig_lineup_trigger_members.sql`.
- Expand the runtime harness and schema-contract test in `supabase/tests/gig_booking_runtime_harness.sql` to assert presence of all trigger-used `gig_performers` columns, verify the seed/trigger uses `active_band_performing_members`, and check that leader-only bookings produce both a scheduled activity and a `gig_performers` row.
- Add unit assertions in `src/utils/__tests__/atomicGigBookingMigration.test.ts` that ensure the audit migration no longer references `song.duration_seconds` and that the new lineup migration uses the canonical helper and refreshes PostgREST; retain development-only RPC error diagnostics in `src/pages/GigBooking.tsx` which now log stage and full safe Supabase error properties.

### Testing
- Ran `git diff --check` to sanity-check diffs with no whitespace issues reported. (passed)
- Ran the Node-only Vitest invocation for the migration/unit assertions (`npx vitest` with a temporary Node config) and observed `24 tests passed` for the augmented migration tests. (passed)
- `npm run test:gig-booking:db` (the disposable-database harness) could not be executed in this environment because `SUPABASE_DB_URL` was not provided, but the SQL harness `supabase/tests/gig_booking_runtime_harness.sql` is included and ready to run against a fully migrated disposable Supabase/Postgres instance (test requires seeding `app.test_gig_*` fixture settings). (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68c0e9007883259c9e1b89e7b56ebf)