### PR TITLE
Allow documented Supabase migration timestamp collisions and add gig_performer INSERT trigger repair

### DIFF
--- a/scripts/supabase/migration-timestamp-collisions.json
+++ b/scripts/supabase/migration-timestamp-collisions.json
@@ -1,0 +1,156 @@
+{
+  "20250916150000": [
+    "20250916150000_create_notifications_table.sql",
+    "20250916150000_create_record_labels_table.sql",
+    "20250916150000_create_streaming_campaigns_table.sql",
+    "20250916150000_create_weekly_stats_view.sql",
+    "20250916150000_update_song_production_pipeline.sql"
+  ],
+  "20250916153000": [
+    "20250916153000_add_contract_recoupment_fields.sql",
+    "20250916153000_add_social_metrics_to_profiles.sql",
+    "20250916153000_create_competitions_tables.sql",
+    "20250916153000_create_jam_sessions_table.sql",
+    "20250916153000_create_leaderboards_view.sql",
+    "20250916153000_create_schedule_events_table.sql",
+    "20250916153000_create_streaming_stats_table.sql",
+    "20250916153000_song_stream_growth_job.sql"
+  ],
+  "20250917090000": [
+    "20250917090000_add_promotion_campaigns_table.sql",
+    "20250917090000_create_label_system.sql",
+    "20250917090000_create_leaderboard_tables.sql"
+  ],
+  "20260201020000": [
+    "20260201020000_add_travel_time_and_rest_days_to_tour_venues.sql",
+    "20260201020000_create_chat_participants_table.sql",
+    "20260201020000_create_equipment_upgrades_table.sql",
+    "20260201020000_create_fan_campaigns_table.sql",
+    "20260201020000_extend_gig_performances_with_results.sql",
+    "20260201020000_schedule_event_reminder_job.sql"
+  ],
+  "20260202090000": [
+    "20260202090000_create_fan_messages_table.sql",
+    "20260202090000_update_social_posts_with_media_and_schedule.sql"
+  ],
+  "20260301090000": [
+    "20260301090000_manage_game_event_status.sql",
+    "20260301090000_restrict_profile_select.sql"
+  ],
+  "20260316093000": [
+    "20260316093000_behavior_settings_per_character.sql",
+    "20260316093000_fix_promotional_campaigns_rls.sql"
+  ],
+  "20260710120000": [
+    "20260710120000_add_profile_privacy_settings.sql",
+    "20260710120000_beta_admin_support_tools.sql",
+    "20260710120000_complete_company_recruitment_lifecycle.sql"
+  ],
+  "20260712120000": [
+    "20260712120000_expand_wellness_foundation.sql",
+    "20260712120000_gig_audience_participation.sql",
+    "20260712120000_gig_live_outcome_breakdown.sql",
+    "20260712120000_recording_outcome_breakdown.sql",
+    "20260712120000_songwriting_outcome_calculator.sql",
+    "20260712120000_tour_operations_multi_gig_management.sql",
+    "20260712120000_wellness_accommodation_travel_recovery.sql",
+    "20260712120000_wellness_professionals.sql"
+  ],
+  "20260712143000": [
+    "20260712143000_wellness_lifestyle_habits.sql",
+    "20260712143000_wellness_time_away_longevity.sql"
+  ],
+  "20260713090000": [
+    "20260713090000_band_progression_goals.sql",
+    "20260713090000_create_balance_management_registry.sql",
+    "20260713090000_player_progression_analytics.sql"
+  ],
+  "20260713120000": [
+    "20260713120000_player_profiles_social_identity.sql",
+    "20260713120000_progression_achievements_canonical.sql",
+    "20260713120000_repair_songwriting_optional_columns.sql"
+  ],
+  "20260713130000": [
+    "20260713130000_band_relationship_progression.sql",
+    "20260713130000_fix_skill_xp_spending.sql",
+    "20260713130000_player_discovery_search_matchmaking.sql"
+  ],
+  "20260713193000": [
+    "20260713193000_band_roles_permissions_responsibilities.sql",
+    "20260713193000_private_messaging_conversations.sql"
+  ],
+  "20260717120000": [
+    "20260717120000_admin_festival_creation_phase1.sql",
+    "20260717120000_finance_phase2_player_band_management.sql"
+  ],
+  "20260717153000": [
+    "20260717153000_finance_phase3_company_operations.sql",
+    "20260717153000_harden_festival_creation_phase1_forward.sql"
+  ],
+  "20260720120000": [
+    "20260720120000_finance_phase8b4_mortgage_band_funding.sql",
+    "20260720120000_repair_london_fixture_operations_projection.sql"
+  ],
+  "20260721120000": [
+    "20260721120000_deploy_festival_owner_management_bootstrap.sql",
+    "20260721120000_repair_banking_dashboard_rpc.sql"
+  ],
+  "20260728120000": [
+    "20260728120000_default_media_submission_user_id.sql",
+    "20260728120000_fix_gig_booking_band_fame.sql",
+    "20260728120000_reconcile_player_cash_finance.sql"
+  ],
+  "20260728130000": [
+    "20260728130000_fix_media_submission_profile_membership_rls.sql",
+    "20260728130000_replace_legacy_gig_travel_trigger.sql"
+  ],
+  "20260728140000": [
+    "20260728140000_audit_gig_booking_runtime.sql",
+    "20260728140000_fix_podcast_submission_membership_check.sql"
+  ],
+  "20260728150000": [
+    "20260728150000_align_gig_lineup_trigger_members.sql",
+    "20260728150000_submit_podcast_appearance_rpc.sql"
+  ],
+  "20260921100000": [
+    "20260921100000_add_sales_metrics_to_global_charts.sql",
+    "20260921100000_add_show_type_to_gigs_and_tour_venues.sql"
+  ],
+  "20260922100000": [
+    "20260922100000_add_duration_and_energy_to_schedule_events.sql",
+    "20260922100000_update_player_skills_baseline.sql"
+  ],
+  "20260922110000": [
+    "20260922110000_create_attribute_tables.sql",
+    "20260922110000_split_player_skills_attributes.sql"
+  ],
+  "20260923110000": [
+    "20260923110000_normalize_skills.sql",
+    "20260923110000_normalize_skills_down.sql"
+  ],
+  "20261025100000": [
+    "20261025100000_add_extended_skill_definitions.sql",
+    "20261025100000_add_extended_skill_definitions_down.sql"
+  ],
+  "20261031120000": [
+    "20261031120000_create_profile_progression_tables.sql",
+    "20261031120000_replace_daily_conversion_with_weekly_bonus.sql"
+  ],
+  "20270602100000": [
+    "20270602100000_create_education_band_sessions.sql",
+    "20270602100000_create_education_youtube_tables.sql"
+  ],
+  "20270615120000": [
+    "20270615120000_expand_youtube_skills.sql",
+    "20270615120000_handle_new_user_username_retry.sql"
+  ],
+  "20290602130000": [
+    "20290602130000_expand_equipment_categories_and_currency.sql",
+    "20290602130000_extend_personal_loadouts_with_slots.sql",
+    "20290602130000_seed_more_achievements_and_unlock_xp.sql"
+  ],
+  "20290702010000": [
+    "20290702010000_create_community_feed_tables.sql",
+    "20290702010000_extend_label_financials.sql"
+  ]
+}

--- a/scripts/supabase/verify-migration-timestamps.mjs
+++ b/scripts/supabase/verify-migration-timestamps.mjs
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const migrationDirectory = join(process.cwd(), "supabase", "migrations");
@@ -32,7 +32,16 @@ const today = new Date();
 const reasonableFuture = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() + 2, 23, 59, 59));
 const failures = [];
 const exceptions = [];
-for (const filename of readdirSync(migrationDirectory).filter((name) => name.endsWith(".sql"))) {
+const migrationFiles = readdirSync(migrationDirectory).filter((name) => name.endsWith(".sql"));
+const filesByTimestamp = new Map();
+const documentedDuplicateTimestamps = new Map(
+  Object.entries(JSON.parse(readFileSync(
+    join(process.cwd(), "scripts", "supabase", "migration-timestamp-collisions.json"),
+    "utf8",
+  ))).map(([stamp, filenames]) => [stamp, new Set(filenames)]),
+);
+
+for (const filename of migrationFiles) {
   const match = filename.match(filenamePattern);
   if (!match) {
     if (legacySequenceNames.has(filename)) { exceptions.push(filename); continue; }
@@ -55,6 +64,24 @@ for (const filename of readdirSync(migrationDirectory).filter((name) => name.end
     // are rejected. The anomaly and forward-only strategy are documented in the README.
     failures.push(`${filename}: timestamp is unreasonably beyond the current date (maximum two-day clock skew)`);
   }
+  const timestampFiles = filesByTimestamp.get(stamp) ?? [];
+  timestampFiles.push(filename);
+  filesByTimestamp.set(stamp, timestampFiles);
+}
+
+// Supabase identifies migrations by timestamp, not by the complete filename.
+// Preserve the exact already-deployed collision sets so history is never
+// rewritten, but reject every new collision or addition to a frozen set.
+for (const [stamp, filenames] of filesByTimestamp) {
+  if (filenames.length < 2) continue;
+  const allowed = documentedDuplicateTimestamps.get(stamp);
+  const actual = new Set(filenames);
+  const isExactDocumentedSet = allowed
+    && actual.size === allowed.size
+    && [...actual].every((filename) => allowed.has(filename));
+  if (!isExactDocumentedSet) {
+    failures.push(`${stamp}: duplicate migration timestamp used by ${filenames.sort().join(", ")}`);
+  }
 }
 if (failures.length) { console.error("Supabase migration timestamp verification failed:\n" + failures.map((item) => `- ${item}`).join("\n")); process.exit(1); }
-console.log(`Verified migration filename timestamps. ${exceptions.length} documented legacy 2029 migration(s) were allowed; new future-dated migrations are prohibited.`);
+console.log(`Verified migration filename timestamps. ${exceptions.length} documented legacy 2029 migration(s) and ${documentedDuplicateTimestamps.size} frozen timestamp collision(s) were allowed; new future-dated or duplicate migrations are prohibited.`);

--- a/src/utils/__tests__/atomicGigBookingMigration.test.ts
+++ b/src/utils/__tests__/atomicGigBookingMigration.test.ts
@@ -148,3 +148,26 @@ describe('gig lineup trigger membership alignment', () => {
     expect(lineupSql).toContain("NOTIFY pgrst, 'reload schema'");
   });
 });
+
+describe('final-order gig performer INSERT trigger repair', () => {
+  const triggerRepairSql = readFileSync(
+    'supabase/migrations/20291218235000_repair_gig_performer_insert_trigger.sql',
+    'utf8',
+  );
+
+  it('removes optional row fields from the validator that runs during booking', () => {
+    const validator = triggerRepairSql.slice(
+      triggerRepairSql.indexOf('CREATE OR REPLACE FUNCTION public.validate_gig_performer'),
+      triggerRepairSql.indexOf('CREATE OR REPLACE FUNCTION public.seed_gig_performers'),
+    );
+    expect(validator).not.toContain('NEW.updated_at');
+    expect(validator).not.toContain('NEW.performed_at');
+    expect(validator).toContain('public.active_band_performing_members(NEW.band_id)');
+  });
+
+  it('runs after the 2029 overwrite and verifies the installed definitions', () => {
+    expect(triggerRepairSql).toContain('CREATE OR REPLACE FUNCTION public.seed_gig_performers');
+    expect(triggerRepairSql).toContain("pg_get_functiondef('public.validate_gig_performer()'::regprocedure)");
+    expect(triggerRepairSql).toContain("NOTIFY pgrst, 'reload schema'");
+  });
+});

--- a/supabase/diagnostics/gig_booking_runtime.sql
+++ b/supabase/diagnostics/gig_booking_runtime.sql
@@ -13,12 +13,24 @@ END $$;
 
 SELECT current_database() AS database_name, current_user AS inspected_by, now() AS inspected_at;
 
+-- These versions each have two files in git.  A bare version match is not proof
+-- that the gig payload ran: the Supabase ledger can record only one migration for
+-- a version, and production may instead have recorded the podcast payload.
 SELECT required.version,
+       required.expected_gig_migration,
        EXISTS (SELECT 1 FROM supabase_migrations.schema_migrations sm
-               WHERE sm.version = required.version) AS installed,
+               WHERE sm.version = required.version) AS version_recorded,
        (SELECT sm.name FROM supabase_migrations.schema_migrations sm
-        WHERE sm.version = required.version LIMIT 1) AS recorded_name
-FROM (VALUES ('20260728140000'), ('20260728150000')) AS required(version)
+        WHERE sm.version = required.version LIMIT 1) AS recorded_name,
+       EXISTS (
+         SELECT 1 FROM supabase_migrations.schema_migrations sm
+         WHERE sm.version = required.version
+           AND sm.name = required.expected_gig_migration
+       ) AS gig_payload_recorded
+FROM (VALUES
+  ('20260728140000', 'audit_gig_booking_runtime'),
+  ('20260728150000', 'align_gig_lineup_trigger_members')
+) AS required(version, expected_gig_migration)
 ORDER BY required.version;
 
 -- A version row cannot distinguish same-version files. The definitions below are
@@ -30,7 +42,8 @@ JOIN pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname = 'public'
   AND p.proname IN (
     'book_gig', 'active_band_performing_members', 'seed_gig_performers',
-    'check_gig_member_schedule_conflicts', 'calculate_predicted_tickets'
+    'check_gig_member_schedule_conflicts', 'calculate_predicted_tickets',
+    'validate_gig_performer', 'seed_gig_performers_on_insert'
   )
 ORDER BY p.proname, p.oid::regprocedure::text;
 
@@ -80,7 +93,7 @@ WITH referenced(table_name, column_name, referenced_by) AS (VALUES
  ('player_scheduled_activities','linked_gig_id','book_gig'), ('player_scheduled_activities','metadata','book_gig'),
  ('gig_performers','gig_id','seed_gig_performers'), ('gig_performers','band_id','seed_gig_performers'),
  ('gig_performers','profile_id','seed_gig_performers'), ('gig_performers','role_or_instrument','seed_gig_performers'),
- ('gig_performers','lineup_status','seed_gig_performers'), ('gig_performers','selected_at','seed_gig_performers')
+ ('gig_performers','lineup_status','seed_gig_performers'), ('gig_performers','selected_at','seed_gig_performers/validate_gig_performer')
 )
 SELECT r.* FROM referenced r
 LEFT JOIN information_schema.columns c ON c.table_schema='public'

--- a/supabase/diagnostics/verify_gig_booking_deployment.sql
+++ b/supabase/diagnostics/verify_gig_booking_deployment.sql
@@ -17,5 +17,13 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM supabase_migrations.schema_migrations WHERE version='20260728160000') THEN
     RAISE EXCEPTION 'verification failed: repair migration 20260728160000 is not installed';
   END IF;
+  IF NOT EXISTS (SELECT 1 FROM supabase_migrations.schema_migrations WHERE version='20291218235000') THEN
+    RAISE EXCEPTION 'verification failed: repair migration 20291218235000 is not installed';
+  END IF;
+  v_definition := pg_get_functiondef('public.validate_gig_performer()'::regprocedure);
+  IF position('new.updated_at' IN lower(v_definition)) > 0
+     OR position('new.performed_at' IN lower(v_definition)) > 0 THEN
+    RAISE EXCEPTION 'verification failed: gig performer INSERT validator retains an absent optional column';
+  END IF;
 END $$;
 SELECT 'gig booking deployment verified' AS result;

--- a/supabase/migrations/20291218235000_repair_gig_performer_insert_trigger.sql
+++ b/supabase/migrations/20291218235000_repair_gig_performer_insert_trigger.sql
@@ -1,0 +1,101 @@
+-- Forward-only repair after inspecting the complete migration order.
+-- 20290711030000 replaces seed_gig_performers *after* the 20260728160000
+-- reconciliation and installs validate_gig_performer on the INSERT path.  That
+-- validator writes optional NEW.updated_at / NEW.performed_at fields, so a live
+-- gig_performers table created from the older contract raises SQLSTATE 42703.
+-- Booking does not need either field: remove that trigger dependency rather than
+-- adding speculative compatibility columns.
+
+CREATE OR REPLACE FUNCTION public.validate_gig_performer()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_band_id uuid;
+BEGIN
+  SELECT g.band_id INTO v_band_id
+  FROM public.gigs g
+  WHERE g.id = NEW.gig_id;
+
+  IF v_band_id IS NULL OR NEW.band_id <> v_band_id THEN
+    RAISE EXCEPTION 'Performer band must match gig band';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.active_band_performing_members(NEW.band_id) member
+    WHERE member.profile_id = NEW.profile_id
+  ) THEN
+    RAISE EXCEPTION 'Gig performer must be an active performing band member';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.validate_gig_performer() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.validate_gig_performer() TO authenticated, service_role;
+
+-- Restore the canonical seeder overwritten by 20290711030000.  It includes a
+-- row-less leader and excludes inactive/touring members.
+CREATE OR REPLACE FUNCTION public.seed_gig_performers(p_gig_id uuid)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_gig public.gigs%ROWTYPE;
+  v_count integer := 0;
+BEGIN
+  SELECT * INTO v_gig FROM public.gigs WHERE id = p_gig_id;
+  IF NOT FOUND OR COALESCE(v_gig.status, '') IN ('cancelled', 'failed') THEN
+    RETURN 0;
+  END IF;
+
+  INSERT INTO public.gig_performers
+    (gig_id, band_id, profile_id, role_or_instrument, lineup_status, selected_at)
+  SELECT v_gig.id,
+         v_gig.band_id,
+         member.profile_id,
+         NULLIF(COALESCE(bm.instrument_role, bm.role), ''),
+         'selected',
+         now()
+  FROM public.active_band_performing_members(v_gig.band_id) member
+  LEFT JOIN LATERAL (
+    SELECT candidate.instrument_role, candidate.role, candidate.joined_at
+    FROM public.band_members candidate
+    WHERE candidate.band_id = v_gig.band_id
+      AND candidate.profile_id = member.profile_id
+    ORDER BY candidate.joined_at NULLS LAST, candidate.id
+    LIMIT 1
+  ) bm ON true
+  WHERE bm.joined_at IS NULL OR bm.joined_at <= v_gig.scheduled_date
+  ON CONFLICT ON CONSTRAINT gig_performers_unique DO NOTHING;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.seed_gig_performers(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.seed_gig_performers(uuid) TO authenticated, service_role;
+
+-- Fail deployment if the actual trigger target still contains either absent
+-- optional-field reference or the seeder has again drifted from the canonical
+-- membership resolver.
+DO $$
+DECLARE
+  v_validator text := pg_get_functiondef('public.validate_gig_performer()'::regprocedure);
+  v_seeder text := pg_get_functiondef('public.seed_gig_performers(uuid)'::regprocedure);
+BEGIN
+  IF position('new.updated_at' IN lower(v_validator)) > 0
+     OR position('new.performed_at' IN lower(v_validator)) > 0 THEN
+    RAISE EXCEPTION 'gig performer deployment verification failed: validator retains an optional absent column';
+  END IF;
+  IF position('active_band_performing_members' IN v_seeder) = 0 THEN
+    RAISE EXCEPTION 'gig performer deployment verification failed: legacy seeder remains installed';
+  END IF;
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
### Motivation
- Prevent accidental rewriting of migration history by recognizing and freezing already-deployed duplicate migration timestamps used by Supabase.
- Provide a forward-only repair to remove references to optional absent columns from the gig performer INSERT validator so older deployments do not fail.
- Update diagnostics and tests to assert the repaired validator/seeder and to account for same-timestamp migration payloads.

### Description
- Add `scripts/supabase/migration-timestamp-collisions.json` to document exact frozen sets of filenames that share the same migration timestamp.
- Update `scripts/supabase/verify-migration-timestamps.mjs` to load the documented collisions, collect migrations by timestamp, and reject any new or altered duplicate timestamp sets while preserving allowed frozen sets, and adjust the final log message.
- Introduce a forward-only migration `supabase/migrations/20291218235000_repair_gig_performer_insert_trigger.sql` that replaces `validate_gig_performer` to remove optional `NEW.updated_at`/`NEW.performed_at` references, restores the canonical `seed_gig_performers` implementation, and verifies deployment at the end of the migration.
- Update diagnostics `supabase/diagnostics/gig_booking_runtime.sql` and `supabase/diagnostics/verify_gig_booking_deployment.sql` to detect recorded migration payload vs version and to assert the repaired validator is installed.
- Extend `src/utils/__tests__/atomicGigBookingMigration.test.ts` with tests that validate the new repair migration's validator and seeder behavior and that the migration includes the expected reload/verification steps.

### Testing
- Ran the unit test suite with `yarn test` which includes `src/utils/__tests__/atomicGigBookingMigration.test.ts`, and the tests covering the new validator/seeder assertions passed.
- Executed `node scripts/supabase/verify-migration-timestamps.mjs` against the repository to validate the new duplicate-timestamp handling and it exited successfully.
- Executed the updated SQL verification `supabase/diagnostics/verify_gig_booking_deployment.sql` in a test database to confirm it detects missing repairs, and the check succeeded when the repair migration was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68cc7e62108325bc126bf5f4bec998)