### PR TITLE
Make tour booking atomic and validate every stop

### DIFF
--- a/src/components/tour/TourCreationWizard.tsx
+++ b/src/components/tour/TourCreationWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -6,11 +6,12 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Calendar, MapPin, Music, DollarSign, Bus, Plane, Waypoints } from "lucide-react";
+import { Bus, MapPin, Plane, Waypoints } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { useTourBooking, type TourBookingData } from "@/hooks/useTourBooking";
+import { useTourBooking } from "@/hooks/useTourBooking";
 import { TourBudgetCalculator } from "./TourBudgetCalculator";
+import { TicketOperatorSelector } from "@/components/gig/TicketOperatorSelector";
 
 interface TourCreationWizardProps {
   isOpen: boolean;
@@ -18,6 +19,18 @@ interface TourCreationWizardProps {
   bandId: string;
   bandName: string;
 }
+
+type SelectedVenue = {
+  venueId: string;
+  venueName: string;
+  capacity: number;
+  cityId: string;
+  cityName: string;
+  date: string;
+  timeSlot: string;
+};
+
+const today = new Date().toISOString().slice(0, 10);
 
 export const TourCreationWizard = ({ isOpen, onClose, bandId, bandName }: TourCreationWizardProps) => {
   const [step, setStep] = useState(1);
@@ -27,70 +40,85 @@ export const TourCreationWizard = ({ isOpen, onClose, bandId, bandName }: TourCr
   const [setlistId, setSetlistId] = useState("");
   const [travelMode, setTravelMode] = useState<'auto' | 'manual' | 'tour_bus'>('auto');
   const [tourBusCost, setTourBusCost] = useState(500);
-  const [selectedVenues, setSelectedVenues] = useState<Array<{
-    venueId: string;
-    venueName: string;
-    cityId: string;
-    cityName: string;
-    date: string;
-    timeSlot: string;
-  }>>([]);
-  const [budgetEstimate, setBudgetEstimate] = useState({
-    travelCosts: 0,
-    accommodationCosts: 0,
-    crewCosts: 0,
-    estimatedRevenue: 0,
-  });
+  const [ticketPrice, setTicketPrice] = useState(20);
+  const [ticketOperatorId, setTicketOperatorId] = useState<string | null>(null);
+  const [selectedVenues, setSelectedVenues] = useState<SelectedVenue[]>([]);
+  const [budgetEstimate, setBudgetEstimate] = useState({ travelCosts: 0, accommodationCosts: 0, crewCosts: 0, estimatedRevenue: 0 });
 
   const { createTour, isCreating, calculateTourCosts } = useTourBooking();
 
-  const { data: setlists } = useQuery({
+  const { data: setlists = [] } = useQuery({
     queryKey: ['setlists', bandId],
     queryFn: async () => {
-      const { data } = await supabase
-        .from('setlists')
-        .select('*')
-        .eq('band_id', bandId);
-      return data || [];
+      const { data, error } = await supabase.from('setlists').select('*').eq('band_id', bandId);
+      if (error) throw error;
+      return data ?? [];
     },
   });
 
-  const { data: venues } = useQuery({
+  const eligibleSetlists = useMemo(() => setlists.filter((setlist) => (setlist.song_count ?? 0) >= 6), [setlists]);
+
+  const { data: venues = [] } = useQuery({
     queryKey: ['venues-with-cities'],
     queryFn: async () => {
-      const { data } = await supabase
-        .from('venues')
-        .select('*, cities(id, name)')
-        .order('prestige_level');
-      return data || [];
+      const { data, error } = await supabase.from('venues').select('*, cities(id, name)').order('prestige_level');
+      if (error) throw error;
+      return data ?? [];
     },
   });
 
+  const operatorRequired = selectedVenues.some((venue) => venue.capacity >= 200);
+  const stopDatesValid = selectedVenues.every((venue) => venue.date && venue.date >= startDate && venue.date <= endDate);
+  const duplicateStops = new Set(selectedVenues.map((venue) => `${venue.venueId}:${venue.date}:${venue.timeSlot}`)).size !== selectedVenues.length;
+
   useEffect(() => {
-    // Recalculate budget when venues or travel mode changes
-    if (selectedVenues.length > 0) {
-      calculateTourCosts({
-        name: tourName,
-        artistId: bandId,
-        startDate,
-        endDate,
-        setlistId,
-        travelMode,
-        tourBusCost,
-        venues: selectedVenues.map(v => ({
-          venueId: v.venueId,
-          cityId: v.cityId,
-          date: v.date,
-          timeSlot: v.timeSlot,
-        })),
-      }).then(costs => {
-        setBudgetEstimate({
-          ...costs,
-          estimatedRevenue: selectedVenues.length * 2000, // Rough estimate
-        });
-      });
-    }
-  }, [selectedVenues, travelMode, tourBusCost, bandId, startDate, endDate, setlistId, tourName, calculateTourCosts]);
+    if (!selectedVenues.length || !startDate || !endDate) return;
+    void calculateTourCosts({
+      name: tourName,
+      artistId: bandId,
+      startDate,
+      endDate,
+      setlistId,
+      travelMode,
+      tourBusCost,
+      ticketPrice,
+      ticketOperatorId: ticketOperatorId ?? undefined,
+      venues: selectedVenues,
+    }).then((costs) => setBudgetEstimate({
+      ...costs,
+      estimatedRevenue: selectedVenues.reduce((total, venue) => total + Math.min(venue.capacity, 100) * ticketPrice, 0),
+    }));
+  }, [selectedVenues, travelMode, tourBusCost, bandId, startDate, endDate, setlistId, tourName, ticketPrice, ticketOperatorId]);
+
+  const resetAndClose = () => {
+    onClose();
+    setStep(1);
+    setTourName("");
+    setStartDate("");
+    setEndDate("");
+    setSetlistId("");
+    setSelectedVenues([]);
+    setTicketOperatorId(null);
+    setTicketPrice(20);
+  };
+
+  const addVenue = (venue: any) => {
+    if (!venue || selectedVenues.some((item) => item.venueId === venue.id)) return;
+    const city = venue.cities as { id?: string; name?: string } | null;
+    setSelectedVenues((current) => [...current, {
+      venueId: venue.id,
+      venueName: venue.name,
+      capacity: venue.capacity ?? 0,
+      cityId: city?.id ?? '',
+      cityName: city?.name ?? 'Unknown',
+      date: startDate,
+      timeSlot: 'headline',
+    }]);
+  };
+
+  const updateStop = (venueId: string, field: 'date' | 'timeSlot', value: string) => {
+    setSelectedVenues((current) => current.map((venue) => venue.venueId === venueId ? { ...venue, [field]: value } : venue));
+  };
 
   const handleSubmit = () => {
     createTour({
@@ -101,288 +129,66 @@ export const TourCreationWizard = ({ isOpen, onClose, bandId, bandName }: TourCr
       setlistId,
       travelMode,
       tourBusCost,
-      venues: selectedVenues.map(v => ({
-        venueId: v.venueId,
-        cityId: v.cityId,
-        date: v.date,
-        timeSlot: v.timeSlot,
-      })),
-    }, {
-      onSuccess: () => {
-        onClose();
-        setStep(1);
-        // Reset form
-        setTourName("");
-        setStartDate("");
-        setEndDate("");
-        setSetlistId("");
-        setSelectedVenues([]);
-      },
-    });
+      ticketPrice,
+      ticketOperatorId: ticketOperatorId ?? undefined,
+      venues: selectedVenues,
+    }, { onSuccess: resetAndClose });
   };
 
-  const addVenue = (venue: any) => {
-    if (!venue || selectedVenues.find(v => v.venueId === venue.id)) return;
-
-    const cities: any = venue.cities;
-    setSelectedVenues([...selectedVenues, {
-      venueId: venue.id,
-      venueName: venue.name,
-      cityId: cities?.id || '',
-      cityName: cities?.name || 'Unknown',
-      date: startDate,
-      timeSlot: 'headline',
-    }]);
-  };
-
-  const removeVenue = (venueId: string) => {
-    setSelectedVenues(selectedVenues.filter(v => v.venueId !== venueId));
-  };
+  const nextDisabled =
+    (step === 1 && (!tourName.trim() || !startDate || !endDate || endDate < startDate || startDate < today || !setlistId)) ||
+    (step === 2 && (!selectedVenues.length || !stopDatesValid || duplicateStops)) ||
+    (step === 4 && (isCreating || ticketPrice <= 0 || (operatorRequired && !ticketOperatorId)));
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>Create New Tour - {bandName}</DialogTitle>
-        </DialogHeader>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && resetAndClose()}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader><DialogTitle>Create New Tour - {bandName}</DialogTitle></DialogHeader>
 
         <div className="space-y-6">
-          {/* Progress Indicator */}
-          <div className="flex items-center justify-between mb-6">
-            {[1, 2, 3, 4].map((s) => (
-              <div key={s} className="flex items-center">
-                <div className={`w-8 h-8 rounded-full flex items-center justify-center font-semibold ${
-                  step >= s ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
-                }`}>
-                  {s}
-                </div>
-                {s < 4 && <div className={`w-12 h-0.5 ${step > s ? 'bg-primary' : 'bg-muted'}`} />}
-              </div>
-            ))}
+          <div className="flex items-center justify-between">
+            {[1, 2, 3, 4].map((value) => <div key={value} className={`flex h-8 w-8 items-center justify-center rounded-full font-semibold ${step >= value ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}>{value}</div>)}
           </div>
 
-          {/* Step 1: Basic Info */}
-          {step === 1 && (
-            <div className="space-y-4">
-              <div>
-                <Label>Tour Name</Label>
-                <Input
-                  value={tourName}
-                  onChange={(e) => setTourName(e.target.value)}
-                  placeholder="e.g., Summer Tour 2025"
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label>Start Date</Label>
-                  <Input
-                    type="date"
-                    value={startDate}
-                    onChange={(e) => setStartDate(e.target.value)}
-                  />
-                </div>
-                <div>
-                  <Label>End Date</Label>
-                  <Input
-                    type="date"
-                    value={endDate}
-                    onChange={(e) => setEndDate(e.target.value)}
-                  />
-                </div>
-              </div>
-              <div>
-                <Label>Setlist</Label>
-                <Select value={setlistId} onValueChange={setSetlistId}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Choose a setlist" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {setlists?.map(sl => (
-                      <SelectItem key={sl.id} value={sl.id}>
-                        {sl.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+          {step === 1 && <div className="space-y-4">
+            <div><Label>Tour Name</Label><Input value={tourName} onChange={(event) => setTourName(event.target.value)} /></div>
+            <div className="grid grid-cols-2 gap-4">
+              <div><Label>Start Date</Label><Input type="date" min={today} value={startDate} onChange={(event) => setStartDate(event.target.value)} /></div>
+              <div><Label>End Date</Label><Input type="date" min={startDate || today} value={endDate} onChange={(event) => setEndDate(event.target.value)} /></div>
             </div>
-          )}
+            <div><Label>Setlist</Label><Select value={setlistId} onValueChange={setSetlistId}><SelectTrigger><SelectValue placeholder="Choose an eligible setlist" /></SelectTrigger><SelectContent>{eligibleSetlists.map((setlist) => <SelectItem key={setlist.id} value={setlist.id}>{setlist.name}</SelectItem>)}</SelectContent></Select></div>
+            {!eligibleSetlists.length && <p className="text-sm text-destructive">Create a setlist containing at least six songs before booking a tour.</p>}
+          </div>}
 
-          {/* Step 2: Select Venues */}
-          {step === 2 && (
-            <div className="space-y-4">
-              <div>
-                <Label>Selected Venues ({selectedVenues.length})</Label>
-                <div className="space-y-2 mt-2">
-                  {selectedVenues.map((v) => (
-                    <Card key={v.venueId}>
-                      <CardContent className="flex items-center justify-between p-3">
-                        <div className="flex items-center gap-2">
-                          <MapPin className="h-4 w-4" />
-                          <div>
-                            <p className="font-semibold text-sm">{v.venueName}</p>
-                            <p className="text-xs text-muted-foreground">{v.cityName}</p>
-                          </div>
-                        </div>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => removeVenue(v.venueId)}
-                        >
-                          Remove
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </div>
-
-              <div>
-                <Label>Available Venues</Label>
-                <div className="grid grid-cols-2 gap-2 mt-2 max-h-[300px] overflow-y-auto">
-                  {venues?.map((venue) => (
-                    <Card
-                      key={venue.id}
-                      className="cursor-pointer hover:bg-accent transition-colors"
-                      onClick={() => addVenue(venue)}
-                    >
-                      <CardContent className="p-3">
-                        <p className="font-semibold text-sm">{venue.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {(venue.cities as any)?.name || 'Unknown'}
-                        </p>
-                        <Badge variant="outline" className="mt-1">
-                          {venue.capacity} capacity
-                        </Badge>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </div>
+          {step === 2 && <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Tour Stops ({selectedVenues.length})</Label>
+              {selectedVenues.map((venue) => <Card key={venue.venueId}><CardContent className="grid gap-3 p-3 md:grid-cols-[1fr_160px_150px_auto] md:items-end">
+                <div><p className="font-semibold">{venue.venueName}</p><p className="text-xs text-muted-foreground">{venue.cityName} · {venue.capacity} capacity</p></div>
+                <div><Label>Date</Label><Input type="date" min={startDate} max={endDate} value={venue.date} onChange={(event) => updateStop(venue.venueId, 'date', event.target.value)} /></div>
+                <div><Label>Slot</Label><Select value={venue.timeSlot} onValueChange={(value) => updateStop(venue.venueId, 'timeSlot', value)}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="kids">Kids</SelectItem><SelectItem value="opening">Opening</SelectItem><SelectItem value="support">Support</SelectItem><SelectItem value="headline">Headline</SelectItem></SelectContent></Select></div>
+                <Button variant="ghost" onClick={() => setSelectedVenues((current) => current.filter((item) => item.venueId !== venue.venueId))}>Remove</Button>
+              </CardContent></Card>)}
             </div>
-          )}
+            {duplicateStops && <p className="text-sm text-destructive">Duplicate venue/date/slot combinations are not allowed.</p>}
+            <div className="grid max-h-[300px] grid-cols-2 gap-2 overflow-y-auto">{venues.map((venue) => <Card key={venue.id} className="cursor-pointer hover:bg-accent" onClick={() => addVenue(venue)}><CardContent className="p-3"><p className="font-semibold">{venue.name}</p><p className="text-xs text-muted-foreground">{(venue.cities as any)?.name ?? 'Unknown'}</p><Badge variant="outline" className="mt-1">{venue.capacity} capacity</Badge></CardContent></Card>)}</div>
+          </div>}
 
-          {/* Step 3: Travel Options */}
-          {step === 3 && (
-            <div className="space-y-4">
-              <Label>Travel Mode</Label>
-              <div className="grid grid-cols-3 gap-3">
-                <Card
-                  className={`cursor-pointer transition-all ${
-                    travelMode === 'auto' ? 'border-primary bg-primary/5' : ''
-                  }`}
-                  onClick={() => setTravelMode('auto')}
-                >
-                  <CardContent className="p-4 text-center">
-                    <Plane className="h-8 w-8 mx-auto mb-2" />
-                    <p className="font-semibold">Auto-Book</p>
-                    <p className="text-xs text-muted-foreground">
-                      System finds cheapest routes
-                    </p>
-                  </CardContent>
-                </Card>
+          {step === 3 && <div className="grid grid-cols-3 gap-3">
+            {([{ id: 'auto', icon: Plane, label: 'Auto-Book' }, { id: 'tour_bus', icon: Bus, label: 'Tour Bus' }, { id: 'manual', icon: Waypoints, label: 'Manual' }] as const).map(({ id, icon: Icon, label }) => <Card key={id} className={`cursor-pointer ${travelMode === id ? 'border-primary bg-primary/5' : ''}`} onClick={() => setTravelMode(id)}><CardContent className="p-4 text-center"><Icon className="mx-auto mb-2 h-8 w-8" /><p className="font-semibold">{label}</p></CardContent></Card>)}
+            {travelMode === 'tour_bus' && <div className="col-span-3"><Label>Daily Tour Bus Cost</Label><Input type="number" min={1} value={tourBusCost} onChange={(event) => setTourBusCost(Number(event.target.value) || 500)} /></div>}
+          </div>}
 
-                <Card
-                  className={`cursor-pointer transition-all ${
-                    travelMode === 'tour_bus' ? 'border-primary bg-primary/5' : ''
-                  }`}
-                  onClick={() => setTravelMode('tour_bus')}
-                >
-                  <CardContent className="p-4 text-center">
-                    <Bus className="h-8 w-8 mx-auto mb-2" />
-                    <p className="font-semibold">Tour Bus</p>
-                    <p className="text-xs text-muted-foreground">
-                      Fixed daily cost
-                    </p>
-                  </CardContent>
-                </Card>
+          {step === 4 && <div className="space-y-4">
+            <div><Label>Ticket Price</Label><Input type="number" min={1} value={ticketPrice} onChange={(event) => setTicketPrice(Number(event.target.value) || 0)} /></div>
+            {operatorRequired && <TicketOperatorSelector venueCapacity={Math.max(...selectedVenues.map((venue) => venue.capacity))} selectedOperatorId={ticketOperatorId} onSelectOperator={setTicketOperatorId} />}
+            <TourBudgetCalculator travelCosts={budgetEstimate.travelCosts} accommodationCosts={budgetEstimate.accommodationCosts} crewCosts={budgetEstimate.crewCosts} estimatedRevenue={budgetEstimate.estimatedRevenue} numberOfGigs={selectedVenues.length} />
+            <Card><CardContent className="space-y-2 p-4 text-sm"><div className="flex justify-between"><span>Tour</span><strong>{tourName}</strong></div><div className="flex justify-between"><span>Dates</span><strong>{startDate} to {endDate}</strong></div><div className="flex justify-between"><span>Stops</span><strong>{selectedVenues.length}</strong></div></CardContent></Card>
+          </div>}
 
-                <Card
-                  className={`cursor-pointer transition-all ${
-                    travelMode === 'manual' ? 'border-primary bg-primary/5' : ''
-                  }`}
-                  onClick={() => setTravelMode('manual')}
-                >
-                  <CardContent className="p-4 text-center">
-                    <Waypoints className="h-8 w-8 mx-auto mb-2" />
-                    <p className="font-semibold">Manual</p>
-                    <p className="text-xs text-muted-foreground">
-                      Book travel yourself
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-
-              {travelMode === 'tour_bus' && (
-                <div>
-                  <Label>Daily Tour Bus Cost</Label>
-                  <Input
-                    type="number"
-                    value={tourBusCost}
-                    onChange={(e) => setTourBusCost(parseInt(e.target.value) || 500)}
-                  />
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Step 4: Budget Review */}
-          {step === 4 && (
-            <div className="space-y-4">
-              <TourBudgetCalculator
-                travelCosts={budgetEstimate.travelCosts}
-                accommodationCosts={budgetEstimate.accommodationCosts}
-                crewCosts={budgetEstimate.crewCosts}
-                estimatedRevenue={budgetEstimate.estimatedRevenue}
-                numberOfGigs={selectedVenues.length}
-              />
-
-              <Card>
-                <CardContent className="p-4">
-                  <h4 className="font-semibold mb-2">Tour Summary</h4>
-                  <div className="space-y-2 text-sm">
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Tour Name:</span>
-                      <span className="font-medium">{tourName}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Duration:</span>
-                      <span className="font-medium">
-                        {startDate} to {endDate}
-                      </span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Venues:</span>
-                      <span className="font-medium">{selectedVenues.length} stops</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-muted-foreground">Travel Mode:</span>
-                      <Badge variant="outline">{travelMode}</Badge>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-          )}
-
-          {/* Navigation Buttons */}
-          <div className="flex justify-between pt-4 border-t">
-            <Button
-              variant="outline"
-              onClick={() => step > 1 ? setStep(step - 1) : onClose()}
-            >
-              {step === 1 ? 'Cancel' : 'Back'}
-            </Button>
-            <Button
-              onClick={() => step < 4 ? setStep(step + 1) : handleSubmit()}
-              disabled={
-                (step === 1 && (!tourName || !startDate || !endDate || !setlistId)) ||
-                (step === 2 && selectedVenues.length === 0) ||
-                (step === 4 && isCreating)
-              }
-            >
-              {step === 4 ? (isCreating ? 'Creating...' : 'Create Tour') : 'Next'}
-            </Button>
+          <div className="flex justify-between border-t pt-4">
+            <Button variant="outline" onClick={() => step > 1 ? setStep(step - 1) : resetAndClose()}>{step === 1 ? 'Cancel' : 'Back'}</Button>
+            <Button onClick={() => step < 4 ? setStep(step + 1) : handleSubmit()} disabled={nextDisabled}>{step === 4 ? (isCreating ? 'Creating...' : 'Create Tour') : 'Next'}</Button>
           </div>
         </div>
       </DialogContent>

--- a/src/hooks/useTourBooking.ts
+++ b/src/hooks/useTourBooking.ts
@@ -12,6 +12,9 @@ export interface TourBookingData {
   setlistId: string;
   travelMode: 'auto' | 'manual' | 'tour_bus';
   tourBusCost?: number;
+  ticketPrice?: number;
+  ticketOperatorId?: string;
+  riderId?: string;
   venues: Array<{
     venueId: string;
     cityId: string;
@@ -20,50 +23,63 @@ export interface TourBookingData {
   }>;
 }
 
+type TourBookingError = {
+  message?: string;
+  details?: string;
+};
+
+function getTourBookingError(error: TourBookingError): string {
+  const message = error.message ?? '';
+  const errors: Record<string, string> = {
+    tour_booking_dates_invalid: 'Choose a valid future tour date range.',
+    tour_booking_stops_invalid: 'Add at least one complete tour stop.',
+    tour_booking_duplicate_stop: 'The tour contains the same venue, date and slot more than once.',
+    tour_booking_stop_outside_dates: 'Every gig must fall within the tour start and end dates.',
+    tour_booking_forbidden: 'You do not have permission to book gigs for this band.',
+    gig_booking_band_conflict: 'A band member already has another activity or gig at that time.',
+    gig_booking_venue_conflict: 'One of the venues is already booked for that time.',
+    gig_booking_venue_cooldown: 'The band has played one of these venues too recently.',
+    gig_booking_past_date: 'One of the selected gig dates is in the past.',
+    gig_booking_setlist_invalid: 'The selected setlist is not eligible or does not fit the chosen slot.',
+    gig_booking_operator_required: 'Select a ticket operator for tours using venues with 200 or more capacity.',
+    gig_booking_insufficient_funds: 'The band cannot afford the total booking fees for this tour.',
+    gig_booking_band_lockout: 'The band is currently unavailable for another booking.',
+  };
+
+  const key = Object.keys(errors).find((candidate) => message.includes(candidate));
+  return key ? errors[key] : 'The tour could not be booked. No partial tour was created; review the dates, venues and band schedule and try again.';
+}
+
 export function useTourBooking() {
   const { toast } = useToast();
   const { profileId } = useActiveProfile();
   const queryClient = useQueryClient();
 
   const calculateTourCosts = async (tourData: TourBookingData) => {
-    // Calculate travel costs between cities
-    const { data: routes } = await supabase
+    const { data: routes, error } = await supabase
       .from('city_transport_routes')
       .select('*');
 
+    if (error) throw error;
+
     let travelCosts = 0;
-    let accommodationCosts = 0;
 
     if (tourData.travelMode === 'tour_bus') {
-      const tourDays = Math.ceil(
-        (new Date(tourData.endDate).getTime() - new Date(tourData.startDate).getTime()) / (1000 * 60 * 60 * 24)
-      );
+      const milliseconds = new Date(tourData.endDate).getTime() - new Date(tourData.startDate).getTime();
+      const tourDays = Math.max(1, Math.ceil(milliseconds / (1000 * 60 * 60 * 24)) + 1);
       travelCosts = (tourData.tourBusCost || 500) * tourDays;
     } else if (tourData.travelMode === 'auto') {
-      // Calculate auto-booked travel costs
-      for (let i = 0; i < tourData.venues.length - 1; i++) {
+      for (let i = 0; i < tourData.venues.length - 1; i += 1) {
         const fromCity = tourData.venues[i].cityId;
         const toCity = tourData.venues[i + 1].cityId;
-
-        const route = routes?.find(
-          (r) => r.from_city_id === fromCity && r.to_city_id === toCity
-        );
-
-        if (route) {
-          travelCosts += route.base_cost;
-        } else {
-          // Estimate if no direct route
-          travelCosts += 200;
-        }
+        const route = routes?.find((item) => item.from_city_id === fromCity && item.to_city_id === toCity);
+        travelCosts += route?.base_cost ?? 200;
       }
     }
 
-    // Estimate accommodation (assuming stays between gigs)
-    const nightsNeeded = tourData.venues.length - 1;
-    accommodationCosts = nightsNeeded * 100; // Average $100 per night
-
-    // Crew costs (assuming 3 crew members)
-    const crewCosts = tourData.venues.length * 3 * 150; // $150 per crew per gig
+    const nightsNeeded = Math.max(0, tourData.venues.length - 1);
+    const accommodationCosts = nightsNeeded * 100;
+    const crewCosts = tourData.venues.length * 3 * 150;
 
     return {
       travelCosts,
@@ -75,93 +91,63 @@ export function useTourBooking() {
 
   const createTour = useMutation({
     mutationFn: async (tourData: TourBookingData) => {
-      const costs = await calculateTourCosts(tourData);
+      if (!profileId) throw new Error('No active profile');
+      if (!tourData.name.trim()) throw new Error('Tour name is required');
+      if (!tourData.setlistId) throw new Error('A setlist is required');
+      if (tourData.venues.length === 0) throw new Error('At least one venue is required');
 
-      if (!profileId) throw new Error("No active profile");
+      const start = new Date(`${tourData.startDate}T00:00:00`);
+      const end = new Date(`${tourData.endDate}T00:00:00`);
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end < start) {
+        throw new Error('tour_booking_dates_invalid');
+      }
 
-      // Wellness gate: a touring artist must be fit enough to hit the road.
-      await assertWellnessAllows(profileId, "travel");
-      await assertWellnessAllows(profileId, "gig");
+      await assertWellnessAllows(profileId, 'travel');
+      await assertWellnessAllows(profileId, 'gig');
 
-      // Create the tour with correct column names
-      const { data: tour, error: tourError } = await supabase
-        .from('tours')
-        .insert({
-          user_id: profileId,
-          band_id: tourData.artistId,
-          name: tourData.name,
-          start_date: tourData.startDate,
-          end_date: tourData.endDate,
-          status: 'active',
-        })
-        .select()
-        .single();
-
-      if (tourError) throw tourError;
-
-      // Create gigs for each venue
-      for (const venue of tourData.venues) {
-        const { error: gigError } = await supabase.from('gigs').insert({
-          band_id: tourData.artistId,
+      const requestId = crypto.randomUUID();
+      const { data, error } = await (supabase.rpc as any)('book_tour', {
+        p_band_id: tourData.artistId,
+        p_name: tourData.name.trim(),
+        p_start_date: tourData.startDate,
+        p_end_date: tourData.endDate,
+        p_setlist_id: tourData.setlistId,
+        p_ticket_price: tourData.ticketPrice ?? 20,
+        p_stops: tourData.venues.map((venue) => ({
           venue_id: venue.venueId,
-          scheduled_date: venue.date,
-          time_slot: venue.timeSlot,
-          setlist_id: tourData.setlistId,
-          status: 'scheduled',
-        });
+          city_id: venue.cityId,
+          date: venue.date,
+          slot: venue.timeSlot,
+        })),
+        p_request_id: requestId,
+        p_ticket_operator_id: tourData.ticketOperatorId || null,
+        p_rider_id: tourData.riderId || null,
+        p_travel_mode: tourData.travelMode,
+      });
 
-        if (gigError) throw gigError;
-      }
+      if (error) throw error;
+      const result = data as { tour?: { id: string }; gig_ids?: string[] } | null;
+      if (!result?.tour?.id) throw new Error('The booking service returned an invalid tour response.');
 
-      // Create travel legs if auto mode (using generic insert)
-      if (tourData.travelMode === 'auto') {
-        for (let i = 0; i < tourData.venues.length - 1; i++) {
-          const from = tourData.venues[i];
-          const to = tourData.venues[i + 1];
-
-          // Find cheapest route
-          const { data: routes } = await supabase
-            .from('city_transport_routes')
-            .select('*')
-            .eq('from_city_id', from.cityId)
-            .eq('to_city_id', to.cityId)
-            .order('base_cost', { ascending: true })
-            .limit(1);
-
-          const route = routes?.[0];
-
-          if (route) {
-            // Will work once migration is applied
-            try {
-              await supabase.rpc('execute_sql' as any, {
-                sql: `INSERT INTO tour_travel_legs (tour_id, from_city_id, to_city_id, travel_mode, departure_time, arrival_time, cost, booked_by_system) 
-                      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-                params: [tour.id, from.cityId, to.cityId, route.transport_type, from.date, to.date, route.base_cost, true]
-              });
-            } catch (error) {
-              // Silently fail if table doesn't exist yet
-              console.log('Tour travel legs table not yet created');
-            }
-          }
-        }
-      }
-
-      return tour;
+      return result;
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
+      const gigCount = result.gig_ids?.length ?? 0;
       toast({
-        title: "Tour Created!",
-        description: "Your tour has been successfully booked with all venues and travel.",
+        title: 'Tour created!',
+        description: `${gigCount} gig${gigCount === 1 ? '' : 's'} booked successfully.`,
       });
       queryClient.invalidateQueries({ queryKey: ['tours'] });
+      queryClient.invalidateQueries({ queryKey: ['tour-gigs'] });
       queryClient.invalidateQueries({ queryKey: ['gigs'] });
+      queryClient.invalidateQueries({ queryKey: ['scheduled-activities'] });
     },
-    onError: (error) => {
+    onError: (error: TourBookingError) => {
       console.error('Error creating tour:', error);
       toast({
-        title: "Tour Creation Failed",
-        description: "There was an error booking your tour. Please try again.",
-        variant: "destructive",
+        title: 'Tour creation failed',
+        description: getTourBookingError(error),
+        variant: 'destructive',
       });
     },
   });
@@ -178,15 +164,9 @@ export function useTourDetails(tourId: string | null) {
     queryKey: ['tour-details', tourId],
     queryFn: async () => {
       if (!tourId) return null;
-
-      const { data: tour, error } = await supabase
-        .from('tours')
-        .select('*')
-        .eq('id', tourId)
-        .single();
-
+      const { data, error } = await supabase.from('tours').select('*').eq('id', tourId).single();
       if (error) throw error;
-      return tour;
+      return data;
     },
     enabled: !!tourId,
   });

--- a/src/hooks/useTourBooking.ts
+++ b/src/hooks/useTourBooking.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "./use-toast";
@@ -15,18 +16,10 @@ export interface TourBookingData {
   ticketPrice?: number;
   ticketOperatorId?: string;
   riderId?: string;
-  venues: Array<{
-    venueId: string;
-    cityId: string;
-    date: string;
-    timeSlot: string;
-  }>;
+  venues: Array<{ venueId: string; cityId: string; date: string; timeSlot: string }>;
 }
 
-type TourBookingError = {
-  message?: string;
-  details?: string;
-};
+type TourBookingError = { message?: string; details?: string };
 
 function getTourBookingError(error: TourBookingError): string {
   const message = error.message ?? '';
@@ -45,7 +38,6 @@ function getTourBookingError(error: TourBookingError): string {
     gig_booking_insufficient_funds: 'The band cannot afford the total booking fees for this tour.',
     gig_booking_band_lockout: 'The band is currently unavailable for another booking.',
   };
-
   const key = Object.keys(errors).find((candidate) => message.includes(candidate));
   return key ? errors[key] : 'The tour could not be booked. No partial tour was created; review the dates, venues and band schedule and try again.';
 }
@@ -55,15 +47,11 @@ export function useTourBooking() {
   const { profileId } = useActiveProfile();
   const queryClient = useQueryClient();
 
-  const calculateTourCosts = async (tourData: TourBookingData) => {
-    const { data: routes, error } = await supabase
-      .from('city_transport_routes')
-      .select('*');
-
+  const calculateTourCosts = useCallback(async (tourData: TourBookingData) => {
+    const { data: routes, error } = await supabase.from('city_transport_routes').select('*');
     if (error) throw error;
 
     let travelCosts = 0;
-
     if (tourData.travelMode === 'tour_bus') {
       const milliseconds = new Date(tourData.endDate).getTime() - new Date(tourData.startDate).getTime();
       const tourDays = Math.max(1, Math.ceil(milliseconds / (1000 * 60 * 60 * 24)) + 1);
@@ -80,14 +68,8 @@ export function useTourBooking() {
     const nightsNeeded = Math.max(0, tourData.venues.length - 1);
     const accommodationCosts = nightsNeeded * 100;
     const crewCosts = tourData.venues.length * 3 * 150;
-
-    return {
-      travelCosts,
-      accommodationCosts,
-      crewCosts,
-      totalCosts: travelCosts + accommodationCosts + crewCosts,
-    };
-  };
+    return { travelCosts, accommodationCosts, crewCosts, totalCosts: travelCosts + accommodationCosts + crewCosts };
+  }, []);
 
   const createTour = useMutation({
     mutationFn: async (tourData: TourBookingData) => {
@@ -98,14 +80,11 @@ export function useTourBooking() {
 
       const start = new Date(`${tourData.startDate}T00:00:00`);
       const end = new Date(`${tourData.endDate}T00:00:00`);
-      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end < start) {
-        throw new Error('tour_booking_dates_invalid');
-      }
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end < start) throw new Error('tour_booking_dates_invalid');
 
       await assertWellnessAllows(profileId, 'travel');
       await assertWellnessAllows(profileId, 'gig');
 
-      const requestId = crypto.randomUUID();
       const { data, error } = await (supabase.rpc as any)('book_tour', {
         p_band_id: tourData.artistId,
         p_name: tourData.name.trim(),
@@ -113,13 +92,8 @@ export function useTourBooking() {
         p_end_date: tourData.endDate,
         p_setlist_id: tourData.setlistId,
         p_ticket_price: tourData.ticketPrice ?? 20,
-        p_stops: tourData.venues.map((venue) => ({
-          venue_id: venue.venueId,
-          city_id: venue.cityId,
-          date: venue.date,
-          slot: venue.timeSlot,
-        })),
-        p_request_id: requestId,
+        p_stops: tourData.venues.map((venue) => ({ venue_id: venue.venueId, city_id: venue.cityId, date: venue.date, slot: venue.timeSlot })),
+        p_request_id: crypto.randomUUID(),
         p_ticket_operator_id: tourData.ticketOperatorId || null,
         p_rider_id: tourData.riderId || null,
         p_travel_mode: tourData.travelMode,
@@ -128,15 +102,11 @@ export function useTourBooking() {
       if (error) throw error;
       const result = data as { tour?: { id: string }; gig_ids?: string[] } | null;
       if (!result?.tour?.id) throw new Error('The booking service returned an invalid tour response.');
-
       return result;
     },
     onSuccess: (result) => {
       const gigCount = result.gig_ids?.length ?? 0;
-      toast({
-        title: 'Tour created!',
-        description: `${gigCount} gig${gigCount === 1 ? '' : 's'} booked successfully.`,
-      });
+      toast({ title: 'Tour created!', description: `${gigCount} gig${gigCount === 1 ? '' : 's'} booked successfully.` });
       queryClient.invalidateQueries({ queryKey: ['tours'] });
       queryClient.invalidateQueries({ queryKey: ['tour-gigs'] });
       queryClient.invalidateQueries({ queryKey: ['gigs'] });
@@ -144,19 +114,11 @@ export function useTourBooking() {
     },
     onError: (error: TourBookingError) => {
       console.error('Error creating tour:', error);
-      toast({
-        title: 'Tour creation failed',
-        description: getTourBookingError(error),
-        variant: 'destructive',
-      });
+      toast({ title: 'Tour creation failed', description: getTourBookingError(error), variant: 'destructive' });
     },
   });
 
-  return {
-    createTour: createTour.mutate,
-    isCreating: createTour.isPending,
-    calculateTourCosts,
-  };
+  return { createTour: createTour.mutate, isCreating: createTour.isPending, calculateTourCosts };
 }
 
 export function useTourDetails(tourId: string | null) {

--- a/supabase/migrations/20260728213000_atomic_tour_booking.sql
+++ b/supabase/migrations/20260728213000_atomic_tour_booking.sql
@@ -1,0 +1,154 @@
+-- Book an entire tour transactionally through the authoritative gig booking function.
+-- Any invalid/conflicting stop rolls back the tour, gigs, schedule blocks and fees.
+CREATE OR REPLACE FUNCTION public.book_tour(
+  p_band_id uuid,
+  p_name text,
+  p_start_date date,
+  p_end_date date,
+  p_setlist_id uuid,
+  p_ticket_price integer,
+  p_stops jsonb,
+  p_request_id uuid,
+  p_ticket_operator_id text DEFAULT NULL,
+  p_rider_id uuid DEFAULT NULL,
+  p_travel_mode text DEFAULT 'manual'
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_actor public.profiles%ROWTYPE;
+  v_tour public.tours%ROWTYPE;
+  v_stop jsonb;
+  v_result jsonb;
+  v_gig_id uuid;
+  v_stop_date date;
+  v_stop_count integer;
+  v_gig_ids jsonb := '[]'::jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'tour_booking_unauthenticated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_actor FROM public.profiles WHERE user_id = auth.uid() LIMIT 1;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'tour_booking_profile_missing' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT public.can_manage_band_gigs(p_band_id, auth.uid()) THEN
+    RAISE EXCEPTION 'tour_booking_forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_request_id IS NULL THEN
+    RAISE EXCEPTION 'tour_booking_request_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF NULLIF(btrim(p_name), '') IS NULL OR char_length(btrim(p_name)) > 120 THEN
+    RAISE EXCEPTION 'tour_booking_name_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_start_date IS NULL OR p_end_date IS NULL OR p_end_date < p_start_date OR p_start_date < current_date THEN
+    RAISE EXCEPTION 'tour_booking_dates_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_travel_mode NOT IN ('auto', 'manual', 'tour_bus') THEN
+    RAISE EXCEPTION 'tour_booking_travel_mode_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_typeof(p_stops) <> 'array' OR jsonb_array_length(p_stops) = 0 THEN
+    RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT count(*) INTO v_stop_count
+  FROM jsonb_array_elements(p_stops) stop
+  WHERE NULLIF(stop->>'venue_id', '') IS NOT NULL
+    AND NULLIF(stop->>'date', '') IS NOT NULL
+    AND NULLIF(stop->>'slot', '') IS NOT NULL;
+
+  IF v_stop_count <> jsonb_array_length(p_stops) THEN
+    RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p_stops) stop
+    GROUP BY stop->>'venue_id', stop->>'date', stop->>'slot'
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'tour_booking_duplicate_stop' USING ERRCODE = '23505';
+  END IF;
+
+  -- A request id doubles as an idempotency key for the tour itself.
+  SELECT * INTO v_tour
+  FROM public.tours
+  WHERE metadata->>'booking_request_id' = p_request_id::text
+    AND band_id = p_band_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'tour', to_jsonb(v_tour),
+      'already_booked', true,
+      'gig_ids', COALESCE((SELECT jsonb_agg(id) FROM public.gigs WHERE tour_id = v_tour.id), '[]'::jsonb)
+    );
+  END IF;
+
+  INSERT INTO public.tours (user_id, band_id, name, start_date, end_date, status, metadata)
+  VALUES (
+    v_actor.id,
+    p_band_id,
+    btrim(p_name),
+    p_start_date,
+    p_end_date,
+    'active',
+    jsonb_build_object(
+      'booking_request_id', p_request_id,
+      'travel_mode', p_travel_mode,
+      'booked_atomically', true
+    )
+  )
+  RETURNING * INTO v_tour;
+
+  FOR v_stop IN SELECT value FROM jsonb_array_elements(p_stops)
+  LOOP
+    BEGIN
+      v_stop_date := (v_stop->>'date')::date;
+    EXCEPTION WHEN others THEN
+      RAISE EXCEPTION 'tour_booking_stop_date_invalid' USING ERRCODE = '22023';
+    END;
+
+    IF v_stop_date < p_start_date OR v_stop_date > p_end_date THEN
+      RAISE EXCEPTION 'tour_booking_stop_outside_dates' USING ERRCODE = '22023';
+    END IF;
+
+    v_result := public.book_gig(
+      p_band_id,
+      (v_stop->>'venue_id')::uuid,
+      p_setlist_id,
+      v_stop_date,
+      v_stop->>'slot',
+      p_ticket_price,
+      gen_random_uuid(),
+      p_rider_id,
+      p_ticket_operator_id
+    );
+
+    v_gig_id := (v_result->'gig'->>'id')::uuid;
+    IF v_gig_id IS NULL THEN
+      RAISE EXCEPTION 'tour_booking_gig_missing' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.gigs SET tour_id = v_tour.id WHERE id = v_gig_id;
+    v_gig_ids := v_gig_ids || jsonb_build_array(v_gig_id);
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'tour', to_jsonb(v_tour),
+    'already_booked', false,
+    'gig_ids', v_gig_ids
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.book_tour(uuid,text,date,date,uuid,integer,jsonb,uuid,text,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.book_tour(uuid,text,date,date,uuid,integer,jsonb,uuid,text,uuid,text) TO authenticated, service_role;

--- a/supabase/migrations/20260728213000_atomic_tour_booking.sql
+++ b/supabase/migrations/20260728213000_atomic_tour_booking.sql
@@ -1,5 +1,13 @@
 -- Book an entire tour transactionally through the authoritative gig booking function.
 -- Any invalid/conflicting stop rolls back the tour, gigs, schedule blocks and fees.
+ALTER TABLE public.tours
+  ADD COLUMN IF NOT EXISTS booking_request_id uuid,
+  ADD COLUMN IF NOT EXISTS travel_mode text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tours_booking_request_uidx
+  ON public.tours (booking_request_id)
+  WHERE booking_request_id IS NOT NULL;
+
 CREATE OR REPLACE FUNCTION public.book_tour(
   p_band_id uuid,
   p_name text,
@@ -26,127 +34,49 @@ DECLARE
   v_stop_count integer;
   v_gig_ids jsonb := '[]'::jsonb;
 BEGIN
-  IF auth.uid() IS NULL THEN
-    RAISE EXCEPTION 'tour_booking_unauthenticated' USING ERRCODE = '42501';
-  END IF;
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'tour_booking_unauthenticated' USING ERRCODE='42501'; END IF;
+  SELECT * INTO v_actor FROM public.profiles WHERE user_id=auth.uid() LIMIT 1;
+  IF NOT FOUND THEN RAISE EXCEPTION 'tour_booking_profile_missing' USING ERRCODE='P0001'; END IF;
+  IF NOT public.can_manage_band_gigs(p_band_id, auth.uid()) THEN RAISE EXCEPTION 'tour_booking_forbidden' USING ERRCODE='42501'; END IF;
+  IF p_request_id IS NULL THEN RAISE EXCEPTION 'tour_booking_request_invalid' USING ERRCODE='22023'; END IF;
+  IF NULLIF(btrim(p_name),'') IS NULL OR char_length(btrim(p_name)) > 120 THEN RAISE EXCEPTION 'tour_booking_name_invalid' USING ERRCODE='22023'; END IF;
+  IF p_start_date IS NULL OR p_end_date IS NULL OR p_end_date < p_start_date OR p_start_date < current_date THEN RAISE EXCEPTION 'tour_booking_dates_invalid' USING ERRCODE='22023'; END IF;
+  IF p_travel_mode NOT IN ('auto','manual','tour_bus') THEN RAISE EXCEPTION 'tour_booking_travel_mode_invalid' USING ERRCODE='22023'; END IF;
+  IF jsonb_typeof(p_stops) <> 'array' OR jsonb_array_length(p_stops)=0 THEN RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE='22023'; END IF;
 
-  SELECT * INTO v_actor FROM public.profiles WHERE user_id = auth.uid() LIMIT 1;
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'tour_booking_profile_missing' USING ERRCODE = 'P0001';
-  END IF;
+  SELECT count(*) INTO v_stop_count FROM jsonb_array_elements(p_stops) stop
+  WHERE NULLIF(stop->>'venue_id','') IS NOT NULL AND NULLIF(stop->>'date','') IS NOT NULL AND NULLIF(stop->>'slot','') IS NOT NULL;
+  IF v_stop_count <> jsonb_array_length(p_stops) THEN RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE='22023'; END IF;
+  IF EXISTS (SELECT 1 FROM jsonb_array_elements(p_stops) stop GROUP BY stop->>'venue_id',stop->>'date',stop->>'slot' HAVING count(*)>1)
+    THEN RAISE EXCEPTION 'tour_booking_duplicate_stop' USING ERRCODE='23505'; END IF;
 
-  IF NOT public.can_manage_band_gigs(p_band_id, auth.uid()) THEN
-    RAISE EXCEPTION 'tour_booking_forbidden' USING ERRCODE = '42501';
-  END IF;
-
-  IF p_request_id IS NULL THEN
-    RAISE EXCEPTION 'tour_booking_request_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  IF NULLIF(btrim(p_name), '') IS NULL OR char_length(btrim(p_name)) > 120 THEN
-    RAISE EXCEPTION 'tour_booking_name_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  IF p_start_date IS NULL OR p_end_date IS NULL OR p_end_date < p_start_date OR p_start_date < current_date THEN
-    RAISE EXCEPTION 'tour_booking_dates_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  IF p_travel_mode NOT IN ('auto', 'manual', 'tour_bus') THEN
-    RAISE EXCEPTION 'tour_booking_travel_mode_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  IF jsonb_typeof(p_stops) <> 'array' OR jsonb_array_length(p_stops) = 0 THEN
-    RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  SELECT count(*) INTO v_stop_count
-  FROM jsonb_array_elements(p_stops) stop
-  WHERE NULLIF(stop->>'venue_id', '') IS NOT NULL
-    AND NULLIF(stop->>'date', '') IS NOT NULL
-    AND NULLIF(stop->>'slot', '') IS NOT NULL;
-
-  IF v_stop_count <> jsonb_array_length(p_stops) THEN
-    RAISE EXCEPTION 'tour_booking_stops_invalid' USING ERRCODE = '22023';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1
-    FROM jsonb_array_elements(p_stops) stop
-    GROUP BY stop->>'venue_id', stop->>'date', stop->>'slot'
-    HAVING count(*) > 1
-  ) THEN
-    RAISE EXCEPTION 'tour_booking_duplicate_stop' USING ERRCODE = '23505';
-  END IF;
-
-  -- A request id doubles as an idempotency key for the tour itself.
-  SELECT * INTO v_tour
-  FROM public.tours
-  WHERE metadata->>'booking_request_id' = p_request_id::text
-    AND band_id = p_band_id
-  LIMIT 1;
-
+  SELECT * INTO v_tour FROM public.tours WHERE booking_request_id=p_request_id;
   IF FOUND THEN
-    RETURN jsonb_build_object(
-      'tour', to_jsonb(v_tour),
-      'already_booked', true,
-      'gig_ids', COALESCE((SELECT jsonb_agg(id) FROM public.gigs WHERE tour_id = v_tour.id), '[]'::jsonb)
-    );
+    IF v_tour.band_id <> p_band_id OR NOT public.can_manage_band_gigs(v_tour.band_id,auth.uid()) THEN
+      RAISE EXCEPTION 'tour_booking_request_conflict' USING ERRCODE='23505';
+    END IF;
+    RETURN jsonb_build_object('tour',to_jsonb(v_tour),'already_booked',true,
+      'gig_ids',COALESCE((SELECT jsonb_agg(id) FROM public.gigs WHERE tour_id=v_tour.id),'[]'::jsonb));
   END IF;
 
-  INSERT INTO public.tours (user_id, band_id, name, start_date, end_date, status, metadata)
-  VALUES (
-    v_actor.id,
-    p_band_id,
-    btrim(p_name),
-    p_start_date,
-    p_end_date,
-    'active',
-    jsonb_build_object(
-      'booking_request_id', p_request_id,
-      'travel_mode', p_travel_mode,
-      'booked_atomically', true
-    )
-  )
+  INSERT INTO public.tours (user_id,band_id,name,start_date,end_date,status,booking_request_id,travel_mode)
+  VALUES (v_actor.id,p_band_id,btrim(p_name),p_start_date,p_end_date,'active',p_request_id,p_travel_mode)
   RETURNING * INTO v_tour;
 
-  FOR v_stop IN SELECT value FROM jsonb_array_elements(p_stops)
-  LOOP
-    BEGIN
-      v_stop_date := (v_stop->>'date')::date;
-    EXCEPTION WHEN others THEN
-      RAISE EXCEPTION 'tour_booking_stop_date_invalid' USING ERRCODE = '22023';
-    END;
+  FOR v_stop IN SELECT value FROM jsonb_array_elements(p_stops) LOOP
+    BEGIN v_stop_date := (v_stop->>'date')::date;
+    EXCEPTION WHEN others THEN RAISE EXCEPTION 'tour_booking_stop_date_invalid' USING ERRCODE='22023'; END;
+    IF v_stop_date < p_start_date OR v_stop_date > p_end_date THEN RAISE EXCEPTION 'tour_booking_stop_outside_dates' USING ERRCODE='22023'; END IF;
 
-    IF v_stop_date < p_start_date OR v_stop_date > p_end_date THEN
-      RAISE EXCEPTION 'tour_booking_stop_outside_dates' USING ERRCODE = '22023';
-    END IF;
-
-    v_result := public.book_gig(
-      p_band_id,
-      (v_stop->>'venue_id')::uuid,
-      p_setlist_id,
-      v_stop_date,
-      v_stop->>'slot',
-      p_ticket_price,
-      gen_random_uuid(),
-      p_rider_id,
-      p_ticket_operator_id
-    );
-
+    v_result := public.book_gig(p_band_id,(v_stop->>'venue_id')::uuid,p_setlist_id,v_stop_date,v_stop->>'slot',
+      p_ticket_price,gen_random_uuid(),p_rider_id,p_ticket_operator_id);
     v_gig_id := (v_result->'gig'->>'id')::uuid;
-    IF v_gig_id IS NULL THEN
-      RAISE EXCEPTION 'tour_booking_gig_missing' USING ERRCODE = 'P0001';
-    END IF;
-
-    UPDATE public.gigs SET tour_id = v_tour.id WHERE id = v_gig_id;
+    IF v_gig_id IS NULL THEN RAISE EXCEPTION 'tour_booking_gig_missing' USING ERRCODE='P0001'; END IF;
+    UPDATE public.gigs SET tour_id=v_tour.id WHERE id=v_gig_id;
     v_gig_ids := v_gig_ids || jsonb_build_array(v_gig_id);
   END LOOP;
 
-  RETURN jsonb_build_object(
-    'tour', to_jsonb(v_tour),
-    'already_booked', false,
-    'gig_ids', v_gig_ids
-  );
+  RETURN jsonb_build_object('tour',to_jsonb(v_tour),'already_booked',false,'gig_ids',v_gig_ids);
 END;
 $$;
 


### PR DESCRIPTION
## What changed

- adds a transactional `book_tour` database RPC
- routes every tour stop through the existing authoritative `book_gig` function
- rolls back the entire tour when any stop, fee, venue, setlist or member schedule check fails
- adds idempotency protection for repeated tour requests
- removes direct client-side gig inserts and the silent `execute_sql` travel fallback
- adds per-stop dates and time slots to the tour wizard
- prevents past dates, invalid ranges and duplicate stops
- adds ticket pricing and mandatory ticket operator selection for larger venues
- limits selectable setlists to those with at least six songs
- improves player-facing booking failure messages
- stabilises tour cost calculation to prevent repeated render/effect loops

## Root cause

Single gigs had moved to a server-authoritative atomic booking flow, while tours still inserted the tour and each gig separately from the browser. A failure midway through the loop could leave a partial tour, and tour gigs bypassed conflict checks, cooldowns, booking fees and member schedule creation.

## Impact

Tour bookings now use the same validation and financial rules as normal gigs. Either every stop is booked successfully or nothing is created and no fees are retained.

## Validation

- reviewed the new RPC against the current `book_gig` signature and tour ownership policies
- confirmed all frontend tour creation now calls `book_tour`
- confirmed the wizard supplies venue, date, slot, ticket price and operator data required by the authoritative gig flow

## Follow-up

Travel-leg generation remains a separate concern and should be moved into its own validated server-side RPC in the next tour operations PR.