### PR TITLE
Migrate Banking UI to canonical savings goals

### DIFF
--- a/src/components/banking/SavingsGoalsPanel.tsx
+++ b/src/components/banking/SavingsGoalsPanel.tsx
@@ -1,0 +1,513 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2, Plus, Target } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createSavingsGoal,
+  fundSavingsGoal,
+  getSavingsGoalFundingSources,
+  previewSavingsGoalFunding,
+  type SavingsGoalFundingPreview,
+  type SavingsGoalFundingSource,
+} from "@/lib/api/savingsGoals";
+import { formatCurrencyMinor } from "@/services/banking/bankingService";
+
+export type BankingSavingsGoal = {
+  id: string;
+  name: string;
+  targetMinor: number;
+  currentMinor: number;
+  currencyCode: string;
+  completionBps?: number;
+  projectedCompletionDate?: string | null;
+};
+
+const parseAmountMinor = (value: string): number | null => {
+  const match = value.trim().match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const amountMinor =
+    Number(match[1]) * 100 + Number((match[2] ?? "").padEnd(2, "0"));
+  return Number.isSafeInteger(amountMinor) ? amountMinor : null;
+};
+
+const sourceKeyFor = (source: SavingsGoalFundingSource) =>
+  `${source.sourceKind}:${source.sourceAccountId ?? "wallet"}`;
+
+const errorMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (message.includes("insufficient")) {
+    return "There is not enough money in the selected funding source.";
+  }
+  if (message.includes("currency_mismatch")) {
+    return "The selected funding source uses a different currency from this goal.";
+  }
+  if (message.includes("source_account_ineligible")) {
+    return "The selected account is locked or cannot currently make this transfer.";
+  }
+  return message || "The savings goal action could not be completed.";
+};
+
+export function SavingsGoalsPanel({
+  goals,
+  currencyCode,
+  onChanged,
+}: {
+  goals: BankingSavingsGoal[];
+  currencyCode: string;
+  onChanged: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <CreateSavingsGoalDialog currencyCode={currencyCode} onChanged={onChanged} />
+      </div>
+
+      {goals.length === 0 ? (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            No savings goals yet. Create one for a new guitar, tour bus or studio deposit.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {goals.map((goal) => (
+            <SavingsGoalCard key={goal.id} goal={goal} onChanged={onChanged} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CreateSavingsGoalDialog({
+  currencyCode,
+  onChanged,
+}: {
+  currencyCode: string;
+  onChanged: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [target, setTarget] = useState("");
+  const [targetDate, setTargetDate] = useState("");
+  const targetMinor = useMemo(() => parseAmountMinor(target), [target]);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createSavingsGoal({
+        name: name.trim(),
+        targetMinor: targetMinor ?? 0,
+        targetDate: targetDate || null,
+      }),
+    onSuccess: () => {
+      toast.success("Savings goal created");
+      setOpen(false);
+      setName("");
+      setTarget("");
+      setTargetDate("");
+      onChanged();
+    },
+    onError: (error) => toast.error(errorMessage(error)),
+  });
+
+  const valid = name.trim().length >= 2 && targetMinor !== null && targetMinor > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <Plus className="mr-2 h-4 w-4" />
+          New goal
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create savings goal</DialogTitle>
+          <DialogDescription>
+            Goal money is ring-fenced in the canonical ledger and remains part of this
+            character&apos;s net worth.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <Label>Name</Label>
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="New guitar"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Target ({currencyCode})</Label>
+            <Input
+              inputMode="decimal"
+              min="0"
+              step="0.01"
+              value={target}
+              onChange={(event) => setTarget(event.target.value)}
+              placeholder="0.00"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Target date (optional)</Label>
+            <Input
+              type="date"
+              value={targetDate}
+              onChange={(event) => setTargetDate(event.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !valid}
+          >
+            {mutation.isPending ? "Creating…" : "Create goal"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SavingsGoalCard({
+  goal,
+  onChanged,
+}: {
+  goal: BankingSavingsGoal;
+  onChanged: () => void;
+}) {
+  const percentage = Math.min(
+    100,
+    goal.completionBps !== undefined
+      ? goal.completionBps / 100
+      : goal.targetMinor > 0
+        ? (goal.currentMinor / goal.targetMinor) * 100
+        : 0,
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Target className="h-4 w-4" />
+            {goal.name}
+          </CardTitle>
+          <span className="text-sm text-muted-foreground">{percentage.toFixed(0)}%</span>
+        </div>
+        {goal.projectedCompletionDate && (
+          <CardDescription>Target date: {goal.projectedCompletionDate}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="mt-1 h-2 overflow-hidden rounded-full bg-muted">
+          <div className="h-full rounded-full bg-primary" style={{ width: `${percentage}%` }} />
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {formatCurrencyMinor({
+            amountMinor: goal.currentMinor,
+            currencyCode: goal.currencyCode,
+          })}{" "}
+          of{" "}
+          {formatCurrencyMinor({
+            amountMinor: goal.targetMinor,
+            currencyCode: goal.currencyCode,
+          })}
+        </p>
+        <FundSavingsGoalDialog goal={goal} onChanged={onChanged} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function FundSavingsGoalDialog({
+  goal,
+  onChanged,
+}: {
+  goal: BankingSavingsGoal;
+  onChanged: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [sources, setSources] = useState<SavingsGoalFundingSource[]>([]);
+  const [sourceKey, setSourceKey] = useState("");
+  const [amount, setAmount] = useState("");
+  const [preview, setPreview] = useState<SavingsGoalFundingPreview | null>(null);
+  const [idempotencyKey, setIdempotencyKey] = useState<string | null>(null);
+  const [loadingSources, setLoadingSources] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const source = useMemo(
+    () => sources.find((candidate) => sourceKeyFor(candidate) === sourceKey),
+    [sourceKey, sources],
+  );
+  const amountMinor = useMemo(() => parseAmountMinor(amount), [amount]);
+  const walletNeedsWholeUnits =
+    source?.sourceKind === "wallet" &&
+    amountMinor !== null &&
+    amountMinor % 100 !== 0;
+
+  const resetPreview = () => {
+    setPreview(null);
+    setIdempotencyKey(null);
+  };
+
+  const loadSources = async () => {
+    setLoadingSources(true);
+    setError(null);
+    resetPreview();
+    try {
+      const result = await getSavingsGoalFundingSources(goal.id);
+      const nextSources = result.sources ?? [];
+      const eligibleSources = nextSources.filter((candidate) => candidate.eligible);
+      const preferredSource =
+        eligibleSources.find((candidate) => candidate.sourceKind === "wallet") ??
+        eligibleSources[0] ??
+        null;
+      setSources(nextSources);
+      setSourceKey(preferredSource ? sourceKeyFor(preferredSource) : "");
+    } catch (loadError) {
+      setSources([]);
+      setSourceKey("");
+      setError(errorMessage(loadError));
+    } finally {
+      setLoadingSources(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    void loadSources();
+    // The goal id is stable for the lifetime of this card.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, goal.id]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setAmount("");
+      setSources([]);
+      setSourceKey("");
+      setError(null);
+      resetPreview();
+    }
+  };
+
+  const preparePreview = async () => {
+    if (!source?.eligible || amountMinor === null || amountMinor <= 0) return;
+    if (walletNeedsWholeUnits) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const nextPreview = await previewSavingsGoalFunding({
+        goalId: goal.id,
+        sourceKind: source.sourceKind,
+        sourceAccountId: source.sourceAccountId,
+        amountMinor,
+      });
+      setPreview(nextPreview);
+      setIdempotencyKey(crypto.randomUUID());
+    } catch (previewError) {
+      setError(errorMessage(previewError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const confirmFunding = async () => {
+    if (!source?.eligible || !preview || !idempotencyKey) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await fundSavingsGoal({
+        goalId: goal.id,
+        sourceKind: source.sourceKind,
+        sourceAccountId: source.sourceAccountId,
+        amountMinor: preview.amountMinor,
+        idempotencyKey,
+      });
+      toast.success(result.completed ? "Savings goal completed" : "Savings goal funded");
+      handleOpenChange(false);
+      onChanged();
+    } catch (fundingError) {
+      setError(errorMessage(fundingError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const hasEligibleSource = sources.some((candidate) => candidate.eligible);
+  const amountIsValid =
+    amountMinor !== null &&
+    amountMinor > 0 &&
+    !walletNeedsWholeUnits &&
+    Boolean(source?.eligible);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" className="mt-3">
+          Add money
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add money to {goal.name}</DialogTitle>
+          <DialogDescription>
+            Pay directly from character cash or choose an eligible bank account. Review
+            both balances before confirming.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loadingSources ? (
+          <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading available funds…
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-1">
+              <Label>Funding source</Label>
+              <Select
+                value={sourceKey}
+                onValueChange={(value) => {
+                  setSourceKey(value);
+                  setError(null);
+                  resetPreview();
+                }}
+                disabled={!hasEligibleSource}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select wallet or account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sources.map((candidate) => (
+                    <SelectItem
+                      key={sourceKeyFor(candidate)}
+                      value={sourceKeyFor(candidate)}
+                      disabled={!candidate.eligible}
+                    >
+                      {candidate.displayName} ·{" "}
+                      {formatCurrencyMinor({
+                        amountMinor: candidate.availableBalanceMinor,
+                        currencyCode: candidate.currencyCode,
+                      })}
+                      {candidate.sourceKind === "wallet" ? " · Recommended" : ""}
+                      {!candidate.eligible && candidate.ineligibleReason
+                        ? ` · ${candidate.ineligibleReason}`
+                        : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label>Amount ({source?.currencyCode ?? goal.currencyCode})</Label>
+              <Input
+                inputMode="decimal"
+                min="0"
+                step={source?.sourceKind === "wallet" ? "1" : "0.01"}
+                value={amount}
+                onChange={(event) => {
+                  setAmount(event.target.value);
+                  setError(null);
+                  resetPreview();
+                }}
+                placeholder="0.00"
+              />
+            </div>
+
+            {walletNeedsWholeUnits && (
+              <p className="text-xs text-destructive">
+                Character wallet payments must use whole currency units.
+              </p>
+            )}
+
+            {!hasEligibleSource && !error && (
+              <p className="text-sm text-muted-foreground">
+                There are no available matching-currency funds for this goal.
+              </p>
+            )}
+
+            {error && (
+              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {preview && (
+              <div className="space-y-1 rounded-md border p-3 text-sm">
+                <p>
+                  Source:{" "}
+                  {formatCurrencyMinor({
+                    amountMinor: preview.sourceBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}{" "}
+                  →{" "}
+                  <strong>
+                    {formatCurrencyMinor({
+                      amountMinor: preview.resultingSourceBalanceMinor,
+                      currencyCode: preview.currencyCode,
+                    })}
+                  </strong>
+                </p>
+                <p>
+                  Goal:{" "}
+                  {formatCurrencyMinor({
+                    amountMinor: preview.goalBalanceMinor,
+                    currencyCode: preview.currencyCode,
+                  })}{" "}
+                  →{" "}
+                  <strong>
+                    {formatCurrencyMinor({
+                      amountMinor: preview.resultingGoalBalanceMinor,
+                      currencyCode: preview.currencyCode,
+                    })}
+                  </strong>
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            onClick={() => void (preview ? confirmFunding() : preparePreview())}
+            disabled={loadingSources || submitting || !amountIsValid}
+          >
+            {submitting
+              ? "Working…"
+              : preview
+                ? "Confirm saving"
+                : "Preview balances"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/Banking.tsx
+++ b/src/pages/Banking.tsx
@@ -1,47 +1,112 @@
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { CalendarClock, Landmark, Loader2, PiggyBank, Plus, Target, TrendingUp, WalletCards, ArrowUpRight, ArrowDownLeft, ArrowLeftRight } from "lucide-react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowDownLeft,
+  ArrowLeftRight,
+  ArrowUpRight,
+  CalendarClock,
+  Landmark,
+  Loader2,
+  PiggyBank,
+  Plus,
+  TrendingUp,
+  WalletCards,
+} from "lucide-react";
+import { AddMoneyToBand } from "@/components/bands/AddMoneyToBand";
+import { SavingsGoalsPanel } from "@/components/banking/SavingsGoalsPanel";
+import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
-import { fetchBankingDashboard, formatCurrencyMinor } from "@/services/banking/bankingService";
 import { supabase } from "@/integrations/supabase/client";
-import { toast } from "sonner";
+import {
+  fetchBankingDashboard,
+  formatCurrencyMinor,
+} from "@/services/banking/bankingService";
 import { format } from "date-fns";
-import { AddMoneyToBand } from "@/components/bands/AddMoneyToBand";
+import { toast } from "sonner";
 
-function errMsg(e: unknown): string {
-  return e instanceof Error ? e.message : "Something went wrong.";
+function errMsg(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (message.includes("insufficient")) return "There is not enough money available.";
+  if (message.includes("wallet_amount_must_be_whole_major_units")) {
+    return "Character wallet transfers must use whole currency units.";
+  }
+  if (message.includes("currency_mismatch")) {
+    return "These accounts use different currencies and cannot be transferred directly.";
+  }
+  return message || "Something went wrong.";
 }
-const toCents = (v: string | number) => Math.max(0, Math.round(Number(v || 0) * 100));
+
+const parseAmountMinor = (value: string): number | null => {
+  const match = value.trim().match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+  const amountMinor =
+    Number(match[1]) * 100 + Number((match[2] ?? "").padEnd(2, "0"));
+  return Number.isSafeInteger(amountMinor) ? amountMinor : null;
+};
 
 export default function Banking() {
-  const qc = useQueryClient();
+  const queryClient = useQueryClient();
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["banking-dashboard"],
     queryFn: fetchBankingDashboard,
   });
 
-  const invalidate = () => qc.invalidateQueries({ queryKey: ["banking-dashboard"] });
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["banking-dashboard"] });
 
   if (isLoading) {
     return (
-      <FMPageScaffold title="Banking" subtitle="Personal accounts, savings, fixed deposits, goals and band deposits." icon={Landmark} backTo="/finances">
-        <div className="flex min-h-[320px] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>
+      <FMPageScaffold
+        title="Banking"
+        subtitle="Personal accounts, savings, fixed deposits, goals and band funding."
+        icon={Landmark}
+        backTo="/finances"
+      >
+        <div className="flex min-h-[320px] items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
       </FMPageScaffold>
     );
   }
 
   if (error) {
     return (
-      <FMPageScaffold title="Banking" subtitle="Personal accounts, savings, fixed deposits, goals and band deposits." icon={Landmark} backTo="/finances">
-        <Card><CardHeader><CardTitle>Banking unavailable</CardTitle><CardDescription>{errMsg(error)}</CardDescription></CardHeader><CardContent><Button onClick={() => void refetch()}>Retry</Button></CardContent></Card>
+      <FMPageScaffold
+        title="Banking"
+        subtitle="Personal accounts, savings, fixed deposits, goals and band funding."
+        icon={Landmark}
+        backTo="/finances"
+      >
+        <Card>
+          <CardHeader>
+            <CardTitle>Banking unavailable</CardTitle>
+            <CardDescription>{errMsg(error)}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => void refetch()}>Retry</Button>
+          </CardContent>
+        </Card>
       </FMPageScaffold>
     );
   }
@@ -50,16 +115,53 @@ export default function Banking() {
   const goals = data?.savingsGoals ?? [];
   const recent = data?.recentActivity ?? [];
   const summary = data?.savingsSummary;
-  const currency = summary?.currencyCode ?? "USD";
+  const currency = summary?.currencyCode ?? "GBP";
 
   return (
-    <FMPageScaffold title="Banking" subtitle="Personal accounts, savings, fixed deposits, goals and band deposits." icon={Landmark} backTo="/finances">
+    <FMPageScaffold
+      title="Banking"
+      subtitle="Personal accounts, savings, fixed deposits, goals and band funding."
+      icon={Landmark}
+      backTo="/finances"
+    >
       <div className="space-y-6">
         <div className="grid gap-4 md:grid-cols-4">
-          <StatCard icon={<WalletCards className="h-5 w-5" />} label="Net worth" value={formatCurrencyMinor({ amountMinor: summary?.netWorthMinor ?? 0, currencyCode: currency })} hint="Wallet + bank" />
-          <StatCard icon={<PiggyBank className="h-5 w-5" />} label="Savings" value={formatCurrencyMinor({ amountMinor: summary?.savingsMinor ?? 0, currencyCode: currency })} hint="Easy access" />
-          <StatCard icon={<CalendarClock className="h-5 w-5" />} label="Locked deposits" value={formatCurrencyMinor({ amountMinor: summary?.lockedDepositsMinor ?? 0, currencyCode: currency })} hint="Fixed term" />
-          <StatCard icon={<TrendingUp className="h-5 w-5" />} label="Wallet cash" value={formatCurrencyMinor({ amountMinor: summary?.cashMinor ?? 0, currencyCode: currency })} hint="Available now" />
+          <StatCard
+            icon={<WalletCards className="h-5 w-5" />}
+            label="Net worth"
+            value={formatCurrencyMinor({
+              amountMinor: summary?.netWorthMinor ?? 0,
+              currencyCode: currency,
+            })}
+            hint="Wallet + bank + goals"
+          />
+          <StatCard
+            icon={<PiggyBank className="h-5 w-5" />}
+            label="Savings"
+            value={formatCurrencyMinor({
+              amountMinor: summary?.savingsMinor ?? 0,
+              currencyCode: currency,
+            })}
+            hint="Accounts and goals"
+          />
+          <StatCard
+            icon={<CalendarClock className="h-5 w-5" />}
+            label="Locked deposits"
+            value={formatCurrencyMinor({
+              amountMinor: summary?.lockedDepositsMinor ?? 0,
+              currencyCode: currency,
+            })}
+            hint="Fixed term"
+          />
+          <StatCard
+            icon={<TrendingUp className="h-5 w-5" />}
+            label="Wallet cash"
+            value={formatCurrencyMinor({
+              amountMinor: summary?.cashMinor ?? 0,
+              currencyCode: currency,
+            })}
+            hint="Available now"
+          />
         </div>
 
         <Tabs defaultValue="accounts">
@@ -67,52 +169,77 @@ export default function Banking() {
             <TabsTrigger value="accounts">Accounts</TabsTrigger>
             <TabsTrigger value="goals">Goals</TabsTrigger>
             <TabsTrigger value="statements">Statements</TabsTrigger>
-            <TabsTrigger value="band">Band deposit</TabsTrigger>
+            <TabsTrigger value="band">Fund band</TabsTrigger>
           </TabsList>
 
           <TabsContent value="accounts" className="space-y-4">
-            <div className="flex justify-end"><OpenAccountDialog onDone={invalidate} /></div>
+            <div className="flex justify-end">
+              <OpenAccountDialog currencyCode={currency} onDone={invalidate} />
+            </div>
             {accounts.length === 0 ? (
-              <Card><CardContent className="py-8 text-center text-sm text-muted-foreground">No accounts yet. Open your first current or savings account to get started.</CardContent></Card>
+              <Card>
+                <CardContent className="py-8 text-center text-sm text-muted-foreground">
+                  No accounts yet. Open your first current or savings account to get
+                  started.
+                </CardContent>
+              </Card>
             ) : (
               <div className="grid gap-4 md:grid-cols-2">
-                {accounts.map((acct) => (
-                  <AccountCard key={acct.id} account={acct} accounts={accounts} onDone={invalidate} />
+                {accounts.map((account) => (
+                  <AccountCard
+                    key={account.id}
+                    account={account}
+                    accounts={accounts}
+                    onDone={invalidate}
+                  />
                 ))}
               </div>
             )}
           </TabsContent>
 
-          <TabsContent value="goals" className="space-y-4">
-            <div className="flex justify-end"><CreateGoalDialog onDone={invalidate} /></div>
-            {goals.length === 0 ? (
-              <Card><CardContent className="py-8 text-center text-sm text-muted-foreground">No savings goals yet. Create one for a new guitar, tour bus or studio deposit.</CardContent></Card>
-            ) : (
-              <div className="grid gap-4 md:grid-cols-2">
-                {goals.map((g) => (
-                  <GoalCard key={g.id} goal={g} accounts={accounts} onDone={invalidate} />
-                ))}
-              </div>
-            )}
+          <TabsContent value="goals">
+            <SavingsGoalsPanel
+              goals={goals}
+              currencyCode={currency}
+              onChanged={invalidate}
+            />
           </TabsContent>
 
           <TabsContent value="statements">
             <Card>
-              <CardHeader><CardTitle>Recent activity</CardTitle><CardDescription>Latest 25 transactions across your accounts.</CardDescription></CardHeader>
+              <CardHeader>
+                <CardTitle>Recent activity</CardTitle>
+                <CardDescription>
+                  Latest transactions across your wallet, accounts and savings goals.
+                </CardDescription>
+              </CardHeader>
               <CardContent className="space-y-2">
                 {recent.length === 0 ? (
                   <p className="text-sm text-muted-foreground">No transactions yet.</p>
-                ) : recent.map((t: any) => (
-                  <div key={t.id} className="flex items-center justify-between border-b py-2 text-sm last:border-0">
-                    <div>
-                      <div className="font-medium">{t.description ?? t.txType}</div>
-                      <div className="text-xs text-muted-foreground">{format(new Date(t.createdAt), "PPp")} · {t.txType}</div>
+                ) : (
+                  recent.map((transaction: any) => (
+                    <div
+                      key={transaction.id}
+                      className="flex items-center justify-between border-b py-2 text-sm last:border-0"
+                    >
+                      <div>
+                        <div className="font-medium">
+                          {transaction.description ?? transaction.txType}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {format(new Date(transaction.createdAt), "PPp")} ·{" "}
+                          {transaction.txType}
+                        </div>
+                      </div>
+                      <div className="font-semibold">
+                        {formatCurrencyMinor({
+                          amountMinor: transaction.amountMinor,
+                          currencyCode: transaction.currencyCode,
+                        })}
+                      </div>
                     </div>
-                    <div className={t.txType?.includes("out") || t.txType === "withdrawal" || t.txType === "band_deposit" || t.txType === "goal_contribution" || t.txType === "fee" ? "text-destructive font-semibold" : "text-emerald-500 font-semibold"}>
-                      {formatCurrencyMinor({ amountMinor: t.amountMinor, currencyCode: t.currencyCode })}
-                    </div>
-                  </div>
-                ))}
+                  ))
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -126,66 +253,154 @@ export default function Banking() {
   );
 }
 
-function StatCard({ icon, label, value, hint }: { icon: React.ReactNode; label: string; value: string; hint: string }) {
+function StatCard({
+  icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  hint: string;
+}) {
   return (
     <Card>
-      <CardHeader className="pb-2"><CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">{icon} {label}</CardTitle></CardHeader>
-      <CardContent><div className="text-2xl font-bold">{value}</div><p className="text-xs text-muted-foreground">{hint}</p></CardContent>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          {icon} {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      </CardContent>
     </Card>
   );
 }
 
-function AccountCard({ account, accounts, onDone }: { account: any; accounts: any[]; onDone: () => void }) {
+function AccountCard({
+  account,
+  accounts,
+  onDone,
+}: {
+  account: any;
+  accounts: any[];
+  onDone: () => void;
+}) {
+  const compatibleDestinations = accounts.filter(
+    (candidate) =>
+      candidate.id !== account.id && candidate.currencyCode === account.currencyCode,
+  );
+
   return (
     <Card>
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <div>
-            <CardTitle className="text-base">{account.nickname || account.providerName}</CardTitle>
-            <CardDescription className="capitalize">{account.accountType.replace("_", " ")} · {account.currencyCode} · {(account.annualRateBps / 100).toFixed(2)}% APR</CardDescription>
+            <CardTitle className="text-base">
+              {account.nickname || account.providerName}
+            </CardTitle>
+            <CardDescription className="capitalize">
+              {account.accountType.replace("_", " ")} · {account.currencyCode} ·{" "}
+              {((account.annualRateBps ?? 0) / 100).toFixed(2)}% APR
+            </CardDescription>
           </div>
-          <Badge variant={account.accountType === "fixed_deposit" ? "secondary" : "outline"}>{account.accountType.replace("_", " ")}</Badge>
+          <Badge
+            variant={account.accountType === "fixed_deposit" ? "secondary" : "outline"}
+          >
+            {account.accountType.replace("_", " ")}
+          </Badge>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="text-3xl font-bold">{formatCurrencyMinor({ amountMinor: account.balanceMinor, currencyCode: account.currencyCode })}</div>
-        {account.restrictionSummary && <p className="text-xs text-muted-foreground">{account.restrictionSummary}</p>}
+        <div className="text-3xl font-bold">
+          {formatCurrencyMinor({
+            amountMinor: account.balanceMinor,
+            currencyCode: account.currencyCode,
+          })}
+        </div>
+        {account.restrictionSummary && (
+          <p className="text-xs text-muted-foreground">{account.restrictionSummary}</p>
+        )}
         <div className="flex flex-wrap gap-2">
           <DepositDialog account={account} onDone={onDone} />
           <WithdrawDialog account={account} onDone={onDone} />
-          <TransferDialog fromAccount={account} accounts={accounts.filter(a => a.id !== account.id)} onDone={onDone} />
+          <TransferDialog
+            fromAccount={account}
+            accounts={compatibleDestinations}
+            onDone={onDone}
+          />
         </div>
       </CardContent>
     </Card>
   );
 }
 
-function OpenAccountDialog({ onDone }: { onDone: () => void }) {
+function OpenAccountDialog({
+  currencyCode,
+  onDone,
+}: {
+  currencyCode: string;
+  onDone: () => void;
+}) {
   const [open, setOpen] = useState(false);
-  const [type, setType] = useState<"current" | "savings" | "fixed_deposit">("current");
+  const [type, setType] = useState<"current" | "savings" | "fixed_deposit">(
+    "current",
+  );
   const [nickname, setNickname] = useState("");
   const [initial, setInitial] = useState("0");
   const [term, setTerm] = useState("6");
-  const mut = useMutation({
+  const initialMinor = parseAmountMinor(initial);
+  const initialIsValid =
+    initialMinor !== null && initialMinor >= 0 && initialMinor % 100 === 0;
+
+  const mutation = useMutation({
     mutationFn: async () => {
       const { data, error } = await (supabase as any).rpc("open_my_bank_account", {
-        p_account_type: type, p_nickname: nickname || null, p_initial_amount_minor: toCents(initial),
-        p_term_months: type === "fixed_deposit" ? Number(term) : null, p_currency_code: "USD", p_idempotency_key: crypto.randomUUID(),
+        p_account_type: type,
+        p_nickname: nickname.trim() || null,
+        p_initial_amount_minor: initialMinor ?? 0,
+        p_term_months: type === "fixed_deposit" ? Number(term) : null,
+        p_currency_code: currencyCode,
+        p_idempotency_key: crypto.randomUUID(),
       });
-      if (error) throw new Error(error.message); return data;
+      if (error) throw new Error(error.message);
+      return data;
     },
-    onSuccess: () => { toast.success("Account opened"); onDone(); setOpen(false); setNickname(""); setInitial("0"); },
-    onError: (e) => toast.error(errMsg(e)),
+    onSuccess: () => {
+      toast.success("Account opened");
+      onDone();
+      setOpen(false);
+      setNickname("");
+      setInitial("0");
+    },
+    onError: (error) => toast.error(errMsg(error)),
   });
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild><Button size="sm"><Plus className="mr-2 h-4 w-4" />Open account</Button></DialogTrigger>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <Plus className="mr-2 h-4 w-4" />
+          Open account
+        </Button>
+      </DialogTrigger>
       <DialogContent>
-        <DialogHeader><DialogTitle>Open a bank account</DialogTitle><DialogDescription>Current (0%), Savings (2.5% APR), or Fixed Deposit (3–8% APR, locked).</DialogDescription></DialogHeader>
+        <DialogHeader>
+          <DialogTitle>Open a bank account</DialogTitle>
+          <DialogDescription>
+            Current (0%), savings (2.5% APR), or fixed deposit (3–8% APR,
+            locked). The account uses this character&apos;s {currencyCode} wallet.
+          </DialogDescription>
+        </DialogHeader>
         <div className="space-y-3">
-          <div><Label>Account type</Label>
-            <Select value={type} onValueChange={(v: any) => setType(v)}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
+          <div className="space-y-1">
+            <Label>Account type</Label>
+            <Select value={type} onValueChange={(value: any) => setType(value)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
               <SelectContent>
                 <SelectItem value="current">Current</SelectItem>
                 <SelectItem value="savings">Savings</SelectItem>
@@ -193,166 +408,268 @@ function OpenAccountDialog({ onDone }: { onDone: () => void }) {
               </SelectContent>
             </Select>
           </div>
-          <div><Label>Nickname (optional)</Label><Input value={nickname} onChange={(e) => setNickname(e.target.value)} placeholder="Tour fund" /></div>
-          <div><Label>Opening deposit ($)</Label><Input type="number" min="0" value={initial} onChange={(e) => setInitial(e.target.value)} /></div>
+          <div className="space-y-1">
+            <Label>Nickname (optional)</Label>
+            <Input
+              value={nickname}
+              onChange={(event) => setNickname(event.target.value)}
+              placeholder="Tour fund"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Opening deposit ({currencyCode})</Label>
+            <Input
+              inputMode="numeric"
+              min="0"
+              step="1"
+              value={initial}
+              onChange={(event) => setInitial(event.target.value)}
+            />
+            {!initialIsValid && (
+              <p className="text-xs text-destructive">
+                Opening deposits must use whole currency units.
+              </p>
+            )}
+          </div>
           {type === "fixed_deposit" && (
-            <div><Label>Term (months)</Label>
+            <div className="space-y-1">
+              <Label>Term (months)</Label>
               <Select value={term} onValueChange={setTerm}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
                 <SelectContent>
-                  {[3, 6, 12, 24, 36].map((m) => <SelectItem key={m} value={String(m)}>{m} months ({(3 + m * 0.25).toFixed(2)}% APR)</SelectItem>)}
+                  {[3, 6, 12, 24, 36].map((months) => (
+                    <SelectItem key={months} value={String(months)}>
+                      {months} months ({(3 + months * 0.25).toFixed(2)}% APR)
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
           )}
         </div>
-        <DialogFooter><Button onClick={() => mut.mutate()} disabled={mut.isPending}>{mut.isPending ? "Opening…" : "Open"}</Button></DialogFooter>
+        <DialogFooter>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !initialIsValid}
+          >
+            {mutation.isPending ? "Opening…" : "Open account"}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
 
-function AmountRpcDialog({ trigger, title, description, rpc, extraArgs = {}, onDone, currency, accountId }: {
-  trigger: React.ReactNode; title: string; description: string; rpc: string; extraArgs?: Record<string, any>; onDone: () => void; currency: string; accountId?: string;
+function AmountRpcDialog({
+  trigger,
+  title,
+  description,
+  rpc,
+  onDone,
+  currency,
+  accountId,
+}: {
+  trigger: React.ReactNode;
+  title: string;
+  description: string;
+  rpc: string;
+  onDone: () => void;
+  currency: string;
+  accountId: string;
 }) {
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState("");
-  const mut = useMutation({
+  const amountMinor = parseAmountMinor(amount);
+  const valid =
+    amountMinor !== null && amountMinor > 0 && amountMinor % 100 === 0;
+
+  const mutation = useMutation({
     mutationFn: async () => {
-      const args: any = { p_amount_minor: toCents(amount), p_idempotency_key: crypto.randomUUID(), ...extraArgs };
-      if (accountId) args.p_bank_account_id = accountId;
-      const { data, error } = await (supabase as any).rpc(rpc, args);
-      if (error) throw new Error(error.message); return data;
+      const { data, error } = await (supabase as any).rpc(rpc, {
+        p_amount_minor: amountMinor ?? 0,
+        p_idempotency_key: crypto.randomUUID(),
+        p_bank_account_id: accountId,
+      });
+      if (error) throw new Error(error.message);
+      return data;
     },
-    onSuccess: () => { toast.success("Done"); onDone(); setOpen(false); setAmount(""); },
-    onError: (e) => toast.error(errMsg(e)),
+    onSuccess: () => {
+      toast.success("Transfer complete");
+      onDone();
+      setOpen(false);
+      setAmount("");
+    },
+    onError: (error) => toast.error(errMsg(error)),
   });
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent>
-        <DialogHeader><DialogTitle>{title}</DialogTitle><DialogDescription>{description}</DialogDescription></DialogHeader>
-        <div><Label>Amount ({currency})</Label><Input type="number" min="0" step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} /></div>
-        <DialogFooter><Button onClick={() => mut.mutate()} disabled={mut.isPending || !amount}>{mut.isPending ? "Working…" : "Confirm"}</Button></DialogFooter>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1">
+          <Label>Amount ({currency})</Label>
+          <Input
+            inputMode="numeric"
+            min="0"
+            step="1"
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+          />
+          {amount && !valid && (
+            <p className="text-xs text-destructive">
+              Wallet transfers must use whole currency units.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !valid}
+          >
+            {mutation.isPending ? "Working…" : "Confirm"}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
 
 function DepositDialog({ account, onDone }: { account: any; onDone: () => void }) {
-  return <AmountRpcDialog
-    trigger={<Button size="sm" variant="outline"><ArrowDownLeft className="mr-1 h-4 w-4" />Deposit</Button>}
-    title="Deposit from wallet" description="Move cash from your wallet into this account."
-    rpc="deposit_my_wallet_to_bank" accountId={account.id} currency={account.currencyCode} onDone={onDone}
-  />;
-}
-function WithdrawDialog({ account, onDone }: { account: any; onDone: () => void }) {
-  return <AmountRpcDialog
-    trigger={<Button size="sm" variant="outline"><ArrowUpRight className="mr-1 h-4 w-4" />Withdraw</Button>}
-    title="Withdraw to wallet" description="Move money from this account into your wallet."
-    rpc="withdraw_my_bank_to_wallet" accountId={account.id} currency={account.currencyCode} onDone={onDone}
-  />;
+  return (
+    <AmountRpcDialog
+      trigger={
+        <Button size="sm" variant="outline">
+          <ArrowDownLeft className="mr-1 h-4 w-4" />
+          Deposit
+        </Button>
+      }
+      title="Deposit from wallet"
+      description="Move whole currency units from this character's wallet into the account."
+      rpc="deposit_my_wallet_to_bank"
+      accountId={account.id}
+      currency={account.currencyCode}
+      onDone={onDone}
+    />
+  );
 }
 
-function TransferDialog({ fromAccount, accounts, onDone }: { fromAccount: any; accounts: any[]; onDone: () => void }) {
+function WithdrawDialog({ account, onDone }: { account: any; onDone: () => void }) {
+  return (
+    <AmountRpcDialog
+      trigger={
+        <Button size="sm" variant="outline">
+          <ArrowUpRight className="mr-1 h-4 w-4" />
+          Withdraw
+        </Button>
+      }
+      title="Withdraw to wallet"
+      description="Move whole currency units from this account into the character wallet."
+      rpc="withdraw_my_bank_to_wallet"
+      accountId={account.id}
+      currency={account.currencyCode}
+      onDone={onDone}
+    />
+  );
+}
+
+function TransferDialog({
+  fromAccount,
+  accounts,
+  onDone,
+}: {
+  fromAccount: any;
+  accounts: any[];
+  onDone: () => void;
+}) {
   const [open, setOpen] = useState(false);
-  const [to, setTo] = useState(accounts[0]?.id ?? "");
+  const [destinationId, setDestinationId] = useState(accounts[0]?.id ?? "");
   const [amount, setAmount] = useState("");
-  const mut = useMutation({
+  const amountMinor = parseAmountMinor(amount);
+  const valid = amountMinor !== null && amountMinor > 0 && Boolean(destinationId);
+
+  const mutation = useMutation({
     mutationFn: async () => {
-      const { error } = await (supabase as any).rpc("transfer_between_my_bank_accounts", { p_source_bank_account_id: fromAccount.id, p_destination_bank_account_id: to, p_amount_minor: toCents(amount), p_idempotency_key: crypto.randomUUID() });
+      const { error } = await (supabase as any).rpc(
+        "transfer_between_my_bank_accounts",
+        {
+          p_source_bank_account_id: fromAccount.id,
+          p_destination_bank_account_id: destinationId,
+          p_amount_minor: amountMinor ?? 0,
+          p_idempotency_key: crypto.randomUUID(),
+        },
+      );
       if (error) throw new Error(error.message);
     },
-    onSuccess: () => { toast.success("Transfer complete"); onDone(); setOpen(false); setAmount(""); },
-    onError: (e) => toast.error(errMsg(e)),
+    onSuccess: () => {
+      toast.success("Transfer complete");
+      onDone();
+      setOpen(false);
+      setAmount("");
+    },
+    onError: (error) => toast.error(errMsg(error)),
   });
+
   if (accounts.length === 0) return null;
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild><Button size="sm" variant="outline"><ArrowLeftRight className="mr-1 h-4 w-4" />Transfer</Button></DialogTrigger>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <ArrowLeftRight className="mr-1 h-4 w-4" />
+          Transfer
+        </Button>
+      </DialogTrigger>
       <DialogContent>
-        <DialogHeader><DialogTitle>Transfer between accounts</DialogTitle></DialogHeader>
+        <DialogHeader>
+          <DialogTitle>Transfer between {fromAccount.currencyCode} accounts</DialogTitle>
+          <DialogDescription>
+            Currency conversion is not performed. Only matching-currency destinations
+            are shown.
+          </DialogDescription>
+        </DialogHeader>
         <div className="space-y-3">
-          <div><Label>To account</Label>
-            <Select value={to} onValueChange={setTo}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>{accounts.map((a) => <SelectItem key={a.id} value={a.id}>{a.nickname || a.providerName} · {a.accountType}</SelectItem>)}</SelectContent>
+          <div className="space-y-1">
+            <Label>To account</Label>
+            <Select value={destinationId} onValueChange={setDestinationId}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((account) => (
+                  <SelectItem key={account.id} value={account.id}>
+                    {account.nickname || account.providerName} ·{" "}
+                    {account.accountType.replace("_", " ")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
             </Select>
           </div>
-          <div><Label>Amount ({fromAccount.currencyCode})</Label><Input type="number" min="0" step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} /></div>
+          <div className="space-y-1">
+            <Label>Amount ({fromAccount.currencyCode})</Label>
+            <Input
+              inputMode="decimal"
+              min="0"
+              step="0.01"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+            />
+          </div>
         </div>
-        <DialogFooter><Button onClick={() => mut.mutate()} disabled={mut.isPending || !amount || !to}>{mut.isPending ? "Working…" : "Transfer"}</Button></DialogFooter>
+        <DialogFooter>
+          <Button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !valid}
+          >
+            {mutation.isPending ? "Working…" : "Transfer"}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function CreateGoalDialog({ onDone }: { onDone: () => void }) {
-  const [open, setOpen] = useState(false);
-  const [name, setName] = useState(""); const [target, setTarget] = useState(""); const [targetDate, setTargetDate] = useState("");
-  const mut = useMutation({
-    mutationFn: async () => {
-      const { error } = await (supabase as any).rpc("create_savings_goal", { p_name: name, p_target_cents: toCents(target), p_target_date: targetDate || null, p_linked_account: null });
-      if (error) throw new Error(error.message);
-    },
-    onSuccess: () => { toast.success("Goal created"); onDone(); setOpen(false); setName(""); setTarget(""); setTargetDate(""); },
-    onError: (e) => toast.error(errMsg(e)),
-  });
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild><Button size="sm"><Plus className="mr-2 h-4 w-4" />New goal</Button></DialogTrigger>
-      <DialogContent>
-        <DialogHeader><DialogTitle>Create savings goal</DialogTitle></DialogHeader>
-        <div className="space-y-3">
-          <div><Label>Name</Label><Input value={name} onChange={(e) => setName(e.target.value)} placeholder="New guitar" /></div>
-          <div><Label>Target ($)</Label><Input type="number" min="0" step="0.01" value={target} onChange={(e) => setTarget(e.target.value)} /></div>
-          <div><Label>Target date (optional)</Label><Input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} /></div>
-        </div>
-        <DialogFooter><Button onClick={() => mut.mutate()} disabled={mut.isPending || !name || !target}>{mut.isPending ? "Saving…" : "Create"}</Button></DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function GoalCard({ goal, accounts, onDone }: { goal: any; accounts: any[]; onDone: () => void }) {
-  const [open, setOpen] = useState(false);
-  const [fromAcct, setFromAcct] = useState(accounts[0]?.id ?? "");
-  const [amount, setAmount] = useState("");
-  const pct = Math.min(100, (goal.completionBps ?? 0) / 100);
-  const mut = useMutation({
-    mutationFn: async () => {
-      const { error } = await (supabase as any).rpc("contribute_to_savings_goal", { p_goal_id: goal.id, p_from_account: fromAcct, p_amount_cents: toCents(amount) });
-      if (error) throw new Error(error.message);
-    },
-    onSuccess: () => { toast.success("Contributed"); onDone(); setOpen(false); setAmount(""); },
-    onError: (e) => toast.error(errMsg(e)),
-  });
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between"><CardTitle className="flex items-center gap-2 text-base"><Target className="h-4 w-4" />{goal.name}</CardTitle><span className="text-sm text-muted-foreground">{pct.toFixed(0)}%</span></div>
-        {goal.projectedCompletionDate && <CardDescription>Target: {goal.projectedCompletionDate}</CardDescription>}
-      </CardHeader>
-      <CardContent>
-        <div className="mt-1 h-2 rounded-full bg-muted"><div className="h-2 rounded-full bg-primary" style={{ width: `${pct}%` }} /></div>
-        <p className="mt-2 text-sm text-muted-foreground">{formatCurrencyMinor({ amountMinor: goal.currentMinor, currencyCode: goal.currencyCode })} of {formatCurrencyMinor({ amountMinor: goal.targetMinor, currencyCode: goal.currencyCode })}</p>
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild><Button size="sm" variant="outline" className="mt-3" disabled={accounts.length === 0}>Contribute</Button></DialogTrigger>
-          <DialogContent>
-            <DialogHeader><DialogTitle>Contribute to {goal.name}</DialogTitle></DialogHeader>
-            <div className="space-y-3">
-              <div><Label>From account</Label>
-                <Select value={fromAcct} onValueChange={setFromAcct}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
-                  <SelectContent>{accounts.map((a) => <SelectItem key={a.id} value={a.id}>{a.nickname || a.providerName} · {formatCurrencyMinor({ amountMinor: a.balanceMinor, currencyCode: a.currencyCode })}</SelectItem>)}</SelectContent>
-                </Select>
-              </div>
-              <div><Label>Amount ($)</Label><Input type="number" min="0" step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} /></div>
-            </div>
-            <DialogFooter><Button onClick={() => mut.mutate()} disabled={mut.isPending || !amount || !fromAcct}>{mut.isPending ? "Working…" : "Confirm"}</Button></DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </CardContent>
-    </Card>
   );
 }

--- a/src/pages/__tests__/Banking.authority.test.ts
+++ b/src/pages/__tests__/Banking.authority.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const bankingSource = fs.readFileSync(
+  path.resolve("src/pages/Banking.tsx"),
+  "utf8",
+);
+const goalsSource = fs.readFileSync(
+  path.resolve("src/components/banking/SavingsGoalsPanel.tsx"),
+  "utf8",
+);
+
+describe("Banking canonical authority boundary", () => {
+  it("uses the canonical savings-goal component and typed API", () => {
+    expect(bankingSource).toContain(
+      'import { SavingsGoalsPanel } from "@/components/banking/SavingsGoalsPanel";',
+    );
+    expect(bankingSource).toContain("<SavingsGoalsPanel");
+
+    for (const operation of [
+      "createSavingsGoal",
+      "getSavingsGoalFundingSources",
+      "previewSavingsGoalFunding",
+      "fundSavingsGoal",
+    ]) {
+      expect(goalsSource).toContain(operation);
+    }
+  });
+
+  it("does not call the revoked facade savings-goal RPCs", () => {
+    expect(bankingSource).not.toContain('"create_savings_goal"');
+    expect(bankingSource).not.toContain('"contribute_to_savings_goal"');
+    expect(goalsSource).not.toContain("supabase");
+    expect(goalsSource).not.toContain('.from("savings_goals")');
+  });
+
+  it("preserves preview-to-confirm idempotency", () => {
+    expect(goalsSource).toContain("setIdempotencyKey(crypto.randomUUID())");
+    expect(goalsSource).toContain("idempotencyKey,");
+    expect(goalsSource).toContain("previewSavingsGoalFunding({");
+    expect(goalsSource).toContain("fundSavingsGoal({");
+  });
+
+  it("uses the active character currency instead of a dollar default", () => {
+    expect(bankingSource).toContain('summary?.currencyCode ?? "GBP"');
+    expect(bankingSource).toContain("p_currency_code: currencyCode");
+    expect(bankingSource).not.toContain('p_currency_code: "USD"');
+    expect(bankingSource).not.toContain("($)");
+    expect(goalsSource).not.toContain("($)");
+  });
+
+  it("only offers matching-currency bank transfer destinations", () => {
+    expect(bankingSource).toContain(
+      "candidate.currencyCode === account.currencyCode",
+    );
+    expect(bankingSource).toContain(
+      "Currency conversion is not performed. Only matching-currency destinations",
+    );
+  });
+
+  it("validates whole-unit wallet movements before invoking the RPC", () => {
+    expect(bankingSource).toContain("initialMinor % 100 === 0");
+    expect(bankingSource).toContain("amountMinor % 100 === 0");
+    expect(goalsSource).toContain('source?.sourceKind === "wallet"');
+    expect(goalsSource).toContain("amountMinor % 100 !== 0");
+  });
+
+  it("keeps direct character-cash funding available", () => {
+    expect(goalsSource).toContain(
+      "Pay directly from character cash or choose an eligible bank account.",
+    );
+    expect(goalsSource).toContain(
+      'eligibleSources.find((candidate) => candidate.sourceKind === "wallet")',
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- replaces the Banking page's revoked `create_savings_goal` and `contribute_to_savings_goal` calls with the typed canonical savings-goal API
- adds a dedicated savings-goal panel with create, funding-source selection, balance preview and confirmation flows
- allows players to fund a goal directly from character cash or from an eligible matching-currency bank account
- prefers the character wallet as the default funding source
- preserves one idempotency key from preview through confirmation
- refreshes the canonical Banking dashboard after account, goal and band-funding actions
- passes the active character wallet currency when opening accounts instead of an explicit USD value
- changes the fallback UI currency to GBP
- removes the remaining dollar-labelled opening-deposit and savings-target fields
- only offers matching-currency bank accounts as transfer destinations
- explains that currency conversion is not performed
- validates whole-unit character-wallet deposits and withdrawals before calling the server
- keeps bank-to-bank transfers penny-precise
- updates the Banking summary wording to include ring-fenced savings-goal funds
- adds source-level authority tests preventing the legacy goal RPCs, USD defaults and cross-currency transfer menu from returning

## Player journey

### Savings goals

1. Create a named goal with a target in the active character's currency.
2. Choose character cash or an eligible bank account.
3. Enter an amount and preview both resulting balances.
4. Confirm once; the canonical ledger moves the money into the goal's ring-fenced account.

A bank account is optional because character cash can be used directly.

### Personal banking

- Opening deposits, wallet deposits and wallet withdrawals use whole currency units, matching the server contract.
- Bank-to-bank transfers can use pennies but only between accounts with the same currency.
- New accounts use the active character wallet currency.

## Authority and accounting

- the browser never writes savings-goal balances or bank balances directly
- goal creation and funding use the RPC boundary introduced in PR #1405
- preview and confirmation share the same idempotency key
- cross-currency transfers remain prohibited; no implicit conversion is introduced
- direct band funding remains available through the repaired `AddMoneyToBand` flow

## Validation

```bash
npm test -- src/pages/__tests__/Banking.authority.test.ts
npm run typecheck
```

The component, page migration and authority test are committed. No GitHub status checks have appeared for the head commit yet, and runtime database execution has not been observed, so this PR is opened as a draft.