### PR TITLE
Migrate subsidiary closure to the authoritative RPC

### DIFF
--- a/.github/workflows/apply-company-closure-authority.yml
+++ b/.github/workflows/apply-company-closure-authority.yml
@@ -1,0 +1,34 @@
+name: Apply company closure authority migration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/company-closure-ui-authority
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node scripts/migrate-company-closure-authority.mjs src/hooks/useCompanies.ts
+      - run: npm test -- src/hooks/__tests__/useCompanies.closure-authority.test.ts src/lib/api/__tests__/companyClosure.database.test.ts
+      - run: npm run typecheck
+      - name: Commit generated migration
+        run: |
+          if git diff --quiet; then
+            echo "No generated changes"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/hooks/useCompanies.ts
+          git commit -m "Migrate company closure to authoritative RPC"
+          git push

--- a/scripts/migrate-company-closure-authority.mjs
+++ b/scripts/migrate-company-closure-authority.mjs
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+
+const target = process.argv[2] ?? "src/hooks/useCompanies.ts";
+let source = fs.readFileSync(target, "utf8");
+
+if (!source.includes('import { closeCompany } from "@/lib/api/companyClosure";')) {
+  source = source.replace(
+    'import { foundCompany } from "@/lib/api/companyFounding";',
+    'import { foundCompany } from "@/lib/api/companyFounding";\nimport { closeCompany } from "@/lib/api/companyClosure";',
+  );
+}
+
+source = source.replace(
+  '.eq("owner_id", userId)\n        .order("created_at", { ascending: false });',
+  '.eq("owner_id", userId)\n        .neq("status", "dissolved")\n        .order("created_at", { ascending: false });',
+);
+
+source = source.replace(
+  '.eq("parent_company_id", parentCompanyId)\n        .order("created_at", { ascending: false });',
+  '.eq("parent_company_id", parentCompanyId)\n        .neq("status", "dissolved")\n        .order("created_at", { ascending: false });',
+);
+
+const start = source.indexOf('export const useCloseSubsidiary = () => {');
+if (start === -1) throw new Error("useCloseSubsidiary start not found");
+const replacement = `export const useCloseSubsidiary = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      companyId,
+      transferBalance = true,
+    }: {
+      companyId: string;
+      profileId?: string;
+      transferBalance?: boolean;
+    }) => closeCompany(companyId, transferBalance),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["companies"] });
+      queryClient.invalidateQueries({ queryKey: ["company-subsidiaries"] });
+      queryClient.invalidateQueries({ queryKey: ["company", result.companyId] });
+      queryClient.invalidateQueries({ queryKey: ["company-financial-summary"] });
+      queryClient.invalidateQueries({ queryKey: ["profile"] });
+      queryClient.invalidateQueries({ queryKey: ["user-cash-balance"] });
+      toast({
+        title: "Company Closed",
+        description: result.transferredAmount > 0
+          ? \`\${result.companyName} was dissolved and \${new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(result.transferredAmount)} was transferred to the owner.\`
+          : \`\${result.companyName} was dissolved successfully.\`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Cannot Close Company",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+};
+`;
+source = source.slice(0, start) + replacement;
+
+for (const forbidden of [
+  '.from("profiles")',
+  '.from("company_transactions")',
+  '.from("company_settings")',
+  '.from("company_tax_records")',
+  '.from("security_firms")',
+  '.from("merch_factories")',
+  '.from("logistics_companies")',
+]) {
+  const closure = source.slice(source.indexOf('export const useCloseSubsidiary'));
+  if (closure.includes(forbidden)) throw new Error(`legacy closure write remains: ${forbidden}`);
+}
+
+fs.writeFileSync(target, source);

--- a/src/hooks/__tests__/useCompanies.closure-authority.test.ts
+++ b/src/hooks/__tests__/useCompanies.closure-authority.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.resolve("src/hooks/useCompanies.ts"), "utf8");
+const closureStart = source.indexOf("export const useCloseSubsidiary");
+const closureSource = closureStart >= 0 ? source.slice(closureStart) : "";
+
+describe("company closure authority boundary", () => {
+  it("uses the authoritative closure API", () => {
+    expect(source).toContain('import { closeCompany } from "@/lib/api/companyClosure";');
+    expect(closureSource).toContain("closeCompany(companyId, transferBalance)");
+  });
+
+  it("does not perform browser-side liquidation writes", () => {
+    for (const forbidden of [
+      '.from("profiles")',
+      '.from("companies").delete',
+      '.from("company_transactions")',
+      '.from("company_settings")',
+      '.from("company_tax_records")',
+      '.from("security_firms")',
+      '.from("merch_factories")',
+      '.from("logistics_companies")',
+    ]) {
+      expect(closureSource).not.toContain(forbidden);
+    }
+  });
+
+  it("hides dissolved companies from active ownership queries", () => {
+    expect(source.match(/\.neq\("status", "dissolved"\)/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses UK currency for liquidation messaging", () => {
+    expect(closureSource).toContain('new Intl.NumberFormat("en-GB"');
+    expect(closureSource).toContain('currency: "GBP"');
+  });
+});


### PR DESCRIPTION
## What changed

- adds a deterministic migration for `src/hooks/useCompanies.ts`
- replaces the legacy `useCloseSubsidiary` browser write sequence with the authoritative `closeCompany` API
- removes direct profile cash updates, company deletion, transaction deletion and extension cleanup from the closure hook
- hides dissolved companies from active company and subsidiary queries
- preserves dissolved company history for audit and reporting
- adds a source-level authority contract preventing browser-side liquidation writes from returning
- updates liquidation messaging to `en-GB` and pounds
- adds a one-shot workflow to apply the focused source migration and run validation

## Dependency

PR #1393 has merged and supplies the transactional `close_company` RPC and typed API boundary.

## Required result

`useCloseSubsidiary` must call `closeCompany` only. It must not directly mutate or delete:

- `profiles`
- `companies`
- `company_transactions`
- `company_settings`
- `company_tax_records`
- company-type extension tables

Dissolved companies must not appear in normal active-company listings.

## Apply and validate

```bash
node scripts/migrate-company-closure-authority.mjs src/hooks/useCompanies.ts
npm test -- src/hooks/__tests__/useCompanies.closure-authority.test.ts src/lib/api/__tests__/companyClosure.database.test.ts
npm run typecheck
```

The workflow `Apply company closure authority migration` performs the same migration and commits the generated source edit. This PR remains draft until that generated edit and CI validation are present.