### PR TITLE
Enforce final Tour Manager authority migration

### DIFF
--- a/docs/tours/PR1388_APPLY_TOUR_MANAGER_MIGRATION.md
+++ b/docs/tours/PR1388_APPLY_TOUR_MANAGER_MIGRATION.md
@@ -1,0 +1,48 @@
+# PR1388 — Apply the Tour Manager authority migration
+
+## Required implementation
+
+Run the existing deterministic migration against the real page and commit the generated source change:
+
+```bash
+node scripts/migrate-tour-manager-authority.mjs src/pages/TourManager.tsx
+```
+
+Then verify and fix any formatting or TypeScript issues without restoring direct browser writes.
+
+## Expected page changes
+
+`src/pages/TourManager.tsx` must:
+
+- import and use `useTourCancellation`
+- import and use `useTourTravelRepair`
+- import and use `useTourCatchUp`
+- remove `useMutation` and `useQueryClient` if no longer required
+- remove the four legacy mutation bodies
+- call `cancelTour.mutate(selectedTour.id, { onSuccess: ... })`
+- close and clear the details dialog after successful cancellation
+- disable catch-up when there is no active profile
+- display the catch-up fee as `£1,500`
+- explain that completed shows and tour history remain visible after cancellation
+
+## Forbidden authority
+
+The page must not directly insert or update:
+
+- tour cancellation state
+- gig cancellation state
+- band balances or refunds
+- tour travel legs
+- player travel history
+- scheduled travel activities
+- profile cash or travel state
+
+## Validation
+
+```bash
+npm test -- src/pages/__tests__/TourManager.authority.test.ts
+npm test -- scripts/__tests__/migrate-tour-manager-authority.test.ts
+npm run typecheck
+```
+
+The new page-level test is deliberately expected to fail until the generated `TourManager.tsx` edit is committed. Do not weaken or remove the test to make CI pass.

--- a/src/pages/__tests__/TourManager.authority.test.ts
+++ b/src/pages/__tests__/TourManager.authority.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("src/pages/TourManager.tsx", "utf8");
+
+describe("TourManager authority boundary", () => {
+  it("routes management actions through authoritative hooks", () => {
+    expect(source).toContain('useTourCancellation');
+    expect(source).toContain('useTourTravelRepair');
+    expect(source).toContain('useTourCatchUp');
+
+    expect(source).toContain('cancelTour.mutate(selectedTour.id');
+    expect(source).toContain('syncMemberTravel.mutate(selectedTour.id)');
+    expect(source).toContain('regenerateTravelLegs.mutate(selectedTour.id)');
+    expect(source).toContain('catchUp.mutate({ tourId: selectedTour.id, profileId })');
+  });
+
+  it("contains no legacy browser-authoritative mutations", () => {
+    const forbidden = [
+      "const cancelTourMutation = useMutation",
+      "const regenerateTravelLegsMutation = useMutation",
+      "const addNewMemberTravelMutation = useMutation",
+      "const catchUpToTourMutation = useMutation",
+      '.from("tour_travel_legs").insert',
+      '.from("player_travel_history").insert',
+      '.from("player_scheduled_activities").insert',
+      '.from("bands").update',
+      '.from("profiles").update',
+    ];
+
+    for (const token of forbidden) {
+      expect(source, `legacy authority remains: ${token}`).not.toContain(token);
+    }
+  });
+
+  it("uses retained-history cancellation wording and UK currency", () => {
+    expect(source).toContain("Completed shows and tour history will remain visible");
+    expect(source).toContain("£1,500");
+    expect(source).not.toContain("delete all associated gigs and travel legs");
+    expect(source).not.toContain("$1,500 charter");
+  });
+});


### PR DESCRIPTION
## What changed

- adds a page-level authority contract for `src/pages/TourManager.tsx`
- verifies cancellation, travel repair and catch-up use authoritative hooks
- rejects the four legacy browser-side mutation bodies
- rejects direct writes to travel, profile and band-finance tables
- enforces retained-history cancellation wording
- enforces UK currency for the £1,500 catch-up fee
- documents the exact Codex/local command needed to generate the final page edit

## Important

The test is intentionally expected to fail against the current page because the migration tooling merged without the generated `TourManager.tsx` change. The required completion step is:

```bash
node scripts/migrate-tour-manager-authority.mjs src/pages/TourManager.tsx
npm test -- src/pages/__tests__/TourManager.authority.test.ts
npm test -- scripts/__tests__/migrate-tour-manager-authority.test.ts
npm run typecheck
```

Commit the generated page change to this PR. Do not weaken the authority test.

## Completion criteria

`TourManager.tsx` must no longer directly mutate:

- tour or gig cancellation state
- band balances or refunds
- tour travel legs
- player travel history
- scheduled activities
- profile cash or travel state

This remains draft until the real source migration and validation are committed.