### PR TITLE
Make tour catch-up travel atomic

### DIFF
--- a/src/lib/api/__tests__/tourCatchUp.database.test.ts
+++ b/src/lib/api/__tests__/tourCatchUp.database.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { catchUpToTour } from "@/lib/api/tourCatchUp";
+import { supabase } from "@/integrations/supabase/client";
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { rpc: vi.fn() },
+}));
+
+describe("catchUpToTour", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses one authoritative RPC for payment and travel creation", async () => {
+    vi.mocked(supabase.rpc as any).mockResolvedValue({
+      data: {
+        tour_id: "tour-1",
+        profile_id: "profile-1",
+        travel_id: "travel-1",
+        fee: 1500,
+        arrival_time: "2026-07-29T00:00:00Z",
+        already_booked: false,
+        request_id: "request-1",
+      },
+      error: null,
+    });
+
+    const result = await catchUpToTour("tour-1", "profile-1", "request-1");
+
+    expect(supabase.rpc).toHaveBeenCalledWith("catch_up_to_tour", {
+      p_tour_id: "tour-1",
+      p_profile_id: "profile-1",
+      p_request_id: "request-1",
+    });
+    expect(result.fee).toBe(1500);
+  });
+
+  it("propagates database failures without a client-side fallback", async () => {
+    vi.mocked(supabase.rpc as any).mockResolvedValue({
+      data: null,
+      error: new Error("tour_catch_up_insufficient_funds"),
+    });
+
+    await expect(
+      catchUpToTour("tour-1", "profile-1", "request-2"),
+    ).rejects.toThrow("tour_catch_up_insufficient_funds");
+  });
+});

--- a/src/lib/api/tourCatchUp.ts
+++ b/src/lib/api/tourCatchUp.ts
@@ -1,0 +1,31 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface CatchUpToTourResult {
+  tour_id: string;
+  profile_id: string;
+  travel_id?: string;
+  fee: number;
+  arrival_time?: string;
+  already_in_city?: boolean;
+  already_booked?: boolean;
+  request_id: string;
+}
+
+const createRequestId = (): string => crypto.randomUUID();
+
+export const catchUpToTour = async (
+  tourId: string,
+  profileId: string,
+  requestId = createRequestId(),
+): Promise<CatchUpToTourResult> => {
+  const { data, error } = await (supabase.rpc as any)("catch_up_to_tour", {
+    p_tour_id: tourId,
+    p_profile_id: profileId,
+    p_request_id: requestId,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error("tour_catch_up_empty_response");
+
+  return data as CatchUpToTourResult;
+};

--- a/supabase/migrations/20260728234500_atomic_tour_catch_up.sql
+++ b/supabase/migrations/20260728234500_atomic_tour_catch_up.sql
@@ -1,0 +1,146 @@
+create or replace function public.catch_up_to_tour(
+  p_tour_id uuid,
+  p_profile_id uuid,
+  p_request_id uuid default gen_random_uuid()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_profile profiles%rowtype;
+  v_target_city_id uuid;
+  v_departure timestamptz := now();
+  v_arrival timestamptz := now() + interval '2 hours';
+  v_fee numeric := 1500;
+  v_existing player_travel_history%rowtype;
+  v_travel_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'tour_catch_up_unauthenticated';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended('tour-catch-up:' || p_profile_id::text, 0));
+
+  select * into v_profile
+  from profiles
+  where id = p_profile_id and user_id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'tour_catch_up_profile_forbidden';
+  end if;
+
+  select pth.* into v_existing
+  from player_travel_history pth
+  where pth.profile_id = p_profile_id
+    and pth.metadata ->> 'request_id' = p_request_id::text
+  limit 1;
+
+  if found then
+    return jsonb_build_object(
+      'tour_id', p_tour_id,
+      'profile_id', p_profile_id,
+      'travel_id', v_existing.id,
+      'fee', v_fee,
+      'arrival_time', v_existing.arrival_time,
+      'already_booked', true,
+      'request_id', p_request_id
+    );
+  end if;
+
+  select coalesce(
+    (
+      select ttl.from_city_id
+      from tour_travel_legs ttl
+      where ttl.tour_id = p_tour_id
+        and ttl.departure_date >= now()
+      order by ttl.departure_date
+      limit 1
+    ),
+    (
+      select v.city_id
+      from gigs g
+      join venues v on v.id = g.venue_id
+      where g.tour_id = p_tour_id
+        and g.scheduled_date >= now()
+        and g.status in ('scheduled', 'in_progress')
+      order by g.scheduled_date
+      limit 1
+    )
+  ) into v_target_city_id;
+
+  if v_target_city_id is null then
+    raise exception 'tour_catch_up_no_upcoming_stop';
+  end if;
+
+  if v_profile.current_city_id = v_target_city_id then
+    return jsonb_build_object(
+      'tour_id', p_tour_id,
+      'profile_id', p_profile_id,
+      'fee', 0,
+      'already_in_city', true,
+      'already_booked', false,
+      'request_id', p_request_id
+    );
+  end if;
+
+  if coalesce(v_profile.cash, 0) < v_fee then
+    raise exception 'tour_catch_up_insufficient_funds';
+  end if;
+
+  update profiles
+  set cash = cash - v_fee,
+      is_traveling = true,
+      travel_arrives_at = v_arrival
+  where id = p_profile_id;
+
+  insert into player_travel_history (
+    user_id,
+    profile_id,
+    from_city_id,
+    to_city_id,
+    transport_type,
+    cost_paid,
+    departure_time,
+    scheduled_departure_time,
+    arrival_time,
+    travel_duration_hours,
+    status,
+    metadata
+  ) values (
+    v_user_id,
+    p_profile_id,
+    v_profile.current_city_id,
+    v_target_city_id,
+    'plane',
+    v_fee,
+    v_departure,
+    v_departure,
+    v_arrival,
+    2,
+    'in_progress',
+    jsonb_build_object(
+      'tour_id', p_tour_id,
+      'request_id', p_request_id,
+      'kind', 'tour_catch_up'
+    )
+  ) returning id into v_travel_id;
+
+  return jsonb_build_object(
+    'tour_id', p_tour_id,
+    'profile_id', p_profile_id,
+    'travel_id', v_travel_id,
+    'fee', v_fee,
+    'arrival_time', v_arrival,
+    'already_in_city', false,
+    'already_booked', false,
+    'request_id', p_request_id
+  );
+end;
+$$;
+
+revoke all on function public.catch_up_to_tour(uuid, uuid, uuid) from public;
+grant execute on function public.catch_up_to_tour(uuid, uuid, uuid) to authenticated;


### PR DESCRIPTION
## What changed

- adds an authoritative `catch_up_to_tour` SQL RPC
- charges the £1,500 catch-up fee and creates travel in one database transaction
- locks the player profile to prevent concurrent double charging
- chooses the next tour departure city or upcoming gig city server-side
- handles players already in the correct city without charging them
- records idempotency through a request id stored in travel metadata
- adds a typed API wrapper and database boundary tests

## Root cause

The current Tour Manager catch-up action performs separate browser writes to `player_travel_history` and `profiles`. A failure after either write can charge a player without creating travel, create travel without charging them, or double charge repeated requests.

## Behaviour

The RPC:

- verifies the authenticated user owns the selected profile
- serialises catch-up requests per profile
- finds the next valid tour destination
- checks the player has at least £1,500
- deducts the fee
- creates a two-hour in-progress flight
- marks the profile as travelling
- returns the same result for a repeated request id

If any step fails, the complete operation rolls back.

## Dependency

This PR is stacked on PR #1382.

Merge order:

1. PR #1376 — atomic tour booking
2. PR #1377 — authoritative cancellation
3. PR #1378 — transactional travel legs
4. PR #1379 — remove legacy lifecycle writes
5. PR #1380 — atomic rescheduling
6. PR #1381 — transactional travel repair APIs
7. PR #1382 — authoritative repair hook
8. this PR — atomic catch-up travel

## Follow-up

`TourManager.tsx` still needs a local or Codex source edit to replace its legacy repair and catch-up mutation bodies with the APIs from PRs #1382 and this PR. The GitHub connector cannot safely replace that file because it exceeds the connector response limit, and the execution environment cannot reach GitHub for a checkout.

## Validation

- compared against `fix/tour-travel-repair-hook`
- three commits ahead
- three new files only
- tests verify one RPC boundary and error propagation

Runtime tests and Supabase migration validation were not available through the GitHub connector, so this remains a draft pending CI.