### PR TITLE
Add authoritative tour catch-up hook

### DIFF
--- a/src/hooks/__tests__/useTourCatchUp.test.tsx
+++ b/src/hooks/__tests__/useTourCatchUp.test.tsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { useTourCatchUp, getCatchUpErrorMessage } from "@/hooks/useTourCatchUp";
+import { catchUpToTour } from "@/lib/api/tourCatchUp";
+
+vi.mock("@/lib/api/tourCatchUp", () => ({ catchUpToTour: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+describe("useTourCatchUp", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+  );
+
+  it("uses the authoritative catch-up API", async () => {
+    vi.mocked(catchUpToTour).mockResolvedValue({
+      tour_id: "tour-1",
+      profile_id: "profile-1",
+      travel_id: "travel-1",
+      fee: 1500,
+      arrival_time: "2026-07-29T00:00:00Z",
+      request_id: "request-1",
+    });
+
+    const { result } = renderHook(() => useTourCatchUp(), { wrapper });
+    await result.current.catchUp.mutateAsync({
+      tourId: "tour-1",
+      profileId: "profile-1",
+    });
+
+    expect(catchUpToTour).toHaveBeenCalledWith("tour-1", "profile-1");
+  });
+
+  it("maps insufficient funds without implying a partial charge", () => {
+    expect(getCatchUpErrorMessage("tour_catch_up_insufficient_funds")).toBe(
+      "You need £1,500 to charter a catch-up flight.",
+    );
+    expect(getCatchUpErrorMessage("unknown")).toContain("No money was charged");
+  });
+});

--- a/src/hooks/useTourCatchUp.ts
+++ b/src/hooks/useTourCatchUp.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { catchUpToTour } from "@/lib/api/tourCatchUp";
+
+interface CatchUpInput {
+  tourId: string;
+  profileId: string;
+}
+
+const getCatchUpErrorMessage = (message: string): string => {
+  if (message.includes("tour_catch_up_forbidden")) {
+    return "You cannot arrange catch-up travel for this character.";
+  }
+  if (message.includes("tour_catch_up_not_found")) {
+    return "This tour could not be found.";
+  }
+  if (message.includes("tour_catch_up_no_destination")) {
+    return "There are no upcoming tour stops to catch up to.";
+  }
+  if (message.includes("tour_catch_up_insufficient_funds")) {
+    return "You need £1,500 to charter a catch-up flight.";
+  }
+  if (message.includes("tour_catch_up_profile_busy")) {
+    return "This character is already travelling or unavailable.";
+  }
+  return "The catch-up flight could not be arranged. No money was charged.";
+};
+
+export const useTourCatchUp = () => {
+  const queryClient = useQueryClient();
+
+  const catchUp = useMutation({
+    mutationFn: ({ tourId, profileId }: CatchUpInput) =>
+      catchUpToTour(tourId, profileId),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["travel-status"] });
+      queryClient.invalidateQueries({ queryKey: ["upcoming-travel"] });
+      queryClient.invalidateQueries({ queryKey: ["travel-plans"] });
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+      queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] });
+
+      if (result.already_in_city) {
+        toast.info("You are already in the correct city for the tour.");
+        return;
+      }
+
+      if (result.already_booked) {
+        toast.info("This catch-up flight was already arranged.");
+        return;
+      }
+
+      toast.success("Catch-up flight chartered for £1,500. Arrival is in two hours.");
+    },
+    onError: (error: Error) => {
+      toast.error(getCatchUpErrorMessage(error.message));
+    },
+  });
+
+  return { catchUp };
+};
+
+export { getCatchUpErrorMessage };

--- a/src/lib/api/__tests__/tourCatchUpHook.contract.test.ts
+++ b/src/lib/api/__tests__/tourCatchUpHook.contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("tour catch-up UI boundary", () => {
+  it("does not restore browser-side finance or travel writes", () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), "src/hooks/useTourCatchUp.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("catchUpToTour");
+    expect(source).not.toContain('.from("profiles")');
+    expect(source).not.toContain('.from("player_travel_history")');
+    expect(source).not.toContain(".insert(");
+    expect(source).not.toContain(".update(");
+  });
+});


### PR DESCRIPTION
## What changed

- adds `useTourCatchUp` as the React boundary for the atomic catch-up RPC
- centralises travel, profile and schedule cache invalidation
- maps database error codes to player-facing messages
- preserves idempotent messaging for already-booked requests
- handles the already-in-city result without charging or showing a failure
- adds hook tests and an authority-boundary regression test

## Why

PR #1383 made the £1,500 catch-up flight atomic, but `TourManager` still needs a small UI mutation boundary before its large legacy mutation can be removed safely. This hook keeps money and travel writes out of the page and ensures the UI never adds a browser-side fallback.

## Behaviour

The hook exposes a single `catchUp` mutation accepting:

- `tourId`
- `profileId`

On success it refreshes profile, travel and scheduled activity data. On failure it gives a specific player-facing message and confirms that no money was charged for unknown failures.

## Dependency

This PR is stacked on PR #1383.

Merge order:

1. PR #1376 — atomic tour booking
2. PR #1377 — authoritative cancellation
3. PR #1378 — transactional travel legs
4. PR #1379 — remove legacy lifecycle writes
5. PR #1380 — atomic rescheduling
6. PR #1381 — transactional travel repair APIs
7. PR #1382 — authoritative repair hook
8. PR #1383 — atomic catch-up travel
9. this PR — authoritative catch-up hook

## Follow-up

The remaining source migration is now mechanical: update `TourManager.tsx` to use `useTourTravelRepair` and `useTourCatchUp`, then delete the three legacy browser mutation bodies.

## Validation

- compared against `fix/atomic-tour-catch-up`
- three commits ahead
- three new files
- tests verify the API call and error mapping
- source contract verifies there are no direct profile or travel table writes

Runtime tests were not available through the GitHub connector, so this remains a draft pending CI.