### PR TITLE
Repair character banking and direct band funding

### DIFF
--- a/src/components/bands/AddMoneyToBand.tsx
+++ b/src/components/bands/AddMoneyToBand.tsx
@@ -1,77 +1,439 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { formatCurrencyMinor } from "@/services/banking/bankingService";
 import { toast } from "sonner";
 import { HandCoins, Loader2 } from "lucide-react";
 
-type Source = { sourceKind: "wallet" | "bank"; sourceAccountId: string | null; displayName: string; accountType: string; currencyCode: string; availableBalanceMinor: number; eligible: boolean; ineligibleReason?: string | null };
-type Preview = { sourceDisplay: string; currencyCode: string; sourceBalanceMinor: number; amountMinor: number; resultingSourceBalanceMinor: number; treasuryBalanceMinor: number; resultingTreasuryBalanceMinor: number; treasuryWillBeCreated: boolean };
-
-const minor = (value: string) => {
-  const match = value.trim().match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  return match ? Number(match[1]) * 100 + Number((match[2] ?? "").padEnd(2, "0")) : 0;
+type FundingSource = {
+  sourceKind: "wallet" | "bank";
+  sourceAccountId: string | null;
+  displayName: string;
+  accountType: string;
+  currencyCode: string;
+  availableBalanceMinor: number;
+  eligible: boolean;
+  ineligibleReason?: string | null;
 };
 
-export function AddMoneyToBand({ bandId: fixedBandId, onComplete }: { bandId?: string; onComplete?: () => void }) {
+type FundingPreview = {
+  sourceDisplay: string;
+  currencyCode: string;
+  sourceBalanceMinor: number;
+  amountMinor: number;
+  resultingSourceBalanceMinor: number;
+  treasuryBalanceMinor: number;
+  resultingTreasuryBalanceMinor: number;
+  treasuryWillBeCreated: boolean;
+};
+
+const sourceKeyFor = (source: FundingSource) =>
+  `${source.sourceKind}:${source.sourceAccountId ?? "wallet"}`;
+
+export const parseFundingAmountMinor = (value: string): number | null => {
+  const match = value.trim().match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const amountMinor =
+    Number(match[1]) * 100 + Number((match[2] ?? "").padEnd(2, "0"));
+  return Number.isSafeInteger(amountMinor) ? amountMinor : null;
+};
+
+const fundingErrorMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+
+  if (message.includes("permission_denied")) {
+    return "This band is missing contribution permissions. Retry after the finance repair is deployed.";
+  }
+  if (message.includes("not_band_member")) {
+    return "Only active members can add money to this band.";
+  }
+  if (message.includes("insufficient")) {
+    return "There is not enough money in the selected funding source.";
+  }
+  if (message.includes("currency_mismatch")) {
+    return "The selected source uses a different currency from the band treasury.";
+  }
+
+  return message || "Band funding could not be loaded. Please try again.";
+};
+
+export function AddMoneyToBand({
+  bandId: fixedBandId,
+  onComplete,
+}: {
+  bandId?: string;
+  onComplete?: () => void;
+}) {
   const { profileId, isLoading: profileLoading } = useActiveProfile();
   const [bands, setBands] = useState<Array<{ id: string; name: string }>>([]);
   const [bandId, setBandId] = useState(fixedBandId ?? "");
-  const [sources, setSources] = useState<Source[]>([]);
+  const [sources, setSources] = useState<FundingSource[]>([]);
   const [sourceKey, setSourceKey] = useState("");
   const [amount, setAmount] = useState("");
-  const [preview, setPreview] = useState<Preview | null>(null);
-  const [busy, setBusy] = useState(false);
-  const source = useMemo(() => sources.find((s) => `${s.sourceKind}:${s.sourceAccountId ?? "wallet"}` === sourceKey), [sources, sourceKey]);
+  const [note, setNote] = useState("");
+  const [preview, setPreview] = useState<FundingPreview | null>(null);
+  const [confirmationKey, setConfirmationKey] = useState<string | null>(null);
+  const [sourcesLoading, setSourcesLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sourceRequestGeneration = useRef(0);
+
+  const source = useMemo(
+    () => sources.find((candidate) => sourceKeyFor(candidate) === sourceKey),
+    [sources, sourceKey],
+  );
+  const amountMinor = useMemo(() => parseFundingAmountMinor(amount), [amount]);
+  const walletNeedsWholeUnits =
+    source?.sourceKind === "wallet" &&
+    amountMinor !== null &&
+    amountMinor % 100 !== 0;
+
+  useEffect(() => {
+    if (fixedBandId !== undefined) setBandId(fixedBandId);
+  }, [fixedBandId]);
+
+  useEffect(() => {
+    setSources([]);
+    setSourceKey("");
+    setAmount("");
+    setNote("");
+    setPreview(null);
+    setConfirmationKey(null);
+    setError(null);
+  }, [bandId, profileId]);
 
   useEffect(() => {
     if (fixedBandId || !profileId) return;
-    void supabase.from("band_members").select("band_id,bands(id,name)").eq("profile_id", profileId).eq("member_status", "active").then(({ data, error }) => {
-      if (error) toast.error(error.message);
-      else setBands((data ?? []).map((row: any) => row.bands).filter(Boolean));
-    });
+
+    let cancelled = false;
+    void supabase
+      .from("band_members")
+      .select("band_id,bands(id,name)")
+      .eq("profile_id", profileId)
+      .eq("member_status", "active")
+      .then(({ data, error: bandsError }) => {
+        if (cancelled) return;
+        if (bandsError) {
+          setError(fundingErrorMessage(bandsError));
+          return;
+        }
+
+        setBands(
+          (data ?? [])
+            .map((row: any) => row.bands)
+            .filter(Boolean) as Array<{ id: string; name: string }>,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [fixedBandId, profileId]);
 
-  const loadSources = async () => {
-    if (!bandId) return;
-    setBusy(true); setPreview(null);
-    const { data, error } = await (supabase as any).rpc("get_my_band_funding_sources", { p_band_id: bandId });
-    setBusy(false);
-    if (error) return toast.error(error.message);
-    const next = (data?.sources ?? []) as Source[];
-    setSources(next); setSourceKey(next[0] ? `${next[0].sourceKind}:${next[0].sourceAccountId ?? "wallet"}` : "");
+  const loadSources = useCallback(async () => {
+    const generation = ++sourceRequestGeneration.current;
+
+    if (!bandId || !profileId) {
+      setSources([]);
+      setSourceKey("");
+      return;
+    }
+
+    setSourcesLoading(true);
+    setError(null);
+    setPreview(null);
+    setConfirmationKey(null);
+
+    try {
+      const { data, error: sourcesError } = await (supabase as any).rpc(
+        "get_my_band_funding_sources",
+        { p_band_id: bandId },
+      );
+      if (sourcesError) throw sourcesError;
+      if (generation !== sourceRequestGeneration.current) return;
+
+      const nextSources = Array.isArray(data?.sources)
+        ? (data.sources as FundingSource[])
+        : [];
+      const eligibleSources = nextSources.filter((candidate) => candidate.eligible);
+      const preferredSource =
+        eligibleSources.find((candidate) => candidate.sourceKind === "wallet") ??
+        eligibleSources[0] ??
+        null;
+
+      setSources(nextSources);
+      setSourceKey(preferredSource ? sourceKeyFor(preferredSource) : "");
+    } catch (loadError) {
+      if (generation !== sourceRequestGeneration.current) return;
+      setSources([]);
+      setSourceKey("");
+      setError(fundingErrorMessage(loadError));
+    } finally {
+      if (generation === sourceRequestGeneration.current) setSourcesLoading(false);
+    }
+  }, [bandId, profileId]);
+
+  useEffect(() => {
+    void loadSources();
+  }, [loadSources]);
+
+  const resetPreview = () => {
+    setPreview(null);
+    setConfirmationKey(null);
   };
-  useEffect(() => { void loadSources(); }, [bandId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const previewFunding = async () => {
-    if (!source || minor(amount) <= 0) return;
-    setBusy(true);
-    const { data, error } = await (supabase as any).rpc("preview_my_band_funding", { p_band_id: bandId, p_source_kind: source.sourceKind, p_source_account_id: source.sourceAccountId, p_amount_minor: minor(amount) });
-    setBusy(false); if (error) toast.error(error.message); else setPreview(data as Preview);
-  };
-  const confirm = async () => {
-    if (!preview || !source) return;
-    setBusy(true);
-    const { error } = await (supabase as any).rpc("fund_my_band", { p_band_id: bandId, p_source_kind: source.sourceKind, p_source_account_id: source.sourceAccountId, p_amount_minor: preview.amountMinor, p_note: null, p_idempotency_key: crypto.randomUUID() });
-    setBusy(false); if (error) return toast.error(error.message);
-    toast.success("Band funded"); setPreview(null); setAmount(""); await loadSources(); onComplete?.();
+    if (!source?.eligible || amountMinor === null || amountMinor <= 0) return;
+    if (walletNeedsWholeUnits) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { data, error: previewError } = await (supabase as any).rpc(
+        "preview_my_band_funding",
+        {
+          p_band_id: bandId,
+          p_source_kind: source.sourceKind,
+          p_source_account_id: source.sourceAccountId,
+          p_amount_minor: amountMinor,
+        },
+      );
+      if (previewError) throw previewError;
+
+      setPreview(data as FundingPreview);
+      setConfirmationKey(crypto.randomUUID());
+    } catch (previewError) {
+      setError(fundingErrorMessage(previewError));
+    } finally {
+      setSubmitting(false);
+    }
   };
 
-  return <Card>
-    <CardHeader><CardTitle className="flex items-center gap-2"><HandCoins className="h-5 w-5" />Add money to band</CardTitle><CardDescription>Fund a matching-currency treasury directly from this character's wallet or bank account. No currency conversion is performed.</CardDescription></CardHeader>
-    <CardContent className="space-y-4">
-      {!fixedBandId && <div><Label>Band</Label><Select value={bandId} onValueChange={setBandId}><SelectTrigger><SelectValue placeholder="Select band" /></SelectTrigger><SelectContent>{bands.map((b) => <SelectItem key={b.id} value={b.id}>{b.name}</SelectItem>)}</SelectContent></Select></div>}
-      {profileLoading ? <Loader2 className="h-5 w-5 animate-spin" /> : bandId && <>
-        <div><Label>Funding source</Label><Select value={sourceKey} onValueChange={(v) => { setSourceKey(v); setPreview(null); }}><SelectTrigger><SelectValue placeholder="Select wallet or account" /></SelectTrigger><SelectContent>{sources.map((s) => <SelectItem disabled={!s.eligible} key={`${s.sourceKind}:${s.sourceAccountId ?? "wallet"}`} value={`${s.sourceKind}:${s.sourceAccountId ?? "wallet"}`}>{s.displayName} · {formatCurrencyMinor({ amountMinor: s.availableBalanceMinor, currencyCode: s.currencyCode })} ({s.currencyCode})</SelectItem>)}</SelectContent></Select></div>
-        <div><Label>Amount ({source?.currencyCode ?? "currency"})</Label><Input inputMode="decimal" value={amount} onChange={(e) => { setAmount(e.target.value); setPreview(null); }} placeholder="0.00" /></div>
-        {preview && <div className="rounded-md border p-3 text-sm space-y-1"><p>Source: {formatCurrencyMinor({ amountMinor: preview.sourceBalanceMinor, currencyCode: preview.currencyCode })} → <strong>{formatCurrencyMinor({ amountMinor: preview.resultingSourceBalanceMinor, currencyCode: preview.currencyCode })}</strong></p><p>Band {preview.currencyCode} treasury: {formatCurrencyMinor({ amountMinor: preview.treasuryBalanceMinor, currencyCode: preview.currencyCode })} → <strong>{formatCurrencyMinor({ amountMinor: preview.resultingTreasuryBalanceMinor, currencyCode: preview.currencyCode })}</strong>{preview.treasuryWillBeCreated ? " (new treasury)" : ""}</p></div>}
-        <Button disabled={busy || !source || !amount} onClick={() => void (preview ? confirm() : previewFunding())}>{busy ? "Working…" : preview ? "Confirm funding" : "Preview balances"}</Button>
-      </>}
-    </CardContent>
-  </Card>;
+  const confirmFunding = async () => {
+    if (!preview || !source?.eligible || !confirmationKey) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { error: fundingError } = await (supabase as any).rpc("fund_my_band", {
+        p_band_id: bandId,
+        p_source_kind: source.sourceKind,
+        p_source_account_id: source.sourceAccountId,
+        p_amount_minor: preview.amountMinor,
+        p_note: note.trim() || null,
+        p_idempotency_key: confirmationKey,
+      });
+      if (fundingError) throw fundingError;
+
+      toast.success("Band funded");
+      setAmount("");
+      setNote("");
+      resetPreview();
+      await loadSources();
+      onComplete?.();
+    } catch (fundingError) {
+      setError(fundingErrorMessage(fundingError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const hasEligibleSource = sources.some((candidate) => candidate.eligible);
+  const amountIsValid =
+    amountMinor !== null &&
+    amountMinor > 0 &&
+    !walletNeedsWholeUnits &&
+    !!source?.eligible;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <HandCoins className="h-5 w-5" />
+          Add money to band
+        </CardTitle>
+        <CardDescription>
+          Pay directly from this character&apos;s wallet, or choose an eligible bank
+          account. Opening a bank account first is not required.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!fixedBandId && (
+          <div className="space-y-1">
+            <Label>Band</Label>
+            <Select value={bandId} onValueChange={setBandId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select band" />
+              </SelectTrigger>
+              <SelectContent>
+                {bands.map((band) => (
+                  <SelectItem key={band.id} value={band.id}>
+                    {band.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!profileLoading && bands.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                This character is not an active member of a band.
+              </p>
+            )}
+          </div>
+        )}
+
+        {profileLoading || sourcesLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading available funds…
+          </div>
+        ) : bandId ? (
+          <>
+            <div className="space-y-1">
+              <Label>Funding source</Label>
+              <Select
+                value={sourceKey}
+                onValueChange={(value) => {
+                  setSourceKey(value);
+                  resetPreview();
+                  setError(null);
+                }}
+                disabled={!hasEligibleSource}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select wallet or account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sources.map((candidate) => (
+                    <SelectItem
+                      disabled={!candidate.eligible}
+                      key={sourceKeyFor(candidate)}
+                      value={sourceKeyFor(candidate)}
+                    >
+                      {candidate.displayName} ·{" "}
+                      {formatCurrencyMinor({
+                        amountMinor: candidate.availableBalanceMinor,
+                        currencyCode: candidate.currencyCode,
+                      })}
+                      {candidate.sourceKind === "wallet" ? " · Recommended" : ""}
+                      {!candidate.eligible && candidate.ineligibleReason
+                        ? ` · ${candidate.ineligibleReason}`
+                        : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {!hasEligibleSource && !error && (
+                <p className="text-xs text-muted-foreground">
+                  There are no available funds in this character&apos;s wallet or bank
+                  accounts.
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <Label>Amount ({source?.currencyCode ?? "currency"})</Label>
+                <Input
+                  inputMode="decimal"
+                  min="0"
+                  step={source?.sourceKind === "wallet" ? "1" : "0.01"}
+                  value={amount}
+                  onChange={(event) => {
+                    setAmount(event.target.value);
+                    resetPreview();
+                    setError(null);
+                  }}
+                  placeholder="0.00"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label>Note (optional)</Label>
+                <Input
+                  value={note}
+                  onChange={(event) => setNote(event.target.value)}
+                  placeholder="Rehearsal fund"
+                />
+              </div>
+            </div>
+
+            {walletNeedsWholeUnits && (
+              <p className="text-xs text-destructive">
+                Character wallet payments must use whole currency units.
+              </p>
+            )}
+
+            {error && (
+              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                <p>{error}</p>
+                <Button
+                  className="mt-2"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void loadSources()}
+                >
+                  Retry
+                </Button>
+              </div>
+            )}
+
+            {preview && (
+              <div className="space-y-1 rounded-md border p-3 text-sm">
+                <p>
+                  Source: {formatCurrencyMinor({
+                    amountMinor: preview.sourceBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}{" "}
+                  → <strong>{formatCurrencyMinor({
+                    amountMinor: preview.resultingSourceBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}</strong>
+                </p>
+                <p>
+                  Band {preview.currencyCode} treasury:{" "}
+                  {formatCurrencyMinor({
+                    amountMinor: preview.treasuryBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}{" "}
+                  → <strong>{formatCurrencyMinor({
+                    amountMinor: preview.resultingTreasuryBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}</strong>
+                  {preview.treasuryWillBeCreated ? " (new treasury)" : ""}
+                </p>
+              </div>
+            )}
+
+            <Button
+              disabled={submitting || !amountIsValid}
+              onClick={() => void (preview ? confirmFunding() : previewFunding())}
+            >
+              {submitting
+                ? "Working…"
+                : preview
+                  ? "Confirm band funding"
+                  : "Preview band funding"}
+            </Button>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
 }

--- a/src/components/bands/__tests__/AddMoneyToBand.authority.test.ts
+++ b/src/components/bands/__tests__/AddMoneyToBand.authority.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const componentSource = fs.readFileSync(
+  path.resolve("src/components/bands/AddMoneyToBand.tsx"),
+  "utf8",
+);
+const migrationSource = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218241000_repair_character_banking_and_band_funding.sql",
+  ),
+  "utf8",
+);
+
+describe("character banking and direct band funding repair", () => {
+  it("keeps direct wallet-to-band funding on the authoritative RPCs", () => {
+    expect(componentSource).toContain('"get_my_band_funding_sources"');
+    expect(componentSource).toContain('"preview_my_band_funding"');
+    expect(componentSource).toContain('"fund_my_band"');
+
+    for (const legacyRpc of [
+      "deposit_to_band_treasury",
+      "contribute_my_personal_funds_to_band",
+      "bank_deposit_from_cash",
+    ]) {
+      expect(componentSource).not.toContain(legacyRpc);
+    }
+  });
+
+  it("prefers an eligible character wallet and blocks ineligible sources", () => {
+    expect(componentSource).toContain(
+      'eligibleSources.find((candidate) => candidate.sourceKind === "wallet")',
+    );
+    expect(componentSource).toContain("!!source?.eligible");
+    expect(componentSource).toContain("disabled={!candidate.eligible}");
+    expect(componentSource).toContain("Opening a bank account first is not required");
+  });
+
+  it("preserves one idempotency key from preview through confirmation", () => {
+    expect(componentSource).toContain("setConfirmationKey(crypto.randomUUID())");
+    expect(componentSource).toContain("p_idempotency_key: confirmationKey");
+  });
+
+  it("derives new bank-account currency from the active wallet", () => {
+    expect(migrationSource).toContain(
+      "v_currency := coalesce(v_wallet.currency_code, v_wallet.default_currency_code)",
+    );
+    expect(migrationSource).toContain("AND v_currency = ANY(supported_currencies)");
+    expect(migrationSource).not.toContain(
+      "AND coalesce(currency_code,default_currency_code)=p_currency_code",
+    );
+  });
+
+  it("backfills and automatically seeds finance permissions for every band", () => {
+    expect(migrationSource).toContain("ensure_band_finance_defaults");
+    expect(migrationSource).toContain("trg_seed_band_finance_defaults");
+    expect(migrationSource).toContain("SELECT public.ensure_band_finance_defaults(id)");
+    expect(migrationSource).toContain("('member', 'make_voluntary_contributions')");
+  });
+});

--- a/supabase/migrations/20291218241000_repair_character_banking_and_band_funding.sql
+++ b/supabase/migrations/20291218241000_repair_character_banking_and_band_funding.sql
@@ -1,0 +1,386 @@
+-- Repair character banking and direct band funding regressions.
+-- Character wallets are authoritative for account currency, and every band must
+-- receive the default finance policy/role rows required for voluntary funding.
+
+CREATE OR REPLACE FUNCTION public.ensure_band_finance_defaults(p_band_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_band_id IS NULL OR NOT EXISTS (SELECT 1 FROM public.bands WHERE id = p_band_id) THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.band_finance_policies (band_id)
+  VALUES (p_band_id)
+  ON CONFLICT (band_id) DO NOTHING;
+
+  INSERT INTO public.band_finance_role_permissions (
+    band_id,
+    role_code,
+    permission
+  )
+  SELECT
+    p_band_id,
+    defaults.role_code,
+    defaults.permission::public.band_finance_permission
+  FROM (
+    VALUES
+      ('leader', 'view_band_balance'),
+      ('leader', 'view_transaction_history'),
+      ('leader', 'view_detailed_income_expenses'),
+      ('leader', 'create_member_contribution_requests'),
+      ('leader', 'make_voluntary_contributions'),
+      ('leader', 'request_reimbursement'),
+      ('leader', 'approve_reimbursements'),
+      ('leader', 'schedule_payments'),
+      ('leader', 'pay_band_expenses'),
+      ('leader', 'change_revenue_split_rules'),
+      ('leader', 'withdraw_band_funds'),
+      ('leader', 'perform_emergency_payments'),
+      ('manager', 'view_band_balance'),
+      ('manager', 'view_transaction_history'),
+      ('manager', 'view_detailed_income_expenses'),
+      ('manager', 'schedule_payments'),
+      ('manager', 'approve_reimbursements'),
+      ('manager', 'pay_band_expenses'),
+      ('manager', 'request_reimbursement'),
+      ('manager', 'make_voluntary_contributions'),
+      ('treasurer', 'view_band_balance'),
+      ('treasurer', 'view_transaction_history'),
+      ('treasurer', 'view_detailed_income_expenses'),
+      ('treasurer', 'schedule_payments'),
+      ('treasurer', 'approve_reimbursements'),
+      ('treasurer', 'pay_band_expenses'),
+      ('treasurer', 'request_reimbursement'),
+      ('treasurer', 'make_voluntary_contributions'),
+      ('member', 'view_band_balance'),
+      ('member', 'make_voluntary_contributions'),
+      ('member', 'request_reimbursement')
+  ) AS defaults(role_code, permission)
+  ON CONFLICT (band_id, role_code, permission) DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.seed_band_finance_defaults_after_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  PERFORM public.ensure_band_finance_defaults(NEW.id);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_seed_band_finance_defaults ON public.bands;
+CREATE TRIGGER trg_seed_band_finance_defaults
+AFTER INSERT ON public.bands
+FOR EACH ROW
+EXECUTE FUNCTION public.seed_band_finance_defaults_after_insert();
+
+SELECT public.ensure_band_finance_defaults(id)
+FROM public.bands;
+
+CREATE OR REPLACE FUNCTION public.get_my_band_funding_sources(p_band_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile_id uuid := public.current_active_player_profile_id();
+  v_sources jsonb;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.band_members
+    WHERE band_id = p_band_id
+      AND profile_id = v_profile_id
+      AND coalesce(member_status, 'active') = 'active'
+  ) THEN
+    RAISE EXCEPTION 'not_band_member' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM public.ensure_band_finance_defaults(p_band_id);
+
+  IF NOT public.user_has_band_finance_permission(
+    p_band_id,
+    v_profile_id,
+    'make_voluntary_contributions'::public.band_finance_permission
+  ) THEN
+    RAISE EXCEPTION 'permission_denied' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT coalesce(
+    jsonb_agg(
+      source
+      ORDER BY
+        CASE source->>'sourceKind' WHEN 'wallet' THEN 0 ELSE 1 END,
+        CASE WHEN coalesce((source->>'eligible')::boolean, false) THEN 0 ELSE 1 END,
+        source->>'displayName'
+    ),
+    '[]'::jsonb
+  )
+  INTO v_sources
+  FROM (
+    SELECT jsonb_build_object(
+      'sourceKind', 'wallet',
+      'sourceAccountId', NULL,
+      'displayName', 'Character wallet',
+      'accountType', 'wallet',
+      'currencyCode', coalesce(currency_code, default_currency_code),
+      'availableBalanceMinor', available_balance_minor,
+      'eligible', account_status = 'active' AND available_balance_minor > 0,
+      'ineligibleReason', CASE
+        WHEN account_status <> 'active' THEN 'Wallet is unavailable'
+        WHEN available_balance_minor <= 0 THEN 'Wallet has no available funds'
+        ELSE NULL
+      END
+    ) AS source
+    FROM public.financial_accounts
+    WHERE owner_type = 'player'
+      AND owner_id = v_profile_id
+      AND is_primary
+
+    UNION ALL
+
+    SELECT jsonb_build_object(
+      'sourceKind', 'bank',
+      'sourceAccountId', bank.id,
+      'displayName', coalesce(
+        nullif(bank.metadata->>'display_name', ''),
+        initcap(replace(bank.account_type::text, '_', ' ')) || ' account'
+      ),
+      'accountType', bank.account_type,
+      'currencyCode', bank.currency_code,
+      'availableBalanceMinor', finance.available_balance_minor,
+      'eligible', coalesce((eligibility.result->>'eligible')::boolean, false),
+      'ineligibleReason', eligibility.result->>'reason'
+    ) AS source
+    FROM public.bank_accounts bank
+    JOIN public.financial_accounts finance
+      ON finance.id = bank.linked_finance_account_id
+    CROSS JOIN LATERAL (
+      SELECT public.is_bank_account_eligible_for_outgoing_payment(
+        bank.id,
+        NULL,
+        bank.currency_code
+      ) AS result
+    ) eligibility
+    WHERE bank.owner_type = 'player'
+      AND bank.owner_id = v_profile_id
+  ) available_sources;
+
+  RETURN jsonb_build_object(
+    'status', 'ok',
+    'profileId', v_profile_id,
+    'sources', v_sources
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.open_my_bank_account(
+  p_account_type public.bank_account_type,
+  p_nickname text,
+  p_initial_amount_minor bigint,
+  p_term_months integer,
+  p_currency_code char(3),
+  p_idempotency_key text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_profile_id uuid := public.current_active_player_profile_id();
+  v_wallet public.financial_accounts%ROWTYPE;
+  v_currency char(3);
+  v_provider_id uuid;
+  v_finance_account_id uuid;
+  v_bank_account_id uuid;
+  v_transaction_id uuid;
+  v_restrictions jsonb := '{}'::jsonb;
+BEGIN
+  IF v_profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF coalesce(p_initial_amount_minor, 0) < 0
+    OR mod(coalesce(p_initial_amount_minor, 0), 100) <> 0 THEN
+    RAISE EXCEPTION 'wallet_amount_must_be_whole_major_units' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT id
+  INTO v_bank_account_id
+  FROM public.bank_accounts
+  WHERE metadata->>'opening_idempotency_key' = p_idempotency_key
+    AND owner_type = 'player'
+    AND owner_id = v_profile_id;
+
+  IF v_bank_account_id IS NOT NULL THEN
+    RETURN (
+      SELECT jsonb_build_object(
+        'accountId', bank.id,
+        'currencyCode', bank.currency_code,
+        'balanceMinor', finance.current_balance_minor,
+        'idempotent', true
+      )
+      FROM public.bank_accounts bank
+      JOIN public.financial_accounts finance
+        ON finance.id = bank.linked_finance_account_id
+      WHERE bank.id = v_bank_account_id
+    );
+  END IF;
+
+  SELECT *
+  INTO v_wallet
+  FROM public.financial_accounts
+  WHERE owner_type = 'player'
+    AND owner_id = v_profile_id
+    AND is_primary
+    AND account_status = 'active'
+  ORDER BY created_at, id
+  LIMIT 1
+  FOR UPDATE;
+
+  IF v_wallet.id IS NULL THEN
+    RAISE EXCEPTION 'active_wallet_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_currency := coalesce(v_wallet.currency_code, v_wallet.default_currency_code);
+  IF v_currency IS NULL OR v_currency !~ '^[A-Z]{3}$' THEN
+    RAISE EXCEPTION 'wallet_currency_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_wallet.available_balance_minor < coalesce(p_initial_amount_minor, 0) THEN
+    RAISE EXCEPTION 'insufficient_funds' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT id
+  INTO v_provider_id
+  FROM public.banking_providers
+  WHERE status = 'active'
+    AND v_currency = ANY(supported_currencies)
+  ORDER BY provider_code
+  LIMIT 1;
+
+  IF v_provider_id IS NULL THEN
+    RAISE EXCEPTION 'banking_provider_unavailable' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_account_type = 'fixed_deposit' THEN
+    IF coalesce(p_term_months, 0) <= 0 THEN
+      RAISE EXCEPTION 'fixed_deposit_term_required' USING ERRCODE = 'P0001';
+    END IF;
+    v_restrictions := jsonb_build_object(
+      'locked_until', (current_date + make_interval(months => p_term_months))::text
+    );
+  END IF;
+
+  INSERT INTO public.financial_accounts (
+    owner_type,
+    owner_id,
+    account_name,
+    account_status,
+    current_balance_minor,
+    default_currency_code,
+    currency_code,
+    is_primary,
+    metadata
+  ) VALUES (
+    'player',
+    v_profile_id,
+    coalesce(nullif(btrim(p_nickname), ''), initcap(replace(p_account_type::text, '_', ' ')) || ' account'),
+    'active',
+    0,
+    v_currency,
+    v_currency,
+    false,
+    jsonb_build_object(
+      'account_role', 'bank_deposit',
+      'display_name', nullif(btrim(p_nickname), '')
+    )
+  )
+  RETURNING id INTO v_finance_account_id;
+
+  INSERT INTO public.bank_accounts (
+    provider_id,
+    owner_type,
+    owner_id,
+    linked_finance_account_id,
+    account_type,
+    currency_code,
+    status,
+    opened_at,
+    withdrawal_restrictions,
+    metadata
+  ) VALUES (
+    v_provider_id,
+    'player',
+    v_profile_id,
+    v_finance_account_id,
+    p_account_type,
+    v_currency,
+    'active',
+    now(),
+    v_restrictions,
+    jsonb_build_object(
+      'display_name', nullif(btrim(p_nickname), ''),
+      'opening_idempotency_key', p_idempotency_key,
+      'requested_currency_code', p_currency_code
+    )
+  )
+  RETURNING id INTO v_bank_account_id;
+
+  IF coalesce(p_initial_amount_minor, 0) > 0 THEN
+    v_transaction_id := public._move_financial_account_money(
+      v_wallet.id,
+      v_finance_account_id,
+      p_initial_amount_minor,
+      'administrative_adjustment',
+      'Wallet opening deposit',
+      p_idempotency_key || ':deposit',
+      v_profile_id,
+      'bank_account',
+      v_bank_account_id,
+      jsonb_build_object('classification', 'transfer')
+    );
+  END IF;
+
+  UPDATE public.profiles
+  SET cash = (v_wallet.current_balance_minor - coalesce(p_initial_amount_minor, 0)) / 100
+  WHERE id = v_profile_id;
+
+  RETURN jsonb_build_object(
+    'accountId', v_bank_account_id,
+    'transactionId', v_transaction_id,
+    'currencyCode', v_currency,
+    'walletBalanceMinor', v_wallet.current_balance_minor - coalesce(p_initial_amount_minor, 0),
+    'balanceMinor', coalesce(p_initial_amount_minor, 0),
+    'idempotent', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_band_finance_defaults(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.seed_band_finance_defaults_after_insert() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_my_band_funding_sources(uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.open_my_bank_account(public.bank_account_type, text, bigint, integer, char(3), text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.get_my_band_funding_sources(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.open_my_bank_account(public.bank_account_type, text, bigint, integer, char(3), text) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- repairs bank-account opening for characters whose wallet uses GBP or another supported currency
- makes the active character wallet authoritative for new bank-account currency instead of trusting the legacy hardcoded UI hint
- backfills default band finance policies and role permissions for every existing band
- automatically seeds the same finance defaults whenever a new band is created
- ensures ordinary active band members retain the `make_voluntary_contributions` permission
- orders direct funding sources with the eligible character wallet first
- prevents locked, empty or otherwise ineligible accounts from being selected or submitted
- makes it explicit that players can fund a band directly from character cash without opening a bank account first
- preserves one idempotency key from preview through confirmation
- resets stale state when the active character or selected band changes
- adds useful loading, empty, retry and player-facing error states
- adds regression coverage protecting the direct wallet-to-band flow

## Root cause

The direct funding backend from PR #1375 was present, but three regressions could still block the player journey:

1. the Banking page sends `USD` when opening an account, while many active character wallets use GBP; the RPC previously required that client value to match the wallet exactly and failed with `wallet_currency_mismatch`;
2. funding sources were alphabetically ordered, so a bank account appeared before the character wallet, and the component selected the first source even when it was locked or otherwise ineligible;
3. Finance Phase 2 only seeded contribution permissions for bands that existed when its migration ran, so newer bands could fail with `permission_denied` even for ordinary active members.

## Player journey after this repair

Players can now:

1. open a bank account in their active character wallet currency;
2. deposit to or withdraw from that account as an optional savings step;
3. open Band Finances or the Banking band-funding tab;
4. fund the band directly from Character wallet, or deliberately choose an eligible bank account;
5. preview both resulting balances and confirm once.

A bank account is no longer required merely to move character funds into a band.

## Security and accounting

- active character resolution remains server-side
- membership and finance permissions remain server-side
- money movement continues through `fund_my_band` and the balanced canonical ledger
- no implicit currency conversion is introduced
- existing and future bands receive the same contribution-permission defaults
- retries remain idempotent

## Validation

```bash
npm test -- src/components/bands/__tests__/AddMoneyToBand.authority.test.ts
npm run typecheck
```

The migration, source repair and regression test are committed. Runtime database and CI execution have not yet been inspected, so this PR is opened as a draft.