### PR TITLE
Reschedule tours atomically

### DIFF
--- a/src/hooks/useTours.ts
+++ b/src/hooks/useTours.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "./use-toast";
-import { listTours, updateTour } from "@/lib/api/tours";
+import { listTours, rescheduleTour, updateTour } from "@/lib/api/tours";
 import type { UpdateTourInput } from "@/lib/api/tours";
 
 export const useTours = (bandId?: string) => {
@@ -48,6 +48,17 @@ export const useTours = (bandId?: string) => {
     },
   });
 
+  const invalidateTourSchedule = () => {
+    queryClient.invalidateQueries({ queryKey: ["tours"] });
+    queryClient.invalidateQueries({ queryKey: ["tour-gigs"] });
+    queryClient.invalidateQueries({ queryKey: ["gigs"] });
+    queryClient.invalidateQueries({ queryKey: ["tour-venues"] });
+    queryClient.invalidateQueries({ queryKey: ["tour-travel-legs"] });
+    queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] });
+    queryClient.invalidateQueries({ queryKey: ["travel-status"] });
+    queryClient.invalidateQueries({ queryKey: ["travel-plans"] });
+  };
+
   const updateTourMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateTourInput }) =>
       updateTour(id, input),
@@ -75,6 +86,39 @@ export const useTours = (bandId?: string) => {
     },
   });
 
+  const rescheduleTourMutation = useMutation({
+    mutationFn: ({ id, newStartDate, requestId }: { id: string; newStartDate: string; requestId?: string }) =>
+      rescheduleTour(id, newStartDate, requestId),
+    onSuccess: (result) => {
+      invalidateTourSchedule();
+      toast({
+        title: result.already_rescheduled ? "Tour already rescheduled" : "Tour rescheduled",
+        description: result.already_rescheduled
+          ? "This rescheduling request had already been applied."
+          : `${result.gigs_moved ?? 0} gigs and ${result.travel_legs_moved ?? 0} travel legs were moved together.`,
+      });
+    },
+    onError: (error: Error) => {
+      const description = error.message.includes("tour_reschedule_forbidden")
+        ? "You do not have permission to reschedule this tour."
+        : error.message.includes("tour_reschedule_state_invalid") || error.message.includes("tour_reschedule_started")
+          ? "Only tours that have not started can be rescheduled."
+          : error.message.includes("tour_reschedule_past_date")
+            ? "The new tour start date cannot be in the past."
+            : error.message.includes("tour_reschedule_band_conflict")
+              ? "The band already has another booking during the proposed dates."
+              : error.message.includes("tour_reschedule_venue_conflict")
+                ? "A venue is unavailable during the proposed dates."
+                : "The tour could not be rescheduled. No dates were changed.";
+
+      toast({
+        title: "Failed to reschedule tour",
+        description,
+        variant: "destructive",
+      });
+    },
+  });
+
   const cancelTourMutation = useMutation({
     mutationFn: async (tourId: string) => {
       const { data, error } = await (supabase.rpc as any)("cancel_tour", {
@@ -90,10 +134,7 @@ export const useTours = (bandId?: string) => {
       };
     },
     onSuccess: (result) => {
-      queryClient.invalidateQueries({ queryKey: ["tours"] });
-      queryClient.invalidateQueries({ queryKey: ["tour-gigs"] });
-      queryClient.invalidateQueries({ queryKey: ["gigs"] });
-      queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] });
+      invalidateTourSchedule();
       queryClient.invalidateQueries({ queryKey: ["band-for-tour"] });
 
       const refundAmount = Number(result.refund_amount ?? 0);
@@ -127,6 +168,7 @@ export const useTours = (bandId?: string) => {
     toursLoading,
     gigsLoading,
     updateTour: updateTourMutation,
+    rescheduleTour: rescheduleTourMutation,
     cancelTour: cancelTourMutation,
   };
 };

--- a/src/lib/api/__tests__/tours.database.test.ts
+++ b/src/lib/api/__tests__/tours.database.test.ts
@@ -4,7 +4,7 @@ vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
 vi.stubEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "test-key");
 
 const { supabase } = await import("@/integrations/supabase/client");
-const { getTour, listTours, updateTour } = await import("@/lib/api/tours");
+const { getTour, listTours, rescheduleTour, updateTour } = await import("@/lib/api/tours");
 
 const fromMock = vi.fn();
 const rpcMock = vi.fn();
@@ -53,6 +53,30 @@ describe("tour database service", () => {
     expect(rpcMock).toHaveBeenCalledWith("update_tour_metadata", {
       p_tour_id: "tour-2",
       p_name: "Beta Run Deluxe",
+    });
+    expect(fromMock).not.toHaveBeenCalledWith("tours");
+  });
+
+  it("reschedules the complete tour through one idempotent RPC", async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: {
+        tour: { id: "tour-2", start_date: "2026-09-01" },
+        already_rescheduled: false,
+        gigs_moved: 4,
+        travel_legs_moved: 3,
+      },
+      error: null,
+    });
+
+    await expect(rescheduleTour("tour-2", "2026-09-01", "request-1")).resolves.toMatchObject({
+      gigs_moved: 4,
+      travel_legs_moved: 3,
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith("reschedule_tour", {
+      p_tour_id: "tour-2",
+      p_new_start_date: "2026-09-01",
+      p_request_id: "request-1",
     });
     expect(fromMock).not.toHaveBeenCalledWith("tours");
   });

--- a/src/lib/api/tours.ts
+++ b/src/lib/api/tours.ts
@@ -7,6 +7,14 @@ export interface UpdateTourInput {
   name: TourRecord["name"];
 }
 
+export interface RescheduleTourResult {
+  tour: TourRecord;
+  already_rescheduled?: boolean;
+  shift_days?: number;
+  gigs_moved?: number;
+  travel_legs_moved?: number;
+}
+
 export const listTours = async (bandId?: string): Promise<TourRecord[]> => {
   let query = supabase.from("tours").select("*").order("start_date", { ascending: true });
 
@@ -55,4 +63,26 @@ export const updateTour = async (
   }
 
   return data as TourRecord;
+};
+
+export const rescheduleTour = async (
+  id: string,
+  newStartDate: string,
+  requestId: string = crypto.randomUUID()
+): Promise<RescheduleTourResult> => {
+  const { data, error } = await (supabase.rpc as any)("reschedule_tour", {
+    p_tour_id: id,
+    p_new_start_date: newStartDate,
+    p_request_id: requestId,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data?.tour) {
+    throw new Error("Unable to locate tour for rescheduling");
+  }
+
+  return data as RescheduleTourResult;
 };

--- a/supabase/migrations/20260728230000_authoritative_tour_rescheduling.sql
+++ b/supabase/migrations/20260728230000_authoritative_tour_rescheduling.sql
@@ -1,0 +1,185 @@
+-- Reschedule an entire future tour as one atomic operation.
+-- Gigs, tour venues, travel legs and linked player schedules move together.
+
+ALTER TABLE public.tours
+  ADD COLUMN IF NOT EXISTS last_reschedule_request_id uuid;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tours_last_reschedule_request_uidx
+  ON public.tours(last_reschedule_request_id)
+  WHERE last_reschedule_request_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.reschedule_tour(
+  p_tour_id uuid,
+  p_new_start_date date,
+  p_request_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_tour public.tours%ROWTYPE;
+  v_shift interval;
+  v_new_end_date date;
+  v_gig_count integer;
+  v_leg_count integer;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'tour_reschedule_unauthenticated' USING ERRCODE='42501';
+  END IF;
+  IF p_request_id IS NULL OR p_new_start_date IS NULL THEN
+    RAISE EXCEPTION 'tour_reschedule_request_invalid' USING ERRCODE='22023';
+  END IF;
+
+  SELECT * INTO v_tour
+  FROM public.tours
+  WHERE id = p_tour_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'tour_reschedule_not_found' USING ERRCODE='P0001';
+  END IF;
+  IF NOT public.can_manage_band_gigs(v_tour.band_id, auth.uid()) THEN
+    RAISE EXCEPTION 'tour_reschedule_forbidden' USING ERRCODE='42501';
+  END IF;
+  IF v_tour.last_reschedule_request_id = p_request_id THEN
+    RETURN jsonb_build_object(
+      'tour', to_jsonb(v_tour),
+      'already_rescheduled', true,
+      'shift_days', 0
+    );
+  END IF;
+  IF v_tour.last_reschedule_request_id IS NOT NULL
+     AND EXISTS (SELECT 1 FROM public.tours WHERE last_reschedule_request_id = p_request_id AND id <> p_tour_id) THEN
+    RAISE EXCEPTION 'tour_reschedule_request_conflict' USING ERRCODE='23505';
+  END IF;
+  IF COALESCE(v_tour.cancelled, false) OR v_tour.status IN ('cancelled','completed') THEN
+    RAISE EXCEPTION 'tour_reschedule_state_invalid' USING ERRCODE='22023';
+  END IF;
+  IF p_new_start_date < current_date THEN
+    RAISE EXCEPTION 'tour_reschedule_past_date' USING ERRCODE='22023';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.gigs
+    WHERE tour_id = p_tour_id
+      AND status NOT IN ('scheduled','cancelled')
+  ) THEN
+    RAISE EXCEPTION 'tour_reschedule_started' USING ERRCODE='22023';
+  END IF;
+
+  v_shift := (p_new_start_date - v_tour.start_date) * interval '1 day';
+  v_new_end_date := v_tour.end_date + (p_new_start_date - v_tour.start_date);
+
+  IF v_shift = interval '0 days' THEN
+    UPDATE public.tours
+    SET last_reschedule_request_id = p_request_id,
+        rescheduled_at = now(),
+        reschedule_count = COALESCE(reschedule_count, 0) + 1,
+        original_start_date = COALESCE(original_start_date, start_date),
+        original_end_date = COALESCE(original_end_date, end_date)
+    WHERE id = p_tour_id
+    RETURNING * INTO v_tour;
+
+    RETURN jsonb_build_object('tour',to_jsonb(v_tour),'already_rescheduled',false,'shift_days',0);
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('tour-reschedule:' || p_tour_id::text, 0));
+  PERFORM pg_advisory_xact_lock(hashtextextended('gig-band:' || v_tour.band_id::text, 0));
+
+  -- Reject band or venue clashes before changing any row.
+  IF EXISTS (
+    SELECT 1
+    FROM public.gigs moved
+    JOIN public.gigs other
+      ON other.id <> moved.id
+     AND other.tour_id IS DISTINCT FROM p_tour_id
+     AND other.status IN ('scheduled','in_progress','ready_for_completion')
+     AND other.band_id = moved.band_id
+     AND (moved.scheduled_date + v_shift) < COALESCE(other.scheduled_end, other.scheduled_date + interval '3 hours')
+     AND (COALESCE(moved.scheduled_end, moved.scheduled_date + interval '3 hours') + v_shift) > other.scheduled_date
+    WHERE moved.tour_id = p_tour_id AND moved.status = 'scheduled'
+  ) THEN
+    RAISE EXCEPTION 'tour_reschedule_band_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.gigs moved
+    JOIN public.gigs other
+      ON other.id <> moved.id
+     AND other.tour_id IS DISTINCT FROM p_tour_id
+     AND other.status IN ('scheduled','in_progress','ready_for_completion')
+     AND other.venue_id = moved.venue_id
+     AND (moved.scheduled_date + v_shift) < COALESCE(other.scheduled_end, other.scheduled_date + interval '3 hours')
+     AND (COALESCE(moved.scheduled_end, moved.scheduled_date + interval '3 hours') + v_shift) > other.scheduled_date
+    WHERE moved.tour_id = p_tour_id AND moved.status = 'scheduled'
+  ) THEN
+    RAISE EXCEPTION 'tour_reschedule_venue_conflict' USING ERRCODE='23P01';
+  END IF;
+
+  UPDATE public.gigs
+  SET scheduled_date = scheduled_date + v_shift,
+      scheduled_end = CASE WHEN scheduled_end IS NULL THEN NULL ELSE scheduled_end + v_shift END
+  WHERE tour_id = p_tour_id AND status = 'scheduled';
+  GET DIAGNOSTICS v_gig_count = ROW_COUNT;
+
+  UPDATE public.tour_venues
+  SET date = date + (p_new_start_date - v_tour.start_date)
+  WHERE tour_id = p_tour_id AND status NOT IN ('completed','cancelled');
+
+  UPDATE public.player_scheduled_activities psa
+  SET scheduled_start = psa.scheduled_start + v_shift,
+      scheduled_end = psa.scheduled_end + v_shift
+  WHERE psa.linked_gig_id IN (
+    SELECT id FROM public.gigs WHERE tour_id = p_tour_id
+  ) AND psa.status = 'scheduled';
+
+  UPDATE public.tour_travel_legs
+  SET departure_date = departure_date + v_shift,
+      arrival_date = arrival_date + v_shift
+  WHERE tour_id = p_tour_id AND status = 'scheduled';
+  GET DIAGNOSTICS v_leg_count = ROW_COUNT;
+
+  UPDATE public.player_travel_history pth
+  SET departure_time = departure_time + v_shift,
+      scheduled_departure_time = CASE WHEN scheduled_departure_time IS NULL THEN NULL ELSE scheduled_departure_time + v_shift END,
+      arrival_time = arrival_time + v_shift
+  WHERE pth.tour_leg_id IN (
+    SELECT id FROM public.tour_travel_legs WHERE tour_id = p_tour_id
+  ) AND pth.status = 'scheduled';
+
+  UPDATE public.player_scheduled_activities psa
+  SET scheduled_start = psa.scheduled_start + v_shift,
+      scheduled_end = psa.scheduled_end + v_shift
+  WHERE psa.status = 'scheduled'
+    AND (
+      psa.metadata->>'tour_id' = p_tour_id::text
+      OR psa.metadata->>'tourId' = p_tour_id::text
+      OR psa.metadata->>'tour_leg_id' IN (
+        SELECT id::text FROM public.tour_travel_legs WHERE tour_id = p_tour_id
+      )
+    )
+    AND psa.linked_gig_id IS NULL;
+
+  UPDATE public.tours
+  SET start_date = p_new_start_date,
+      end_date = v_new_end_date,
+      original_start_date = COALESCE(original_start_date, v_tour.start_date),
+      original_end_date = COALESCE(original_end_date, v_tour.end_date),
+      rescheduled_at = now(),
+      reschedule_count = COALESCE(reschedule_count, 0) + 1,
+      last_reschedule_request_id = p_request_id
+  WHERE id = p_tour_id
+  RETURNING * INTO v_tour;
+
+  RETURN jsonb_build_object(
+    'tour', to_jsonb(v_tour),
+    'already_rescheduled', false,
+    'shift_days', (p_new_start_date - COALESCE(v_tour.original_start_date, p_new_start_date)),
+    'gigs_moved', v_gig_count,
+    'travel_legs_moved', v_leg_count
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reschedule_tour(uuid,date,uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reschedule_tour(uuid,date,uuid) TO authenticated, service_role;


### PR DESCRIPTION
## What changed

- adds an authoritative `reschedule_tour` SQL RPC
- moves an entire future tour by selecting a new start date
- shifts scheduled gigs and their end times together
- shifts tour venue dates
- shifts tour travel legs
- shifts linked player gig activities
- shifts player travel history and travel activities
- updates tour start/end dates and reschedule history
- adds request-id idempotency
- validates band-management permission and tour state
- rejects past dates and tours that have already started
- checks band and venue clashes before applying any changes
- exposes the RPC through the shared tour API and `useTours`
- invalidates all affected tour, gig, travel and schedule queries
- adds API coverage for the rescheduling boundary

## Root cause

Tour dates could not safely be changed through the generic metadata update because a date change affects several linked systems. Updating only the `tours` row would leave gigs, venue stops, member activities and travel bookings on the old dates.

## Behaviour

Rescheduling preserves the spacing and order of the existing tour. The caller supplies a new start date and the transaction applies the same day offset to every future tour record. Any conflict causes the complete transaction to roll back.

Completed, cancelled or already-started tours cannot be rescheduled.

## Dependency

This is stacked on PR #1379. Merge order:

1. PR #1376 — atomic tour booking
2. PR #1377 — authoritative Tour Manager cancellation
3. PR #1378 — authoritative travel-leg generation
4. PR #1379 — remove legacy lifecycle writes
5. this PR — atomic tour rescheduling

## Validation

- compared against `fix/authoritative-tour-metadata`
- confirmed the branch is four commits ahead and changes four files only
- added an API test asserting that rescheduling uses one idempotent RPC
- no direct client-side schedule writes were introduced

Runtime tests and Supabase migration validation were not available through the GitHub connector, so this remains a draft pending CI.