### PR TITLE
Automate final Tour Manager authority migration

### DIFF
--- a/docs/tours/TOUR_MANAGER_AUTHORITY_MIGRATION.md
+++ b/docs/tours/TOUR_MANAGER_AUTHORITY_MIGRATION.md
@@ -1,0 +1,24 @@
+# Tour Manager authority migration
+
+Run:
+
+```bash
+node scripts/migrate-tour-manager-authority.mjs
+```
+
+The codemod updates `src/pages/TourManager.tsx` to:
+
+- import `useTourTravelRepair`
+- import `useTourCatchUp`
+- remove the legacy browser mutation bodies for travel-leg repair, new-member travel and catch-up flights
+- wire the existing buttons to the authoritative mutations
+- disable catch-up when there is no active profile
+
+After running it, verify:
+
+```bash
+npm test -- scripts/__tests__/migrate-tour-manager-authority.test.ts
+npm run typecheck
+```
+
+The resulting page must not directly insert into `tour_travel_legs`, `player_travel_history` or `player_scheduled_activities`, and must not update profile cash or travel state for catch-up journeys.

--- a/scripts/__tests__/migrate-tour-manager-authority.test.ts
+++ b/scripts/__tests__/migrate-tour-manager-authority.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const fixture = `import { useBandTourTotals } from "@/hooks/useTourStats";
+
+const queryClient = useQueryClient();
+
+  // Regenerate missing travel legs mutation
+  const regenerateTravelLegsMutation = useMutation({ mutationFn: async () => supabase.from("tour_travel_legs").insert([]) });
+  const addNewMemberTravelMutation = useMutation({ mutationFn: async () => supabase.from("player_travel_history").insert({}) });
+  const catchUpToTourMutation = useMutation({ mutationFn: async () => supabase.from("profiles").update({}) });
+
+  const { data: otherToursData, isLoading: loadingOtherTours } = useQuery({});
+
+addNewMemberTravelMutation.mutate(selectedTour.id)
+addNewMemberTravelMutation.isPending
+regenerateTravelLegsMutation.mutate(selectedTour.id)
+regenerateTravelLegsMutation.isPending
+catchUpToTourMutation.mutate(selectedTour.id)
+catchUpToTourMutation.isPending
+disabled={catchUpToTourMutation.isPending}
+`;
+
+describe("migrate-tour-manager-authority", () => {
+  it("replaces all three browser-authoritative mutations with hooks", () => {
+    const directory = mkdtempSync(join(tmpdir(), "tour-manager-codemod-"));
+    const target = join(directory, "TourManager.tsx");
+    writeFileSync(target, fixture);
+
+    execFileSync("node", ["scripts/migrate-tour-manager-authority.mjs", target], {
+      cwd: process.cwd(),
+    });
+
+    const result = readFileSync(target, "utf8");
+    expect(result).toContain('useTourTravelRepair');
+    expect(result).toContain('useTourCatchUp');
+    expect(result).toContain('syncMemberTravel.mutate(selectedTour.id)');
+    expect(result).toContain('regenerateTravelLegs.mutate(selectedTour.id)');
+    expect(result).toContain('catchUp.mutate({ tourId: selectedTour.id, profileId })');
+    expect(result).not.toContain('addNewMemberTravelMutation');
+    expect(result).not.toContain('regenerateTravelLegsMutation');
+    expect(result).not.toContain('catchUpToTourMutation');
+  });
+});

--- a/scripts/migrate-tour-manager-authority.mjs
+++ b/scripts/migrate-tour-manager-authority.mjs
@@ -1,0 +1,60 @@
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const target = process.argv[2] ?? "src/pages/TourManager.tsx";
+let source = await readFile(target, "utf8");
+
+const addImport = (anchor, addition) => {
+  if (!source.includes(addition.trim())) {
+    if (!source.includes(anchor)) throw new Error(`Missing import anchor: ${anchor}`);
+    source = source.replace(anchor, `${anchor}\n${addition}`);
+  }
+};
+
+addImport(
+  'import { useBandTourTotals } from "@/hooks/useTourStats";',
+  'import { useTourTravelRepair } from "@/hooks/useTourTravelRepair";\nimport { useTourCatchUp } from "@/hooks/useTourCatchUp";',
+);
+
+const startMarker = "  // Regenerate missing travel legs mutation";
+const endMarker = "  const { data: otherToursData, isLoading: loadingOtherTours } = useQuery({";
+const start = source.indexOf(startMarker);
+const end = source.indexOf(endMarker);
+
+if (start === -1 || end === -1 || end <= start) {
+  throw new Error("Could not locate legacy Tour Manager mutation range");
+}
+
+const authoritativeMutations = `  const {\n    regenerateTravelLegs,\n    syncMemberTravel,\n  } = useTourTravelRepair();\n  const { catchUp } = useTourCatchUp();\n\n`;
+
+source = source.slice(0, start) + authoritativeMutations + source.slice(end);
+
+const replacements = [
+  ["addNewMemberTravelMutation.mutate(selectedTour.id)", "syncMemberTravel.mutate(selectedTour.id)"],
+  ["addNewMemberTravelMutation.isPending", "syncMemberTravel.isPending"],
+  ["regenerateTravelLegsMutation.mutate(selectedTour.id)", "regenerateTravelLegs.mutate(selectedTour.id)"],
+  ["regenerateTravelLegsMutation.isPending", "regenerateTravelLegs.isPending"],
+  ["catchUpToTourMutation.mutate(selectedTour.id)", "profileId && catchUp.mutate({ tourId: selectedTour.id, profileId })"],
+  ["catchUpToTourMutation.isPending", "catchUp.isPending"],
+  ['disabled={catchUp.isPending}', 'disabled={catchUp.isPending || !profileId}'],
+];
+
+for (const [before, after] of replacements) {
+  if (!source.includes(before)) throw new Error(`Missing expected source: ${before}`);
+  source = source.split(before).join(after);
+}
+
+const forbidden = [
+  'const regenerateTravelLegsMutation = useMutation',
+  'const addNewMemberTravelMutation = useMutation',
+  'const catchUpToTourMutation = useMutation',
+  '.from("player_travel_history").insert',
+  '.from("player_scheduled_activities").insert',
+];
+
+for (const token of forbidden) {
+  if (source.includes(token)) throw new Error(`Legacy authority remains: ${token}`);
+}
+
+await writeFile(target, source, "utf8");
+console.log(`Migrated ${target} to authoritative tour travel hooks.`);


### PR DESCRIPTION
## What changed

- adds a deterministic codemod for `src/pages/TourManager.tsx`
- removes the three legacy browser-authoritative travel mutation bodies
- wires the existing management buttons to `useTourTravelRepair` and `useTourCatchUp`
- disables catch-up when no active profile is available
- adds a Vitest fixture proving the migration removes all legacy mutation identifiers
- documents the exact migration and verification commands

## Why

`TourManager.tsx` is a 1,700+ line legacy page. Replacing the complete file through the GitHub connector risks truncating unrelated UI code. This codemod makes the final edit small, deterministic and reproducible while protecting the rest of the page.

## Result after running

The page will no longer directly:

- insert `tour_travel_legs`
- insert `player_travel_history`
- insert `player_scheduled_activities`
- update profile cash or travel state for catch-up flights

The existing buttons instead call the authoritative hooks introduced by PRs #1382 and #1384.

## Dependency

This PR is stacked on PR #1384.

## Apply

```bash
node scripts/migrate-tour-manager-authority.mjs
npm test -- scripts/__tests__/migrate-tour-manager-authority.test.ts
npm run typecheck
```

## Validation

- three commits ahead of `fix/tour-catch-up-hook`
- three new files
- codemod fails loudly when expected legacy markers are missing
- regression test runs against an isolated fixture

The codemod has not been executed against the repository source in this PR because the GitHub connector cannot safely replace the full 1,700+ line page. This remains a draft until Codex or a local checkout runs the included command and commits the generated `TourManager.tsx` change.