### PR TITLE
Migrate company funding flows to the authoritative RPC

### DIFF
--- a/.github/workflows/apply-company-fund-transfer-authority.yml
+++ b/.github/workflows/apply-company-fund-transfer-authority.yml
@@ -1,0 +1,34 @@
+name: Apply company fund transfer authority migration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/company-fund-transfer-ui-authority
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node scripts/migrate-company-fund-transfer-authority.mjs src/hooks/useCompanyFinance.ts
+      - run: npm test -- src/hooks/__tests__/useCompanyFinance.transfer-authority.test.ts src/lib/api/__tests__/companyFundTransfers.database.test.ts
+      - run: npm run typecheck
+      - name: Commit generated migration
+        run: |
+          if git diff --quiet; then
+            echo "No generated changes"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/hooks/useCompanyFinance.ts
+          git commit -m "Migrate company fund transfers to authoritative RPC"
+          git push

--- a/scripts/migrate-company-fund-transfer-authority.mjs
+++ b/scripts/migrate-company-fund-transfer-authority.mjs
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+
+const target = process.argv[2] ?? "src/hooks/useCompanyFinance.ts";
+let source = fs.readFileSync(target, "utf8");
+
+source = source.replace('import { financeService } from "@/services/finance/financeService";\n', 'import { transferCompanyFunds } from "@/lib/api/companyFundTransfers";\n');
+
+const format = 'const formatGBP = (amount: number) => new Intl.NumberFormat("en-GB", { style: "currency", currency: "GBP" }).format(amount);\n\n';
+if (!source.includes('const formatGBP =')) source = source.replace('export interface CompanyTransaction {', format + 'export interface CompanyTransaction {');
+
+const replaceHook = (name, nextName, body) => {
+  const start = source.indexOf(`export const ${name} = () => {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = nextName ? source.indexOf(`export const ${nextName} = () => {`, start) : source.length;
+  if (end < 0) throw new Error(`${nextName} not found`);
+  source = source.slice(0, start) + body + "\n\n" + source.slice(end);
+};
+
+replaceHook("useDepositToCompany", "useWithdrawFromCompany", `export const useDepositToCompany = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ companyId, amount }: { companyId: string; amount: number; profileId: string }) =>
+      transferCompanyFunds({ transferKind: "deposit", companyId, amount }),
+    onSuccess: (_, variables) => {
+      for (const key of [["company-balance", variables.companyId], ["company-transactions", variables.companyId], ["company-income-expenses", variables.companyId], ["user-cash-balance"], ["company", variables.companyId], ["company-financial-summary"], ["profile"]]) queryClient.invalidateQueries({ queryKey: key });
+      toast({ title: "Deposit Successful", description: \`${formatGBPPlaceholder} deposited to company.\`.replace("${formatGBPPlaceholder}", formatGBP(variables.amount)) });
+    },
+    onError: (error: Error) => toast({ title: "Deposit Failed", description: error.message, variant: "destructive" }),
+  });
+};`.replaceAll('formatGBPPlaceholder', '${formatGBP(variables.amount)}'));
+
+replaceHook("useWithdrawFromCompany", "useTransferBetweenCompanies", `export const useWithdrawFromCompany = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ companyId, amount }: { companyId: string; amount: number; profileId: string }) =>
+      transferCompanyFunds({ transferKind: "withdrawal", companyId, amount }),
+    onSuccess: (_, variables) => {
+      for (const key of [["company-balance", variables.companyId], ["company-transactions", variables.companyId], ["company-income-expenses", variables.companyId], ["user-cash-balance"], ["company", variables.companyId], ["company-financial-summary"], ["profile"]]) queryClient.invalidateQueries({ queryKey: key });
+      toast({ title: "Withdrawal Successful", description: \`${formatGBPPlaceholder} withdrawn from company.\`.replace("${formatGBPPlaceholder}", formatGBP(variables.amount)) });
+    },
+    onError: (error: Error) => toast({ title: "Withdrawal Failed", description: error.message, variant: "destructive" }),
+  });
+};`.replaceAll('formatGBPPlaceholder', '${formatGBP(variables.amount)}'));
+
+const transferStart = source.indexOf('export const useTransferBetweenCompanies = () => {');
+const transferEnd = source.indexOf('export const ', transferStart + 20);
+const end = transferEnd < 0 ? source.length : transferEnd;
+const transferBody = `export const useTransferBetweenCompanies = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ fromCompanyId, toCompanyId, amount }: { fromCompanyId: string; toCompanyId: string; amount: number; fromName: string; toName: string }) =>
+      transferCompanyFunds({ transferKind: "intercompany", companyId: fromCompanyId, destinationCompanyId: toCompanyId, amount }),
+    onSuccess: (_, variables) => {
+      for (const companyId of [variables.fromCompanyId, variables.toCompanyId]) {
+        queryClient.invalidateQueries({ queryKey: ["company-balance", companyId] });
+        queryClient.invalidateQueries({ queryKey: ["company-transactions", companyId] });
+        queryClient.invalidateQueries({ queryKey: ["company-income-expenses", companyId] });
+        queryClient.invalidateQueries({ queryKey: ["company", companyId] });
+      }
+      queryClient.invalidateQueries({ queryKey: ["company-financial-summary"] });
+      toast({ title: "Transfer Successful", description: \`${formatGBPPlaceholder} transferred from \${variables.fromName} to \${variables.toName}.\`.replace("${formatGBPPlaceholder}", formatGBP(variables.amount)) });
+    },
+    onError: (error: Error) => toast({ title: "Transfer Failed", description: error.message, variant: "destructive" }),
+  });
+};`.replaceAll('formatGBPPlaceholder', '${formatGBP(variables.amount)}');
+source = source.slice(0, transferStart) + transferBody + "\n\n" + source.slice(end);
+
+const authority = source.slice(source.indexOf('export const useDepositToCompany'));
+for (const forbidden of ['financeService.transfer(', '.from("profiles")', '.from("companies")\n        .update', '.from("company_transactions")\n        .insert']) {
+  if (authority.includes(forbidden)) throw new Error(`legacy company transfer write remains: ${forbidden}`);
+}
+
+fs.writeFileSync(target, source);

--- a/src/hooks/__tests__/useCompanyFinance.transfer-authority.test.ts
+++ b/src/hooks/__tests__/useCompanyFinance.transfer-authority.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.resolve("src/hooks/useCompanyFinance.ts"), "utf8");
+const start = source.indexOf("export const useDepositToCompany");
+const authority = start >= 0 ? source.slice(start) : "";
+
+describe("company fund transfer authority boundary", () => {
+  it("uses the authoritative transfer API for all three flows", () => {
+    expect(source).toContain('import { transferCompanyFunds } from "@/lib/api/companyFundTransfers";');
+    expect(authority).toContain('transferKind: "deposit"');
+    expect(authority).toContain('transferKind: "withdrawal"');
+    expect(authority).toContain('transferKind: "intercompany"');
+  });
+
+  it("does not write money mirrors from the browser", () => {
+    for (const forbidden of [
+      "financeService.transfer(",
+      '.from("profiles")',
+      '.from("companies")\n        .update',
+      '.from("company_transactions")\n        .insert',
+    ]) expect(authority).not.toContain(forbidden);
+  });
+
+  it("uses UK currency formatting", () => {
+    expect(source).toContain('new Intl.NumberFormat("en-GB"');
+    expect(source).toContain('currency: "GBP"');
+  });
+});


### PR DESCRIPTION
## What changed

- adds a deterministic migration for `src/hooks/useCompanyFinance.ts`
- replaces owner deposits, owner withdrawals and company-to-company transfers with `transferCompanyFunds`
- removes direct browser writes to `profiles.cash`, `companies.balance` and `company_transactions`
- removes the duplicated client call to `financeService.transfer`
- keeps all relevant React Query balances and transaction views invalidated after success
- standardises transfer messaging to `en-GB` and pounds
- adds a source-level authority contract preventing legacy browser-side money writes from returning
- adds a one-shot workflow to apply the focused source migration and run validation

## Dependency

PR #1395 has merged and supplies the transactional `transfer_company_funds` RPC and typed API boundary.

## Required result

The following hooks must use the authoritative API only:

- `useDepositToCompany`
- `useWithdrawFromCompany`
- `useTransferBetweenCompanies`

They must not directly update or insert into:

- `profiles`
- `companies`
- `company_transactions`

## Apply and validate

```bash
node scripts/migrate-company-fund-transfer-authority.mjs src/hooks/useCompanyFinance.ts
npm test -- src/hooks/__tests__/useCompanyFinance.transfer-authority.test.ts src/lib/api/__tests__/companyFundTransfers.database.test.ts
npm run typecheck
```

The workflow `Apply company fund transfer authority migration` performs the same migration and commits the generated source edit. This PR remains draft until that edit and CI validation are present.