### PR TITLE
Migrate company creation to the authoritative founding RPC

### DIFF
--- a/.github/workflows/apply-company-founding-authority.yml
+++ b/.github/workflows/apply-company-founding-authority.yml
@@ -1,0 +1,38 @@
+name: Apply company founding authority migration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/atomic-company-founding
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: node scripts/migrate-company-founding-authority.mjs src/hooks/useCompanies.ts
+      - run: npm test -- src/hooks/__tests__/useCompanies.founding-authority.test.ts src/lib/api/__tests__/companyFounding.database.test.ts
+      - run: npm run typecheck
+
+      - name: Commit migrated source
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/hooks/useCompanies.ts
+          if git diff --cached --quiet; then
+            echo "Source already migrated"
+          else
+            git commit -m "Migrate company founding to authoritative RPC"
+            git push origin HEAD:fix/atomic-company-founding
+          fi

--- a/scripts/migrate-company-founding-authority.mjs
+++ b/scripts/migrate-company-founding-authority.mjs
@@ -1,0 +1,107 @@
+import { readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const target = process.argv[2] ?? "src/hooks/useCompanies.ts";
+const source = await readFile(target, "utf8");
+
+const importAnchor = 'import { COMPANY_CREATION_COSTS } from "@/types/company";';
+const importReplacement = 'import { COMPANY_CREATION_COSTS } from "@/types/company";\nimport { foundCompany } from "@/lib/api/companyFounding";';
+
+if (!source.includes(importAnchor) && !source.includes('import { foundCompany } from "@/lib/api/companyFounding";')) {
+  throw new Error("Could not find company type import anchor");
+}
+
+const startMarker = "export const useCreateCompany = () => {";
+const endMarker = "\nexport const useUpdateCompany = () => {";
+const start = source.indexOf(startMarker);
+const end = source.indexOf(endMarker, start);
+
+if (start === -1 || end === -1) {
+  throw new Error("Could not locate useCreateCompany block");
+}
+
+const replacement = `export const useCreateCompany = () => {
+  const { userId } = useActiveProfile();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: CreateCompanyInput & { profileId?: string }): Promise<Company> => {
+      if (!userId) throw new Error("Not authenticated");
+
+      if (input.company_type === "festival") {
+        throw new Error("Festival companies must be founded through the secure VIP festival RPC.");
+      }
+
+      const result = await foundCompany({
+        name: input.name,
+        company_type: input.company_type,
+        description: input.description,
+        headquarters_city_id: input.headquarters_city_id,
+        parent_company_id: input.parent_company_id,
+      });
+
+      return {
+        id: result.companyId,
+        owner_id: userId,
+        name: input.name,
+        logo_url: null,
+        company_type: input.company_type,
+        parent_company_id: input.parent_company_id ?? null,
+        headquarters_city_id: input.headquarters_city_id ?? null,
+        balance: result.startingBalance,
+        is_bankrupt: false,
+        bankruptcy_date: null,
+        founded_at: new Date().toISOString(),
+        status: "active",
+        reputation_score: 0,
+        weekly_operating_costs: result.weeklyOperatingCosts,
+        description: input.description ?? null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        negative_balance_since: null,
+      };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["companies"] });
+      queryClient.invalidateQueries({ queryKey: ["user-cash-balance"] });
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+      toast({
+        title: "Company Created",
+        description: \\`${data.name} has been successfully registered with £${Number(data.balance).toLocaleString("en-GB")} starting capital.\\`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to create company",
+        variant: "destructive",
+      });
+    },
+  });
+};
+`;
+
+let next = source;
+if (!next.includes('import { foundCompany } from "@/lib/api/companyFounding";')) {
+  next = next.replace(importAnchor, importReplacement);
+}
+
+const adjustedStart = next.indexOf(startMarker);
+const adjustedEnd = next.indexOf(endMarker, adjustedStart);
+next = next.slice(0, adjustedStart) + replacement + next.slice(adjustedEnd);
+
+const forbidden = [
+  '.from("profiles")\n          .update({ cash:',
+  '.from("companies")\n        .insert({',
+  'supabase.from("company_transactions").insert',
+  'supabase.from("company_shareholders" as any).insert',
+];
+
+for (const pattern of forbidden) {
+  const block = next.slice(next.indexOf(startMarker), next.indexOf(endMarker, next.indexOf(startMarker)));
+  if (block.includes(pattern)) throw new Error(`Legacy founding write remains: ${pattern}`);
+}
+
+await writeFile(target, next, "utf8");
+console.log(`Migrated company founding authority in ${target}`);

--- a/src/hooks/__tests__/useCompanies.founding-authority.test.ts
+++ b/src/hooks/__tests__/useCompanies.founding-authority.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("src/hooks/useCompanies.ts", "utf8");
+const start = source.indexOf("export const useCreateCompany = () => {");
+const end = source.indexOf("\nexport const useUpdateCompany = () => {", start);
+const block = source.slice(start, end);
+
+describe("useCreateCompany authority boundary", () => {
+  it("uses the authoritative company founding API", () => {
+    expect(source).toContain('import { foundCompany } from "@/lib/api/companyFounding";');
+    expect(block).toContain("await foundCompany({");
+  });
+
+  it("contains no browser-side founding writes", () => {
+    expect(block).not.toContain('.from("profiles")');
+    expect(block).not.toContain('.from("companies")');
+    expect(block).not.toContain('from("company_transactions")');
+    expect(block).not.toContain('from("company_shareholders")');
+    expect(block).not.toContain("refund");
+  });
+
+  it("keeps festival founding on its dedicated secure flow", () => {
+    expect(block).toContain('input.company_type === "festival"');
+    expect(block).toContain("secure VIP festival RPC");
+  });
+
+  it("uses UK currency presentation", () => {
+    expect(block).toContain('toLocaleString("en-GB")');
+    expect(block).toContain("£");
+  });
+});


### PR DESCRIPTION
## What changed

- adds a deterministic migration for `src/hooks/useCompanies.ts`
- replaces the legacy `useCreateCompany` browser write sequence with the authoritative `foundCompany` API
- removes direct profile cash deductions, company inserts, transaction inserts, shareholder inserts and manual refund logic from the founding hook
- adds a source-level authority contract that rejects those direct writes
- preserves the dedicated secure VIP flow for festival companies
- switches company-created messaging to `en-GB` and pounds
- adds a one-shot workflow that applies the focused source migration and validates it

## Dependency

PR #1391 has merged and supplies the transactional `found_company` RPC and typed API boundary.

## Required result

`useCreateCompany` must call `foundCompany` only. It must not directly mutate:

- `profiles`
- `companies`
- `company_transactions`
- `company_shareholders`

## Apply and validate

```bash
node scripts/migrate-company-founding-authority.mjs src/hooks/useCompanies.ts
npm test -- src/hooks/__tests__/useCompanies.founding-authority.test.ts src/lib/api/__tests__/companyFounding.database.test.ts
npm run typecheck
```

The workflow `Apply company founding authority migration` performs the same migration and commits the generated source change. This PR remains draft until that generated edit and CI validation are present.