### PR TITLE
Harden annual company profit distributions

### DIFF
--- a/src/lib/api/__tests__/companyProfitDistributions.database.test.ts
+++ b/src/lib/api/__tests__/companyProfitDistributions.database.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.fn();
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: { rpc },
+}));
+
+import { distributeCompanyAnnualProfit } from "@/lib/api/companyProfitDistributions";
+
+describe("company annual profit distribution database boundary", () => {
+  beforeEach(() => rpc.mockReset());
+
+  it("uses the authoritative annual distribution RPC", async () => {
+    rpc.mockResolvedValue({
+      data: [{ distributed_profit: 12_500, game_year: 3 }],
+      error: null,
+    });
+
+    const result = await distributeCompanyAnnualProfit("company-1");
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith("distribute_company_annual_profit", {
+      p_company_id: "company-1",
+    });
+    expect(result).toEqual({ distributedProfit: 12_500, gameYear: 3 });
+  });
+
+  it("supports scalar PostgREST responses", async () => {
+    rpc.mockResolvedValue({
+      data: { distributed_profit: "2500", game_year: "4" },
+      error: null,
+    });
+
+    await expect(distributeCompanyAnnualProfit("company-2")).resolves.toEqual({
+      distributedProfit: 2500,
+      gameYear: 4,
+    });
+  });
+
+  it("propagates database failures without browser-side payout fallbacks", async () => {
+    const error = new Error("shareholder_active_profile_required");
+    rpc.mockResolvedValue({ data: null, error });
+
+    await expect(distributeCompanyAnnualProfit("company-1")).rejects.toBe(error);
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api/companyProfitDistributions.ts
+++ b/src/lib/api/companyProfitDistributions.ts
@@ -1,0 +1,25 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface CompanyProfitDistributionResult {
+  distributedProfit: number;
+  gameYear: number;
+}
+
+export const distributeCompanyAnnualProfit = async (
+  companyId: string,
+): Promise<CompanyProfitDistributionResult> => {
+  const { data, error } = await (supabase.rpc as any)(
+    "distribute_company_annual_profit",
+    { p_company_id: companyId },
+  );
+
+  if (error) throw error;
+
+  const result = Array.isArray(data) ? data[0] : data;
+  if (!result) throw new Error("company_profit_distribution_empty_response");
+
+  return {
+    distributedProfit: Number(result.distributed_profit),
+    gameYear: Number(result.game_year),
+  };
+};

--- a/supabase/migrations/20260729110000_harden_company_profit_distribution.sql
+++ b/supabase/migrations/20260729110000_harden_company_profit_distribution.sql
@@ -31,8 +31,8 @@ BEGIN
   END IF;
 
   SELECT * INTO v_company
-  FROM public.companies
-  WHERE id = p_company_id
+  FROM public.companies c
+  WHERE c.id = p_company_id
   FOR UPDATE;
 
   IF NOT FOUND THEN
@@ -57,10 +57,10 @@ BEGIN
     ) / 360
   ) + 1;
 
-  SELECT distributed_profit INTO v_existing_profit
-  FROM public.company_profit_distributions
-  WHERE company_id = p_company_id
-    AND game_year = v_game_year
+  SELECT d.distributed_profit INTO v_existing_profit
+  FROM public.company_profit_distributions d
+  WHERE d.company_id = p_company_id
+    AND d.game_year = v_game_year
   FOR UPDATE;
 
   IF FOUND THEN
@@ -72,10 +72,10 @@ BEGIN
     RETURN;
   END IF;
 
-  SELECT distributed_at INTO v_latest_distributed_at
-  FROM public.company_profit_distributions
-  WHERE company_id = p_company_id
-  ORDER BY distributed_at DESC
+  SELECT d.distributed_at INTO v_latest_distributed_at
+  FROM public.company_profit_distributions d
+  WHERE d.company_id = p_company_id
+  ORDER BY d.distributed_at DESC
   LIMIT 1;
 
   SELECT coalesce(sum(t.amount), 0) INTO v_profit
@@ -96,13 +96,13 @@ BEGIN
   END IF;
 
   PERFORM 1
-  FROM public.company_shareholders
-  WHERE company_id = p_company_id
+  FROM public.company_shareholders sh
+  WHERE sh.company_id = p_company_id
   FOR UPDATE;
 
-  SELECT coalesce(sum(shares), 0) INTO v_total_shares
-  FROM public.company_shareholders
-  WHERE company_id = p_company_id;
+  SELECT coalesce(sum(sh.shares), 0) INTO v_total_shares
+  FROM public.company_shareholders sh
+  WHERE sh.company_id = p_company_id;
 
   IF v_total_shares <= 0 THEN
     RAISE EXCEPTION 'no_valid_company_shareholders' USING ERRCODE = 'P0001';
@@ -156,38 +156,41 @@ BEGIN
       WHERE sh.company_id = p_company_id
     ), base_allocations AS (
       SELECT
-        user_id,
-        shares,
-        profile_id,
-        floor(exact_payout) AS base_payout,
-        exact_payout - floor(exact_payout) AS fractional_remainder
+        shareholder_profiles.user_id,
+        shareholder_profiles.shares,
+        shareholder_profiles.profile_id,
+        floor(shareholder_profiles.exact_payout) AS base_payout,
+        shareholder_profiles.exact_payout - floor(shareholder_profiles.exact_payout) AS fractional_remainder
       FROM shareholder_profiles
     ), ranked_allocations AS (
       SELECT
         base_allocations.*,
-        sum(base_payout) OVER () AS base_total,
+        sum(base_allocations.base_payout) OVER () AS base_total,
         row_number() OVER (
-          ORDER BY fractional_remainder DESC, shares DESC, user_id
+          ORDER BY base_allocations.fractional_remainder DESC,
+                   base_allocations.shares DESC,
+                   base_allocations.user_id
         ) AS remainder_rank
       FROM base_allocations
     )
     SELECT
-      user_id,
-      profile_id,
-      base_payout + CASE
-        WHEN remainder_rank <= (v_distributable_profit - base_total)::integer THEN 1
+      ranked_allocations.user_id,
+      ranked_allocations.profile_id,
+      ranked_allocations.base_payout + CASE
+        WHEN ranked_allocations.remainder_rank <=
+             (v_distributable_profit - ranked_allocations.base_total)::integer THEN 1
         ELSE 0
       END AS payout
     FROM ranked_allocations
-    ORDER BY user_id
+    ORDER BY ranked_allocations.user_id
   LOOP
     IF v_payout.payout <= 0 THEN
       CONTINUE;
     END IF;
 
     PERFORM 1
-    FROM public.profiles
-    WHERE id = v_payout.profile_id
+    FROM public.profiles p
+    WHERE p.id = v_payout.profile_id
     FOR UPDATE;
 
     SELECT public.finance_transfer(
@@ -210,10 +213,10 @@ BEGIN
       )
     ) INTO v_financial_transaction_id;
 
-    UPDATE public.profiles
-    SET cash = coalesce(cash, 0) + v_payout.payout,
+    UPDATE public.profiles p
+    SET cash = coalesce(p.cash, 0) + v_payout.payout,
         updated_at = now()
-    WHERE id = v_payout.profile_id;
+    WHERE p.id = v_payout.profile_id;
 
     v_paid_total := v_paid_total + v_payout.payout;
   END LOOP;
@@ -222,10 +225,10 @@ BEGIN
     RAISE EXCEPTION 'company_profit_allocation_mismatch' USING ERRCODE = 'P0001';
   END IF;
 
-  UPDATE public.companies
-  SET balance = balance - v_paid_total,
+  UPDATE public.companies c
+  SET balance = c.balance - v_paid_total,
       updated_at = now()
-  WHERE id = p_company_id;
+  WHERE c.id = p_company_id;
 
   INSERT INTO public.company_transactions(
     company_id,
@@ -245,10 +248,10 @@ BEGIN
     'company_profit_distribution'
   );
 
-  UPDATE public.company_profit_distributions
+  UPDATE public.company_profit_distributions d
   SET distributed_profit = v_paid_total,
       distributed_at = now()
-  WHERE id = v_distribution_id;
+  WHERE d.id = v_distribution_id;
 
   RETURN QUERY SELECT v_paid_total, v_game_year;
 END;

--- a/supabase/migrations/20260729110000_harden_company_profit_distribution.sql
+++ b/supabase/migrations/20260729110000_harden_company_profit_distribution.sql
@@ -1,0 +1,261 @@
+-- Harden annual company profit distribution around the canonical finance ledger.
+-- The public RPC signature is preserved so existing clients continue to work.
+
+CREATE OR REPLACE FUNCTION public.distribute_company_annual_profit(p_company_id uuid)
+RETURNS TABLE(distributed_profit numeric, game_year integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_actor_profile_id uuid := public._caller_profile_id();
+  v_company public.companies%ROWTYPE;
+  v_distribution_id uuid;
+  v_existing_profit numeric;
+  v_game_year integer;
+  v_latest_distributed_at timestamptz;
+  v_profit numeric := 0;
+  v_distributable_profit numeric := 0;
+  v_total_shares bigint := 0;
+  v_paid_total numeric := 0;
+  v_financial_transaction_id uuid;
+  v_payout record;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'not_authenticated' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_actor_profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_company
+  FROM public.companies
+  WHERE id = p_company_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'company_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_company.owner_id <> v_user_id THEN
+    RAISE EXCEPTION 'company_not_owned' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_company.status <> 'active' OR coalesce(v_company.is_bankrupt, false) THEN
+    RAISE EXCEPTION 'company_not_active' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Mirrors the canonical defaults currently used by src/utils/gameCalendar.ts.
+  v_game_year := floor(
+    floor(
+      greatest(
+        0,
+        extract(epoch FROM (now() - timestamptz '2026-01-01T00:00:00Z')) / 86400
+      ) * 3
+    ) / 360
+  ) + 1;
+
+  SELECT distributed_profit INTO v_existing_profit
+  FROM public.company_profit_distributions
+  WHERE company_id = p_company_id
+    AND game_year = v_game_year
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF coalesce(v_existing_profit, 0) <= 0 THEN
+      RAISE EXCEPTION 'company_profit_distribution_incomplete' USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN QUERY SELECT v_existing_profit, v_game_year;
+    RETURN;
+  END IF;
+
+  SELECT distributed_at INTO v_latest_distributed_at
+  FROM public.company_profit_distributions
+  WHERE company_id = p_company_id
+  ORDER BY distributed_at DESC
+  LIMIT 1;
+
+  SELECT coalesce(sum(t.amount), 0) INTO v_profit
+  FROM public.company_transactions t
+  WHERE t.company_id = p_company_id
+    AND (v_latest_distributed_at IS NULL OR t.created_at > v_latest_distributed_at)
+    AND coalesce(t.category, '') <> 'owner_transfer'
+    AND t.transaction_type NOT IN ('investment', 'dividend', 'transfer_in', 'transfer_out');
+
+  v_distributable_profit := greatest(0, floor(v_profit));
+
+  IF v_distributable_profit <= 0 THEN
+    RAISE EXCEPTION 'no_profit_available_to_distribute' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF coalesce(v_company.balance, 0) < v_distributable_profit THEN
+    RAISE EXCEPTION 'insufficient_company_balance' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM 1
+  FROM public.company_shareholders
+  WHERE company_id = p_company_id
+  FOR UPDATE;
+
+  SELECT coalesce(sum(shares), 0) INTO v_total_shares
+  FROM public.company_shareholders
+  WHERE company_id = p_company_id;
+
+  IF v_total_shares <= 0 THEN
+    RAISE EXCEPTION 'no_valid_company_shareholders' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.company_shareholders sh
+    WHERE sh.company_id = p_company_id
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.profiles p
+        WHERE p.user_id = sh.user_id
+          AND p.is_active = true
+          AND p.died_at IS NULL
+      )
+  ) THEN
+    RAISE EXCEPTION 'shareholder_active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.company_profit_distributions(
+    company_id,
+    game_year,
+    distributed_profit,
+    distributed_by
+  ) VALUES (
+    p_company_id,
+    v_game_year,
+    0,
+    v_user_id
+  )
+  RETURNING id INTO v_distribution_id;
+
+  FOR v_payout IN
+    WITH shareholder_profiles AS (
+      SELECT
+        sh.user_id,
+        sh.shares,
+        p.id AS profile_id,
+        (v_distributable_profit * sh.shares::numeric / v_total_shares::numeric) AS exact_payout
+      FROM public.company_shareholders sh
+      CROSS JOIN LATERAL (
+        SELECT profile.id
+        FROM public.profiles profile
+        WHERE profile.user_id = sh.user_id
+          AND profile.is_active = true
+          AND profile.died_at IS NULL
+        ORDER BY profile.updated_at DESC NULLS LAST, profile.id
+        LIMIT 1
+      ) p
+      WHERE sh.company_id = p_company_id
+    ), base_allocations AS (
+      SELECT
+        user_id,
+        shares,
+        profile_id,
+        floor(exact_payout) AS base_payout,
+        exact_payout - floor(exact_payout) AS fractional_remainder
+      FROM shareholder_profiles
+    ), ranked_allocations AS (
+      SELECT
+        base_allocations.*,
+        sum(base_payout) OVER () AS base_total,
+        row_number() OVER (
+          ORDER BY fractional_remainder DESC, shares DESC, user_id
+        ) AS remainder_rank
+      FROM base_allocations
+    )
+    SELECT
+      user_id,
+      profile_id,
+      base_payout + CASE
+        WHEN remainder_rank <= (v_distributable_profit - base_total)::integer THEN 1
+        ELSE 0
+      END AS payout
+    FROM ranked_allocations
+    ORDER BY user_id
+  LOOP
+    IF v_payout.payout <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    PERFORM 1
+    FROM public.profiles
+    WHERE id = v_payout.profile_id
+    FOR UPDATE;
+
+    SELECT public.finance_transfer(
+      'company',
+      p_company_id,
+      'player',
+      v_payout.profile_id,
+      round(v_payout.payout * 100)::bigint,
+      'company_revenue',
+      format('Annual shareholder distribution, game year %s', v_game_year),
+      format('company-profit-distribution:%s:%s:%s', p_company_id, v_game_year, v_payout.user_id),
+      'company_profit_distribution',
+      v_distribution_id,
+      v_actor_profile_id,
+      jsonb_build_object(
+        'flow', 'shareholder_dividend',
+        'companyId', p_company_id,
+        'gameYear', v_game_year,
+        'shareholderUserId', v_payout.user_id
+      )
+    ) INTO v_financial_transaction_id;
+
+    UPDATE public.profiles
+    SET cash = coalesce(cash, 0) + v_payout.payout,
+        updated_at = now()
+    WHERE id = v_payout.profile_id;
+
+    v_paid_total := v_paid_total + v_payout.payout;
+  END LOOP;
+
+  IF v_paid_total <> v_distributable_profit THEN
+    RAISE EXCEPTION 'company_profit_allocation_mismatch' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.companies
+  SET balance = balance - v_paid_total,
+      updated_at = now()
+  WHERE id = p_company_id;
+
+  INSERT INTO public.company_transactions(
+    company_id,
+    transaction_type,
+    amount,
+    description,
+    category,
+    related_entity_id,
+    related_entity_type
+  ) VALUES (
+    p_company_id,
+    'dividend',
+    -v_paid_total,
+    format('Annual profit distribution (Game Year %s)', v_game_year),
+    'owner_transfer',
+    v_distribution_id,
+    'company_profit_distribution'
+  );
+
+  UPDATE public.company_profit_distributions
+  SET distributed_profit = v_paid_total,
+      distributed_at = now()
+  WHERE id = v_distribution_id;
+
+  RETURN QUERY SELECT v_paid_total, v_game_year;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.distribute_company_annual_profit(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.distribute_company_annual_profit(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.distribute_company_annual_profit(uuid) TO service_role;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- replaces the existing `distribute_company_annual_profit` implementation while preserving its public one-argument RPC contract
- validates authentication, active character, company ownership, company status and bankruptcy state server-side
- computes the canonical game year in the database
- excludes owner funding, share-sale capital and prior dividend/transfer movements from distributable operating profit
- locks the company and shareholder set before calculating payouts
- pays exactly one active character for each shareholder account
- allocates every whole pound deterministically, including rounding remainders
- posts each shareholder payment through the canonical finance ledger
- updates character cash, company balance, company transaction history and annual distribution history atomically
- returns an existing completed annual distribution idempotently
- adds a typed API boundary and regression tests

## Root cause

The current browser implementation separately calculates profit, loops over shareholders, updates character cash, updates the company balance, inserts a dividend transaction and creates the annual distribution record. Any failure can leave only part of the shareholder list paid.

An earlier secure RPC exists, but it is no longer used by the current hook and has two accounting defects:

1. it updates profiles by `user_id`, so an account with multiple character profiles can receive the dividend more than once;
2. it deducts the full distributable profit while flooring each shareholder payout, so rounding can permanently remove money that nobody receives.

## Behaviour

- one distribution is allowed per company per in-game year
- repeated calls after success return the completed distribution rather than paying twice
- every shareholder must have a living active character before distribution begins
- owner deposits, intercompany transfers and paid share issuance do not count as operating profit
- payouts use largest-remainder allocation so the exact amount removed from the company equals the exact amount credited to shareholders
- any ledger, cash, history or validation failure rolls the entire operation back

## Compatibility

The existing RPC name and arguments are unchanged:

```sql
distribute_company_annual_profit(p_company_id uuid)
```

This allows the backend hardening to merge before the UI migration without breaking the current action.

## Follow-up

The next PR will migrate `useDistributeAnnualProfit` to `distributeCompanyAnnualProfit`, remove all browser-side payout and balance writes, use `en-GB`/GBP messaging and add an authority contract.

## Validation

```bash
npm test -- src/lib/api/__tests__/companyProfitDistributions.database.test.ts
npm run typecheck
```

The migration, typed API and tests are committed. Runtime database and CI execution have not yet been inspected, so this PR is opened as a draft.