### PR TITLE
Migrate company share sales to buyer-approved offers

### DIFF
--- a/src/components/company/CompanySharesPanel.tsx
+++ b/src/components/company/CompanySharesPanel.tsx
@@ -3,7 +3,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useCompanyShareholders, useDistributeAnnualProfit, useIssueCompanyShares } from "@/hooks/useCompanyShares";
+import { Badge } from "@/components/ui/badge";
+import { useCompanyShareholders, useDistributeAnnualProfit } from "@/hooks/useCompanyShares";
+import {
+  useCompanyShareOffers,
+  useIssueCompanyShares,
+  useRespondToCompanyShareOffer,
+} from "@/hooks/useCompanyShareOffers";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { supabase } from "@/integrations/supabase/client";
 import { useQuery } from "@tanstack/react-query";
 
@@ -12,9 +19,20 @@ interface CompanySharesPanelProps {
   isMajorityOwner: boolean;
 }
 
+const formatGBP = (amount: number) =>
+  new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
 export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanySharesPanelProps) {
+  const { profileId } = useActiveProfile();
   const { data: shareholders = [] } = useCompanyShareholders(companyId);
+  const { data: incomingOffers = [] } = useCompanyShareOffers(companyId, profileId);
   const issueShares = useIssueCompanyShares();
+  const respondToOffer = useRespondToCompanyShareOffer();
   const distributeProfit = useDistributeAnnualProfit();
 
   const [recipientQuery, setRecipientQuery] = useState("");
@@ -37,12 +55,63 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
   });
 
   const totalShares = useMemo(
-    () => shareholders.reduce((sum, sh) => sum + Number(sh.shares || 0), 0),
+    () => shareholders.reduce((sum, shareholder) => sum + Number(shareholder.shares || 0), 0),
     [shareholders],
   );
 
   return (
     <div className="space-y-4">
+      {incomingOffers.length > 0 && (
+        <Card className="border-primary/30">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle>Incoming Share Offers</CardTitle>
+                <CardDescription>
+                  Paid offers only move money and issue shares after you accept them.
+                </CardDescription>
+              </div>
+              <Badge>{incomingOffers.length} pending</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {incomingOffers.map((offer) => (
+              <div key={offer.id} className="rounded-lg border p-4">
+                <div className="flex flex-col justify-between gap-3 md:flex-row md:items-center">
+                  <div>
+                    <p className="font-medium">
+                      {offer.shares.toLocaleString("en-GB")} shares for {formatGBP(offer.total_price)}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Offered by {offer.issuerProfile?.stage_name || offer.issuerProfile?.username || "Company owner"}
+                      {" · "}{formatGBP(offer.price_per_share)} per share
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Expires {new Date(offer.expires_at).toLocaleString("en-GB")}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      disabled={respondToOffer.isPending}
+                      onClick={() => respondToOffer.mutate({ offerId: offer.id, accept: false })}
+                    >
+                      Decline
+                    </Button>
+                    <Button
+                      disabled={respondToOffer.isPending}
+                      onClick={() => respondToOffer.mutate({ offerId: offer.id, accept: true })}
+                    >
+                      Accept for {formatGBP(offer.total_price)}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>Shareholders</CardTitle>
@@ -52,14 +121,14 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
         </CardHeader>
         <CardContent className="space-y-2">
           {shareholders.map((holder) => {
-            const pct = totalShares > 0 ? (Number(holder.shares) / totalShares) * 100 : 0;
+            const percentage = totalShares > 0 ? (Number(holder.shares) / totalShares) * 100 : 0;
             return (
               <div key={holder.id} className="flex items-center justify-between rounded border p-3">
                 <div>
                   <p className="font-medium">{holder.profile?.stage_name || holder.profile?.username || "Unknown player"}</p>
                   <p className="text-xs text-muted-foreground">{holder.shares} shares</p>
                 </div>
-                <p className="text-sm font-semibold">{pct.toFixed(1)}%</p>
+                <p className="text-sm font-semibold">{percentage.toFixed(1)}%</p>
               </div>
             );
           })}
@@ -69,7 +138,9 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
       <Card>
         <CardHeader>
           <CardTitle>Create and Transfer Shares</CardTitle>
-          <CardDescription>Issue new shares and either sell or gift them to a player.</CardDescription>
+          <CardDescription>
+            Gifts are issued immediately. Paid sales send a seven-day offer that the buyer must accept.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           {!isMajorityOwner ? (
@@ -78,17 +149,17 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
             <>
               <div>
                 <Label>Find player</Label>
-                <Input value={recipientQuery} onChange={(e) => setRecipientQuery(e.target.value)} placeholder="Search by stage name or username" />
+                <Input value={recipientQuery} onChange={(event) => setRecipientQuery(event.target.value)} placeholder="Search by stage name or username" />
                 {profiles.length > 0 && (
                   <div className="mt-2 space-y-1 rounded border p-2">
-                    {profiles.map((p: any) => (
+                    {profiles.map((profile: any) => (
                       <button
-                        key={p.id}
-                        className={`w-full rounded px-2 py-1 text-left text-sm hover:bg-accent ${recipientId === p.id ? "bg-accent" : ""}`}
-                        onClick={() => setRecipientId(p.id)}
+                        key={profile.id}
+                        className={`w-full rounded px-2 py-1 text-left text-sm hover:bg-accent ${recipientId === profile.id ? "bg-accent" : ""}`}
+                        onClick={() => setRecipientId(profile.id)}
                         type="button"
                       >
-                        {p.stage_name || p.username}
+                        {profile.stage_name || profile.username}
                       </button>
                     ))}
                   </div>
@@ -98,11 +169,11 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
               <div className="grid gap-3 md:grid-cols-2">
                 <div>
                   <Label>Shares</Label>
-                  <Input type="number" min={1} value={shares} onChange={(e) => setShares(e.target.value)} />
+                  <Input type="number" min={1} value={shares} onChange={(event) => setShares(event.target.value)} />
                 </div>
                 <div>
-                  <Label>Price per share (0 = gift)</Label>
-                  <Input type="number" min={0} value={pricePerShare} onChange={(e) => setPricePerShare(e.target.value)} />
+                  <Label>Price per share (£0 = gift)</Label>
+                  <Input type="number" min={0} value={pricePerShare} onChange={(event) => setPricePerShare(event.target.value)} />
                 </div>
               </div>
 
@@ -117,7 +188,7 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
                 }
                 disabled={!recipientId || Number(shares) <= 0 || Number(pricePerShare) < 0 || issueShares.isPending}
               >
-                {Number(pricePerShare) > 0 ? "Sell shares" : "Gift shares"}
+                {Number(pricePerShare) > 0 ? "Send paid offer" : "Gift shares"}
               </Button>
             </>
           )}

--- a/src/hooks/__tests__/useCompanyShareOffers.authority.test.ts
+++ b/src/hooks/__tests__/useCompanyShareOffers.authority.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const legacySource = fs.readFileSync(
+  path.resolve("src/hooks/useCompanyShares.ts"),
+  "utf8",
+);
+const offerSource = fs.readFileSync(
+  path.resolve("src/hooks/useCompanyShareOffers.ts"),
+  "utf8",
+);
+const panelSource = fs.readFileSync(
+  path.resolve("src/components/company/CompanySharesPanel.tsx"),
+  "utf8",
+);
+
+const legacyIssuanceArea = legacySource.slice(
+  0,
+  legacySource.indexOf("export const useDistributeAnnualProfit"),
+);
+
+describe("company share offer authority", () => {
+  it("removes the legacy browser-side issuance mutation", () => {
+    expect(legacySource).toContain(
+      'export { useIssueCompanyShares } from "@/hooks/useCompanyShareOffers";',
+    );
+    expect(legacySource).not.toContain("export const useIssueCompanyShares =");
+
+    for (const forbidden of [
+      '.from("companies")\n          .update',
+      '.from("profiles")\n          .update',
+      '.from("company_transactions").insert',
+      '.from("company_shareholders" as any)\n          .update',
+      '.from("company_shareholders" as any)\n          .insert',
+      '.from("company_share_transfers" as any).insert',
+    ]) {
+      expect(legacyIssuanceArea).not.toContain(forbidden);
+    }
+  });
+
+  it("uses the authoritative proposal and response APIs", () => {
+    expect(offerSource).toContain("mutationFn: proposeCompanyShareIssuance");
+    expect(offerSource).toContain("mutationFn: respondCompanyShareOffer");
+    expect(offerSource).toContain('.from("company_share_offers" as any)');
+  });
+
+  it("requires buyer action for paid offers", () => {
+    expect(panelSource).toContain("Incoming Share Offers");
+    expect(panelSource).toContain("offerId: offer.id, accept: false");
+    expect(panelSource).toContain("offerId: offer.id, accept: true");
+    expect(panelSource).toContain("Send paid offer");
+    expect(panelSource).toContain("buyer must accept");
+  });
+
+  it("uses UK currency formatting", () => {
+    expect(offerSource).toContain('new Intl.NumberFormat("en-GB"');
+    expect(offerSource).toContain('currency: "GBP"');
+    expect(panelSource).toContain('new Intl.NumberFormat("en-GB"');
+    expect(panelSource).toContain('currency: "GBP"');
+  });
+});

--- a/src/hooks/useCompanyShareOffers.ts
+++ b/src/hooks/useCompanyShareOffers.ts
@@ -1,0 +1,140 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  proposeCompanyShareIssuance,
+  respondCompanyShareOffer,
+  type CompanyShareOfferResult,
+  type CompanyShareOfferStatus,
+} from "@/lib/api/companyShareOffers";
+
+export interface CompanyShareOffer {
+  id: string;
+  company_id: string;
+  issuer_profile_id: string;
+  recipient_profile_id: string;
+  shares: number;
+  price_per_share: number;
+  total_price: number;
+  status: CompanyShareOfferStatus;
+  expires_at: string;
+  created_at: string;
+  issuerProfile?: { id: string; stage_name: string | null; username: string | null } | null;
+}
+
+const invalidateShareData = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  companyId: string,
+) => {
+  for (const queryKey of [
+    ["company-shareholders", companyId],
+    ["company-share-offers", companyId],
+    ["company", companyId],
+    ["companies"],
+    ["company-balance", companyId],
+    ["company-transactions", companyId],
+    ["profile"],
+    ["user-cash-balance"],
+  ]) {
+    queryClient.invalidateQueries({ queryKey });
+  }
+};
+
+export const useIssueCompanyShares = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: proposeCompanyShareIssuance,
+    onSuccess: (result: CompanyShareOfferResult) => {
+      invalidateShareData(queryClient, result.companyId);
+      toast({
+        title: result.status === "accepted" ? "Shares gifted" : "Share offer sent",
+        description:
+          result.status === "accepted"
+            ? `${result.shares.toLocaleString("en-GB")} shares were issued immediately.`
+            : `The buyer must accept the ${new Intl.NumberFormat("en-GB", {
+                style: "currency",
+                currency: "GBP",
+              }).format(result.totalPrice)} offer before any money moves.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Share offer failed",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+};
+
+export const useCompanyShareOffers = (
+  companyId: string | undefined,
+  recipientProfileId: string | undefined,
+) => {
+  return useQuery({
+    queryKey: ["company-share-offers", companyId, recipientProfileId],
+    queryFn: async (): Promise<CompanyShareOffer[]> => {
+      if (!companyId || !recipientProfileId) return [];
+
+      const { data: offers, error } = await supabase
+        .from("company_share_offers" as any)
+        .select(
+          "id, company_id, issuer_profile_id, recipient_profile_id, shares, price_per_share, total_price, status, expires_at, created_at",
+        )
+        .eq("company_id", companyId)
+        .eq("recipient_profile_id", recipientProfileId)
+        .eq("status", "pending")
+        .order("created_at", { ascending: false });
+
+      if (error) throw error;
+      const rows = (offers || []) as unknown as CompanyShareOffer[];
+      if (rows.length === 0) return rows;
+
+      const issuerProfileIds = [...new Set(rows.map((offer) => offer.issuer_profile_id))];
+      const { data: profiles, error: profileError } = await supabase
+        .from("profiles")
+        .select("id, stage_name, username")
+        .in("id", issuerProfileIds);
+
+      if (profileError) throw profileError;
+      const profileById = new Map((profiles || []).map((profile) => [profile.id, profile]));
+
+      return rows.map((offer) => ({
+        ...offer,
+        issuerProfile: profileById.get(offer.issuer_profile_id) ?? null,
+      }));
+    },
+    enabled: !!companyId && !!recipientProfileId,
+  });
+};
+
+export const useRespondToCompanyShareOffer = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: respondCompanyShareOffer,
+    onSuccess: (result: CompanyShareOfferResult) => {
+      invalidateShareData(queryClient, result.companyId);
+      toast({
+        title: result.status === "accepted" ? "Share offer accepted" : "Share offer declined",
+        description:
+          result.status === "accepted"
+            ? `${result.shares.toLocaleString("en-GB")} shares were added to your holding for ${new Intl.NumberFormat(
+                "en-GB",
+                { style: "currency", currency: "GBP" },
+              ).format(result.totalPrice)}.`
+            : "No money or shares were transferred.",
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Could not respond to offer",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+};

--- a/src/hooks/useCompanyShares.ts
+++ b/src/hooks/useCompanyShares.ts
@@ -4,6 +4,8 @@ import { useAuth } from "@/hooks/use-auth-context";
 import { useToast } from "@/components/ui/use-toast";
 import { calculateInGameDate } from "@/utils/gameCalendar";
 
+export { useIssueCompanyShares } from "@/hooks/useCompanyShareOffers";
+
 export interface CompanyShareholder {
   id: string;
   company_id: string;
@@ -29,151 +31,19 @@ export const useCompanyShareholders = (companyId: string | undefined) => {
 
       if (shareholders.length === 0) return shareholders;
 
-      const userIds = shareholders.map((s) => s.user_id);
+      const userIds = shareholders.map((shareholder) => shareholder.user_id);
       const { data: profiles } = await supabase
         .from("profiles")
         .select("id, user_id, stage_name, username")
         .in("user_id", userIds as string[]);
 
-      const profileByUserId = new Map((profiles || []).map((p: any) => [p.user_id, p]));
-      return shareholders.map((s) => ({ ...s, profile: profileByUserId.get(s.user_id) ?? null }));
+      const profileByUserId = new Map((profiles || []).map((profile: any) => [profile.user_id, profile]));
+      return shareholders.map((shareholder) => ({
+        ...shareholder,
+        profile: profileByUserId.get(shareholder.user_id) ?? null,
+      }));
     },
     enabled: !!companyId,
-  });
-};
-
-export const useIssueCompanyShares = () => {
-  const { user } = useAuth();
-  const { toast } = useToast();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async ({
-      companyId,
-      recipientProfileId,
-      shares,
-      pricePerShare,
-    }: {
-      companyId: string;
-      recipientProfileId: string;
-      shares: number;
-      pricePerShare: number;
-    }) => {
-      if (!user?.id) throw new Error("Not authenticated");
-      if (shares <= 0) throw new Error("Shares must be greater than 0");
-      if (pricePerShare < 0) throw new Error("Price per share cannot be negative");
-
-      const { data: recipient, error: recipientError } = await supabase
-        .from("profiles")
-        .select("id, user_id, cash")
-        .eq("id", recipientProfileId)
-        .single();
-
-      if (recipientError) throw recipientError;
-      const totalPrice = shares * pricePerShare;
-
-      if (totalPrice > 0) {
-        if ((recipient.cash || 0) < totalPrice) {
-          throw new Error("Recipient does not have enough cash to buy these shares");
-        }
-
-        const { error: buyerCashError } = await supabase
-          .from("profiles")
-          .update({ cash: Number(recipient.cash) - totalPrice })
-          .eq("id", recipient.id);
-        if (buyerCashError) throw buyerCashError;
-
-        const { data: company, error: companyError } = await supabase
-          .from("companies")
-          .select("balance")
-          .eq("id", companyId)
-          .single();
-        if (companyError) throw companyError;
-
-        const { error: companyUpdateError } = await supabase
-          .from("companies")
-          .update({ balance: Number(company.balance) + totalPrice })
-          .eq("id", companyId);
-        if (companyUpdateError) throw companyUpdateError;
-
-        await supabase.from("company_transactions").insert({
-          company_id: companyId,
-          transaction_type: "income",
-          amount: totalPrice,
-          description: `Share sale (${shares} shares)` ,
-          category: "owner_transfer",
-        });
-      }
-
-      const { data: existingShareholder } = await supabase
-        .from("company_shareholders" as any)
-        .select("id, shares")
-        .eq("company_id", companyId)
-        .eq("user_id", recipient.user_id)
-        .maybeSingle();
-
-      if (existingShareholder) {
-        const existing = existingShareholder as any;
-        const { error: updateSharesError } = await supabase
-          .from("company_shareholders" as any)
-          .update({ shares: Number(existing.shares) + shares })
-          .eq("id", existing.id);
-        if (updateSharesError) throw updateSharesError;
-      } else {
-        const { error: insertSharesError } = await supabase
-          .from("company_shareholders" as any)
-          .insert({ company_id: companyId, user_id: recipient.user_id, shares });
-        if (insertSharesError) throw insertSharesError;
-      }
-
-      // Look up the current user's profile for the transfer record
-      const { data: senderProfile } = await supabase
-        .from("profiles")
-        .select("user_id")
-        .eq("user_id", user.id)
-        .eq("is_active", true)
-        .is("died_at", null)
-        .maybeSingle();
-
-      await supabase.from("company_share_transfers" as any).insert({
-        company_id: companyId,
-        from_user_id: senderProfile?.user_id ?? user.id,
-        to_user_id: recipient.user_id,
-        shares,
-        price_per_share: pricePerShare,
-        total_price: totalPrice,
-        transfer_type: totalPrice > 0 ? "sale" : "gift",
-      });
-
-      const { data: allShareholders } = await supabase
-        .from("company_shareholders" as any)
-        .select("user_id, shares")
-        .eq("company_id", companyId)
-        .order("shares", { ascending: false })
-        .limit(1);
-
-      if (allShareholders && allShareholders.length > 0) {
-        await supabase
-          .from("companies")
-          .update({ owner_id: (allShareholders[0] as any).user_id })
-          .eq("id", companyId);
-      }
-
-      return { totalPrice };
-    },
-    onSuccess: (_, vars) => {
-      queryClient.invalidateQueries({ queryKey: ["company-shareholders", vars.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company", vars.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["companies"] });
-      queryClient.invalidateQueries({ queryKey: ["company-balance", vars.companyId] });
-      toast({
-        title: "Shares created",
-        description: "Shares were successfully created and transferred.",
-      });
-    },
-    onError: (error: Error) => {
-      toast({ title: "Share transfer failed", description: error.message, variant: "destructive" });
-    },
   });
 };
 
@@ -203,7 +73,7 @@ export const useDistributeAnnualProfit = () => {
         .single();
       if (companyError) throw companyError;
 
-      const { data: latestDist } = await supabase
+      const { data: latestDistribution } = await supabase
         .from("company_profit_distributions" as any)
         .select("distributed_at")
         .eq("company_id", companyId)
@@ -211,45 +81,58 @@ export const useDistributeAnnualProfit = () => {
         .limit(1)
         .maybeSingle();
 
-      let txQuery = supabase
+      let transactionQuery = supabase
         .from("company_transactions")
         .select("amount")
         .eq("company_id", companyId);
 
-      if ((latestDist as any)?.distributed_at) {
-        txQuery = txQuery.gt("created_at", (latestDist as any).distributed_at);
+      if ((latestDistribution as any)?.distributed_at) {
+        transactionQuery = transactionQuery.gt(
+          "created_at",
+          (latestDistribution as any).distributed_at,
+        );
       }
 
-      const { data: txns, error: txError } = await txQuery;
-      if (txError) throw txError;
+      const { data: transactions, error: transactionError } = await transactionQuery;
+      if (transactionError) throw transactionError;
 
-      const profit = (txns || []).reduce((sum, t) => sum + Number(t.amount), 0);
+      const profit = (transactions || []).reduce(
+        (sum, transaction) => sum + Number(transaction.amount),
+        0,
+      );
       const distributableProfit = Math.max(0, Math.floor(profit));
       if (distributableProfit <= 0) throw new Error("No profit available to distribute");
-      if (Number(company.balance) < distributableProfit) throw new Error("Insufficient company balance");
+      if (Number(company.balance) < distributableProfit) {
+        throw new Error("Insufficient company balance");
+      }
 
-      const { data: shareholders, error: shError } = await supabase
+      const { data: shareholders, error: shareholderError } = await supabase
         .from("company_shareholders" as any)
         .select("user_id, shares")
         .eq("company_id", companyId);
-      if (shError) throw shError;
+      if (shareholderError) throw shareholderError;
       if (!shareholders || shareholders.length === 0) throw new Error("No shareholders found");
 
-      const totalShares = shareholders.reduce((sum: number, sh: any) => sum + Number(sh.shares), 0);
+      const totalShares = shareholders.reduce(
+        (sum: number, shareholder: any) => sum + Number(shareholder.shares),
+        0,
+      );
       if (totalShares <= 0) throw new Error("Invalid total shares");
 
-      const userIds = shareholders.map((s: any) => s.user_id);
+      const userIds = shareholders.map((shareholder: any) => shareholder.user_id);
       const { data: profiles } = await supabase
         .from("profiles")
         .select("id, user_id, cash")
         .in("user_id", userIds);
 
-      const profileByUserId = new Map((profiles || []).map((p: any) => [p.user_id, p]));
+      const profileByUserId = new Map((profiles || []).map((profile: any) => [profile.user_id, profile]));
 
-      for (const sh of shareholders as any[]) {
-        const payout = Math.floor((distributableProfit * Number(sh.shares)) / totalShares);
+      for (const shareholder of shareholders as any[]) {
+        const payout = Math.floor(
+          (distributableProfit * Number(shareholder.shares)) / totalShares,
+        );
         if (payout <= 0) continue;
-        const profile = profileByUserId.get(sh.user_id);
+        const profile = profileByUserId.get(shareholder.user_id);
         if (!profile) continue;
 
         const { error: profileUpdateError } = await supabase
@@ -273,26 +156,29 @@ export const useDistributeAnnualProfit = () => {
         category: "owner_transfer",
       });
 
-      const { error: distError } = await supabase
+      const { error: distributionError } = await supabase
         .from("company_profit_distributions" as any)
         .insert({
           company_id: companyId,
           game_year: gameYear,
           distributed_profit: distributableProfit,
-          distributed_by: user.id, // account-level action, user_id is correct here
+          distributed_by: user.id,
         });
-      if (distError) throw distError;
+      if (distributionError) throw distributionError;
 
       return { distributableProfit, gameYear };
     },
-    onSuccess: ({ distributableProfit, gameYear }, vars) => {
-      queryClient.invalidateQueries({ queryKey: ["company", vars.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-balance", vars.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-transactions", vars.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-shareholders", vars.companyId] });
+    onSuccess: ({ distributableProfit, gameYear }, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["company", variables.companyId] });
+      queryClient.invalidateQueries({ queryKey: ["company-balance", variables.companyId] });
+      queryClient.invalidateQueries({ queryKey: ["company-transactions", variables.companyId] });
+      queryClient.invalidateQueries({ queryKey: ["company-shareholders", variables.companyId] });
       toast({
         title: "Profit distributed",
-        description: `$${distributableProfit.toLocaleString()} distributed for game year ${gameYear}.`,
+        description: `${new Intl.NumberFormat("en-GB", {
+          style: "currency",
+          currency: "GBP",
+        }).format(distributableProfit)} distributed for game year ${gameYear}.`,
       });
     },
     onError: (error: Error) => {


### PR DESCRIPTION
## What changed

- replaces the legacy `useIssueCompanyShares` browser-write sequence with `proposeCompanyShareIssuance`
- keeps a compatibility re-export so existing imports automatically use the safe hook
- adds pending share-offer queries scoped to the active recipient character and current company
- adds explicit accept and decline controls to the company Shares tab
- processes responses through `respondCompanyShareOffer`
- refreshes shareholder, company, balance, transaction and character cash views after completion
- updates share values and messages to `en-GB` and pounds
- adds a source-level authority test preventing direct share-sale money and ownership writes from returning

## Dependency

PR #1400 has merged and supplies the authoritative `propose_company_share_issuance` and `respond_company_share_offer` RPCs.

## Root cause

The previous hook charged the selected recipient, credited the company, changed shareholder rows, inserted transfer history and recalculated ownership through separate browser operations. It could also charge another player without their acceptance.

## Behaviour

- free gifts complete immediately
- paid sales create a seven-day pending offer
- the selected active character sees the offer in the company's Shares tab
- accepting performs payment and share issuance atomically
- declining moves no money and issues no shares
- the old browser-side issuance function no longer exists

## Scope note

This PR surfaces offers within the relevant company Shares tab. A later usability pass can additionally aggregate all incoming offers on the My Companies dashboard.

## Validation

```bash
npm test -- src/hooks/__tests__/useCompanyShareOffers.authority.test.ts src/lib/api/__tests__/companyShareOffers.database.test.ts
npm run typecheck
```

The actual source migration, UI controls and authority test are committed. Runtime CI has not yet been inspected, so this PR is opened as a draft.