### PR TITLE
Make company deposits and transfers atomic

### DIFF
--- a/src/lib/api/__tests__/companyFundTransfers.database.test.ts
+++ b/src/lib/api/__tests__/companyFundTransfers.database.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { rpc },
+}));
+
+import { transferCompanyFunds } from "@/lib/api/companyFundTransfers";
+
+describe("company fund transfer database boundary", () => {
+  beforeEach(() => rpc.mockReset());
+
+  it.each([
+    ["deposit", undefined],
+    ["withdrawal", undefined],
+    ["intercompany", "company-2"],
+  ] as const)("uses one authoritative RPC for %s", async (transferKind, destinationCompanyId) => {
+    rpc.mockResolvedValue({
+      data: {
+        transferKind,
+        sourceCompanyId: "company-1",
+        destinationCompanyId: destinationCompanyId ?? null,
+        amount: 25000,
+        personalCash: 75000,
+        sourceBalance: 125000,
+        destinationBalance: destinationCompanyId ? 225000 : null,
+        financialTransactionId: "finance-1",
+        idempotent: false,
+      },
+      error: null,
+    });
+
+    const result = await transferCompanyFunds({
+      transferKind,
+      companyId: "company-1",
+      amount: 25000,
+      destinationCompanyId,
+      idempotencyKey: `request-${transferKind}`,
+    });
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith("transfer_company_funds", {
+      p_transfer_kind: transferKind,
+      p_company_id: "company-1",
+      p_amount: 25000,
+      p_destination_company_id: destinationCompanyId ?? null,
+      p_idempotency_key: `request-${transferKind}`,
+    });
+    expect(result.transferKind).toBe(transferKind);
+  });
+
+  it("propagates failures without browser-side fallback writes", async () => {
+    const error = new Error("minimum_company_balance_required");
+    rpc.mockResolvedValue({ data: null, error });
+
+    await expect(transferCompanyFunds({
+      transferKind: "withdrawal",
+      companyId: "company-1",
+      amount: 25000,
+      idempotencyKey: "request-failed",
+    })).rejects.toBe(error);
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api/companyFundTransfers.ts
+++ b/src/lib/api/companyFundTransfers.ts
@@ -1,0 +1,44 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type CompanyFundTransferKind = "deposit" | "withdrawal" | "intercompany";
+
+export interface CompanyFundTransferResult {
+  transferKind: CompanyFundTransferKind;
+  sourceCompanyId: string;
+  destinationCompanyId: string | null;
+  amount: number;
+  personalCash: number;
+  sourceBalance: number;
+  destinationBalance: number | null;
+  financialTransactionId: string;
+  idempotent: boolean;
+}
+
+const createIdempotencyKey = (): string => crypto.randomUUID();
+
+export const transferCompanyFunds = async ({
+  transferKind,
+  companyId,
+  amount,
+  destinationCompanyId,
+  idempotencyKey = createIdempotencyKey(),
+}: {
+  transferKind: CompanyFundTransferKind;
+  companyId: string;
+  amount: number;
+  destinationCompanyId?: string;
+  idempotencyKey?: string;
+}): Promise<CompanyFundTransferResult> => {
+  const { data, error } = await (supabase.rpc as any)("transfer_company_funds", {
+    p_transfer_kind: transferKind,
+    p_company_id: companyId,
+    p_amount: amount,
+    p_destination_company_id: destinationCompanyId ?? null,
+    p_idempotency_key: idempotencyKey,
+  });
+
+  if (error) throw error;
+  if (!data) throw new Error("company_fund_transfer_empty_response");
+
+  return data as CompanyFundTransferResult;
+};

--- a/supabase/migrations/20260729101500_atomic_company_fund_transfers.sql
+++ b/supabase/migrations/20260729101500_atomic_company_fund_transfers.sql
@@ -1,0 +1,130 @@
+-- Make owner/company and company/company transfers server-authoritative and atomic.
+
+CREATE TABLE IF NOT EXISTS public.company_fund_transfer_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id uuid NOT NULL,
+  actor_profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  transfer_kind text NOT NULL CHECK (transfer_kind IN ('deposit', 'withdrawal', 'intercompany')),
+  source_company_id uuid REFERENCES public.companies(id) ON DELETE CASCADE,
+  destination_company_id uuid REFERENCES public.companies(id) ON DELETE CASCADE,
+  amount numeric NOT NULL CHECK (amount > 0),
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  result jsonb,
+  status text NOT NULL DEFAULT 'processing' CHECK (status IN ('processing', 'succeeded')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (actor_user_id, idempotency_key)
+);
+
+ALTER TABLE public.company_fund_transfer_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.transfer_company_funds(
+  p_transfer_kind text,
+  p_company_id uuid,
+  p_amount numeric,
+  p_destination_company_id uuid DEFAULT NULL,
+  p_idempotency_key text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_profile_id uuid := public._caller_profile_id();
+  v_profile public.profiles%ROWTYPE;
+  v_source public.companies%ROWTYPE;
+  v_destination public.companies%ROWTYPE;
+  v_request public.company_fund_transfer_requests%ROWTYPE;
+  v_request_hash text;
+  v_minimum_balance numeric := 10000;
+  v_amount_minor bigint;
+  v_financial_transaction_id uuid;
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN RAISE EXCEPTION 'not_authenticated' USING ERRCODE='P0001'; END IF;
+  IF v_profile_id IS NULL THEN RAISE EXCEPTION 'active_profile_required' USING ERRCODE='P0001'; END IF;
+  IF p_transfer_kind NOT IN ('deposit','withdrawal','intercompany') THEN RAISE EXCEPTION 'invalid_transfer_kind' USING ERRCODE='P0001'; END IF;
+  IF p_amount IS NULL OR p_amount <= 0 THEN RAISE EXCEPTION 'invalid_transfer_amount' USING ERRCODE='P0001'; END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN RAISE EXCEPTION 'idempotency_key_required' USING ERRCODE='P0001'; END IF;
+  IF p_transfer_kind = 'intercompany' AND (p_destination_company_id IS NULL OR p_destination_company_id = p_company_id) THEN RAISE EXCEPTION 'invalid_destination_company' USING ERRCODE='P0001'; END IF;
+
+  v_request_hash := encode(digest(concat_ws('|', p_transfer_kind, p_company_id, p_destination_company_id, p_amount), 'sha256'), 'hex');
+  PERFORM pg_advisory_xact_lock(hashtextextended(v_user_id::text || ':' || p_idempotency_key, 0));
+
+  SELECT * INTO v_request FROM public.company_fund_transfer_requests
+  WHERE actor_user_id=v_user_id AND idempotency_key=p_idempotency_key FOR UPDATE;
+  IF FOUND THEN
+    IF v_request.request_hash <> v_request_hash THEN RAISE EXCEPTION 'idempotency_conflict' USING ERRCODE='P0001'; END IF;
+    IF v_request.status='succeeded' THEN RETURN v_request.result || jsonb_build_object('idempotent', true); END IF;
+    RAISE EXCEPTION 'company_transfer_in_progress' USING ERRCODE='P0001';
+  END IF;
+
+  SELECT * INTO v_profile FROM public.profiles
+  WHERE id=v_profile_id AND user_id=v_user_id AND died_at IS NULL FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'profile_not_eligible' USING ERRCODE='P0001'; END IF;
+
+  SELECT * INTO v_source FROM public.companies WHERE id=p_company_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'company_not_found' USING ERRCODE='P0001'; END IF;
+  IF v_source.owner_id <> v_user_id THEN RAISE EXCEPTION 'company_not_owned' USING ERRCODE='P0001'; END IF;
+  IF v_source.status <> 'active' OR COALESCE(v_source.is_bankrupt,false) THEN RAISE EXCEPTION 'company_not_active' USING ERRCODE='P0001'; END IF;
+
+  IF p_transfer_kind='intercompany' THEN
+    SELECT * INTO v_destination FROM public.companies WHERE id=p_destination_company_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'destination_company_not_found' USING ERRCODE='P0001'; END IF;
+    IF v_destination.owner_id <> v_user_id THEN RAISE EXCEPTION 'destination_company_not_owned' USING ERRCODE='P0001'; END IF;
+    IF v_destination.status <> 'active' OR COALESCE(v_destination.is_bankrupt,false) THEN RAISE EXCEPTION 'destination_company_not_active' USING ERRCODE='P0001'; END IF;
+  END IF;
+
+  IF p_transfer_kind='deposit' AND COALESCE(v_profile.cash,0) < p_amount THEN RAISE EXCEPTION 'insufficient_personal_funds' USING ERRCODE='P0001'; END IF;
+  IF p_transfer_kind IN ('withdrawal','intercompany') AND COALESCE(v_source.balance,0) - p_amount < v_minimum_balance THEN RAISE EXCEPTION 'minimum_company_balance_required' USING ERRCODE='P0001'; END IF;
+
+  INSERT INTO public.company_fund_transfer_requests(actor_user_id,actor_profile_id,transfer_kind,source_company_id,destination_company_id,amount,idempotency_key,request_hash)
+  VALUES(v_user_id,v_profile.id,p_transfer_kind,p_company_id,p_destination_company_id,p_amount,p_idempotency_key,v_request_hash)
+  RETURNING * INTO v_request;
+
+  v_amount_minor := round(p_amount * 100)::bigint;
+
+  IF p_transfer_kind='deposit' THEN
+    SELECT public.finance_transfer('player',v_profile.id,'company',v_source.id,v_amount_minor,'company_revenue','Owner deposit','company-transfer:'||p_idempotency_key,'company',v_source.id,v_profile.id,jsonb_build_object('transferKind',p_transfer_kind)) INTO v_financial_transaction_id;
+    UPDATE public.profiles SET cash=cash-p_amount, updated_at=now() WHERE id=v_profile.id;
+    UPDATE public.companies SET balance=balance+p_amount, negative_balance_since=NULL, updated_at=now() WHERE id=v_source.id;
+    INSERT INTO public.company_transactions(company_id,transaction_type,amount,description,category,related_entity_id,related_entity_type)
+    VALUES(v_source.id,'investment',p_amount,'Owner deposit','owner_transfer',v_profile.id,'profile');
+  ELSIF p_transfer_kind='withdrawal' THEN
+    SELECT public.finance_transfer('company',v_source.id,'player',v_profile.id,v_amount_minor,'company_revenue','Owner withdrawal','company-transfer:'||p_idempotency_key,'company',v_source.id,v_profile.id,jsonb_build_object('transferKind',p_transfer_kind)) INTO v_financial_transaction_id;
+    UPDATE public.companies SET balance=balance-p_amount, updated_at=now() WHERE id=v_source.id;
+    UPDATE public.profiles SET cash=cash+p_amount, updated_at=now() WHERE id=v_profile.id;
+    INSERT INTO public.company_transactions(company_id,transaction_type,amount,description,category,related_entity_id,related_entity_type)
+    VALUES(v_source.id,'dividend',-p_amount,'Owner withdrawal','owner_transfer',v_profile.id,'profile');
+  ELSE
+    SELECT public.finance_transfer('company',v_source.id,'company',v_destination.id,v_amount_minor,'company_revenue','Intercompany transfer','company-transfer:'||p_idempotency_key,'company',v_source.id,v_profile.id,jsonb_build_object('transferKind',p_transfer_kind,'destinationCompanyId',v_destination.id)) INTO v_financial_transaction_id;
+    UPDATE public.companies SET balance=balance-p_amount, updated_at=now() WHERE id=v_source.id;
+    UPDATE public.companies SET balance=balance+p_amount, negative_balance_since=NULL, updated_at=now() WHERE id=v_destination.id;
+    INSERT INTO public.company_transactions(company_id,transaction_type,amount,description,category,related_entity_id,related_entity_type) VALUES
+      (v_source.id,'transfer_out',-p_amount,'Transfer to '||v_destination.name,'owner_transfer',v_destination.id,'company'),
+      (v_destination.id,'transfer_in',p_amount,'Transfer from '||v_source.name,'owner_transfer',v_source.id,'company');
+  END IF;
+
+  SELECT jsonb_build_object(
+    'transferKind',p_transfer_kind,
+    'sourceCompanyId',v_source.id,
+    'destinationCompanyId',CASE WHEN p_transfer_kind='intercompany' THEN v_destination.id ELSE NULL END,
+    'amount',p_amount,
+    'personalCash',(SELECT cash FROM public.profiles WHERE id=v_profile.id),
+    'sourceBalance',(SELECT balance FROM public.companies WHERE id=v_source.id),
+    'destinationBalance',CASE WHEN p_transfer_kind='intercompany' THEN (SELECT balance FROM public.companies WHERE id=v_destination.id) ELSE NULL END,
+    'financialTransactionId',v_financial_transaction_id,
+    'idempotent',false
+  ) INTO v_result;
+
+  UPDATE public.company_fund_transfer_requests SET status='succeeded',result=v_result,updated_at=now() WHERE id=v_request.id;
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.transfer_company_funds(text,uuid,numeric,uuid,text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.transfer_company_funds(text,uuid,numeric,uuid,text) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- adds one authoritative `transfer_company_funds` SQL RPC for owner deposits, owner withdrawals and transfers between owned companies
- validates the active character, company ownership, company status, transfer amount and destination server-side
- preserves the existing £10,000 minimum company balance for withdrawals and intercompany transfers
- executes the canonical finance-ledger transfer and all legacy compatibility-mirror updates in one database transaction
- records matching company transaction history for every transfer direction
- adds idempotency and advisory locking to prevent duplicate deposits, withdrawals or transfers
- adds a typed API boundary and regression tests for all three transfer kinds

## Root cause

`useCompanyFinance` currently calls the finance ledger and then separately updates `profiles.cash`, `companies.balance` and `company_transactions` from the browser. A failure after any individual write can charge the wrong account, duplicate money or leave the ledger and visible balances out of sync.

## Behaviour

Supported operations:

- character to owned company deposit
- owned company to character withdrawal
- owned company to owned company transfer

All operations are all-or-nothing. Dissolved, suspended or bankrupt companies cannot participate. Intercompany transfers require both companies to be owned by the authenticated user.

## Follow-up

The next PR will migrate `useDepositToCompany`, `useWithdrawFromCompany` and `useTransferBetweenCompanies` to this API, remove their browser-side balance writes and add an authority contract.

## Validation

```bash
npm test -- src/lib/api/__tests__/companyFundTransfers.database.test.ts
npm run typecheck
```

Runtime CI has not yet been executed, so this PR is opened as a draft.