### PR TITLE
Complete authoritative Tour Manager migration

### DIFF
--- a/src/hooks/__tests__/useTourCancellation.contract.test.ts
+++ b/src/hooks/__tests__/useTourCancellation.contract.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("useTourCancellation authority boundary", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "src/hooks/useTourCancellation.ts"),
+    "utf8",
+  );
+
+  it("uses the authoritative cancellation RPC", () => {
+    expect(source).toContain('"cancel_tour"');
+    expect(source).toContain("p_tour_id");
+  });
+
+  it("does not directly mutate tour, gig or band finance tables", () => {
+    expect(source).not.toMatch(/\.from\(["']tours["']\)/);
+    expect(source).not.toMatch(/\.from\(["']gigs["']\)/);
+    expect(source).not.toMatch(/\.from\(["']bands["']\)/);
+    expect(source).not.toContain("band_balance");
+  });
+
+  it("uses UK currency formatting for refunds", () => {
+    expect(source).toContain('toLocaleString("en-GB")');
+    expect(source).toContain("£");
+  });
+});

--- a/src/hooks/useTourCancellation.ts
+++ b/src/hooks/useTourCancellation.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+
+export interface CancelTourResult {
+  tour_id: string;
+  already_cancelled?: boolean;
+  same_day?: boolean;
+  refund_amount?: number;
+}
+
+const getCancellationErrorMessage = (error: Error): string => {
+  if (error.message.includes("tour_cancel_forbidden")) {
+    return "You do not have permission to cancel this tour.";
+  }
+  if (error.message.includes("tour_cancel_not_found")) {
+    return "This tour no longer exists.";
+  }
+  return "The tour could not be cancelled. No partial cancellation or refund was applied.";
+};
+
+export const useTourCancellation = () => {
+  const queryClient = useQueryClient();
+
+  const cancelTour = useMutation({
+    mutationFn: async (tourId: string): Promise<CancelTourResult> => {
+      const { data, error } = await (supabase.rpc as any)("cancel_tour", {
+        p_tour_id: tourId,
+      });
+
+      if (error) throw error;
+      if (!data) throw new Error("tour_cancel_empty_response");
+      return data as CancelTourResult;
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["my-tours"] });
+      queryClient.invalidateQueries({ queryKey: ["tours"] });
+      queryClient.invalidateQueries({ queryKey: ["tour-gigs"] });
+      queryClient.invalidateQueries({ queryKey: ["tour-venues"] });
+      queryClient.invalidateQueries({ queryKey: ["tour-travel-legs"] });
+      queryClient.invalidateQueries({ queryKey: ["scheduled-activities"] });
+      queryClient.invalidateQueries({ queryKey: ["band-for-tour"] });
+
+      const refundAmount = Number(result.refund_amount ?? 0);
+      if (result.already_cancelled) {
+        toast.info("This tour was already cancelled.");
+      } else if (refundAmount > 0) {
+        toast.success(
+          `Tour cancelled. £${refundAmount.toLocaleString("en-GB")} was refunded.`,
+        );
+      } else {
+        toast.success("Tour cancelled. No refund is available after the booking day.");
+      }
+    },
+    onError: (error: Error) => {
+      console.error("Failed to cancel tour:", error);
+      toast.error(getCancellationErrorMessage(error));
+    },
+  });
+
+  return { cancelTour };
+};


### PR DESCRIPTION
## What changed

- adds `useTourCancellation` as the React boundary for transactional `cancel_tour`
- adds a full deterministic migration for `src/pages/TourManager.tsx`
- replaces browser-side cancellation, travel regeneration, member travel sync and catch-up mutations
- removes unused `useMutation` and `useQueryClient` imports from the page
- closes and clears the details dialog after successful cancellation
- corrects cancellation copy so it explains that history is retained
- adds fixture-based migration tests and migration documentation

## Authority boundary

After applying the codemod, `TourManager.tsx` no longer directly:

- updates tour cancellation state
- updates gig status
- updates band balances or refunds
- inserts travel legs
- inserts player travel history
- inserts scheduled travel activities
- updates profile cash or travel state

All changes route through `useTourCancellation`, `useTourTravelRepair` and `useTourCatchUp`.

## Apply

```bash
node scripts/migrate-tour-manager-authority.mjs
npm test -- scripts/__tests__/migrate-tour-manager-authority.test.ts
npm run typecheck
```

The primary migration and test entry points now delegate to the full v2 migration.

## Dependency

This PR remains stacked on PR #1385.

## Validation

- authority-boundary hook test
- deterministic migration fixture test
- forbidden direct-write checks
- corrected UK refund formatting using `£` and `en-GB`

Runtime CI was not available through the connector, so this remains a draft pending Codex or local execution of the migration and checks.