### PR TITLE
Make Tour Manager cancellation atomic

### DIFF
--- a/src/hooks/useTours.ts
+++ b/src/hooks/useTours.ts
@@ -17,7 +17,7 @@ export const useTours = (bandId?: string) => {
     queryKey: ["tour-gigs", bandId],
     queryFn: async () => {
       if (!bandId) return [];
-      
+
       const { data, error } = await supabase
         .from("gigs")
         .select(`
@@ -91,106 +91,45 @@ export const useTours = (bandId?: string) => {
 
   const cancelTourMutation = useMutation({
     mutationFn: async (tourId: string) => {
-      // Fetch tour details
-      const { data: tour, error: fetchError } = await supabase
-        .from("tours")
-        .select("*, bands!tours_band_id_fkey(band_balance)")
-        .eq("id", tourId)
-        .single();
+      const { data, error } = await (supabase.rpc as any)("cancel_tour", {
+        p_tour_id: tourId,
+      });
 
-      if (fetchError || !tour) throw new Error("Tour not found");
-
-      // Check if same-day cancellation for full refund
-      const createdAt = new Date(tour.created_at);
-      const now = new Date();
-      const isSameDay = createdAt.toDateString() === now.toDateString();
-      const refundAmount = isSameDay ? (tour.total_upfront_cost || 0) : 0;
-
-      // Delete associated gigs
-      await supabase
-        .from("gigs")
-        .delete()
-        .eq("tour_id", tourId);
-
-      // Delete associated tour venues
-      await supabase
-        .from("tour_venues")
-        .delete()
-        .eq("tour_id", tourId);
-
-      // Delete associated travel legs
-      await supabase
-        .from("tour_travel_legs")
-        .delete()
-        .eq("tour_id", tourId);
-
-      // Refund band if same-day
-      if (refundAmount > 0 && tour.band_id) {
-        const currentBalance = tour.bands?.band_balance || 0;
-        await supabase
-          .from("bands")
-          .update({ band_balance: currentBalance + refundAmount })
-          .eq("id", tour.band_id);
-      }
-
-      // Delete the tour
-      const { error: deleteError } = await supabase
-        .from("tours")
-        .delete()
-        .eq("id", tourId);
-
-      if (deleteError) throw deleteError;
-
-      return { refundAmount, isSameDay };
+      if (error) throw error;
+      return data as {
+        tour_id: string;
+        already_cancelled?: boolean;
+        same_day?: boolean;
+        refund_amount?: number;
+      };
     },
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: ["tours"] });
       queryClient.invalidateQueries({ queryKey: ["tour-gigs"] });
+      queryClient.invalidateQueries({ queryKey: ["gigs"] });
+      queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] });
       queryClient.invalidateQueries({ queryKey: ["band-for-tour"] });
+
+      const refundAmount = Number(result.refund_amount ?? 0);
       toast({
-        title: "Tour cancelled",
-        description: result.refundAmount > 0 
-          ? `Full refund of $${result.refundAmount.toLocaleString()} applied (same-day cancellation).`
-          : "Tour has been cancelled. No refund available after booking day.",
+        title: result.already_cancelled ? "Tour already cancelled" : "Tour cancelled",
+        description: refundAmount > 0
+          ? `Full refund of £${refundAmount.toLocaleString("en-GB")} applied (same-day cancellation).`
+          : "Tour has been cancelled. No refund is available after the booking day.",
       });
     },
     onError: (error: Error) => {
+      console.error("Failed to cancel tour:", error);
+      const description = error.message.includes("tour_cancel_forbidden")
+        ? "You do not have permission to cancel this tour."
+        : error.message.includes("tour_cancel_not_found")
+          ? "This tour no longer exists."
+          : "The tour could not be cancelled. No partial cancellation or refund was applied.";
+
       toast({
         title: "Failed to cancel tour",
-        description: error.message,
+        description,
         variant: "destructive",
-      });
-    },
-  });
-
-  const addGigToTour = useMutation({
-    mutationFn: async (params: {
-      tourId: string;
-      venueId: string;
-      bandId: string;
-      scheduledDate: string;
-      setlistId?: string;
-    }) => {
-      const { data, error } = await supabase
-        .from("gigs")
-        .insert({
-          band_id: params.bandId,
-          venue_id: params.venueId,
-          scheduled_date: params.scheduledDate,
-          setlist_id: params.setlistId,
-          status: "scheduled",
-        })
-        .select()
-        .single();
-
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tour-gigs"] });
-      toast({
-        title: "Gig added",
-        description: "Gig has been added to the tour.",
       });
     },
   });
@@ -205,6 +144,5 @@ export const useTours = (bandId?: string) => {
     updateTour: updateTourMutation,
     deleteTour: deleteTourMutation,
     cancelTour: cancelTourMutation,
-    addGigToTour,
   };
 };

--- a/supabase/migrations/20260728211500_authoritative_tour_manager_actions.sql
+++ b/supabase/migrations/20260728211500_authoritative_tour_manager_actions.sql
@@ -1,0 +1,64 @@
+-- Make Tour Manager cancellation authoritative and atomic.
+CREATE OR REPLACE FUNCTION public.cancel_tour(
+  p_tour_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_tour public.tours%ROWTYPE;
+  v_refund numeric := 0;
+  v_same_day boolean := false;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'tour_cancel_unauthenticated' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_tour
+  FROM public.tours
+  WHERE id = p_tour_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'tour_cancel_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.can_manage_band_gigs(v_tour.band_id, auth.uid())
+     AND NOT public.is_caller_identity(v_tour.user_id) THEN
+    RAISE EXCEPTION 'tour_cancel_forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_tour.status = 'cancelled' THEN
+    RETURN jsonb_build_object('tour_id', v_tour.id, 'already_cancelled', true, 'refund_amount', 0);
+  END IF;
+
+  v_same_day := (v_tour.created_at AT TIME ZONE 'UTC')::date = (now() AT TIME ZONE 'UTC')::date;
+  v_refund := CASE WHEN v_same_day THEN COALESCE(v_tour.total_upfront_cost, 0) ELSE 0 END;
+
+  UPDATE public.tours
+  SET status = 'cancelled'
+  WHERE id = v_tour.id;
+
+  UPDATE public.gigs
+  SET status = 'cancelled'
+  WHERE tour_id = v_tour.id
+    AND status NOT IN ('completed', 'cancelled');
+
+  IF v_refund > 0 THEN
+    UPDATE public.bands
+    SET band_balance = COALESCE(band_balance, 0) + v_refund
+    WHERE id = v_tour.band_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'tour_id', v_tour.id,
+    'already_cancelled', false,
+    'same_day', v_same_day,
+    'refund_amount', v_refund
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.cancel_tour(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.cancel_tour(uuid) TO authenticated, service_role;


### PR DESCRIPTION
## What changed

- adds an authoritative `cancel_tour` database RPC
- locks the tour row before cancellation to prevent duplicate refunds
- validates that the caller can manage the band
- marks the tour and unfinished tour gigs as cancelled in one transaction
- relies on the existing cancellation trigger to cancel travel legs and scheduled travel
- applies same-day refunds with an atomic band-balance increment
- makes repeated cancellation requests idempotent
- replaces the Tour Manager's multi-step browser deletes and balance read/write sequence
- removes the unused direct `addGigToTour` insertion path, which bypassed normal gig validation
- refreshes tours, gigs, schedules and band finance queries after cancellation
- changes the cancellation refund display to the project's en-GB currency format

## Root cause

Tour Manager performed cancellation as several independent client-side operations. Any failed request could leave gigs, travel legs, activities or refunds in an inconsistent state. The refund also used a stale read-modify-write balance update that could lose concurrent transactions.

## Impact

Cancellation is now all-or-nothing. Players cannot receive duplicate refunds, partially cancel tours, or use the old helper to insert an unvalidated tour gig.

## Dependency

This is a stacked PR based on `fix/gig-tour-booking-review` / PR #1376 because it builds on the new authoritative tour-booking migration.

## Validation

- confirmed the cancellation function uses the existing `can_manage_band_gigs` and `is_caller_identity` ownership rules
- confirmed the existing tour cancellation trigger handles travel legs and travel activities
- confirmed the frontend no longer deletes gigs, venues, legs and tours separately
