### PR TITLE
Migrate shared company expense deductions to the authoritative RPC

### DIFF
--- a/src/hooks/__tests__/useCompanyBalanceDeduction.authority.test.ts
+++ b/src/hooks/__tests__/useCompanyBalanceDeduction.authority.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(
+  path.resolve("src/hooks/useCompanyBalanceDeduction.ts"),
+  "utf8",
+);
+
+const deductionStart = source.indexOf("export async function deductCompanyBalance");
+const nextHelperStart = source.indexOf(
+  "/** Look up company_id from a security_firms row */",
+  deductionStart,
+);
+const deductionSource = source.slice(deductionStart, nextHelperStart);
+
+describe("shared company expense deduction authority", () => {
+  it("delegates generic company expenses to the authoritative API", () => {
+    expect(source).toContain(
+      'import { deductCompanyExpense } from "@/lib/api/companyExpenseDeductions";',
+    );
+    expect(deductionSource).toContain("return deductCompanyExpense({");
+    expect(deductionSource).toContain("companyId,");
+    expect(deductionSource).toContain("amount,");
+    expect(deductionSource).toContain("description,");
+    expect(deductionSource).toContain("category,");
+  });
+
+  it("does not read or mutate company money directly in the browser", () => {
+    for (const forbidden of [
+      '.from("companies")',
+      '.from("company_transactions")',
+      ".update(",
+      ".insert(",
+    ]) {
+      expect(deductionSource).not.toContain(forbidden);
+    }
+  });
+
+  it("retains the shared business entity lookup helpers", () => {
+    for (const helper of [
+      "getCompanyIdFromSecurityFirm",
+      "getCompanyIdFromMerchFactory",
+      "getCompanyIdFromLogistics",
+      "getCompanyIdFromVenue",
+      "getCompanyIdFromRehearsalRoom",
+      "getCompanyIdFromRecordingStudio",
+      "getCompanyIdFromLabel",
+    ]) {
+      expect(source).toContain(`export async function ${helper}`);
+    }
+  });
+});

--- a/src/hooks/useCompanyBalanceDeduction.ts
+++ b/src/hooks/useCompanyBalanceDeduction.ts
@@ -1,8 +1,9 @@
 import { supabase } from "@/integrations/supabase/client";
+import { deductCompanyExpense } from "@/lib/api/companyExpenseDeductions";
 
 /**
- * Deducts an amount from a company's balance and records a transaction.
- * Throws if insufficient funds.
+ * Deducts an amount from a company's balance through the authoritative,
+ * transactional company-expense boundary.
  */
 export async function deductCompanyBalance({
   companyId,
@@ -15,40 +16,12 @@ export async function deductCompanyBalance({
   description: string;
   category: string;
 }) {
-  // Fetch current balance
-  const { data: company, error: fetchError } = await supabase
-    .from("companies")
-    .select("balance")
-    .eq("id", companyId)
-    .single();
-
-  if (fetchError) throw new Error(`Failed to fetch company: ${fetchError.message}`);
-  if (!company) throw new Error("Company not found");
-
-  if ((company.balance || 0) < amount) {
-    throw new Error(`Insufficient funds. Need $${amount.toLocaleString()} but only have $${(company.balance || 0).toLocaleString()}`);
-  }
-
-  // Deduct balance
-  const { error: updateError } = await supabase
-    .from("companies")
-    .update({ balance: (company.balance || 0) - amount })
-    .eq("id", companyId);
-
-  if (updateError) throw new Error(`Failed to update balance: ${updateError.message}`);
-
-  // Record transaction
-  const { error: txError } = await supabase
-    .from("company_transactions")
-    .insert({
-      company_id: companyId,
-      transaction_type: "expense",
-      amount: -amount,
-      description,
-      category,
-    });
-
-  if (txError) console.error("Failed to record transaction:", txError);
+  return deductCompanyExpense({
+    companyId,
+    amount,
+    description,
+    category,
+  });
 }
 
 /** Look up company_id from a security_firms row */


### PR DESCRIPTION
## What changed

- replaces the browser-side implementation of `deductCompanyBalance` with the typed `deductCompanyExpense` API
- removes direct balance reads and updates from the shared helper
- removes direct `company_transactions` inserts from the shared helper
- preserves the existing company lookup helpers used by venue, studio, label, logistics, security and merchandise systems
- adds a source-level authority contract preventing direct company-money writes from returning

## Dependency

PR #1398 has merged and supplies the transactional `deduct_company_balance` RPC and typed API boundary.

## Root cause

The shared helper previously performed three separate browser operations: read the company balance, update `companies.balance`, then insert the expense into `company_transactions`. Partial failures could remove money without recording the expense, and concurrent calls could overspend the same visible balance.

## Impact

Every existing caller of `deductCompanyBalance` now receives the same atomic behaviour without requiring individual feature rewrites, including venues, recording studios, rehearsal studios, labels, logistics companies, security firms, merchandise factories and upgrade managers.

## Validation

```bash
npm test -- src/hooks/__tests__/useCompanyBalanceDeduction.authority.test.ts src/lib/api/__tests__/companyExpenseDeductions.database.test.ts
npm run typecheck
```

The source migration and authority test are committed. Runtime CI has not yet been inspected, so this PR is opened as a draft.