### PR TITLE
Migrate annual company profit distribution to the authoritative RPC

### DIFF
--- a/src/hooks/__tests__/useCompanyShares.profit-distribution-authority.test.ts
+++ b/src/hooks/__tests__/useCompanyShares.profit-distribution-authority.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.resolve("src/hooks/useCompanyShares.ts"), "utf8");
+const distributionStart = source.indexOf("export const useDistributeAnnualProfit");
+const distributionSource = distributionStart >= 0 ? source.slice(distributionStart) : "";
+
+describe("company annual profit distribution authority boundary", () => {
+  it("uses the typed authoritative distribution API", () => {
+    expect(source).toContain(
+      'import { distributeCompanyAnnualProfit } from "@/lib/api/companyProfitDistributions";',
+    );
+    expect(distributionSource).toContain("distributeCompanyAnnualProfit(companyId)");
+  });
+
+  it("does not calculate or write shareholder payouts in the browser", () => {
+    expect(distributionSource).not.toContain("supabase");
+    expect(distributionSource).not.toContain("calculateInGameDate");
+
+    for (const forbidden of [
+      '.from("profiles")',
+      '.from("companies")',
+      '.from("company_transactions")',
+      '.from("company_profit_distributions")',
+      '.from("company_shareholders")',
+      ".update(",
+      ".insert(",
+    ]) {
+      expect(distributionSource).not.toContain(forbidden);
+    }
+  });
+
+  it("refreshes company and shareholder finance views", () => {
+    for (const queryKey of [
+      '"company-balance"',
+      '"company-transactions"',
+      '"company-income-expenses"',
+      '"company-shareholders"',
+      '"company-financial-summary"',
+      '"user-cash-balance"',
+      '"financial-ledger-history"',
+    ]) {
+      expect(distributionSource).toContain(queryKey);
+    }
+  });
+
+  it("uses UK pound formatting", () => {
+    expect(source).toContain('new Intl.NumberFormat("en-GB"');
+    expect(source).toContain('currency: "GBP"');
+  });
+});

--- a/src/hooks/useCompanyShares.ts
+++ b/src/hooks/useCompanyShares.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/hooks/use-auth-context";
 import { useToast } from "@/components/ui/use-toast";
-import { calculateInGameDate } from "@/utils/gameCalendar";
+import { distributeCompanyAnnualProfit } from "@/lib/api/companyProfitDistributions";
 
 export { useIssueCompanyShares } from "@/hooks/useCompanyShareOffers";
 
@@ -47,138 +46,39 @@ export const useCompanyShareholders = (companyId: string | undefined) => {
   });
 };
 
+const formatGBP = (amount: number) =>
+  new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: "GBP",
+    maximumFractionDigits: 0,
+  }).format(amount);
+
 export const useDistributeAnnualProfit = () => {
-  const { user } = useAuth();
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ companyId }: { companyId: string }) => {
-      if (!user?.id) throw new Error("Not authenticated");
-
-      const gameYear = calculateInGameDate().gameYear;
-      const { data: existing } = await supabase
-        .from("company_profit_distributions" as any)
-        .select("id")
-        .eq("company_id", companyId)
-        .eq("game_year", gameYear)
-        .maybeSingle();
-
-      if (existing) throw new Error("Profit already distributed for this game year");
-
-      const { data: company, error: companyError } = await supabase
-        .from("companies")
-        .select("balance")
-        .eq("id", companyId)
-        .single();
-      if (companyError) throw companyError;
-
-      const { data: latestDistribution } = await supabase
-        .from("company_profit_distributions" as any)
-        .select("distributed_at")
-        .eq("company_id", companyId)
-        .order("distributed_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      let transactionQuery = supabase
-        .from("company_transactions")
-        .select("amount")
-        .eq("company_id", companyId);
-
-      if ((latestDistribution as any)?.distributed_at) {
-        transactionQuery = transactionQuery.gt(
-          "created_at",
-          (latestDistribution as any).distributed_at,
-        );
+    mutationFn: ({ companyId }: { companyId: string }) =>
+      distributeCompanyAnnualProfit(companyId),
+    onSuccess: ({ distributedProfit, gameYear }, variables) => {
+      for (const queryKey of [
+        ["company", variables.companyId],
+        ["company-balance", variables.companyId],
+        ["company-transactions", variables.companyId],
+        ["company-income-expenses", variables.companyId],
+        ["company-shareholders", variables.companyId],
+        ["company-financial-summary"],
+        ["companies"],
+        ["profile"],
+        ["user-cash-balance"],
+        ["financial-ledger-history"],
+      ]) {
+        queryClient.invalidateQueries({ queryKey });
       }
 
-      const { data: transactions, error: transactionError } = await transactionQuery;
-      if (transactionError) throw transactionError;
-
-      const profit = (transactions || []).reduce(
-        (sum, transaction) => sum + Number(transaction.amount),
-        0,
-      );
-      const distributableProfit = Math.max(0, Math.floor(profit));
-      if (distributableProfit <= 0) throw new Error("No profit available to distribute");
-      if (Number(company.balance) < distributableProfit) {
-        throw new Error("Insufficient company balance");
-      }
-
-      const { data: shareholders, error: shareholderError } = await supabase
-        .from("company_shareholders" as any)
-        .select("user_id, shares")
-        .eq("company_id", companyId);
-      if (shareholderError) throw shareholderError;
-      if (!shareholders || shareholders.length === 0) throw new Error("No shareholders found");
-
-      const totalShares = shareholders.reduce(
-        (sum: number, shareholder: any) => sum + Number(shareholder.shares),
-        0,
-      );
-      if (totalShares <= 0) throw new Error("Invalid total shares");
-
-      const userIds = shareholders.map((shareholder: any) => shareholder.user_id);
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, user_id, cash")
-        .in("user_id", userIds);
-
-      const profileByUserId = new Map((profiles || []).map((profile: any) => [profile.user_id, profile]));
-
-      for (const shareholder of shareholders as any[]) {
-        const payout = Math.floor(
-          (distributableProfit * Number(shareholder.shares)) / totalShares,
-        );
-        if (payout <= 0) continue;
-        const profile = profileByUserId.get(shareholder.user_id);
-        if (!profile) continue;
-
-        const { error: profileUpdateError } = await supabase
-          .from("profiles")
-          .update({ cash: Number(profile.cash) + payout })
-          .eq("id", profile.id);
-        if (profileUpdateError) throw profileUpdateError;
-      }
-
-      const { error: companyUpdateError } = await supabase
-        .from("companies")
-        .update({ balance: Number(company.balance) - distributableProfit })
-        .eq("id", companyId);
-      if (companyUpdateError) throw companyUpdateError;
-
-      await supabase.from("company_transactions").insert({
-        company_id: companyId,
-        transaction_type: "dividend",
-        amount: -distributableProfit,
-        description: `Annual profit distribution (Game Year ${gameYear})`,
-        category: "owner_transfer",
-      });
-
-      const { error: distributionError } = await supabase
-        .from("company_profit_distributions" as any)
-        .insert({
-          company_id: companyId,
-          game_year: gameYear,
-          distributed_profit: distributableProfit,
-          distributed_by: user.id,
-        });
-      if (distributionError) throw distributionError;
-
-      return { distributableProfit, gameYear };
-    },
-    onSuccess: ({ distributableProfit, gameYear }, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["company", variables.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-balance", variables.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-transactions", variables.companyId] });
-      queryClient.invalidateQueries({ queryKey: ["company-shareholders", variables.companyId] });
       toast({
         title: "Profit distributed",
-        description: `${new Intl.NumberFormat("en-GB", {
-          style: "currency",
-          currency: "GBP",
-        }).format(distributableProfit)} distributed for game year ${gameYear}.`,
+        description: `${formatGBP(distributedProfit)} distributed for game year ${gameYear}.`,
       });
     },
     onError: (error: Error) => {


### PR DESCRIPTION
## What changed

- replaces the browser-side `useDistributeAnnualProfit` payout sequence with `distributeCompanyAnnualProfit`
- removes client calculation of the in-game year and distributable profit
- removes browser reads and writes across shareholder profiles, company balance, company transactions and annual distribution history
- leaves shareholder display queries unchanged
- refreshes company finance, shareholder, character cash and canonical ledger views after success
- formats distribution messages using `en-GB` and GBP
- adds a source-level authority contract preventing browser-side payout logic from returning

## Dependency

PR #1402 has merged and supplies the hardened `distribute_company_annual_profit` RPC and typed API boundary.

## Root cause

The current hook bypasses the existing server operation and performs each shareholder payout, company balance deduction and history write separately in the browser. A failure partway through can leave only some shareholders paid, while concurrent requests can distribute the same profit more than once.

## Behaviour

- the button now performs one authoritative RPC call
- the database determines the eligible game year and distributable operating profit
- shareholder allocation and all money movement complete atomically
- successful calls refresh legacy company balance views and canonical player ledger history
- failures surface without a client-side fallback

## Validation

```bash
npm test -- src/hooks/__tests__/useCompanyShares.profit-distribution-authority.test.ts src/lib/api/__tests__/companyProfitDistributions.database.test.ts
npm run typecheck
```

The actual source migration and authority test are committed. Runtime CI has not yet been inspected, so this PR is opened as a draft.