### PR TITLE
Harden personal banking transfers and retries

### DIFF
--- a/src/lib/api/__tests__/financialTransferIdempotency.database.test.ts
+++ b/src/lib/api/__tests__/financialTransferIdempotency.database.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218242310_harden_financial_transfer_idempotency.sql",
+  ),
+  "utf8",
+);
+
+describe("canonical financial transfer idempotency", () => {
+  it("serialises every movement on the raw globally unique key", () => {
+    expect(migration).toContain(
+      "pg_advisory_xact_lock(hashtextextended(p_key, 0))",
+    );
+    expect(migration).not.toContain("wallet-bank-deposit:");
+    expect(migration).not.toContain("bank-wallet-withdrawal:");
+    expect(migration).not.toContain("bank-account-transfer:");
+  });
+
+  it("returns an existing transaction only for the same actor and movement", () => {
+    for (const assertion of [
+      "existing_transaction.status <> 'completed'",
+      "existing_transaction.created_by_profile_id IS DISTINCT FROM p_profile",
+      "existing_transaction.source_account_id IS DISTINCT FROM p_source",
+      "existing_transaction.destination_account_id IS DISTINCT FROM p_destination",
+      "existing_transaction.net_amount_minor IS DISTINCT FROM p_amount",
+      "RAISE EXCEPTION 'idempotency_key_conflict'",
+    ]) {
+      expect(migration).toContain(assertion);
+    }
+  });
+
+  it("locks accounts deterministically and rejects invalid movements", () => {
+    expect(migration).toContain("WHERE id IN (p_source, p_destination)");
+    expect(migration).toContain("ORDER BY id");
+    expect(migration).toContain("FOR UPDATE");
+    expect(migration).toContain("RAISE EXCEPTION 'account_not_active'");
+    expect(migration).toContain("RAISE EXCEPTION 'currency_mismatch_no_conversion'");
+    expect(migration).toContain("RAISE EXCEPTION 'insufficient_funds'");
+  });
+
+  it("writes one completed transaction and two balanced ledger entries", () => {
+    expect(migration).toContain("INSERT INTO public.financial_transactions");
+    expect(migration).toContain("INSERT INTO public.financial_ledger_entries");
+    expect(migration).toContain("'debit'");
+    expect(migration).toContain("'credit'");
+    expect(migration).toContain("source_account.current_balance_minor - p_amount");
+    expect(migration).toContain(
+      "destination_account.current_balance_minor + p_amount",
+    );
+  });
+
+  it("keeps the primitive private from browser roles", () => {
+    expect(migration).toContain("FROM PUBLIC, anon, authenticated");
+    expect(migration).toContain("TO service_role");
+  });
+});

--- a/src/lib/api/__tests__/personalBanking.database.test.ts
+++ b/src/lib/api/__tests__/personalBanking.database.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218242300_harden_personal_banking_transfers.sql",
+  ),
+  "utf8",
+);
+const apiSource = fs.readFileSync(
+  path.resolve("src/lib/api/personalBanking.ts"),
+  "utf8",
+);
+
+const depositStart = migration.indexOf(
+  "CREATE OR REPLACE FUNCTION public.deposit_my_wallet_to_bank",
+);
+const withdrawalStart = migration.indexOf(
+  "CREATE OR REPLACE FUNCTION public.withdraw_my_bank_to_wallet",
+);
+const transferStart = migration.indexOf(
+  "CREATE OR REPLACE FUNCTION public.transfer_between_my_bank_accounts",
+);
+const depositSource = migration.slice(depositStart, withdrawalStart);
+const withdrawalSource = migration.slice(withdrawalStart, transferStart);
+const transferSource = migration.slice(transferStart);
+
+describe("personal banking transfer database contract", () => {
+  it("derives all account operations from the selected active character", () => {
+    expect(migration).toContain("current_active_player_profile_id()");
+    expect(migration).toContain("owner_type = 'player'");
+    expect(migration).toContain("owner_id = profile_id");
+  });
+
+  it("moves money only through the balanced canonical primitive", () => {
+    expect(migration.match(/public\._move_financial_account_money\(/g)).toHaveLength(3);
+    expect(migration).toContain("'bank_transfer'::public.financial_transaction_category");
+    expect(migration).not.toContain("UPDATE public.bank_accounts");
+    expect(migration).not.toContain("current_balance_minor = current_balance_minor");
+  });
+
+  it("scopes every completed replay to the original character and transfer", () => {
+    for (const source of [depositSource, withdrawalSource, transferSource]) {
+      expect(source).toContain(
+        "existing_transaction.created_by_profile_id IS DISTINCT FROM profile_id",
+      );
+      expect(source).toContain(
+        "existing_transaction.source_account_id IS DISTINCT FROM",
+      );
+      expect(source).toContain(
+        "existing_transaction.destination_account_id IS DISTINCT FROM",
+      );
+      expect(source).toContain(
+        "existing_transaction.net_amount_minor IS DISTINCT FROM p_amount_minor",
+      );
+      expect(source).toContain("RAISE EXCEPTION 'idempotency_key_conflict'");
+      expect(source).toContain("'idempotent', true");
+    }
+  });
+
+  it("serialises operation keys before checking or moving money", () => {
+    expect(migration.match(/pg_advisory_xact_lock/g)).toHaveLength(3);
+  });
+
+  it("keeps wallet projections whole-unit while bank transfers retain pennies", () => {
+    expect(depositSource).toContain("mod(p_amount_minor, 100) <> 0");
+    expect(withdrawalSource).toContain("mod(p_amount_minor, 100) <> 0");
+    expect(transferSource).not.toContain("mod(p_amount_minor, 100)");
+    expect(depositSource).toContain("UPDATE public.profiles");
+    expect(withdrawalSource).toContain("UPDATE public.profiles");
+    expect(transferSource).not.toContain("UPDATE public.profiles");
+  });
+
+  it("checks outgoing bank eligibility for withdrawals and account transfers", () => {
+    expect(withdrawalSource).toContain(
+      "public.is_bank_account_eligible_for_outgoing_payment(",
+    );
+    expect(transferSource).toContain(
+      "public.is_bank_account_eligible_for_outgoing_payment(",
+    );
+  });
+
+  it("exposes typed APIs that require caller-owned idempotency keys", () => {
+    for (const rpc of [
+      "deposit_my_wallet_to_bank",
+      "withdraw_my_bank_to_wallet",
+      "transfer_between_my_bank_accounts",
+    ]) {
+      expect(apiSource).toContain(`\"${rpc}\"`);
+      expect(migration).toContain(`public.${rpc}`);
+    }
+    expect(apiSource).toContain("idempotencyKey: string");
+    expect(apiSource).not.toContain("crypto.randomUUID");
+  });
+});

--- a/src/lib/api/personalBanking.ts
+++ b/src/lib/api/personalBanking.ts
@@ -1,0 +1,93 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export type WalletBankTransferResult = {
+  transactionId: string;
+  currencyCode: string;
+  walletBalanceMinor: number;
+  bankBalanceMinor: number;
+  idempotent: boolean;
+};
+
+export type BankAccountTransferResult = {
+  transactionId: string;
+  currencyCode: string;
+  sourceBalanceMinor: number;
+  destinationBalanceMinor: number;
+  idempotent: boolean;
+};
+
+const throwRpcError = (error: { message?: string } | null, fallback: string) => {
+  if (error) throw new Error(error.message || fallback);
+};
+
+export const depositWalletToBank = async ({
+  bankAccountId,
+  amountMinor,
+  idempotencyKey,
+}: {
+  bankAccountId: string;
+  amountMinor: number;
+  idempotencyKey: string;
+}): Promise<WalletBankTransferResult> => {
+  const { data, error } = await (supabase.rpc as any)(
+    "deposit_my_wallet_to_bank",
+    {
+      p_bank_account_id: bankAccountId,
+      p_amount_minor: amountMinor,
+      p_idempotency_key: idempotencyKey,
+    },
+  );
+
+  throwRpcError(error, "The wallet deposit could not be completed.");
+  if (!data) throw new Error("wallet_deposit_empty_response");
+  return data as WalletBankTransferResult;
+};
+
+export const withdrawBankToWallet = async ({
+  bankAccountId,
+  amountMinor,
+  idempotencyKey,
+}: {
+  bankAccountId: string;
+  amountMinor: number;
+  idempotencyKey: string;
+}): Promise<WalletBankTransferResult> => {
+  const { data, error } = await (supabase.rpc as any)(
+    "withdraw_my_bank_to_wallet",
+    {
+      p_bank_account_id: bankAccountId,
+      p_amount_minor: amountMinor,
+      p_idempotency_key: idempotencyKey,
+    },
+  );
+
+  throwRpcError(error, "The bank withdrawal could not be completed.");
+  if (!data) throw new Error("bank_withdrawal_empty_response");
+  return data as WalletBankTransferResult;
+};
+
+export const transferBetweenBankAccounts = async ({
+  sourceBankAccountId,
+  destinationBankAccountId,
+  amountMinor,
+  idempotencyKey,
+}: {
+  sourceBankAccountId: string;
+  destinationBankAccountId: string;
+  amountMinor: number;
+  idempotencyKey: string;
+}): Promise<BankAccountTransferResult> => {
+  const { data, error } = await (supabase.rpc as any)(
+    "transfer_between_my_bank_accounts",
+    {
+      p_source_bank_account_id: sourceBankAccountId,
+      p_destination_bank_account_id: destinationBankAccountId,
+      p_amount_minor: amountMinor,
+      p_idempotency_key: idempotencyKey,
+    },
+  );
+
+  throwRpcError(error, "The account transfer could not be completed.");
+  if (!data) throw new Error("bank_transfer_empty_response");
+  return data as BankAccountTransferResult;
+};

--- a/supabase/migrations/20291218242300_harden_personal_banking_transfers.sql
+++ b/supabase/migrations/20291218242300_harden_personal_banking_transfers.sql
@@ -1,0 +1,452 @@
+-- Harden personal banking transfers without changing the public RPC signatures.
+-- Every replay is scoped to the selected active character and must match the
+-- original source, destination and amount before a completed result is returned.
+
+CREATE OR REPLACE FUNCTION public.deposit_my_wallet_to_bank(
+  p_bank_account_id uuid,
+  p_amount_minor bigint,
+  p_idempotency_key text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  profile_id uuid := public.current_active_player_profile_id();
+  bank_account public.bank_accounts%ROWTYPE;
+  wallet_account public.financial_accounts%ROWTYPE;
+  deposit_account public.financial_accounts%ROWTYPE;
+  existing_transaction public.financial_transactions%ROWTYPE;
+  transaction_id uuid;
+  currency_code char(3);
+BEGIN
+  IF profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF mod(p_amount_minor, 100) <> 0 THEN
+    RAISE EXCEPTION 'wallet_amount_must_be_whole_major_units' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Serialise retries using the same browser operation key.
+  PERFORM pg_advisory_xact_lock(hashtextextended('wallet-bank-deposit:' || p_idempotency_key, 0));
+
+  SELECT *
+  INTO bank_account
+  FROM public.bank_accounts
+  WHERE id = p_bank_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id
+  FOR UPDATE;
+
+  IF bank_account.id IS NULL THEN
+    RAISE EXCEPTION 'bank_account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO deposit_account
+  FROM public.financial_accounts
+  WHERE id = bank_account.linked_finance_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  SELECT *
+  INTO wallet_account
+  FROM public.financial_accounts
+  WHERE owner_type = 'player'
+    AND owner_id = profile_id
+    AND is_primary
+  ORDER BY created_at, id
+  LIMIT 1;
+
+  IF deposit_account.id IS NULL OR wallet_account.id IS NULL THEN
+    RAISE EXCEPTION 'canonical_account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO existing_transaction
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_idempotency_key;
+
+  IF existing_transaction.id IS NOT NULL THEN
+    IF existing_transaction.status <> 'completed'
+      OR existing_transaction.created_by_profile_id IS DISTINCT FROM profile_id
+      OR existing_transaction.source_account_id IS DISTINCT FROM wallet_account.id
+      OR existing_transaction.destination_account_id IS DISTINCT FROM deposit_account.id
+      OR existing_transaction.net_amount_minor IS DISTINCT FROM p_amount_minor THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.profiles
+    SET cash = wallet_account.current_balance_minor / 100
+    WHERE id = profile_id;
+
+    RETURN jsonb_build_object(
+      'transactionId', existing_transaction.id,
+      'currencyCode', existing_transaction.currency_code,
+      'walletBalanceMinor', wallet_account.current_balance_minor,
+      'bankBalanceMinor', deposit_account.current_balance_minor,
+      'idempotent', true
+    );
+  END IF;
+
+  IF bank_account.status <> 'active'
+    OR deposit_account.account_status <> 'active'
+    OR wallet_account.account_status <> 'active'
+    OR coalesce(bank_account.deposit_restrictions, '{}'::jsonb) <> '{}'::jsonb THEN
+    RAISE EXCEPTION 'bank_account_cannot_receive_deposit' USING ERRCODE = 'P0001';
+  END IF;
+
+  currency_code := coalesce(wallet_account.currency_code, wallet_account.default_currency_code);
+  IF currency_code IS DISTINCT FROM bank_account.currency_code
+    OR coalesce(deposit_account.currency_code, deposit_account.default_currency_code) IS DISTINCT FROM bank_account.currency_code THEN
+    RAISE EXCEPTION 'currency_mismatch_no_conversion' USING ERRCODE = 'P0001';
+  END IF;
+
+  transaction_id := public._move_financial_account_money(
+    wallet_account.id,
+    deposit_account.id,
+    p_amount_minor,
+    'bank_transfer'::public.financial_transaction_category,
+    'Wallet to bank',
+    p_idempotency_key,
+    profile_id,
+    'bank_account',
+    bank_account.id,
+    jsonb_build_object(
+      'classification', 'transfer',
+      'transfer_kind', 'wallet_to_bank'
+    )
+  );
+
+  SELECT * INTO wallet_account FROM public.financial_accounts WHERE id = wallet_account.id;
+  SELECT * INTO deposit_account FROM public.financial_accounts WHERE id = deposit_account.id;
+
+  UPDATE public.profiles
+  SET cash = wallet_account.current_balance_minor / 100
+  WHERE id = profile_id;
+
+  RETURN jsonb_build_object(
+    'transactionId', transaction_id,
+    'currencyCode', currency_code,
+    'walletBalanceMinor', wallet_account.current_balance_minor,
+    'bankBalanceMinor', deposit_account.current_balance_minor,
+    'idempotent', false
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.withdraw_my_bank_to_wallet(
+  p_bank_account_id uuid,
+  p_amount_minor bigint,
+  p_idempotency_key text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  profile_id uuid := public.current_active_player_profile_id();
+  bank_account public.bank_accounts%ROWTYPE;
+  wallet_account public.financial_accounts%ROWTYPE;
+  withdrawal_account public.financial_accounts%ROWTYPE;
+  existing_transaction public.financial_transactions%ROWTYPE;
+  eligibility jsonb;
+  transaction_id uuid;
+  currency_code char(3);
+BEGIN
+  IF profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF mod(p_amount_minor, 100) <> 0 THEN
+    RAISE EXCEPTION 'wallet_amount_must_be_whole_major_units' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('bank-wallet-withdrawal:' || p_idempotency_key, 0));
+
+  SELECT *
+  INTO bank_account
+  FROM public.bank_accounts
+  WHERE id = p_bank_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id
+  FOR UPDATE;
+
+  IF bank_account.id IS NULL THEN
+    RAISE EXCEPTION 'bank_account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO withdrawal_account
+  FROM public.financial_accounts
+  WHERE id = bank_account.linked_finance_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  SELECT *
+  INTO wallet_account
+  FROM public.financial_accounts
+  WHERE owner_type = 'player'
+    AND owner_id = profile_id
+    AND is_primary
+  ORDER BY created_at, id
+  LIMIT 1;
+
+  IF withdrawal_account.id IS NULL OR wallet_account.id IS NULL THEN
+    RAISE EXCEPTION 'canonical_account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO existing_transaction
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_idempotency_key;
+
+  IF existing_transaction.id IS NOT NULL THEN
+    IF existing_transaction.status <> 'completed'
+      OR existing_transaction.created_by_profile_id IS DISTINCT FROM profile_id
+      OR existing_transaction.source_account_id IS DISTINCT FROM withdrawal_account.id
+      OR existing_transaction.destination_account_id IS DISTINCT FROM wallet_account.id
+      OR existing_transaction.net_amount_minor IS DISTINCT FROM p_amount_minor THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.profiles
+    SET cash = wallet_account.current_balance_minor / 100
+    WHERE id = profile_id;
+
+    RETURN jsonb_build_object(
+      'transactionId', existing_transaction.id,
+      'currencyCode', existing_transaction.currency_code,
+      'walletBalanceMinor', wallet_account.current_balance_minor,
+      'bankBalanceMinor', withdrawal_account.current_balance_minor,
+      'idempotent', true
+    );
+  END IF;
+
+  currency_code := coalesce(wallet_account.currency_code, wallet_account.default_currency_code);
+  IF bank_account.status <> 'active'
+    OR withdrawal_account.account_status <> 'active'
+    OR wallet_account.account_status <> 'active'
+    OR currency_code IS DISTINCT FROM bank_account.currency_code
+    OR coalesce(withdrawal_account.currency_code, withdrawal_account.default_currency_code) IS DISTINCT FROM bank_account.currency_code THEN
+    RAISE EXCEPTION 'bank_account_cannot_withdraw' USING ERRCODE = 'P0001';
+  END IF;
+
+  eligibility := public.is_bank_account_eligible_for_outgoing_payment(
+    bank_account.id,
+    p_amount_minor,
+    bank_account.currency_code
+  );
+  IF NOT coalesce((eligibility->>'eligible')::boolean, false) THEN
+    RAISE EXCEPTION 'bank_account_cannot_withdraw' USING ERRCODE = 'P0001';
+  END IF;
+
+  transaction_id := public._move_financial_account_money(
+    withdrawal_account.id,
+    wallet_account.id,
+    p_amount_minor,
+    'bank_transfer'::public.financial_transaction_category,
+    'Bank to wallet',
+    p_idempotency_key,
+    profile_id,
+    'bank_account',
+    bank_account.id,
+    jsonb_build_object(
+      'classification', 'transfer',
+      'transfer_kind', 'bank_to_wallet'
+    )
+  );
+
+  SELECT * INTO wallet_account FROM public.financial_accounts WHERE id = wallet_account.id;
+  SELECT * INTO withdrawal_account FROM public.financial_accounts WHERE id = withdrawal_account.id;
+
+  UPDATE public.profiles
+  SET cash = wallet_account.current_balance_minor / 100
+  WHERE id = profile_id;
+
+  RETURN jsonb_build_object(
+    'transactionId', transaction_id,
+    'currencyCode', currency_code,
+    'walletBalanceMinor', wallet_account.current_balance_minor,
+    'bankBalanceMinor', withdrawal_account.current_balance_minor,
+    'idempotent', false
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.transfer_between_my_bank_accounts(
+  p_source_bank_account_id uuid,
+  p_destination_bank_account_id uuid,
+  p_amount_minor bigint,
+  p_idempotency_key text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  profile_id uuid := public.current_active_player_profile_id();
+  source_bank public.bank_accounts%ROWTYPE;
+  destination_bank public.bank_accounts%ROWTYPE;
+  source_account public.financial_accounts%ROWTYPE;
+  destination_account public.financial_accounts%ROWTYPE;
+  existing_transaction public.financial_transactions%ROWTYPE;
+  eligibility jsonb;
+  transaction_id uuid;
+BEGIN
+  IF profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_source_bank_account_id IS NULL
+    OR p_destination_bank_account_id IS NULL
+    OR p_source_bank_account_id = p_destination_bank_account_id THEN
+    RAISE EXCEPTION 'bank_transfer_accounts_invalid' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('bank-account-transfer:' || p_idempotency_key, 0));
+
+  -- Keep bank-row locking deterministic as well as the underlying finance locks.
+  PERFORM 1
+  FROM public.bank_accounts
+  WHERE id IN (p_source_bank_account_id, p_destination_bank_account_id)
+  ORDER BY id
+  FOR UPDATE;
+
+  SELECT *
+  INTO source_bank
+  FROM public.bank_accounts
+  WHERE id = p_source_bank_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  SELECT *
+  INTO destination_bank
+  FROM public.bank_accounts
+  WHERE id = p_destination_bank_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  IF source_bank.id IS NULL OR destination_bank.id IS NULL THEN
+    RAISE EXCEPTION 'bank_transfer_accounts_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO source_account
+  FROM public.financial_accounts
+  WHERE id = source_bank.linked_finance_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  SELECT *
+  INTO destination_account
+  FROM public.financial_accounts
+  WHERE id = destination_bank.linked_finance_account_id
+    AND owner_type = 'player'
+    AND owner_id = profile_id;
+
+  IF source_account.id IS NULL OR destination_account.id IS NULL THEN
+    RAISE EXCEPTION 'canonical_account_not_found' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT *
+  INTO existing_transaction
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_idempotency_key;
+
+  IF existing_transaction.id IS NOT NULL THEN
+    IF existing_transaction.status <> 'completed'
+      OR existing_transaction.created_by_profile_id IS DISTINCT FROM profile_id
+      OR existing_transaction.source_account_id IS DISTINCT FROM source_account.id
+      OR existing_transaction.destination_account_id IS DISTINCT FROM destination_account.id
+      OR existing_transaction.net_amount_minor IS DISTINCT FROM p_amount_minor THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN jsonb_build_object(
+      'transactionId', existing_transaction.id,
+      'currencyCode', existing_transaction.currency_code,
+      'sourceBalanceMinor', source_account.current_balance_minor,
+      'destinationBalanceMinor', destination_account.current_balance_minor,
+      'idempotent', true
+    );
+  END IF;
+
+  IF source_bank.status <> 'active'
+    OR destination_bank.status <> 'active'
+    OR source_account.account_status <> 'active'
+    OR destination_account.account_status <> 'active'
+    OR source_bank.currency_code IS DISTINCT FROM destination_bank.currency_code
+    OR coalesce(source_account.currency_code, source_account.default_currency_code) IS DISTINCT FROM source_bank.currency_code
+    OR coalesce(destination_account.currency_code, destination_account.default_currency_code) IS DISTINCT FROM destination_bank.currency_code THEN
+    RAISE EXCEPTION 'bank_transfer_accounts_invalid_or_currency_mismatch' USING ERRCODE = 'P0001';
+  END IF;
+
+  eligibility := public.is_bank_account_eligible_for_outgoing_payment(
+    source_bank.id,
+    p_amount_minor,
+    source_bank.currency_code
+  );
+  IF NOT coalesce((eligibility->>'eligible')::boolean, false) THEN
+    RAISE EXCEPTION 'source_account_cannot_transfer' USING ERRCODE = 'P0001';
+  END IF;
+
+  transaction_id := public._move_financial_account_money(
+    source_account.id,
+    destination_account.id,
+    p_amount_minor,
+    'bank_transfer'::public.financial_transaction_category,
+    'Bank account transfer',
+    p_idempotency_key,
+    profile_id,
+    'bank_account',
+    destination_bank.id,
+    jsonb_build_object(
+      'classification', 'transfer',
+      'transfer_kind', 'bank_to_bank',
+      'source_bank_account_id', source_bank.id,
+      'destination_bank_account_id', destination_bank.id
+    )
+  );
+
+  SELECT * INTO source_account FROM public.financial_accounts WHERE id = source_account.id;
+  SELECT * INTO destination_account FROM public.financial_accounts WHERE id = destination_account.id;
+
+  RETURN jsonb_build_object(
+    'transactionId', transaction_id,
+    'currencyCode', source_bank.currency_code,
+    'sourceBalanceMinor', source_account.current_balance_minor,
+    'destinationBalanceMinor', destination_account.current_balance_minor,
+    'idempotent', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.deposit_my_wallet_to_bank(uuid, bigint, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.withdraw_my_bank_to_wallet(uuid, bigint, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.transfer_between_my_bank_accounts(uuid, uuid, bigint, text) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.deposit_my_wallet_to_bank(uuid, bigint, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.withdraw_my_bank_to_wallet(uuid, bigint, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.transfer_between_my_bank_accounts(uuid, uuid, bigint, text) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218242310_harden_financial_transfer_idempotency.sql
+++ b/supabase/migrations/20291218242310_harden_financial_transfer_idempotency.sql
@@ -1,0 +1,186 @@
+-- Financial transaction idempotency keys are globally unique. Serialise every
+-- canonical movement on the raw key so simultaneous calls from different flows
+-- cannot race past the completed-transaction lookup.
+
+CREATE OR REPLACE FUNCTION public._move_financial_account_money(
+  p_source uuid,
+  p_destination uuid,
+  p_amount bigint,
+  p_category public.financial_transaction_category,
+  p_description text,
+  p_key text,
+  p_profile uuid,
+  p_related_type text DEFAULT NULL,
+  p_related_id uuid DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  source_account public.financial_accounts%ROWTYPE;
+  destination_account public.financial_accounts%ROWTYPE;
+  existing_transaction public.financial_transactions%ROWTYPE;
+  transaction_id uuid;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_key IS NULL OR length(btrim(p_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_key, 0));
+
+  SELECT *
+  INTO existing_transaction
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_key;
+
+  IF existing_transaction.id IS NOT NULL THEN
+    IF existing_transaction.status <> 'completed'
+      OR existing_transaction.created_by_profile_id IS DISTINCT FROM p_profile
+      OR existing_transaction.source_account_id IS DISTINCT FROM p_source
+      OR existing_transaction.destination_account_id IS DISTINCT FROM p_destination
+      OR existing_transaction.net_amount_minor IS DISTINCT FROM p_amount THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+    RETURN existing_transaction.id;
+  END IF;
+
+  PERFORM 1
+  FROM public.financial_accounts
+  WHERE id IN (p_source, p_destination)
+  ORDER BY id
+  FOR UPDATE;
+
+  SELECT * INTO source_account
+  FROM public.financial_accounts
+  WHERE id = p_source;
+
+  SELECT * INTO destination_account
+  FROM public.financial_accounts
+  WHERE id = p_destination;
+
+  IF source_account.id IS NULL
+    OR destination_account.id IS NULL
+    OR source_account.id = destination_account.id THEN
+    RAISE EXCEPTION 'account_invalid' USING ERRCODE = 'P0001';
+  END IF;
+  IF source_account.account_status <> 'active'
+    OR destination_account.account_status <> 'active' THEN
+    RAISE EXCEPTION 'account_not_active' USING ERRCODE = 'P0001';
+  END IF;
+  IF coalesce(source_account.currency_code, source_account.default_currency_code)
+    IS DISTINCT FROM coalesce(destination_account.currency_code, destination_account.default_currency_code) THEN
+    RAISE EXCEPTION 'currency_mismatch_no_conversion' USING ERRCODE = 'P0001';
+  END IF;
+  IF source_account.available_balance_minor < p_amount THEN
+    RAISE EXCEPTION 'insufficient_funds' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.financial_transactions (
+    transaction_category,
+    status,
+    currency_code,
+    gross_amount_minor,
+    net_amount_minor,
+    source_account_id,
+    destination_account_id,
+    related_entity_type,
+    related_entity_id,
+    description,
+    idempotency_key,
+    created_by_user_id,
+    created_by_profile_id,
+    created_by_actor,
+    completed_at,
+    metadata
+  ) VALUES (
+    p_category,
+    'completed',
+    coalesce(source_account.currency_code, source_account.default_currency_code),
+    p_amount,
+    p_amount,
+    source_account.id,
+    destination_account.id,
+    p_related_type,
+    p_related_id,
+    p_description,
+    p_key,
+    auth.uid(),
+    p_profile,
+    coalesce(auth.uid()::text, 'system'),
+    now(),
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  RETURNING id INTO transaction_id;
+
+  UPDATE public.financial_accounts
+  SET current_balance_minor = current_balance_minor - p_amount,
+      updated_at = now()
+  WHERE id = source_account.id;
+
+  UPDATE public.financial_accounts
+  SET current_balance_minor = current_balance_minor + p_amount,
+      updated_at = now()
+  WHERE id = destination_account.id;
+
+  INSERT INTO public.financial_ledger_entries (
+    transaction_id,
+    account_id,
+    entry_direction,
+    amount_minor,
+    balance_before_minor,
+    balance_after_minor
+  ) VALUES
+    (
+      transaction_id,
+      source_account.id,
+      'debit',
+      p_amount,
+      source_account.current_balance_minor,
+      source_account.current_balance_minor - p_amount
+    ),
+    (
+      transaction_id,
+      destination_account.id,
+      'credit',
+      p_amount,
+      destination_account.current_balance_minor,
+      destination_account.current_balance_minor + p_amount
+    );
+
+  RETURN transaction_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._move_financial_account_money(
+  uuid,
+  uuid,
+  bigint,
+  public.financial_transaction_category,
+  text,
+  text,
+  uuid,
+  text,
+  uuid,
+  jsonb
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public._move_financial_account_money(
+  uuid,
+  uuid,
+  bigint,
+  public.financial_transaction_category,
+  text,
+  text,
+  uuid,
+  text,
+  uuid,
+  jsonb
+) TO service_role;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- hardens `deposit_my_wallet_to_bank`, `withdraw_my_bank_to_wallet` and `transfer_between_my_bank_accounts` without changing their public signatures
- derives every operation from the selected active character
- verifies both bank-account ownership and linked canonical financial-account ownership
- validates positive amounts, whole-unit wallet movements, account status and matching currencies
- keeps bank-to-bank transfers penny-precise
- checks outgoing-account eligibility before withdrawals and account transfers
- scopes completed retries to the original character, source, destination and amount
- returns explicit `idempotent` response metadata and current canonical balances
- serialises retries with advisory transaction locks
- hardens `_move_financial_account_money` on the raw globally unique idempotency key so different finance flows cannot race using the same key
- preserves deterministic account locking, balanced transaction records and paired ledger entries
- keeps the low-level movement primitive unavailable to browser roles
- adds a typed personal-banking API that requires the caller to supply and retain the idempotency key
- adds source-level authority and global-idempotency regression coverage

## Root cause

The account-money RPCs already used the canonical ledger, but the browser currently creates a fresh random idempotency key inside each request. If the database completed a deposit, withdrawal or transfer but the response was lost, a user retry could submit a second valid movement with a different key.

The original replay handling also relied mainly on source, destination and amount inside the shared primitive. This repair explicitly scopes a replay to the active character and protects the globally unique transaction key against simultaneous reuse across different finance operations.

## Player impact

- a safely retried operation returns the already-completed result instead of moving money again
- another character cannot receive or inspect a result by reusing a transaction key
- wallet cash, bank balances and the canonical ledger remain aligned
- bank withdrawals and transfers still respect locks, restrictions and available funds
- no implicit currency conversion is introduced

## Compatibility

The existing Banking page remains compatible because all three RPC signatures are unchanged. The typed API is additive.

## Follow-up

The next PR will migrate the Banking page to the typed API and retain one operation key for the lifetime of each dialog submission, including network-error retries. It will also improve success and retry messaging using the returned `idempotent` flag.

## Validation

```bash
npm test -- src/lib/api/__tests__/personalBanking.database.test.ts src/lib/api/__tests__/financialTransferIdempotency.database.test.ts
npm run typecheck
```

The migrations, typed API and authority tests are committed. Runtime database execution and GitHub CI have not yet been observed, so this PR is opened as a draft.