### PR TITLE
Remove legacy direct tour lifecycle writes

### DIFF
--- a/src/hooks/useTours.ts
+++ b/src/hooks/useTours.ts
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "./use-toast";
-import { listTours, createTour, updateTour, deleteTour } from "@/lib/api/tours";
-import type { CreateTourInput, UpdateTourInput } from "@/lib/api/tours";
+import { listTours, updateTour } from "@/lib/api/tours";
+import type { UpdateTourInput } from "@/lib/api/tours";
 
 export const useTours = (bandId?: string) => {
   const { toast } = useToast();
@@ -48,24 +48,6 @@ export const useTours = (bandId?: string) => {
     },
   });
 
-  const createTourMutation = useMutation({
-    mutationFn: (input: CreateTourInput) => createTour(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tours"] });
-      toast({
-        title: "Tour created",
-        description: "Your tour has been created successfully!",
-      });
-    },
-    onError: (error: Error) => {
-      toast({
-        title: "Failed to create tour",
-        description: error.message,
-        variant: "destructive",
-      });
-    },
-  });
-
   const updateTourMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateTourInput }) =>
       updateTour(id, input),
@@ -76,15 +58,19 @@ export const useTours = (bandId?: string) => {
         description: "Tour details have been updated.",
       });
     },
-  });
+    onError: (error: Error) => {
+      const description = error.message.includes("tour_update_forbidden")
+        ? "You do not have permission to update this tour."
+        : error.message.includes("tour_update_status_locked")
+          ? "Completed and cancelled tours cannot be edited."
+          : error.message.includes("tour_update_name_invalid")
+            ? "Enter a tour name between 1 and 120 characters."
+            : "The tour could not be updated.";
 
-  const deleteTourMutation = useMutation({
-    mutationFn: (id: string) => deleteTour(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tours"] });
       toast({
-        title: "Tour deleted",
-        description: "The tour has been removed.",
+        title: "Failed to update tour",
+        description,
+        variant: "destructive",
       });
     },
   });
@@ -140,9 +126,7 @@ export const useTours = (bandId?: string) => {
     venues,
     toursLoading,
     gigsLoading,
-    createTour: createTourMutation,
     updateTour: updateTourMutation,
-    deleteTour: deleteTourMutation,
     cancelTour: cancelTourMutation,
   };
 };

--- a/src/lib/api/__tests__/tours.database.test.ts
+++ b/src/lib/api/__tests__/tours.database.test.ts
@@ -4,9 +4,10 @@ vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
 vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
 
 const { supabase } = await import("@/integrations/supabase/client");
-const { createTour, deleteTour, getTour, listTours, updateTour } = await import("@/lib/api/tours");
+const { getTour, listTours, updateTour } = await import("@/lib/api/tours");
 
 const fromMock = vi.fn();
+const rpcMock = vi.fn();
 let query: any;
 let result: any;
 
@@ -16,18 +17,17 @@ beforeEach(() => {
     select: vi.fn(() => query),
     order: vi.fn(() => query),
     eq: vi.fn(() => query),
-    insert: vi.fn(() => query),
-    update: vi.fn(() => query),
-    delete: vi.fn(() => query),
     single: vi.fn(async () => result),
     then: (resolve: any) => Promise.resolve(resolve(result)),
   };
   fromMock.mockReturnValue(query);
+  rpcMock.mockResolvedValue({ data: { id: "tour-2", name: "Beta Run Deluxe" }, error: null });
   (supabase as any).from = fromMock;
+  (supabase as any).rpc = rpcMock;
   vi.clearAllMocks();
 });
 
-describe("database service smoke tests", () => {
+describe("tour database service", () => {
   it("lists tours ordered by start date and filters by band", async () => {
     result.data = [{ id: "tour-1", band_id: "band-1" }];
 
@@ -44,20 +44,22 @@ describe("database service smoke tests", () => {
     await expect(getTour("missing-tour")).resolves.toBeNull();
   });
 
-  it("creates and updates tours with camelCase API inputs converted to database columns", async () => {
-    query.single.mockResolvedValueOnce({ data: { id: "tour-2" }, error: null });
-    await createTour({ name: "Beta Run", bandId: "band-2", userId: "user-2", startDate: "2026-08-01", endDate: "2026-08-10" } as any);
-    expect(query.insert).toHaveBeenCalledWith([{ name: "Beta Run", band_id: "band-2", user_id: "user-2", start_date: "2026-08-01", end_date: "2026-08-10" }]);
+  it("updates safe metadata through the authoritative RPC", async () => {
+    await expect(updateTour("tour-2", { name: "Beta Run Deluxe" } as any)).resolves.toMatchObject({
+      id: "tour-2",
+      name: "Beta Run Deluxe",
+    });
 
-    query.single.mockResolvedValueOnce({ data: { id: "tour-2", name: "Beta Run Deluxe" }, error: null });
-    await updateTour("tour-2", { name: "Beta Run Deluxe", bandId: "band-3" } as any);
-    expect(query.update).toHaveBeenCalledWith({ name: "Beta Run Deluxe", band_id: "band-3" });
-    expect(query.eq).toHaveBeenCalledWith("id", "tour-2");
+    expect(rpcMock).toHaveBeenCalledWith("update_tour_metadata", {
+      p_tour_id: "tour-2",
+      p_name: "Beta Run Deluxe",
+    });
+    expect(fromMock).not.toHaveBeenCalledWith("tours");
   });
 
-  it("deletes a tour by id", async () => {
-    await expect(deleteTour("tour-3")).resolves.toBeUndefined();
-    expect(query.delete).toHaveBeenCalled();
-    expect(query.eq).toHaveBeenCalledWith("id", "tour-3");
+  it("propagates authoritative update failures", async () => {
+    rpcMock.mockResolvedValueOnce({ data: null, error: new Error("tour_update_forbidden") });
+
+    await expect(updateTour("tour-2", { name: "Blocked" } as any)).rejects.toThrow("tour_update_forbidden");
   });
 });

--- a/src/lib/api/tours.ts
+++ b/src/lib/api/tours.ts
@@ -3,46 +3,9 @@ import type { Tables } from "@/lib/supabase-types";
 
 export type TourRecord = Tables<"tours">;
 
-export interface CreateTourInput {
-  name: TourRecord["name"];
-  bandId: TourRecord["band_id"];
-  startDate: TourRecord["start_date"];
-  endDate: TourRecord["end_date"];
-  userId: TourRecord["user_id"];
-}
-
 export interface UpdateTourInput {
-  name?: TourRecord["name"];
-  bandId?: TourRecord["band_id"];
-  startDate?: TourRecord["start_date"];
-  endDate?: TourRecord["end_date"];
+  name: TourRecord["name"];
 }
-
-const toDbPayload = (input: Partial<CreateTourInput & UpdateTourInput>): Record<string, any> => {
-  const payload: Record<string, any> = {};
-
-  if (input.name !== undefined) {
-    payload.name = input.name;
-  }
-
-  if (input.bandId !== undefined) {
-    payload.band_id = input.bandId;
-  }
-
-  if ((input as CreateTourInput).userId !== undefined) {
-    payload.user_id = (input as CreateTourInput).userId;
-  }
-
-  if (input.startDate !== undefined) {
-    payload.start_date = input.startDate;
-  }
-
-  if (input.endDate !== undefined) {
-    payload.end_date = input.endDate;
-  }
-
-  return payload;
-};
 
 export const listTours = async (bandId?: string): Promise<TourRecord[]> => {
   let query = supabase.from("tours").select("*").order("start_date", { ascending: true });
@@ -74,34 +37,14 @@ export const getTour = async (id: string): Promise<TourRecord | null> => {
   return data ?? null;
 };
 
-export const createTour = async (input: CreateTourInput): Promise<TourRecord> => {
-  const payload = toDbPayload(input);
-
-  const { data, error } = await (supabase as any)
-    .from("tours")
-    .insert([payload])
-    .select()
-    .single();
-
-  if (error) {
-    throw error;
-  }
-
-  return data as TourRecord;
-};
-
 export const updateTour = async (
   id: string,
   input: UpdateTourInput
 ): Promise<TourRecord> => {
-  const payload = toDbPayload(input);
-
-  const { data, error } = await supabase
-    .from("tours")
-    .update(payload as never)
-    .eq("id", id)
-    .select()
-    .single();
+  const { data, error } = await (supabase.rpc as any)("update_tour_metadata", {
+    p_tour_id: id,
+    p_name: input.name,
+  });
 
   if (error) {
     throw error;
@@ -112,12 +55,4 @@ export const updateTour = async (
   }
 
   return data as TourRecord;
-};
-
-export const deleteTour = async (id: string): Promise<void> => {
-  const { error } = await supabase.from("tours").delete().eq("id", id);
-
-  if (error) {
-    throw error;
-  }
 };

--- a/supabase/migrations/20260728223000_authoritative_tour_metadata.sql
+++ b/supabase/migrations/20260728223000_authoritative_tour_metadata.sql
@@ -1,0 +1,58 @@
+-- Keep non-scheduling tour edits behind the same permission boundary as booking and cancellation.
+-- Date, band and lifecycle changes are deliberately excluded: those require dedicated transactional flows.
+CREATE OR REPLACE FUNCTION public.update_tour_metadata(
+  p_tour_id uuid,
+  p_name text
+) RETURNS public.tours
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_tour public.tours%ROWTYPE;
+  v_name text := btrim(p_name);
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'tour_update_unauthenticated' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_tour_id IS NULL THEN
+    RAISE EXCEPTION 'tour_update_id_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF NULLIF(v_name, '') IS NULL OR char_length(v_name) > 120 THEN
+    RAISE EXCEPTION 'tour_update_name_invalid' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+    INTO v_tour
+    FROM public.tours
+   WHERE id = p_tour_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'tour_update_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT public.can_manage_band_gigs(v_tour.band_id, auth.uid()) THEN
+    RAISE EXCEPTION 'tour_update_forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_tour.status IN ('cancelled', 'completed') THEN
+    RAISE EXCEPTION 'tour_update_status_locked' USING ERRCODE = '55000';
+  END IF;
+
+  IF v_tour.name IS DISTINCT FROM v_name THEN
+    UPDATE public.tours
+       SET name = v_name,
+           updated_at = now()
+     WHERE id = p_tour_id
+     RETURNING * INTO v_tour;
+  END IF;
+
+  RETURN v_tour;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_tour_metadata(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.update_tour_metadata(uuid, text) TO authenticated, service_role;


### PR DESCRIPTION
## What changed

- adds an authoritative `update_tour_metadata` RPC for safe, non-scheduling tour edits
- validates authentication, tour existence, tour state and band-management permission
- locks the tour row while applying metadata changes
- limits generic edits to the tour name only
- rejects edits to cancelled or completed tours
- removes legacy direct tour creation and deletion helpers from the shared API
- removes the corresponding direct mutations from `useTours`
- routes tour renaming through the RPC
- updates the tour database smoke tests to assert the RPC boundary

## Root cause

Although booking and cancellation had been moved behind transactional RPCs, the generic tour API still exposed direct inserts, updates and deletes. That left an alternative path capable of bypassing booking validation, refunds, travel-leg generation and lifecycle rules.

## Impact

The shared tour hook can no longer create or delete tours directly. Creation remains owned by `book_tour`, cancellation remains owned by `cancel_tour`, and safe metadata edits now use a permission-checked server function.

Date and route changes are deliberately not supported by this generic update. They require a dedicated rescheduling transaction that can validate gigs, activities and travel legs together.

## Dependency

This is stacked on PR #1378. Merge order:

1. PR #1376 — atomic tour booking
2. PR #1377 — atomic Tour Manager cancellation
3. PR #1378 — authoritative travel-leg generation
4. this PR — remove legacy lifecycle writes

## Validation

- compared against `fix/authoritative-tour-travel-legs`
- confirmed the branch changes four files only
- updated the API tests to verify `update_tour_metadata` is called and direct table writes are not
- searched the repository for remaining `deleteTour` consumers; only the removed API, hook and old test referenced it

Runtime test execution and Supabase migration validation were not available through the GitHub connector, so this remains a draft pending CI.