### PR TITLE
Migrate Financial Command Center to canonical ledger

### DIFF
--- a/src/components/company/CompanySharesPanel.tsx
+++ b/src/components/company/CompanySharesPanel.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import { useCompanyShareholders, useDistributeAnnualProfit } from "@/hooks/useCompanyShares";
 import {
   useCompanyShareOffers,
@@ -12,12 +13,17 @@ import {
 } from "@/hooks/useCompanyShareOffers";
 import { useActiveProfile } from "@/hooks/useActiveProfile";
 import { supabase } from "@/integrations/supabase/client";
-import { useQuery } from "@tanstack/react-query";
 
 interface CompanySharesPanelProps {
   companyId: string;
   isMajorityOwner: boolean;
 }
+
+type ShareRecipientProfile = {
+  id: string;
+  display_name: string | null;
+  username: string | null;
+};
 
 const formatGBP = (amount: number) =>
   new Intl.NumberFormat("en-GB", {
@@ -26,6 +32,11 @@ const formatGBP = (amount: number) =>
     minimumFractionDigits: 0,
     maximumFractionDigits: 2,
   }).format(amount);
+
+const publicName = (profile: {
+  display_name?: string | null;
+  username?: string | null;
+} | null | undefined) => profile?.display_name || profile?.username || "Unknown player";
 
 export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanySharesPanelProps) {
   const { profileId } = useActiveProfile();
@@ -42,16 +53,20 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
 
   const { data: profiles = [] } = useQuery({
     queryKey: ["share-recipient-profiles", recipientQuery],
-    queryFn: async () => {
-      if (!recipientQuery || recipientQuery.length < 2) return [];
-      const { data } = await supabase
-        .from("profiles")
-        .select("id, stage_name, username")
-        .or(`stage_name.ilike.%${recipientQuery}%,username.ilike.%${recipientQuery}%`)
+    queryFn: async (): Promise<ShareRecipientProfile[]> => {
+      const query = recipientQuery.trim().replace(/[,%()]/g, " ");
+      if (query.length < 2) return [];
+
+      const { data, error } = await supabase
+        .from("public_profiles")
+        .select("id, display_name, username")
+        .or(`display_name.ilike.%${query}%,username.ilike.%${query}%`)
         .limit(8);
-      return data || [];
+
+      if (error) throw error;
+      return (data || []) as ShareRecipientProfile[];
     },
-    enabled: recipientQuery.length >= 2,
+    enabled: recipientQuery.trim().length >= 2,
   });
 
   const totalShares = useMemo(
@@ -83,8 +98,7 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
                       {offer.shares.toLocaleString("en-GB")} shares for {formatGBP(offer.total_price)}
                     </p>
                     <p className="text-sm text-muted-foreground">
-                      Offered by {offer.issuerProfile?.stage_name || offer.issuerProfile?.username || "Company owner"}
-                      {" · "}{formatGBP(offer.price_per_share)} per share
+                      Offered by {publicName(offer.issuerProfile)} · {formatGBP(offer.price_per_share)} per share
                     </p>
                     <p className="text-xs text-muted-foreground">
                       Expires {new Date(offer.expires_at).toLocaleString("en-GB")}
@@ -115,9 +129,7 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
       <Card>
         <CardHeader>
           <CardTitle>Shareholders</CardTitle>
-          <CardDescription>
-            Ownership is determined by who owns the most shares.
-          </CardDescription>
+          <CardDescription>Ownership is determined by who owns the most shares.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-2">
           {shareholders.map((holder) => {
@@ -125,7 +137,7 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
             return (
               <div key={holder.id} className="flex items-center justify-between rounded border p-3">
                 <div>
-                  <p className="font-medium">{holder.profile?.stage_name || holder.profile?.username || "Unknown player"}</p>
+                  <p className="font-medium">{publicName(holder.profile)}</p>
                   <p className="text-xs text-muted-foreground">{holder.shares} shares</p>
                 </div>
                 <p className="text-sm font-semibold">{percentage.toFixed(1)}%</p>
@@ -149,17 +161,24 @@ export function CompanySharesPanel({ companyId, isMajorityOwner }: CompanyShares
             <>
               <div>
                 <Label>Find player</Label>
-                <Input value={recipientQuery} onChange={(event) => setRecipientQuery(event.target.value)} placeholder="Search by stage name or username" />
+                <Input
+                  value={recipientQuery}
+                  onChange={(event) => {
+                    setRecipientQuery(event.target.value);
+                    setRecipientId("");
+                  }}
+                  placeholder="Search by display name or username"
+                />
                 {profiles.length > 0 && (
                   <div className="mt-2 space-y-1 rounded border p-2">
-                    {profiles.map((profile: any) => (
+                    {profiles.map((profile) => (
                       <button
                         key={profile.id}
                         className={`w-full rounded px-2 py-1 text-left text-sm hover:bg-accent ${recipientId === profile.id ? "bg-accent" : ""}`}
                         onClick={() => setRecipientId(profile.id)}
                         type="button"
                       >
-                        {profile.stage_name || profile.username}
+                        {publicName(profile)}
                       </button>
                     ))}
                   </div>

--- a/src/components/finance/BandFinanceDetail.tsx
+++ b/src/components/finance/BandFinanceDetail.tsx
@@ -1,84 +1,31 @@
 import { useMemo, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { ShieldCheck, Users } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Users, TrendingUp, TrendingDown, ShieldCheck } from "lucide-react";
-import { FMFilterBar, type FilterPill } from "@/components/fm/FMFilterBar";
-import type { BandFinance, FinancialTransaction } from "@/hooks/useFinances";
-
-const fmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
-
-type PnlFilter = "all" | "profit" | "loss";
+import { FMFilterBar } from "@/components/fm/FMFilterBar";
+import type { BandFinance } from "@/hooks/useFinances";
+import { formatMoney } from "@/lib/financeFormatting";
 
 interface BandFinanceDetailProps {
   bands: BandFinance[];
-  transactions: FinancialTransaction[];
 }
 
-export const BandFinanceDetail = ({ bands, transactions }: BandFinanceDetailProps) => {
+export const BandFinanceDetail = ({ bands }: BandFinanceDetailProps) => {
   const [search, setSearch] = useState("");
-  const [pnlFilter, setPnlFilter] = useState<PnlFilter>("all");
-
-  const totalBandEquity = bands.reduce((sum, b) => sum + b.playerShare, 0);
-
-  // Per-band income/expense breakdown from transactions
-  const bandBreakdowns = useMemo(
-    () =>
-      bands.map((band) => {
-        const bandTxns = transactions.filter((t) => t.bandName === band.name);
-        const income = bandTxns.filter((t) => t.type === "income").reduce((s, t) => s + t.amount, 0);
-        const expenses = bandTxns.filter((t) => t.type === "expense").reduce((s, t) => s + t.amount, 0);
-        const incomeSources: Record<string, number> = {};
-        bandTxns
-          .filter((t) => t.type === "income")
-          .forEach((t) => {
-            incomeSources[t.source] = (incomeSources[t.source] || 0) + t.amount;
-          });
-        return { ...band, income, expenses, profit: income - expenses, incomeSources };
-      }),
-    [bands, transactions],
-  );
-
-  const counts = useMemo(() => {
-    let profit = 0;
-    let loss = 0;
-    for (const b of bandBreakdowns) {
-      if (b.profit >= 0) profit++;
-      else loss++;
-    }
-    return { all: bandBreakdowns.length, profit, loss };
-  }, [bandBreakdowns]);
-
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return bandBreakdowns.filter((b) => {
-      if (pnlFilter === "profit" && b.profit < 0) return false;
-      if (pnlFilter === "loss" && b.profit >= 0) return false;
-      if (!q) return true;
-      return b.name.toLowerCase().includes(q);
-    });
-  }, [bandBreakdowns, search, pnlFilter]);
+    const query = search.trim().toLowerCase();
+    return query ? bands.filter((band) => band.name.toLowerCase().includes(query)) : bands;
+  }, [bands, search]);
 
-  const pills: FilterPill<PnlFilter>[] = [
-    { value: "all", label: "All", count: counts.all },
-    { value: "profit", label: "Profitable", count: counts.profit },
-    { value: "loss", label: "Loss", count: counts.loss },
-  ];
+  const treasuryCount = bands.reduce((sum, band) => sum + band.treasuries.length, 0);
 
-  if (bands.length === 0) {
+  if (!bands.length) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle>Band Finances</CardTitle>
-          <CardDescription>Your share of band funds</CardDescription>
-        </CardHeader>
+        <CardHeader><CardTitle>Band Treasuries</CardTitle><CardDescription>Shared funds remain separate from personal wealth.</CardDescription></CardHeader>
         <CardContent className="flex h-[150px] items-center justify-center">
-          <div className="text-center">
-            <Users className="mx-auto h-8 w-8 text-fm-fg-muted/50" />
-            <p className="mt-2 text-xs text-fm-fg-muted">
-              Join or create a band to track shared finances
-            </p>
-          </div>
+          <div className="text-center"><Users className="mx-auto h-8 w-8 text-fm-fg-muted/50" /><p className="mt-2 text-xs text-fm-fg-muted">Join or create a band to see its treasury.</p></div>
         </CardContent>
       </Card>
     );
@@ -87,96 +34,37 @@ export const BandFinanceDetail = ({ bands, transactions }: BandFinanceDetailProp
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Band Finances</CardTitle>
-        <CardDescription>
-          Treasury access: {fmt.format(totalBandEquity)} member share across {bands.length} band{bands.length !== 1 ? "s" : ""}
-        </CardDescription>
+        <CardTitle>Band Treasuries</CardTitle>
+        <CardDescription>{treasuryCount} canonical treasury account{treasuryCount === 1 ? "" : "s"} across {bands.length} band{bands.length === 1 ? "" : "s"}</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <FMFilterBar
-          label="Bands"
-          search={search}
-          onSearchChange={setSearch}
-          searchPlaceholder="Search band name…"
-          pills={pills}
-          activePill={pnlFilter}
-          onPillChange={(v) => setPnlFilter(v as PnlFilter)}
-        />
+      <CardContent className="space-y-3">
+        <FMFilterBar label="Bands" search={search} onSearchChange={setSearch} searchPlaceholder="Search band name…" />
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Band</TableHead>
-              <TableHead className="text-right">Balance</TableHead>
-              <TableHead className="text-right">Income</TableHead>
-              <TableHead className="text-right">Expenses</TableHead>
-              <TableHead className="text-right">P&L</TableHead>
-              <TableHead className="text-right">Your Share</TableHead>
-            </TableRow>
-          </TableHeader>
+          <TableHeader><TableRow><TableHead>Band</TableHead><TableHead>Members</TableHead><TableHead>Currency</TableHead><TableHead className="text-right">Balance</TableHead><TableHead className="text-right">Available</TableHead></TableRow></TableHeader>
           <TableBody>
-            {filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-fm-fg-muted py-6">
-                  No bands match your filters.
-                </TableCell>
-              </TableRow>
-            ) : (
-              filtered.map((band) => (
-              <TableRow key={band.id}>
-                <TableCell className="font-medium">{band.name}</TableCell>
-                <TableCell className="text-right text-fm-fg-muted">
-                  {fmt.format(band.balance)}
-                </TableCell>
-                <TableCell className="text-right text-fm-good">{fmt.format(band.income)}</TableCell>
-                <TableCell className="text-right text-fm-bad">{fmt.format(band.expenses)}</TableCell>
-                <TableCell className="text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    {band.profit >= 0 ? (
-                      <TrendingUp className="h-3 w-3 text-fm-good" />
-                    ) : (
-                      <TrendingDown className="h-3 w-3 text-fm-bad" />
-                    )}
-                    <span className={band.profit >= 0 ? "text-fm-good" : "text-fm-bad"}>
-                      {fmt.format(band.profit)}
-                    </span>
-                  </div>
-                </TableCell>
-                <TableCell className="text-right font-semibold text-fm-good">
-                  {fmt.format(band.playerShare)}
-                </TableCell>
-              </TableRow>
-              ))
+            {filtered.flatMap((band) =>
+              band.treasuries.length
+                ? band.treasuries.map((treasury, index) => (
+                    <TableRow key={`${band.id}-${treasury.accountId}`}>
+                      <TableCell className="font-medium">{index === 0 ? band.name : ""}</TableCell>
+                      <TableCell>{index === 0 ? band.memberCount : ""}</TableCell>
+                      <TableCell><Badge variant="outline">{treasury.currencyCode}</Badge></TableCell>
+                      <TableCell className="text-right">{formatMoney(treasury.balance, treasury.currencyCode)}</TableCell>
+                      <TableCell className="text-right text-fm-good">{formatMoney(treasury.availableBalance, treasury.currencyCode)}</TableCell>
+                    </TableRow>
+                  ))
+                : [
+                    <TableRow key={`${band.id}-empty`}>
+                      <TableCell className="font-medium">{band.name}</TableCell><TableCell>{band.memberCount}</TableCell><TableCell colSpan={3} className="text-muted-foreground">No canonical treasury account found.</TableCell>
+                    </TableRow>,
+                  ],
             )}
           </TableBody>
         </Table>
-
-        <div className="grid gap-3 md:grid-cols-3" aria-label="Band treasury summary cards">
-          <div className="rounded-lg border p-3"><p className="text-xs text-muted-foreground">Reserve target progress</p><p className="font-semibold">Tracked by band finance policy</p></div>
-          <div className="rounded-lg border p-3"><p className="text-xs text-muted-foreground">Awaiting approvals</p><p className="font-semibold">Withdrawals and reimbursements</p></div>
-          <div className="rounded-lg border p-3"><p className="text-xs text-muted-foreground">Permissions</p><p className="font-semibold flex items-center gap-1"><ShieldCheck className="h-4 w-4" /> Role-based actions</p></div>
+        <div className="rounded-lg border p-3 text-sm text-muted-foreground">
+          <span className="inline-flex items-center gap-1 font-medium text-foreground"><ShieldCheck className="h-4 w-4" /> Shared ownership</span>{" "}
+          Treasury funds are controlled by band finance roles and are not divided into a fictional personal share.
         </div>
-
-        {/* Income source badges */}
-        {bandBreakdowns.map(
-          (band) =>
-            Object.keys(band.incomeSources).length > 0 && (
-              <div key={band.id + "-sources"} className="space-y-1">
-                <p className="text-xs text-muted-foreground">
-                  {band.name} — Income by Source
-                </p>
-                <div className="flex flex-wrap gap-1">
-                  {Object.entries(band.incomeSources)
-                    .sort(([, a], [, b]) => b - a)
-                    .slice(0, 6)
-                    .map(([source, amount]) => (
-                      <Badge key={source} variant="secondary" className="text-xs">
-                        {source}: {fmt.format(amount)}
-                      </Badge>
-                    ))}
-                </div>
-              </div>
-            )
-        )}
       </CardContent>
     </Card>
   );

--- a/src/components/finance/CanonicalFinanceHoldings.tsx
+++ b/src/components/finance/CanonicalFinanceHoldings.tsx
@@ -1,0 +1,149 @@
+import { Link } from "react-router-dom";
+import { AlertTriangle, Landmark, PiggyBank, WalletCards } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import type { OtherCurrencyBalance } from "@/lib/api/financeCommandCenter";
+import { formatMinorMoney, formatMoney } from "@/lib/financeFormatting";
+import type { PlayerInvestment, PlayerLoan } from "@/hooks/useFinances";
+
+export const CanonicalInvestmentsPanel = ({
+  investments,
+  currencyCode,
+}: {
+  investments: PlayerInvestment[];
+  currencyCode: string;
+}) => {
+  const totalInvested = investments.reduce((sum, item) => sum + item.invested_amount, 0);
+  const currentValue = investments.reduce((sum, item) => sum + item.current_value, 0);
+
+  return (
+    <div className="space-y-4">
+      <LegacyMutationNotice
+        title="Investment trading is temporarily read-only"
+        body="The old buy and withdraw buttons edited compatibility cash directly. They are disabled until ledger-backed investment transactions are available."
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2"><PiggyBank className="h-5 w-5" /> Investment portfolio</CardTitle>
+          <CardDescription>
+            {formatMoney(currentValue, currencyCode)} current value from {formatMoney(totalInvested, currencyCode)} invested
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {investments.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">No canonical investment positions are recorded.</p>
+          ) : (
+            <Table>
+              <TableHeader><TableRow><TableHead>Investment</TableHead><TableHead>Category</TableHead><TableHead className="text-right">Invested</TableHead><TableHead className="text-right">Current value</TableHead><TableHead className="text-right">Return</TableHead></TableRow></TableHeader>
+              <TableBody>
+                {investments.map((investment) => {
+                  const gain = investment.current_value - investment.invested_amount;
+                  return (
+                    <TableRow key={investment.id}>
+                      <TableCell className="font-medium">{investment.investment_name}</TableCell>
+                      <TableCell><Badge variant="outline">{investment.category}</Badge></TableCell>
+                      <TableCell className="text-right">{formatMoney(investment.invested_amount, investment.currencyCode)}</TableCell>
+                      <TableCell className="text-right">{formatMoney(investment.current_value, investment.currencyCode)}</TableCell>
+                      <TableCell className={`text-right font-medium ${gain >= 0 ? "text-fm-good" : "text-fm-bad"}`}>
+                        {gain >= 0 ? "+" : ""}{formatMoney(gain, investment.currencyCode)}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export const CanonicalLoansPanel = ({ loans }: { loans: PlayerLoan[] }) => {
+  const activeLoans = loans.filter((loan) => !["paid_off", "written_off", "cancelled"].includes(loan.status));
+
+  return (
+    <div className="space-y-4">
+      <LegacyMutationNotice
+        title="Loan actions are managed by the banking system"
+        body="Legacy borrowing and repayment buttons edited old loan rows and compatibility cash. This view now shows canonical loan contracts only."
+        showBankingLink
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2"><Landmark className="h-5 w-5" /> Canonical loan contracts</CardTitle>
+          <CardDescription>{activeLoans.length} active agreement{activeLoans.length === 1 ? "" : "s"}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {activeLoans.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">No active canonical loans.</p>
+          ) : (
+            <Table>
+              <TableHeader><TableRow><TableHead>Lender and purpose</TableHead><TableHead>Status</TableHead><TableHead className="text-right">Principal</TableHead><TableHead className="text-right">Outstanding</TableHead><TableHead className="text-right">Scheduled payment</TableHead><TableHead>Maturity</TableHead></TableRow></TableHeader>
+              <TableBody>
+                {activeLoans.map((loan) => (
+                  <TableRow key={loan.id}>
+                    <TableCell className="font-medium capitalize">{loan.loan_name}</TableCell>
+                    <TableCell><Badge variant="outline" className="capitalize">{loan.status.replaceAll("_", " ")}</Badge></TableCell>
+                    <TableCell className="text-right">{formatMoney(loan.principal, loan.currencyCode)}</TableCell>
+                    <TableCell className="text-right text-fm-bad">{formatMoney(loan.remaining_balance, loan.currencyCode)}</TableCell>
+                    <TableCell className="text-right">{formatMoney(loan.weekly_payment, loan.currencyCode)}</TableCell>
+                    <TableCell>{new Date(loan.due_date).toLocaleDateString("en-GB")}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export const OtherCurrencyBalancesPanel = ({
+  balances,
+}: {
+  balances: OtherCurrencyBalance[];
+}) => {
+  if (!balances.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><WalletCards className="h-5 w-5" /> Other currency holdings</CardTitle>
+        <CardDescription>Shown separately because no exchange rate is being assumed.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {balances.map((balance) => (
+          <div key={balance.currencyCode} className="rounded-lg border p-3">
+            <p className="text-xs font-medium text-muted-foreground">{balance.currencyCode}</p>
+            <p className="text-xl font-semibold">{formatMinorMoney(balance.balanceMinor, balance.currencyCode)}</p>
+            <p className="text-xs text-muted-foreground">Available {formatMinorMoney(balance.availableBalanceMinor, balance.currencyCode)}</p>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+};
+
+export const LegacyMutationNotice = ({
+  title,
+  body,
+  showBankingLink = false,
+}: {
+  title: string;
+  body: string;
+  showBankingLink?: boolean;
+}) => (
+  <Card className="border-amber-500/40">
+    <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+        <div><p className="font-medium">{title}</p><p className="text-sm text-muted-foreground">{body}</p></div>
+      </div>
+      {showBankingLink && <Button asChild size="sm" variant="outline"><Link to="/finance/banking">Open Banking</Link></Button>}
+    </CardContent>
+  </Card>
+);

--- a/src/components/finance/FinanceSummaryCards.tsx
+++ b/src/components/finance/FinanceSummaryCards.tsx
@@ -1,12 +1,7 @@
+import { ArrowUpDown, Landmark, TrendingUp, Wallet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
-import { Wallet, TrendingUp, Landmark, ArrowUpDown } from "lucide-react";
 import type { FinancialSummary } from "@/hooks/useFinances";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+import { formatMoney } from "@/lib/financeFormatting";
 
 interface FinanceSummaryCardsProps {
   summary: FinancialSummary;
@@ -14,36 +9,43 @@ interface FinanceSummaryCardsProps {
 
 export const FinanceSummaryCards = ({ summary }: FinanceSummaryCardsProps) => {
   const monthlyNet = summary.monthlyIncome - summary.monthlyExpenses;
+  const money = (amount: number) => formatMoney(amount, summary.currencyCode);
 
   const cards = [
     {
-      label: "Cash on Hand",
-      value: currencyFormatter.format(summary.cash),
+      label: "Wallet cash",
+      value: money(summary.cash),
+      subtext:
+        summary.personalAccounts !== summary.cash
+          ? `${money(summary.personalAccounts)} across personal accounts`
+          : undefined,
       icon: Wallet,
       color: "text-emerald-500",
       bg: "bg-emerald-500/10",
     },
     {
-      label: "Net Worth",
-      value: currencyFormatter.format(summary.netWorth),
+      label: "Personal net worth",
+      value: money(summary.netWorth),
+      subtext: "Band treasuries excluded",
       icon: TrendingUp,
       color: "text-primary",
       bg: "bg-primary/10",
     },
     {
       label: "Investments",
-      value: currencyFormatter.format(summary.investmentValue),
-      subtext: summary.totalInvested > 0 
-        ? `${((summary.investmentValue - summary.totalInvested) / summary.totalInvested * 100).toFixed(1)}% gain`
-        : undefined,
+      value: money(summary.investmentValue),
+      subtext:
+        summary.totalInvested > 0
+          ? `${(((summary.investmentValue - summary.totalInvested) / summary.totalInvested) * 100).toFixed(1)}% return`
+          : undefined,
       icon: Landmark,
       color: "text-blue-500",
       bg: "bg-blue-500/10",
     },
     {
-      label: "Monthly Cash Flow",
-      value: currencyFormatter.format(monthlyNet),
-      subtext: `${currencyFormatter.format(summary.monthlyIncome)} in / ${currencyFormatter.format(summary.monthlyExpenses)} out`,
+      label: "Average monthly cash flow",
+      value: money(monthlyNet),
+      subtext: `${money(summary.monthlyIncome)} in / ${money(summary.monthlyExpenses)} out`,
       icon: ArrowUpDown,
       color: monthlyNet >= 0 ? "text-emerald-500" : "text-destructive",
       bg: monthlyNet >= 0 ? "bg-emerald-500/10" : "bg-destructive/10",
@@ -59,9 +61,7 @@ export const FinanceSummaryCards = ({ summary }: FinanceSummaryCardsProps) => {
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">{card.label}</p>
                 <p className={`text-2xl font-bold ${card.color}`}>{card.value}</p>
-                {card.subtext && (
-                  <p className="text-xs text-muted-foreground">{card.subtext}</p>
-                )}
+                {card.subtext && <p className="text-xs text-muted-foreground">{card.subtext}</p>}
               </div>
               <div className={`rounded-lg p-2 ${card.bg}`}>
                 <card.icon className={`h-5 w-5 ${card.color}`} />

--- a/src/components/finance/FinancialHistoryLedger.tsx
+++ b/src/components/finance/FinancialHistoryLedger.tsx
@@ -1,28 +1,37 @@
 import { AlertCircle, Loader2, ReceiptText } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useFinancialHistory } from "@/hooks/useFinancialHistory";
+import { formatMoney } from "@/lib/financeFormatting";
 
-const money = (value: number, currency = "USD") => new Intl.NumberFormat("en-US", { style: "currency", currency }).format(value);
-const label = (value: string) => value.replaceAll("_", " ").replace(/\b\w/g, (c) => c.toUpperCase());
+const label = (value: string) => value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
 
 export const FinancialHistoryLedger = () => {
   const { data, isLoading, error } = useFinancialHistory(25);
-  if (isLoading) return <Card><CardContent className="flex min-h-40 items-center justify-center gap-2 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading financial history…</CardContent></Card>;
-  if (error) return <Card className="border-destructive/40"><CardContent className="flex min-h-40 items-center justify-center gap-2 text-destructive"><AlertCircle className="h-4 w-4" /> Could not load financial history.</CardContent></Card>;
-  const currency = data?.account.default_currency_code ?? "USD";
-  return <div className="space-y-4">
-    <div className="grid gap-3 md:grid-cols-3">
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Current balance</CardTitle></CardHeader><CardContent className="text-2xl font-semibold">{money(data?.account.currentBalance ?? 0, currency)}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Available</CardTitle></CardHeader><CardContent className="text-2xl font-semibold text-fm-good">{money(data?.account.availableBalance ?? 0, currency)}</CardContent></Card>
-      <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Reserved</CardTitle></CardHeader><CardContent className="text-2xl font-semibold text-muted-foreground">{money(data?.account.reservedBalance ?? 0, currency)}</CardContent></Card>
+  if (isLoading) return <Card><CardContent className="flex min-h-40 items-center justify-center gap-2 text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading wallet history…</CardContent></Card>;
+  if (error) return <Card className="border-destructive/40"><CardContent className="flex min-h-40 items-center justify-center gap-2 text-destructive"><AlertCircle className="h-4 w-4" /> Could not load wallet history.</CardContent></Card>;
+
+  const currency = data?.account.default_currency_code ?? "GBP";
+  const money = (value: number) => formatMoney(value, currency, 2);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">This tab shows the primary wallet only. Use Transactions for the combined wallet, bank and savings history.</p>
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Current balance</CardTitle></CardHeader><CardContent className="text-2xl font-semibold">{money(data?.account.currentBalance ?? 0)}</CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Available</CardTitle></CardHeader><CardContent className="text-2xl font-semibold text-fm-good">{money(data?.account.availableBalance ?? 0)}</CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Reserved</CardTitle></CardHeader><CardContent className="text-2xl font-semibold text-muted-foreground">{money(data?.account.reservedBalance ?? 0)}</CardContent></Card>
+      </div>
+      <Card>
+        <CardHeader><CardTitle className="flex items-center gap-2"><ReceiptText className="h-4 w-4" /> Recent wallet transactions</CardTitle></CardHeader>
+        <CardContent>
+          {!data?.transactions.length ? (
+            <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">No wallet transactions yet.</div>
+          ) : (
+            <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr className="border-b text-left text-muted-foreground"><th className="py-2 pr-3">Date</th><th className="py-2 pr-3">Description</th><th className="py-2 pr-3">Category</th><th className="py-2 pr-3 text-right">Money in</th><th className="py-2 pr-3 text-right">Money out</th><th className="py-2">Status</th></tr></thead><tbody>{data.transactions.map((transaction: any) => <tr key={transaction.id} className="border-b last:border-0"><td className="whitespace-nowrap py-3 pr-3 text-muted-foreground">{new Date(transaction.created_at).toLocaleDateString("en-GB")}</td><td className="min-w-48 py-3 pr-3">{transaction.description ?? "Financial transaction"}</td><td className="py-3 pr-3"><Badge variant="outline">{label(transaction.transaction_category)}</Badge></td><td className="py-3 pr-3 text-right text-fm-good">{transaction.moneyIn ? money(transaction.moneyIn) : "—"}</td><td className="py-3 pr-3 text-right text-fm-bad">{transaction.moneyOut ? money(transaction.moneyOut) : "—"}</td><td className="py-3"><Badge>{label(transaction.status)}</Badge></td></tr>)}</tbody></table></div>
+          )}
+        </CardContent>
+      </Card>
     </div>
-    <Card>
-      <CardHeader><CardTitle className="flex items-center gap-2"><ReceiptText className="h-4 w-4" /> Recent ledger transactions</CardTitle></CardHeader>
-      <CardContent>
-        {!data?.transactions.length ? <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">No ledger transactions yet.</div> :
-          <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr className="border-b text-left text-muted-foreground"><th className="py-2 pr-3">Date</th><th className="py-2 pr-3">Description</th><th className="py-2 pr-3">Category</th><th className="py-2 pr-3 text-right">Money in</th><th className="py-2 pr-3 text-right">Money out</th><th className="py-2">Status</th></tr></thead><tbody>{data.transactions.map((tx: any) => <tr key={tx.id} className="border-b last:border-0"><td className="whitespace-nowrap py-3 pr-3 text-muted-foreground">{new Date(tx.created_at).toLocaleDateString()}</td><td className="min-w-48 py-3 pr-3">{tx.description ?? "Financial transaction"}</td><td className="py-3 pr-3"><Badge variant="outline">{label(tx.transaction_category)}</Badge></td><td className="py-3 pr-3 text-right text-fm-good">{tx.moneyIn ? money(tx.moneyIn, currency) : "—"}</td><td className="py-3 pr-3 text-right text-fm-bad">{tx.moneyOut ? money(tx.moneyOut, currency) : "—"}</td><td className="py-3"><Badge>{label(tx.status)}</Badge></td></tr>)}</tbody></table></div>}
-      </CardContent>
-    </Card>
-  </div>;
+  );
 };

--- a/src/components/finance/IncomeBreakdownChart.tsx
+++ b/src/components/finance/IncomeBreakdownChart.tsx
@@ -1,7 +1,8 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend, Sector } from "recharts";
-import { useState, useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip } from "recharts";
 import { TrendingUp } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { createCurrencyFormatter } from "@/lib/financeFormatting";
 
 const COLORS = [
   "hsl(var(--chart-1))",
@@ -14,17 +15,10 @@ const COLORS = [
   "hsl(262, 83%, 58%)",
 ];
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
 const SOURCE_LABELS: Record<string, string> = {
   gig_performance: "Gig Performance",
   recording: "Recording",
   release: "Release Revenue",
-  deposit: "Direct Deposit",
   merchandise: "Merchandise",
   streaming: "Streaming",
   sync_licensing: "Sync Licensing",
@@ -32,70 +26,41 @@ const SOURCE_LABELS: Record<string, string> = {
   sponsorship: "Sponsorship",
 };
 
-const renderActiveShape = (props: any) => {
+const renderActiveShape = (props: any, formatCurrency: (value: number) => string) => {
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill, payload, percent, value } = props;
   return (
     <g>
-      <text x={cx} y={cy - 8} textAnchor="middle" fill="hsl(var(--foreground))" className="text-xs font-semibold">
-        {payload.name}
-      </text>
-      <text x={cx} y={cy + 10} textAnchor="middle" fill="hsl(var(--muted-foreground))" className="text-[10px]">
-        {currencyFormatter.format(value)}
-      </text>
-      <text x={cx} y={cy + 24} textAnchor="middle" fill="hsl(var(--muted-foreground))" className="text-[10px]">
-        {(percent * 100).toFixed(1)}%
-      </text>
-      <Sector
-        cx={cx} cy={cy}
-        innerRadius={innerRadius} outerRadius={outerRadius + 6}
-        startAngle={startAngle} endAngle={endAngle}
-        fill={fill}
-      />
-      <Sector
-        cx={cx} cy={cy}
-        innerRadius={outerRadius + 8} outerRadius={outerRadius + 11}
-        startAngle={startAngle} endAngle={endAngle}
-        fill={fill}
-        opacity={0.4}
-      />
+      <text x={cx} y={cy - 8} textAnchor="middle" fill="hsl(var(--foreground))" className="text-xs font-semibold">{payload.name}</text>
+      <text x={cx} y={cy + 10} textAnchor="middle" fill="hsl(var(--muted-foreground))" className="text-[10px]">{formatCurrency(value)}</text>
+      <text x={cx} y={cy + 24} textAnchor="middle" fill="hsl(var(--muted-foreground))" className="text-[10px]">{(percent * 100).toFixed(1)}%</text>
+      <Sector cx={cx} cy={cy} innerRadius={innerRadius} outerRadius={outerRadius + 6} startAngle={startAngle} endAngle={endAngle} fill={fill} />
+      <Sector cx={cx} cy={cy} innerRadius={outerRadius + 8} outerRadius={outerRadius + 11} startAngle={startAngle} endAngle={endAngle} fill={fill} opacity={0.4} />
     </g>
   );
 };
 
 interface IncomeBreakdownChartProps {
   earningsBySource: Record<string, number>;
+  currencyCode: string;
 }
 
-export const IncomeBreakdownChart = ({ earningsBySource }: IncomeBreakdownChartProps) => {
+export const IncomeBreakdownChart = ({ earningsBySource, currencyCode }: IncomeBreakdownChartProps) => {
   const [activeIndex, setActiveIndex] = useState(0);
-
+  const currencyFormatter = useMemo(() => createCurrencyFormatter(currencyCode), [currencyCode]);
   const data = Object.entries(earningsBySource)
     .map(([source, amount]) => ({
-      name: SOURCE_LABELS[source] || source.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      name: SOURCE_LABELS[source] || source.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase()),
       value: amount,
     }))
-    .sort((a, b) => b.value - a.value);
+    .sort((left, right) => right.value - left.value);
+  const total = data.reduce((sum, entry) => sum + entry.value, 0);
+  const onPieEnter = useCallback((_: unknown, index: number) => setActiveIndex(index), []);
 
-  const total = data.reduce((sum, d) => sum + d.value, 0);
-  const topSource = data[0];
-
-  const onPieEnter = useCallback((_: any, index: number) => {
-    setActiveIndex(index);
-  }, []);
-
-  if (data.length === 0) {
+  if (!data.length) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <TrendingUp className="h-5 w-5 text-primary" />
-            Income Breakdown
-          </CardTitle>
-          <CardDescription>Revenue by source</CardDescription>
-        </CardHeader>
-        <CardContent className="flex h-[200px] items-center justify-center">
-          <p className="text-sm text-muted-foreground">No income data yet</p>
-        </CardContent>
+        <CardHeader><CardTitle className="flex items-center gap-2"><TrendingUp className="h-5 w-5 text-primary" /> Income Breakdown</CardTitle><CardDescription>External income by canonical ledger category</CardDescription></CardHeader>
+        <CardContent className="flex h-[200px] items-center justify-center"><p className="text-sm text-muted-foreground">No external income data yet.</p></CardContent>
       </Card>
     );
   }
@@ -103,69 +68,27 @@ export const IncomeBreakdownChart = ({ earningsBySource }: IncomeBreakdownChartP
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="flex items-center gap-2">
-          <TrendingUp className="h-5 w-5 text-primary" />
-          Income Breakdown
-        </CardTitle>
-        <CardDescription>
-          {currencyFormatter.format(total)} total • {data.length} source{data.length !== 1 ? "s" : ""}
-        </CardDescription>
+        <CardTitle className="flex items-center gap-2"><TrendingUp className="h-5 w-5 text-primary" /> Income Breakdown</CardTitle>
+        <CardDescription>{currencyFormatter.format(total)} total • {data.length} source{data.length === 1 ? "" : "s"}</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="h-[220px]">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
-              <Pie
-                activeIndex={activeIndex}
-                activeShape={renderActiveShape}
-                data={data}
-                cx="50%"
-                cy="50%"
-                innerRadius={45}
-                outerRadius={70}
-                paddingAngle={2}
-                dataKey="value"
-                onMouseEnter={onPieEnter}
-              >
-                {data.map((_, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} strokeWidth={0} />
-                ))}
+              <Pie activeIndex={activeIndex} activeShape={(props: any) => renderActiveShape(props, (value) => currencyFormatter.format(value))} data={data} cx="50%" cy="50%" innerRadius={45} outerRadius={70} paddingAngle={2} dataKey="value" onMouseEnter={onPieEnter}>
+                {data.map((_, index) => <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} strokeWidth={0} />)}
               </Pie>
-              <Tooltip
-                formatter={(value: number) => [currencyFormatter.format(value), "Revenue"]}
-                contentStyle={{
-                  backgroundColor: "hsl(var(--card))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "8px",
-                  fontSize: "12px",
-                }}
-              />
+              <Tooltip formatter={(value: number) => [currencyFormatter.format(value), "Revenue"]} contentStyle={{ backgroundColor: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: "8px", fontSize: "12px" }} />
             </PieChart>
           </ResponsiveContainer>
         </div>
-
-        {/* Source breakdown list */}
-        <div className="mt-2 space-y-1.5 max-h-[120px] overflow-y-auto">
-          {data.map((item, i) => {
-            const pct = ((item.value / total) * 100).toFixed(1);
-            return (
-              <div key={item.name} className="flex items-center justify-between text-xs">
-                <div className="flex items-center gap-2">
-                  <div
-                    className="h-2.5 w-2.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: COLORS[i % COLORS.length] }}
-                  />
-                  <span className="text-foreground truncate max-w-[120px]">{item.name}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground">{pct}%</span>
-                  <span className="font-medium text-foreground w-[70px] text-right">
-                    {currencyFormatter.format(item.value)}
-                  </span>
-                </div>
-              </div>
-            );
-          })}
+        <div className="mt-2 max-h-[120px] space-y-1.5 overflow-y-auto">
+          {data.map((item, index) => (
+            <div key={item.name} className="flex items-center justify-between text-xs">
+              <div className="flex items-center gap-2"><div className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: COLORS[index % COLORS.length] }} /><span className="max-w-[140px] truncate text-foreground">{item.name}</span></div>
+              <div className="flex items-center gap-2"><span className="text-muted-foreground">{((item.value / total) * 100).toFixed(1)}%</span><span className="w-[82px] text-right font-medium text-foreground">{currencyFormatter.format(item.value)}</span></div>
+            </div>
+          ))}
         </div>
       </CardContent>
     </Card>

--- a/src/components/finance/IncomeExpenseChart.tsx
+++ b/src/components/finance/IncomeExpenseChart.tsx
@@ -1,119 +1,60 @@
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis, Line, ComposedChart, Bar } from "recharts";
-
+import { useMemo } from "react";
+import { Area, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
+import { BarChart3 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
-import { useMemo } from "react";
-import { BarChart3 } from "lucide-react";
+import { createCurrencyFormatter } from "@/lib/financeFormatting";
 
 interface IncomeExpenseChartProps {
   data: { month: string; income: number; expenses: number }[];
+  currencyCode: string;
 }
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
 const chartConfig = {
-  income: {
-    label: "Income",
-    color: "hsl(142, 76%, 36%)",
-  },
-  expenses: {
-    label: "Expenses",
-    color: "hsl(var(--destructive))",
-  },
-  net: {
-    label: "Net Profit",
-    color: "hsl(var(--primary))",
-  },
+  income: { label: "Income", color: "hsl(142, 76%, 36%)" },
+  expenses: { label: "Expenses", color: "hsl(var(--destructive))" },
+  net: { label: "Net Cash Flow", color: "hsl(var(--primary))" },
 };
 
-export const IncomeExpenseChart = ({ data }: IncomeExpenseChartProps) => {
-  const enrichedData = useMemo(() => {
-    return data.map((d) => ({
-      ...d,
-      net: d.income - d.expenses,
-    }));
-  }, [data]);
-
-  const hasData = data.length > 0;
-  const totalIncome = data.reduce((s, d) => s + d.income, 0);
-  const totalExpenses = data.reduce((s, d) => s + d.expenses, 0);
+export const IncomeExpenseChart = ({ data, currencyCode }: IncomeExpenseChartProps) => {
+  const currencyFormatter = useMemo(() => createCurrencyFormatter(currencyCode), [currencyCode]);
+  const enrichedData = useMemo(() => data.map((entry) => ({ ...entry, net: entry.income - entry.expenses })), [data]);
+  const hasData = data.some((entry) => entry.income !== 0 || entry.expenses !== 0);
+  const totalIncome = data.reduce((sum, entry) => sum + entry.income, 0);
+  const totalExpenses = data.reduce((sum, entry) => sum + entry.expenses, 0);
   const totalNet = totalIncome - totalExpenses;
 
   return (
     <Card className="h-full">
       <CardHeader className="pb-2">
-        <CardTitle className="flex items-center gap-2">
-          <BarChart3 className="h-5 w-5 text-primary" />
-          Income vs. Expenses
-        </CardTitle>
+        <CardTitle className="flex items-center gap-2"><BarChart3 className="h-5 w-5 text-primary" /> Income vs. Expenses</CardTitle>
         <CardDescription>
           {hasData ? (
             <span className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
               <span className="text-emerald-500">↑ {currencyFormatter.format(totalIncome)}</span>
               <span className="text-destructive">↓ {currencyFormatter.format(totalExpenses)}</span>
-              <span className={totalNet >= 0 ? "text-primary font-medium" : "text-destructive font-medium"}>
-                Net: {totalNet >= 0 ? "+" : ""}{currencyFormatter.format(totalNet)}
-              </span>
+              <span className={totalNet >= 0 ? "font-medium text-primary" : "font-medium text-destructive"}>Net: {totalNet >= 0 ? "+" : ""}{currencyFormatter.format(totalNet)}</span>
             </span>
-          ) : (
-            "Track the monthly cash flow of your creative business."
-          )}
+          ) : "External cash flow will appear here once ledger activity exists."}
         </CardDescription>
       </CardHeader>
       <CardContent className="h-72">
         {!hasData ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            No transactions yet. Connect revenue streams to populate the chart.
-          </div>
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">No external income or expenses recorded yet.</div>
         ) : (
           <ChartContainer config={chartConfig} className="h-full w-full">
             <ComposedChart data={enrichedData} margin={{ left: 8, right: 8, top: 8 }}>
               <defs>
-                <linearGradient id="income-gradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--color-income)" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="var(--color-income)" stopOpacity={0.02} />
-                </linearGradient>
-                <linearGradient id="expense-gradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--color-expenses)" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="var(--color-expenses)" stopOpacity={0.02} />
-                </linearGradient>
+                <linearGradient id="income-gradient" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="var(--color-income)" stopOpacity={0.3} /><stop offset="95%" stopColor="var(--color-income)" stopOpacity={0.02} /></linearGradient>
+                <linearGradient id="expense-gradient" x1="0" y1="0" x2="0" y2="1"><stop offset="5%" stopColor="var(--color-expenses)" stopOpacity={0.3} /><stop offset="95%" stopColor="var(--color-expenses)" stopOpacity={0.02} /></linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" vertical={false} />
               <XAxis dataKey="month" tickLine={false} axisLine={false} tickMargin={8} tick={{ fontSize: 11 }} />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                tickMargin={4}
-                width={60}
-                tick={{ fontSize: 10 }}
-                tickFormatter={(value) => currencyFormatter.format(Number(value))}
-              />
-              <ChartTooltip
-                cursor={{ strokeDasharray: "4 4" }}
-                content={
-                  <ChartTooltipContent
-                    formatter={(value, name) => [
-                      currencyFormatter.format(typeof value === "number" ? value : Number(value)),
-                      chartConfig[name as keyof typeof chartConfig]?.label ?? name,
-                    ]}
-                  />
-                }
-              />
+              <YAxis tickLine={false} axisLine={false} tickMargin={4} width={70} tick={{ fontSize: 10 }} tickFormatter={(value) => currencyFormatter.format(Number(value))} />
+              <ChartTooltip cursor={{ strokeDasharray: "4 4" }} content={<ChartTooltipContent formatter={(value, name) => [currencyFormatter.format(typeof value === "number" ? value : Number(value)), chartConfig[name as keyof typeof chartConfig]?.label ?? name]} />} />
               <Area type="monotone" dataKey="income" stroke="var(--color-income)" fill="url(#income-gradient)" strokeWidth={2} />
               <Area type="monotone" dataKey="expenses" stroke="var(--color-expenses)" fill="url(#expense-gradient)" strokeWidth={2} />
-              <Line
-                type="monotone"
-                dataKey="net"
-                stroke="var(--color-net)"
-                strokeWidth={2}
-                strokeDasharray="5 3"
-                dot={{ r: 3, fill: "var(--color-net)" }}
-                activeDot={{ r: 5 }}
-              />
+              <Line type="monotone" dataKey="net" stroke="var(--color-net)" strokeWidth={2} strokeDasharray="5 3" dot={{ r: 3, fill: "var(--color-net)" }} activeDot={{ r: 5 }} />
             </ComposedChart>
           </ChartContainer>
         )}

--- a/src/components/finance/PersonalFinanceBreakdown.tsx
+++ b/src/components/finance/PersonalFinanceBreakdown.tsx
@@ -1,20 +1,8 @@
+import { Car, Guitar, Home, Landmark, TrendingDown, Wallet, WalletCards } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import {
-  Wallet,
-  Home,
-  Car,
-  Guitar,
-  Landmark,
-  TrendingDown,
-} from "lucide-react";
 import type { FinancialSummary } from "@/hooks/useFinances";
-
-const fmt = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+import { formatMoney } from "@/lib/financeFormatting";
 
 interface PersonalFinanceBreakdownProps {
   summary: FinancialSummary;
@@ -29,49 +17,27 @@ export const PersonalFinanceBreakdown = ({
   vehicleValue = 0,
   gearValue = 0,
 }: PersonalFinanceBreakdownProps) => {
-  const totalAssets =
-    summary.cash +
-    summary.investmentValue +
-    propertyValue +
-    vehicleValue +
-    gearValue;
+  const money = (amount: number) => formatMoney(amount, summary.currencyCode);
+  const totalAssets = summary.personalAccounts + summary.investmentValue + propertyValue + vehicleValue + gearValue;
   const totalLiabilities = summary.totalLoans;
   const netWorth = totalAssets - totalLiabilities;
 
   const assetRows = [
+    { label: "Wallet cash", value: summary.cash, icon: Wallet, color: "text-emerald-500" },
     {
-      label: "Cash",
-      value: summary.cash,
-      icon: Wallet,
-      color: "text-emerald-500",
+      label: "Bank and savings balances",
+      value: Math.max(0, summary.personalAccounts - summary.cash),
+      icon: WalletCards,
+      color: "text-cyan-500",
     },
-    {
-      label: "Investments",
-      value: summary.investmentValue,
-      icon: Landmark,
-      color: "text-blue-500",
-    },
-    {
-      label: "Property",
-      value: propertyValue,
-      icon: Home,
-      color: "text-amber-500",
-    },
-    {
-      label: "Vehicles",
-      value: vehicleValue,
-      icon: Car,
-      color: "text-purple-500",
-    },
-    {
-      label: "Gear & Equipment",
-      value: gearValue,
-      icon: Guitar,
-      color: "text-orange-500",
-    },
+    { label: "Investments", value: summary.investmentValue, icon: Landmark, color: "text-blue-500" },
+    { label: "Property", value: propertyValue, icon: Home, color: "text-amber-500" },
+    { label: "Vehicles", value: vehicleValue, icon: Car, color: "text-purple-500" },
+    { label: "Gear and equipment", value: gearValue, icon: Guitar, color: "text-orange-500" },
   ];
 
-  const assetsNonZero = assetRows.filter((r) => r.value > 0);
+  const assetsNonZero = assetRows.filter((row) => row.value > 0);
+  const solvencyPercent = totalAssets > 0 ? Math.max(0, Math.min(100, (netWorth / totalAssets) * 100)) : 0;
 
   return (
     <Card>
@@ -79,79 +45,42 @@ export const PersonalFinanceBreakdown = ({
         <CardTitle className="text-lg">Personal Finance Breakdown</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Net Worth Bar */}
         <div className="space-y-1">
           <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Net Worth</span>
-            <span
-              className={`font-bold ${netWorth >= 0 ? "text-emerald-500" : "text-destructive"}`}
-            >
-              {fmt.format(netWorth)}
-            </span>
+            <span className="text-muted-foreground">Personal net worth</span>
+            <span className={`font-bold ${netWorth >= 0 ? "text-emerald-500" : "text-destructive"}`}>{money(netWorth)}</span>
           </div>
-          <Progress
-            value={
-              totalAssets > 0
-                ? Math.min(
-                    ((totalAssets - totalLiabilities) / totalAssets) * 100,
-                    100,
-                  )
-                : 0
-            }
-            className="h-2"
-          />
+          <Progress value={solvencyPercent} className="h-2" />
+          <p className="text-xs text-muted-foreground">Band treasuries and foreign currencies are excluded.</p>
         </div>
 
-        {/* Assets */}
         <div className="space-y-2">
           <p className="text-xs font-semibold text-muted-foreground">Assets</p>
           {assetsNonZero.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No assets recorded yet
-            </p>
+            <p className="text-sm text-muted-foreground">No personal assets recorded yet.</p>
           ) : (
             assetsNonZero.map((row) => (
-              <div
-                key={row.label}
-                className="flex items-center justify-between"
-              >
-                <div className="flex items-center gap-2">
-                  <row.icon className={`h-4 w-4 ${row.color}`} />
-                  <span className="text-sm">{row.label}</span>
-                </div>
-                <span className="text-sm font-medium">
-                  {fmt.format(row.value)}
-                </span>
+              <div key={row.label} className="flex items-center justify-between">
+                <div className="flex items-center gap-2"><row.icon className={`h-4 w-4 ${row.color}`} /><span className="text-sm">{row.label}</span></div>
+                <span className="text-sm font-medium">{money(row.value)}</span>
               </div>
             ))
           )}
           <div className="flex items-center justify-between border-t border-border pt-1">
-            <span className="text-sm font-semibold">Total Assets</span>
-            <span className="text-sm font-bold text-emerald-500">
-              {fmt.format(totalAssets)}
-            </span>
+            <span className="text-sm font-semibold">Total personal assets</span>
+            <span className="text-sm font-bold text-emerald-500">{money(totalAssets)}</span>
           </div>
         </div>
 
-        {/* Liabilities */}
         <div className="space-y-2">
-          <p className="text-xs font-semibold text-muted-foreground">
-            Liabilities
-          </p>
+          <p className="text-xs font-semibold text-muted-foreground">Liabilities</p>
           {totalLiabilities > 0 ? (
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <TrendingDown className="h-4 w-4 text-destructive" />
-                <span className="text-sm">Active Loans</span>
-              </div>
-              <span className="text-sm font-medium text-destructive">
-                {fmt.format(totalLiabilities)}
-              </span>
+              <div className="flex items-center gap-2"><TrendingDown className="h-4 w-4 text-destructive" /><span className="text-sm">Canonical loan contracts</span></div>
+              <span className="text-sm font-medium text-destructive">{money(totalLiabilities)}</span>
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">
-              No outstanding liabilities
-            </p>
+            <p className="text-sm text-muted-foreground">No outstanding canonical liabilities.</p>
           )}
         </div>
       </CardContent>

--- a/src/components/finance/PlayerFinanceHub.tsx
+++ b/src/components/finance/PlayerFinanceHub.tsx
@@ -1,43 +1,70 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { ArrowDownRight, ArrowLeftRight, ArrowUpRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { FinancialSummary, FinancialTransaction } from "@/hooks/useFinances";
+import { formatMoney } from "@/lib/financeFormatting";
 
-const money = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+export function PlayerFinanceHub({
+  summary,
+  transactions,
+}: {
+  summary: FinancialSummary;
+  transactions: FinancialTransaction[];
+}) {
+  const money = (amount: number) => formatMoney(amount, summary.currencyCode);
+  const netMonthly = summary.monthlyIncome - summary.monthlyExpenses;
+  const recent = transactions.slice(0, 12);
 
-const incomeCategories = ["Wages", "Gig earnings", "Royalties", "Streaming", "Merchandise", "Songwriting", "Session work", "Teaching", "Company dividends", "Player transfers", "Administrative grants", "Other income"];
-const expenseCategories = ["Rent", "Travel", "Accommodation", "Food or lifestyle", "Rehearsals", "Recording", "Equipment", "Repairs", "Education", "Band contributions", "Taxes", "Fees", "Subscriptions", "Debt payments", "Other spending"];
-
-export function PlayerFinanceHub({ summary, transactions }: { summary: FinancialSummary; transactions: FinancialTransaction[] }) {
-  const weeklyIncome = transactions.filter((t) => t.type === "income").slice(0, 20).reduce((sum, t) => sum + t.amount, 0);
-  const weeklyExpenses = transactions.filter((t) => t.type === "expense").slice(0, 20).reduce((sum, t) => sum + t.amount, 0);
-  const upcoming = transactions.filter((t) => t.type === "expense").slice(0, 3);
   return (
     <div className="space-y-6" aria-label="Personal finance hub">
       <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
-        <FinanceMetric label="Available cash" value={money.format(summary.cash)} />
-        <FinanceMetric label="Reserved" value={money.format(Math.max(0, summary.totalLoans / 12))} />
-        <FinanceMetric label="Weekly income" value={money.format(weeklyIncome)} tone="good" />
-        <FinanceMetric label="Weekly expenses" value={money.format(weeklyExpenses)} tone="bad" />
-        <FinanceMetric label="Net cash flow" value={money.format(weeklyIncome - weeklyExpenses)} />
-        <FinanceMetric label="Taxable this period" value={money.format(weeklyIncome)} />
+        <FinanceMetric label="Wallet cash" value={money(summary.cash)} />
+        <FinanceMetric label="Personal accounts" value={money(summary.personalAccounts)} />
+        <FinanceMetric label="Average monthly income" value={money(summary.monthlyIncome)} tone="good" />
+        <FinanceMetric label="Average monthly expenses" value={money(summary.monthlyExpenses)} tone="bad" />
+        <FinanceMetric label="Average monthly net" value={money(netMonthly)} tone={netMonthly >= 0 ? "good" : "bad"} />
+        <FinanceMetric label="Canonical liabilities" value={money(summary.totalLoans)} tone={summary.totalLoans > 0 ? "bad" : undefined} />
       </div>
+
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
-          <CardHeader><CardTitle>Income breakdown</CardTitle><CardDescription>Extensible categories; only connected ledger sources show values.</CardDescription></CardHeader>
-          <CardContent className="flex flex-wrap gap-2">{incomeCategories.map((c) => <Badge key={c} variant="secondary">{c}</Badge>)}</CardContent>
+          <CardHeader><CardTitle>All-time external cash flow</CardTitle><CardDescription>Internal account transfers are excluded.</CardDescription></CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-lg border p-4"><p className="text-xs text-muted-foreground">External income</p><p className="text-xl font-semibold text-fm-good">{money(summary.totalEarnings)}</p></div>
+            <div className="rounded-lg border p-4"><p className="text-xs text-muted-foreground">External spending</p><p className="text-xl font-semibold text-fm-bad">{money(summary.totalExpenses)}</p></div>
+          </CardContent>
         </Card>
         <Card>
-          <CardHeader><CardTitle>Expense breakdown</CardTitle><CardDescription>Recurring obligations and ledger categories feed this view.</CardDescription></CardHeader>
-          <CardContent className="flex flex-wrap gap-2">{expenseCategories.map((c) => <Badge key={c} variant="outline">{c}</Badge>)}</CardContent>
+          <CardHeader><CardTitle>Personal wealth boundary</CardTitle><CardDescription>Only balances in {summary.currencyCode} enter the headline total.</CardDescription></CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between"><span className="text-muted-foreground">Personal accounts</span><span>{money(summary.personalAccounts)}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Investments</span><span>{money(summary.investmentValue)}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Less liabilities</span><span className="text-fm-bad">-{money(summary.totalLoans)}</span></div>
+            <div className="flex justify-between border-t pt-2 font-semibold"><span>Personal net worth</span><span>{money(summary.netWorth)}</span></div>
+          </CardContent>
         </Card>
       </div>
+
       <Card>
-        <CardHeader><CardTitle>Upcoming confirmed expenses</CardTitle><CardDescription>Shows due payments, auto-pay status and current recoverability once obligations exist.</CardDescription></CardHeader>
+        <CardHeader><CardTitle>Recent canonical activity</CardTitle><CardDescription>Wallet, bank, savings and external transactions in one history.</CardDescription></CardHeader>
         <CardContent>
-          <Table><TableHeader><TableRow><TableHead>Due</TableHead><TableHead>Description</TableHead><TableHead>Category</TableHead><TableHead className="text-right">Amount</TableHead><TableHead>Status</TableHead></TableRow></TableHeader><TableBody>
-            {upcoming.length ? upcoming.map((t) => <TableRow key={t.id}><TableCell>{new Date(t.date).toLocaleDateString()}</TableCell><TableCell>{t.description ?? t.source}</TableCell><TableCell>{t.source}</TableCell><TableCell className="text-right">{money.format(t.amount)}</TableCell><TableCell><Badge>Scheduled</Badge></TableCell></TableRow>) : <TableRow><TableCell colSpan={5} className="py-6 text-center text-muted-foreground">No upcoming obligations yet.</TableCell></TableRow>}
-          </TableBody></Table></CardContent>
+          <Table>
+            <TableHeader><TableRow><TableHead>Date</TableHead><TableHead>Description</TableHead><TableHead>Type</TableHead><TableHead className="text-right">Amount</TableHead></TableRow></TableHeader>
+            <TableBody>
+              {recent.length ? recent.map((transaction) => (
+                <TableRow key={transaction.id}>
+                  <TableCell>{new Date(transaction.date).toLocaleDateString("en-GB")}</TableCell>
+                  <TableCell>{transaction.description ?? transaction.source}</TableCell>
+                  <TableCell>
+                    {transaction.type === "income" ? <Badge variant="outline" className="text-fm-good"><ArrowUpRight className="mr-1 h-3 w-3" />Income</Badge> : transaction.type === "expense" ? <Badge variant="outline" className="text-fm-bad"><ArrowDownRight className="mr-1 h-3 w-3" />Expense</Badge> : <Badge variant="outline"><ArrowLeftRight className="mr-1 h-3 w-3" />Transfer</Badge>}
+                  </TableCell>
+                  <TableCell className="text-right">{formatMoney(transaction.amount, transaction.currencyCode)}</TableCell>
+                </TableRow>
+              )) : <TableRow><TableCell colSpan={4} className="py-6 text-center text-muted-foreground">No canonical activity yet.</TableCell></TableRow>}
+            </TableBody>
+          </Table>
+        </CardContent>
       </Card>
     </div>
   );

--- a/src/components/finance/SpendingCategoriesChart.tsx
+++ b/src/components/finance/SpendingCategoriesChart.tsx
@@ -1,7 +1,9 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, Cell } from "recharts";
+import { useMemo } from "react";
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ShoppingCart } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { FinancialTransaction } from "@/hooks/useFinances";
+import { createCurrencyFormatter } from "@/lib/financeFormatting";
 
 const COLORS = [
   "hsl(var(--chart-2))",
@@ -12,12 +14,6 @@ const COLORS = [
   "hsl(221, 83%, 53%)",
 ];
 
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
-
 const SOURCE_LABELS: Record<string, string> = {
   manufacturing: "Manufacturing",
   marketing: "Marketing",
@@ -27,41 +23,35 @@ const SOURCE_LABELS: Record<string, string> = {
   venue: "Venue Costs",
   merchandise: "Merch Production",
   promotion: "Promotion",
+  band_contribution: "Band Contributions",
 };
 
 interface SpendingCategoriesChartProps {
   transactions: FinancialTransaction[];
+  currencyCode: string;
 }
 
-export const SpendingCategoriesChart = ({ transactions }: SpendingCategoriesChartProps) => {
-  const expenses = transactions.filter((t) => t.type === "expense");
-
+export const SpendingCategoriesChart = ({ transactions, currencyCode }: SpendingCategoriesChartProps) => {
+  const currencyFormatter = useMemo(() => createCurrencyFormatter(currencyCode), [currencyCode]);
   const byCategory: Record<string, number> = {};
-  expenses.forEach((t) => {
-    const label = SOURCE_LABELS[t.source] || t.source.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-    byCategory[label] = (byCategory[label] || 0) + t.amount;
-  });
+  transactions
+    .filter((transaction) => transaction.type === "expense" && transaction.externalCashFlow)
+    .forEach((transaction) => {
+      const label = SOURCE_LABELS[transaction.source] || transaction.source.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+      byCategory[label] = (byCategory[label] || 0) + transaction.amount;
+    });
 
   const data = Object.entries(byCategory)
     .map(([name, value]) => ({ name, value }))
-    .sort((a, b) => b.value - a.value)
+    .sort((left, right) => right.value - left.value)
     .slice(0, 6);
+  const total = data.reduce((sum, entry) => sum + entry.value, 0);
 
-  const total = data.reduce((s, d) => s + d.value, 0);
-
-  if (data.length === 0) {
+  if (!data.length) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <ShoppingCart className="h-5 w-5 text-destructive" />
-            Spending Categories
-          </CardTitle>
-          <CardDescription>Where your money goes</CardDescription>
-        </CardHeader>
-        <CardContent className="flex h-[200px] items-center justify-center">
-          <p className="text-sm text-muted-foreground">No expenses recorded yet</p>
-        </CardContent>
+        <CardHeader><CardTitle className="flex items-center gap-2"><ShoppingCart className="h-5 w-5 text-destructive" /> Spending Categories</CardTitle><CardDescription>External spending by ledger category</CardDescription></CardHeader>
+        <CardContent className="flex h-[200px] items-center justify-center"><p className="text-sm text-muted-foreground">No external expenses recorded yet.</p></CardContent>
       </Card>
     );
   }
@@ -69,47 +59,17 @@ export const SpendingCategoriesChart = ({ transactions }: SpendingCategoriesChar
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="flex items-center gap-2">
-          <ShoppingCart className="h-5 w-5 text-destructive" />
-          Spending Categories
-        </CardTitle>
-        <CardDescription>
-          {currencyFormatter.format(total)} spent across {data.length} categories
-        </CardDescription>
+        <CardTitle className="flex items-center gap-2"><ShoppingCart className="h-5 w-5 text-destructive" /> Spending Categories</CardTitle>
+        <CardDescription>{currencyFormatter.format(total)} spent across {data.length} categories</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="h-[200px]">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={data} layout="vertical" margin={{ left: 0, right: 8 }}>
-              <XAxis
-                type="number"
-                tickFormatter={(v) => currencyFormatter.format(v)}
-                tick={{ fontSize: 10 }}
-                axisLine={false}
-                tickLine={false}
-              />
-              <YAxis
-                type="category"
-                dataKey="name"
-                tick={{ fontSize: 10, fill: "hsl(var(--foreground))" }}
-                axisLine={false}
-                tickLine={false}
-                width={90}
-              />
-              <Tooltip
-                formatter={(value: number) => [currencyFormatter.format(value), "Spent"]}
-                contentStyle={{
-                  backgroundColor: "hsl(var(--card))",
-                  border: "1px solid hsl(var(--border))",
-                  borderRadius: "8px",
-                  fontSize: "12px",
-                }}
-              />
-              <Bar dataKey="value" radius={[0, 4, 4, 0]} barSize={18}>
-                {data.map((_, index) => (
-                  <Cell key={index} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Bar>
+              <XAxis type="number" tickFormatter={(value) => currencyFormatter.format(value)} tick={{ fontSize: 10 }} axisLine={false} tickLine={false} />
+              <YAxis type="category" dataKey="name" tick={{ fontSize: 10, fill: "hsl(var(--foreground))" }} axisLine={false} tickLine={false} width={100} />
+              <Tooltip formatter={(value: number) => [currencyFormatter.format(value), "Spent"]} contentStyle={{ backgroundColor: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: "8px", fontSize: "12px" }} />
+              <Bar dataKey="value" radius={[0, 4, 4, 0]} barSize={18}>{data.map((_, index) => <Cell key={index} fill={COLORS[index % COLORS.length]} />)}</Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/src/components/finance/TransactionsList.tsx
+++ b/src/components/finance/TransactionsList.tsx
@@ -1,24 +1,21 @@
 import { useMemo, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { format } from "date-fns";
+import { ArrowDownRight, ArrowLeftRight, ArrowUpRight, Circle, History } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { format } from "date-fns";
-import { ArrowUpRight, ArrowDownRight, History } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { FMFilterBar, type FilterPill } from "@/components/fm/FMFilterBar";
-import type { FinancialTransaction } from "@/hooks/useFinances";
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+import type { FinancialTransaction, FinancialTransactionType } from "@/hooks/useFinances";
+import { formatMoney } from "@/lib/financeFormatting";
 
 const SOURCE_LABELS: Record<string, string> = {
   gig_performance: "Gig Performance",
   recording: "Recording",
   release: "Release Revenue",
-  deposit: "Direct Deposit",
+  bank_transfer: "Account Transfer",
+  bank_deposit: "Bank Deposit",
+  bank_withdrawal: "Bank Withdrawal",
   merchandise: "Merchandise",
   streaming: "Streaming",
   manufacturing: "Manufacturing",
@@ -28,76 +25,61 @@ const SOURCE_LABELS: Record<string, string> = {
 };
 
 const labelFor = (source: string) =>
-  SOURCE_LABELS[source] || source.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  SOURCE_LABELS[source] || source.replace(/_/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
 
 interface TransactionsListProps {
   transactions: FinancialTransaction[];
+  currencyCode: string;
 }
 
-type TypeFilter = "all" | "income" | "expense";
+type TypeFilter = "all" | FinancialTransactionType;
 
-export const TransactionsList = ({ transactions }: TransactionsListProps) => {
+const TypeBadge = ({ type }: { type: FinancialTransactionType }) => {
+  if (type === "income") return <Badge variant="outline" className="text-fm-good border-fm-good/30"><ArrowUpRight className="mr-1 h-3 w-3" />Income</Badge>;
+  if (type === "expense") return <Badge variant="outline" className="text-fm-bad border-fm-bad/30"><ArrowDownRight className="mr-1 h-3 w-3" />Expense</Badge>;
+  if (type === "transfer") return <Badge variant="outline" className="text-blue-500 border-blue-500/30"><ArrowLeftRight className="mr-1 h-3 w-3" />Transfer</Badge>;
+  return <Badge variant="outline"><Circle className="mr-1 h-2.5 w-2.5" />Activity</Badge>;
+};
+
+export const TransactionsList = ({ transactions, currencyCode }: TransactionsListProps) => {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
-  const [sourceFilter, setSourceFilter] = useState<string>("all");
+  const [sourceFilter, setSourceFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [limit, setLimit] = useState(25);
 
   const counts = useMemo(() => {
-    let income = 0;
-    let expense = 0;
-    for (const t of transactions) {
-      if (t.type === "income") income++;
-      else if (t.type === "expense") expense++;
-    }
-    return { all: transactions.length, income, expense };
+    const result = { all: transactions.length, income: 0, expense: 0, transfer: 0, other: 0 };
+    transactions.forEach((transaction) => { result[transaction.type] += 1; });
+    return result;
   }, [transactions]);
 
-  const sources = useMemo(() => {
-    const set = new Set<string>();
-    transactions.forEach((t) => set.add(t.source));
-    return Array.from(set).sort();
-  }, [transactions]);
+  const sources = useMemo(() => Array.from(new Set(transactions.map((transaction) => transaction.source))).sort(), [transactions]);
 
   const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    return transactions.filter((t) => {
-      if (typeFilter !== "all" && t.type !== typeFilter) return false;
-      if (sourceFilter !== "all" && t.source !== sourceFilter) return false;
-      if (!q) return true;
-      const hay = `${t.description ?? ""} ${t.bandName ?? ""} ${labelFor(t.source)}`.toLowerCase();
-      return hay.includes(q);
+    const query = search.trim().toLowerCase();
+    return transactions.filter((transaction) => {
+      if (typeFilter !== "all" && transaction.type !== typeFilter) return false;
+      if (sourceFilter !== "all" && transaction.source !== sourceFilter) return false;
+      if (!query) return true;
+      return `${transaction.description ?? ""} ${transaction.bandName ?? ""} ${labelFor(transaction.source)}`.toLowerCase().includes(query);
     });
   }, [transactions, typeFilter, sourceFilter, search]);
 
-  const totalIncome = filtered.filter((t) => t.type === "income").reduce((s, t) => s + t.amount, 0);
-  const totalExpenses = filtered.filter((t) => t.type === "expense").reduce((s, t) => s + t.amount, 0);
-
+  const totalIncome = filtered.filter((item) => item.type === "income" && item.externalCashFlow).reduce((sum, item) => sum + item.amount, 0);
+  const totalExpenses = filtered.filter((item) => item.type === "expense" && item.externalCashFlow).reduce((sum, item) => sum + item.amount, 0);
   const visible = filtered.slice(0, limit);
-
   const pills: FilterPill<TypeFilter>[] = [
     { value: "all", label: "All", count: counts.all },
     { value: "income", label: "Income", count: counts.income },
     { value: "expense", label: "Expense", count: counts.expense },
+    { value: "transfer", label: "Transfers", count: counts.transfer },
   ];
 
-  if (transactions.length === 0) {
+  if (!transactions.length) {
     return (
       <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <History className="h-4 w-4" />
-            Transaction History
-          </CardTitle>
-          <CardDescription>Your financial activity</CardDescription>
-        </CardHeader>
-        <CardContent className="flex h-[200px] items-center justify-center">
-          <div className="text-center">
-            <History className="mx-auto h-8 w-8 text-fm-fg-muted/50" />
-            <p className="mt-2 text-xs text-fm-fg-muted">
-              No transactions yet. Start earning to see your history.
-            </p>
-          </div>
-        </CardContent>
+        <CardHeader><CardTitle className="flex items-center gap-2"><History className="h-4 w-4" /> Transaction History</CardTitle><CardDescription>Canonical financial activity</CardDescription></CardHeader>
+        <CardContent className="flex h-[200px] items-center justify-center"><div className="text-center"><History className="mx-auto h-8 w-8 text-fm-fg-muted/50" /><p className="mt-2 text-xs text-fm-fg-muted">No canonical transactions yet.</p></div></CardContent>
       </Card>
     );
   }
@@ -105,111 +87,48 @@ export const TransactionsList = ({ transactions }: TransactionsListProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <History className="h-4 w-4" />
-          Transaction History
-        </CardTitle>
+        <CardTitle className="flex items-center gap-2"><History className="h-4 w-4" /> Transaction History</CardTitle>
         <CardDescription>
-          {currencyFormatter.format(totalIncome)} earned • {currencyFormatter.format(totalExpenses)} spent
-          {filtered.length !== transactions.length && (
-            <> • {filtered.length} of {transactions.length} shown</>
-          )}
+          {formatMoney(totalIncome, currencyCode)} external income • {formatMoney(totalExpenses, currencyCode)} external spending
+          {filtered.length !== transactions.length && <> • {filtered.length} of {transactions.length} shown</>}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-2">
         <FMFilterBar
           label="Filter"
           search={search}
-          onSearchChange={(v) => {
-            setSearch(v);
-            setLimit(25);
-          }}
-          searchPlaceholder="Search description, source, band…"
+          onSearchChange={(value) => { setSearch(value); setLimit(25); }}
+          searchPlaceholder="Search description, source or band…"
           pills={pills}
           activePill={typeFilter}
-          onPillChange={(v) => {
-            setTypeFilter(v as TypeFilter);
-            setLimit(25);
-          }}
+          onPillChange={(value) => { setTypeFilter(value as TypeFilter); setLimit(25); }}
           right={
-            <select
-              value={sourceFilter}
-              onChange={(e) => {
-                setSourceFilter(e.target.value);
-                setLimit(25);
-              }}
-              className="h-6 px-1.5 text-xs bg-fm-panel border border-fm-border rounded-sm text-fm-fg focus:outline-none focus:border-fm-accent"
-            >
+            <select value={sourceFilter} onChange={(event) => { setSourceFilter(event.target.value); setLimit(25); }} className="h-6 rounded-sm border border-fm-border bg-fm-panel px-1.5 text-xs text-fm-fg focus:border-fm-accent focus:outline-none">
               <option value="all">All sources</option>
-              {sources.map((s) => (
-                <option key={s} value={s}>
-                  {labelFor(s)}
-                </option>
-              ))}
+              {sources.map((source) => <option key={source} value={source}>{labelFor(source)}</option>)}
             </select>
           }
         />
 
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Date</TableHead>
-              <TableHead>Type</TableHead>
-              <TableHead>Source</TableHead>
-              <TableHead>Description</TableHead>
-              <TableHead className="text-right">Amount</TableHead>
-            </TableRow>
-          </TableHeader>
+          <TableHeader><TableRow><TableHead>Date</TableHead><TableHead>Type</TableHead><TableHead>Source</TableHead><TableHead>Description</TableHead><TableHead className="text-right">Amount</TableHead></TableRow></TableHeader>
           <TableBody>
-            {visible.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-fm-fg-muted py-6">
-                  No transactions match your filters.
+            {!visible.length ? (
+              <TableRow><TableCell colSpan={5} className="py-6 text-center text-fm-fg-muted">No transactions match your filters.</TableCell></TableRow>
+            ) : visible.map((transaction) => (
+              <TableRow key={transaction.id}>
+                <TableCell className="text-fm-fg-muted">{format(new Date(transaction.date), "dd MMM yyyy")}</TableCell>
+                <TableCell><TypeBadge type={transaction.type} /></TableCell>
+                <TableCell className="font-medium">{labelFor(transaction.source)}</TableCell>
+                <TableCell className="max-w-[240px] truncate text-fm-fg-muted">{transaction.description || transaction.bandName || "—"}</TableCell>
+                <TableCell className={`text-right font-semibold ${transaction.type === "income" ? "text-fm-good" : transaction.type === "expense" ? "text-fm-bad" : "text-foreground"}`}>
+                  {transaction.type === "income" ? "+" : transaction.type === "expense" ? "-" : ""}{formatMoney(transaction.amount, transaction.currencyCode)}
                 </TableCell>
               </TableRow>
-            ) : (
-              visible.map((t) => (
-                <TableRow key={t.id}>
-                  <TableCell className="text-fm-fg-muted">
-                    {format(new Date(t.date), "MMM d, yyyy")}
-                  </TableCell>
-                  <TableCell>
-                    {t.type === "income" ? (
-                      <Badge variant="outline" className="text-fm-good border-fm-good/30">
-                        <ArrowUpRight className="mr-1 h-3 w-3" />
-                        Income
-                      </Badge>
-                    ) : (
-                      <Badge variant="outline" className="text-fm-bad border-fm-bad/30">
-                        <ArrowDownRight className="mr-1 h-3 w-3" />
-                        Expense
-                      </Badge>
-                    )}
-                  </TableCell>
-                  <TableCell className="font-medium">{labelFor(t.source)}</TableCell>
-                  <TableCell className="text-fm-fg-muted max-w-[200px] truncate">
-                    {t.description || t.bandName || "—"}
-                  </TableCell>
-                  <TableCell
-                    className={`text-right font-semibold ${
-                      t.type === "income" ? "text-fm-good" : "text-fm-bad"
-                    }`}
-                  >
-                    {t.type === "income" ? "+" : "-"}
-                    {currencyFormatter.format(t.amount)}
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
+            ))}
           </TableBody>
         </Table>
-        {filtered.length > limit && (
-          <div className="mt-2 text-center">
-            <Button variant="outline" size="sm" onClick={() => setLimit(limit + 25)}>
-              Load More ({filtered.length - limit} remaining)
-            </Button>
-          </div>
-        )}
+        {filtered.length > limit && <div className="mt-2 text-center"><Button variant="outline" size="sm" onClick={() => setLimit((current) => current + 25)}>Load More ({filtered.length - limit} remaining)</Button></div>}
       </CardContent>
     </Card>
   );

--- a/src/hooks/__tests__/useCompanyShareOffers.authority.test.ts
+++ b/src/hooks/__tests__/useCompanyShareOffers.authority.test.ts
@@ -45,6 +45,14 @@ describe("company share offer authority", () => {
     expect(offerSource).toContain('.from("company_share_offers" as any)');
   });
 
+  it("uses the public profile view for cross-player identity", () => {
+    expect(offerSource).toContain('.from("public_profiles")');
+    expect(legacySource).toContain('.from("public_profiles")');
+    expect(panelSource).toContain('.from("public_profiles")');
+    expect(`${offerSource}\n${legacySource}\n${panelSource}`).not.toContain("stage_name");
+    expect(panelSource).toContain("display_name");
+  });
+
   it("requires buyer action for paid offers", () => {
     expect(panelSource).toContain("Incoming Share Offers");
     expect(panelSource).toContain("offerId: offer.id, accept: false");

--- a/src/hooks/__tests__/useFinances.authority.test.ts
+++ b/src/hooks/__tests__/useFinances.authority.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { formatMoney, fromMinorUnits } from "@/lib/financeFormatting";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const hookSource = read("src/hooks/useFinances.ts");
+const pageSource = read("src/pages/Finances.tsx");
+const holdingsSource = read("src/components/finance/CanonicalFinanceHoldings.tsx");
+const transactionSource = read("src/components/finance/TransactionsList.tsx");
+const summarySource = read("src/components/finance/FinanceSummaryCards.tsx");
+const personalSource = read("src/components/finance/PersonalFinanceBreakdown.tsx");
+const bandSource = read("src/components/finance/BandFinanceDetail.tsx");
+const formattingSource = read("src/lib/financeFormatting.ts");
+
+const migratedUiSources = [
+  pageSource,
+  holdingsSource,
+  transactionSource,
+  summarySource,
+  personalSource,
+  bandSource,
+  read("src/components/finance/IncomeExpenseChart.tsx"),
+  read("src/components/finance/IncomeBreakdownChart.tsx"),
+  read("src/components/finance/SpendingCategoriesChart.tsx"),
+  read("src/components/finance/PlayerFinanceHub.tsx"),
+  read("src/components/finance/FinancialHistoryLedger.tsx"),
+].join("\n");
+
+describe("canonical Financial Command Center UI", () => {
+  it("loads the active-character command center instead of compatibility tables", () => {
+    expect(hookSource).toContain("fetchFinanceCommandCenter(250)");
+    expect(hookSource).toContain('["finance-command-center", profileId]');
+    expect(hookSource).not.toContain('.from("profiles")');
+    expect(hookSource).not.toContain("band_earnings");
+    expect(hookSource).not.toContain("band_balance");
+  });
+
+  it("keeps transfers visible without classifying them as spending", () => {
+    expect(hookSource).toContain('"transfer"');
+    expect(hookSource).toContain("externalCashFlow");
+    expect(transactionSource).toContain('value: "transfer"');
+    expect(transactionSource).toContain("transaction.externalCashFlow");
+  });
+
+  it("keeps band treasuries separate from personal net worth", () => {
+    expect(summarySource).toContain("Band treasuries excluded");
+    expect(personalSource).toContain("Band treasuries and foreign currencies are excluded");
+    expect(bandSource).toContain("fictional personal share");
+    expect(bandSource).not.toContain("playerShare")
+  });
+
+  it("uses en-GB formatting and the active currency rather than USD", () => {
+    expect(formattingSource).toContain('new Intl.NumberFormat("en-GB"');
+    expect(formattingSource).toContain('currencyCode = "GBP"');
+    expect(migratedUiSources).not.toContain('currency: "USD"');
+    expect(formatMoney(1234, "GBP")).toContain("£");
+    expect(fromMinorUnits(12345)).toBe(123.45);
+  });
+
+  it("removes unsafe legacy cash mutations from reachable finance tabs", () => {
+    expect(pageSource).not.toContain("InvestmentsTab");
+    expect(pageSource).not.toContain("LoansTab");
+    expect(pageSource).not.toContain("CharityDonationsTab");
+    expect(pageSource).toContain("CanonicalInvestmentsPanel");
+    expect(pageSource).toContain("CanonicalLoansPanel");
+    expect(holdingsSource).not.toContain("supabase");
+    expect(holdingsSource).toContain("temporarily read-only");
+  });
+
+  it("discloses other currencies without fake conversion", () => {
+    expect(pageSource).toContain("OtherCurrencyBalancesPanel");
+    expect(holdingsSource).toContain("no exchange rate is being assumed");
+    expect(holdingsSource).toContain("formatMinorMoney");
+  });
+});

--- a/src/hooks/__tests__/useFinances.authority.test.ts
+++ b/src/hooks/__tests__/useFinances.authority.test.ts
@@ -48,7 +48,7 @@ describe("canonical Financial Command Center UI", () => {
     expect(summarySource).toContain("Band treasuries excluded");
     expect(personalSource).toContain("Band treasuries and foreign currencies are excluded");
     expect(bandSource).toContain("fictional personal share");
-    expect(bandSource).not.toContain("playerShare")
+    expect(bandSource).not.toContain("playerShare");
   });
 
   it("uses en-GB formatting and the active currency rather than USD", () => {

--- a/src/hooks/useCompanyShareOffers.ts
+++ b/src/hooks/useCompanyShareOffers.ts
@@ -8,6 +8,12 @@ import {
   type CompanyShareOfferStatus,
 } from "@/lib/api/companyShareOffers";
 
+type ShareOfferPublicProfile = {
+  id: string;
+  display_name: string | null;
+  username: string | null;
+};
+
 export interface CompanyShareOffer {
   id: string;
   company_id: string;
@@ -19,7 +25,7 @@ export interface CompanyShareOffer {
   status: CompanyShareOfferStatus;
   expires_at: string;
   created_at: string;
-  issuerProfile?: { id: string; stage_name: string | null; username: string | null } | null;
+  issuerProfile?: ShareOfferPublicProfile | null;
 }
 
 const invalidateShareData = (
@@ -94,12 +100,13 @@ export const useCompanyShareOffers = (
 
       const issuerProfileIds = [...new Set(rows.map((offer) => offer.issuer_profile_id))];
       const { data: profiles, error: profileError } = await supabase
-        .from("profiles")
-        .select("id, stage_name, username")
+        .from("public_profiles")
+        .select("id, display_name, username")
         .in("id", issuerProfileIds);
 
       if (profileError) throw profileError;
-      const profileById = new Map((profiles || []).map((profile) => [profile.id, profile]));
+      const publicProfiles = (profiles || []) as ShareOfferPublicProfile[];
+      const profileById = new Map(publicProfiles.map((profile) => [profile.id, profile]));
 
       return rows.map((offer) => ({
         ...offer,

--- a/src/hooks/useCompanyShares.ts
+++ b/src/hooks/useCompanyShares.ts
@@ -5,12 +5,19 @@ import { distributeCompanyAnnualProfit } from "@/lib/api/companyProfitDistributi
 
 export { useIssueCompanyShares } from "@/hooks/useCompanyShareOffers";
 
+type ShareholderPublicProfile = {
+  id: string;
+  user_id: string;
+  display_name: string | null;
+  username: string | null;
+};
+
 export interface CompanyShareholder {
   id: string;
   company_id: string;
   user_id: string;
   shares: number;
-  profile?: { id: string; stage_name: string | null; username: string | null } | null;
+  profile?: ShareholderPublicProfile | null;
 }
 
 export const useCompanyShareholders = (companyId: string | undefined) => {
@@ -27,16 +34,20 @@ export const useCompanyShareholders = (companyId: string | undefined) => {
 
       if (error) throw error;
       const shareholders = (data || []) as unknown as CompanyShareholder[];
-
       if (shareholders.length === 0) return shareholders;
 
       const userIds = shareholders.map((shareholder) => shareholder.user_id);
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, user_id, stage_name, username")
-        .in("user_id", userIds as string[]);
+      const { data: profiles, error: profileError } = await supabase
+        .from("public_profiles")
+        .select("id, user_id, display_name, username")
+        .in("user_id", userIds);
 
-      const profileByUserId = new Map((profiles || []).map((profile: any) => [profile.user_id, profile]));
+      if (profileError) throw profileError;
+      const publicProfiles = (profiles || []) as ShareholderPublicProfile[];
+      const profileByUserId = new Map(
+        publicProfiles.map((profile) => [profile.user_id, profile]),
+      );
+
       return shareholders.map((shareholder) => ({
         ...shareholder,
         profile: profileByUserId.get(shareholder.user_id) ?? null,

--- a/src/hooks/useFinances.ts
+++ b/src/hooks/useFinances.ts
@@ -1,24 +1,41 @@
 import { useQuery } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-// useAuth removed — profileId sourced from useActiveProfile
 import { useActiveProfile } from "@/hooks/useActiveProfile";
+import {
+  fetchFinanceCommandCenter,
+  type FinanceCommandBand,
+  type FinanceCommandCenter,
+} from "@/lib/api/financeCommandCenter";
+import { fromMinorUnits } from "@/lib/financeFormatting";
+
+export type FinancialTransactionType = "income" | "expense" | "transfer" | "other";
 
 export interface FinancialTransaction {
   id: string;
   date: string;
-  type: "income" | "expense";
+  type: FinancialTransactionType;
   source: string;
   amount: number;
   description: string | null;
   bandName?: string;
+  currencyCode: string;
+  externalCashFlow: boolean;
+}
+
+export interface BandTreasury {
+  accountId: string;
+  currencyCode: string;
+  balance: number;
+  availableBalance: number;
 }
 
 export interface BandFinance {
   id: string;
   name: string;
   balance: number;
+  currencyCode: string;
   memberCount: number;
   playerShare: number;
+  treasuries: BandTreasury[];
 }
 
 export interface PlayerLoan {
@@ -32,6 +49,8 @@ export interface PlayerLoan {
   started_at: string;
   due_date: string;
   status: string;
+  currencyCode: string;
+  purpose?: string;
 }
 
 export interface PlayerInvestment {
@@ -43,6 +62,7 @@ export interface PlayerInvestment {
   growth_rate: number;
   purchased_at: string;
   notes: string | null;
+  currencyCode: string;
 }
 
 export interface LoanOffer {
@@ -69,10 +89,13 @@ export interface MonthlyLedgerEntry {
   month: string;
   income: number;
   expenses: number;
+  currencyCode: string;
 }
 
 export interface FinancialSummary {
+  currencyCode: string;
   cash: number;
+  personalAccounts: number;
   totalInvested: number;
   investmentValue: number;
   totalLoans: number;
@@ -83,282 +106,155 @@ export interface FinancialSummary {
   monthlyExpenses: number;
 }
 
-// Static loan offers based on player fame/level
-const LOAN_OFFERS: LoanOffer[] = [
-  {
-    id: "starter-loan",
-    name: "Starter Equipment Loan",
-    maxAmount: 5000,
-    interestRate: 8.5,
-    termWeeks: 24,
-    description: "Perfect for upgrading your first instruments or recording gear.",
-    requirements: ["No active loans", "At least 1 week in-game"],
-  },
-  {
-    id: "tour-loan",
-    name: "Tour Advance",
-    maxAmount: 15000,
-    interestRate: 6.5,
-    termWeeks: 36,
-    description: "Fund your tour expenses upfront with flexible repayment.",
-    requirements: ["Band fame > 100", "Completed at least 5 gigs"],
-  },
-  {
-    id: "studio-loan",
-    name: "Studio Investment Loan",
-    maxAmount: 50000,
-    interestRate: 5.0,
-    termWeeks: 52,
-    description: "Major financing for studio time, album production, or equipment upgrades.",
-    requirements: ["Band fame > 500", "Net worth > $10,000"],
-  },
-];
+const LOAN_OFFERS: LoanOffer[] = [];
+const INVESTMENT_OPTIONS: InvestmentOption[] = [];
 
-// Static investment options
-const INVESTMENT_OPTIONS: InvestmentOption[] = [
-  {
-    id: "music-etf",
-    name: "Music Industry ETF",
-    category: "Equity",
-    minInvestment: 500,
-    expectedReturn: "4-8% annually",
-    risk: "Medium",
-    description: "Diversified fund tracking major music and entertainment companies.",
-  },
-  {
-    id: "studio-coop",
-    name: "Studio Co-op Share",
-    category: "Real Assets",
-    minInvestment: 2000,
-    expectedReturn: "6-12% annually",
-    risk: "Medium",
-    description: "Partial ownership in a community recording studio with profit sharing.",
-  },
-  {
-    id: "royalty-pool",
-    name: "Royalty Exchange Pool",
-    category: "Royalties",
-    minInvestment: 1000,
-    expectedReturn: "3-7% annually",
-    risk: "Low",
-    description: "Invest in a pool of music royalties from established artists.",
-  },
-  {
-    id: "creator-fund",
-    name: "Creator Startup Fund",
-    category: "Startups",
-    minInvestment: 500,
-    expectedReturn: "10-25% annually",
-    risk: "High",
-    description: "High-risk fund investing in emerging music tech startups.",
-  },
-  {
-    id: "savings",
-    name: "High-Yield Savings",
-    category: "Cash",
-    minInvestment: 100,
-    expectedReturn: "2-3% annually",
-    risk: "Low",
-    description: "Safe, liquid savings with modest but guaranteed returns.",
-  },
-];
+const emptySummary = (currencyCode = "GBP"): FinancialSummary => ({
+  currencyCode,
+  cash: 0,
+  personalAccounts: 0,
+  totalInvested: 0,
+  investmentValue: 0,
+  totalLoans: 0,
+  netWorth: 0,
+  totalEarnings: 0,
+  totalExpenses: 0,
+  monthlyIncome: 0,
+  monthlyExpenses: 0,
+});
 
-export const useFinances = () => {
-  const { profileId } = useActiveProfile();
-
-  // Fetch player's cash from profiles
-  const { data: profile } = useQuery({
-    queryKey: ["profile-cash", profileId],
-    queryFn: async () => {
-      if (!profileId) return null;
-      const { data, error } = await supabase
-        .from("profiles")
-        .select("cash, fame")
-        .eq("id", profileId)
-        .single();
-      if (error) throw error;
-      return data;
-    },
-    enabled: !!profileId,
-  });
-
-  // Fetch player's bands and their balances (via profile_id on band_members)
-  const { data: bands } = useQuery({
-    queryKey: ["player-bands-finances", profileId],
-    queryFn: async () => {
-      if (!profileId) return [];
-      const { data: memberships, error: memberError } = await supabase
-        .from("band_members")
-        .select("band_id, bands!band_members_band_id_fkey(id, name, band_balance)")
-        .eq("profile_id", profileId);
-      
-      if (memberError) throw memberError;
-
-      const bandFinances: BandFinance[] = [];
-      for (const m of memberships || []) {
-        const band = m.bands as unknown as { id: string; name: string; band_balance: number };
-        if (!band) continue;
-        
-        const { count } = await supabase
-          .from("band_members")
-          .select("*", { count: "exact", head: true })
-          .eq("band_id", band.id);
-        
-        const memberCount = count || 1;
-        bandFinances.push({
-          id: band.id,
-          name: band.name,
-          balance: band.band_balance || 0,
-          memberCount,
-          playerShare: (band.band_balance || 0) / memberCount,
-        });
-      }
-      return bandFinances;
-    },
-    enabled: !!profileId,
-  });
-
-  // Fetch transaction history from band_earnings via profile_id
-  const { data: transactions } = useQuery({
-    queryKey: ["finance-transactions", profileId],
-    queryFn: async () => {
-      if (!profileId) return [];
-      
-      const { data: earnings, error: earningsError } = await (supabase as any)
-        .from("band_earnings")
-        .select("id, created_at, source, amount, description, band_id, bands(name)")
-        .eq("profile_id", profileId)
-        .order("created_at", { ascending: false })
-        .limit(100);
-      
-      if (earningsError) throw earningsError;
-
-      const txns: FinancialTransaction[] = (earnings || []).map((e: any) => ({
-        id: e.id,
-        date: e.created_at,
-        type: e.amount >= 0 ? "income" : "expense",
-        source: e.source,
-        amount: Math.abs(e.amount),
-        description: e.description,
-        bandName: (e.bands as unknown as { name: string })?.name,
-      }));
-
-      return txns;
-    },
-    enabled: !!profileId,
-  });
-
-  // Fetch player investments
-  const { data: investments } = useQuery({
-    queryKey: ["player-investments", profileId],
-    queryFn: async () => {
-      if (!profileId) return [];
-      const { data, error } = await (supabase as any)
-        .from("player_investments")
-        .select("*")
-        .eq("profile_id", profileId)
-        .order("purchased_at", { ascending: false });
-      if (error) throw error;
-      return data as PlayerInvestment[];
-    },
-    enabled: !!profileId,
-  });
-
-  // Fetch player loans
-  const { data: loans } = useQuery({
-    queryKey: ["player-loans", profileId],
-    queryFn: async () => {
-      if (!profileId) return [];
-      const { data, error } = await (supabase as any)
-        .from("player_loans")
-        .select("*")
-        .eq("profile_id", profileId)
-        .order("started_at", { ascending: false });
-      if (error) throw error;
-      return data as PlayerLoan[];
-    },
-    enabled: !!profileId,
-  });
-
-  // Calculate monthly ledger from transactions
-  const monthlyLedger: MonthlyLedgerEntry[] = (() => {
-    if (!transactions?.length) return [];
-    
-    const now = new Date();
-    const months: MonthlyLedgerEntry[] = [];
-    
-    for (let i = 5; i >= 0; i--) {
-      const monthDate = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const monthKey = monthDate.toLocaleDateString("en-US", { month: "short" });
-      const monthStart = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1);
-      const monthEnd = new Date(monthDate.getFullYear(), monthDate.getMonth() + 1, 0);
-      
-      const monthTxns = transactions.filter((t) => {
-        const d = new Date(t.date);
-        return d >= monthStart && d <= monthEnd;
-      });
-      
-      const income = monthTxns.filter((t) => t.type === "income").reduce((s, t) => s + t.amount, 0);
-      const expenses = monthTxns.filter((t) => t.type === "expense").reduce((s, t) => s + t.amount, 0);
-      
-      months.push({ month: monthKey, income, expenses });
-    }
-    
-    return months;
-  })();
-
-  // Calculate summary
-  const summary: FinancialSummary = (() => {
-    const cash = profile?.cash || 0;
-    const totalInvested = investments?.reduce((s, i) => s + i.invested_amount, 0) || 0;
-    const investmentValue = investments?.reduce((s, i) => s + i.current_value, 0) || 0;
-    const activeLoans = loans?.filter((l) => l.status === "active") || [];
-    const totalLoans = activeLoans.reduce((s, l) => s + l.remaining_balance, 0);
-    const bandEquity = bands?.reduce((s, b) => s + b.playerShare, 0) || 0;
-    
-    const totalEarnings = transactions?.filter((t) => t.type === "income").reduce((s, t) => s + t.amount, 0) || 0;
-    const totalExpenses = transactions?.filter((t) => t.type === "expense").reduce((s, t) => s + t.amount, 0) || 0;
-    
-    const monthlyIncome = monthlyLedger.length 
-      ? monthlyLedger.reduce((s, m) => s + m.income, 0) / monthlyLedger.length 
-      : 0;
-    const monthlyExpenses = monthlyLedger.length 
-      ? monthlyLedger.reduce((s, m) => s + m.expenses, 0) / monthlyLedger.length 
-      : 0;
-
-    return {
-      cash,
-      totalInvested,
-      investmentValue,
-      totalLoans,
-      netWorth: cash + investmentValue + bandEquity - totalLoans,
-      totalEarnings,
-      totalExpenses,
-      monthlyIncome,
-      monthlyExpenses,
-    };
-  })();
-
-  const earningsBySource: Record<string, number> = (() => {
-    if (!transactions?.length) return {};
-    const bySource: Record<string, number> = {};
-    transactions.filter((t) => t.type === "income").forEach((t) => {
-      bySource[t.source] = (bySource[t.source] || 0) + t.amount;
-    });
-    return bySource;
-  })();
+const mapBand = (band: FinanceCommandBand, primaryCurrency: string): BandFinance => {
+  const treasuries = band.treasuries.map((treasury) => ({
+    accountId: treasury.accountId,
+    currencyCode: treasury.currencyCode,
+    balance: fromMinorUnits(treasury.balanceMinor),
+    availableBalance: fromMinorUnits(treasury.availableBalanceMinor),
+  }));
+  const primaryTreasury =
+    treasuries.find((treasury) => treasury.currencyCode === primaryCurrency) ?? treasuries[0];
 
   return {
-    profile,
-    bands: bands || [],
-    transactions: transactions || [],
-    investments: investments || [],
-    loans: loans || [],
+    id: band.id,
+    name: band.name,
+    balance: primaryTreasury?.balance ?? 0,
+    currencyCode: primaryTreasury?.currencyCode ?? primaryCurrency,
+    memberCount: band.memberCount,
+    playerShare: 0,
+    treasuries,
+  };
+};
+
+const mapCommandCenter = (data: FinanceCommandCenter) => {
+  const bands = data.bands.map((band) => mapBand(band, data.currencyCode));
+  const bandNames = new Map(bands.map((band) => [band.id, band.name]));
+
+  const transactions: FinancialTransaction[] = data.transactions.map((transaction) => ({
+    id: transaction.id,
+    date: transaction.createdAt,
+    type: transaction.direction,
+    source: transaction.category || transaction.source,
+    amount: Math.abs(fromMinorUnits(transaction.amountMinor)),
+    description: transaction.description,
+    bandName:
+      transaction.relatedEntityType === "band" && transaction.relatedEntityId
+        ? bandNames.get(transaction.relatedEntityId)
+        : undefined,
+    currencyCode: transaction.currencyCode,
+    externalCashFlow: transaction.externalCashFlow,
+  }));
+
+  const summary: FinancialSummary = {
+    currencyCode: data.currencyCode,
+    cash: fromMinorUnits(data.summary.cashMinor),
+    personalAccounts: fromMinorUnits(data.summary.personalAccountsMinor),
+    totalInvested: fromMinorUnits(data.summary.totalInvestedMinor),
+    investmentValue: fromMinorUnits(data.summary.investmentValueMinor),
+    totalLoans: fromMinorUnits(data.summary.totalLoansMinor),
+    netWorth: fromMinorUnits(data.summary.netWorthMinor),
+    totalEarnings: fromMinorUnits(data.summary.totalEarningsMinor),
+    totalExpenses: fromMinorUnits(data.summary.totalExpensesMinor),
+    monthlyIncome: fromMinorUnits(data.summary.monthlyIncomeMinor),
+    monthlyExpenses: fromMinorUnits(data.summary.monthlyExpensesMinor),
+  };
+
+  const investments: PlayerInvestment[] = data.investments.map((investment) => ({
+    id: investment.id,
+    investment_name: investment.name,
+    category: investment.category,
+    invested_amount: fromMinorUnits(investment.investedMinor),
+    current_value: fromMinorUnits(investment.currentValueMinor),
+    growth_rate: investment.growthRate,
+    purchased_at: investment.purchasedAt,
+    notes: investment.notes,
+    currencyCode: investment.currencyCode,
+  }));
+
+  const loans: PlayerLoan[] = data.loans.map((loan) => ({
+    id: loan.id,
+    loan_name: `${loan.providerName} · ${loan.purpose.replaceAll("_", " ")}`,
+    principal: fromMinorUnits(loan.principalMinor),
+    interest_rate: loan.interestRateBps / 100,
+    remaining_balance: fromMinorUnits(loan.outstandingMinor),
+    weekly_payment: fromMinorUnits(loan.scheduledPaymentMinor),
+    total_paid: Math.max(0, fromMinorUnits(loan.principalMinor - loan.outstandingMinor)),
+    started_at: loan.nextPaymentDate ?? loan.maturityDate,
+    due_date: loan.maturityDate,
+    status: loan.status,
+    currencyCode: loan.currencyCode,
+    purpose: loan.purpose,
+  }));
+
+  const monthlyLedger: MonthlyLedgerEntry[] = data.monthlyLedger.map((entry) => ({
+    month: entry.month,
+    income: fromMinorUnits(entry.incomeMinor),
+    expenses: fromMinorUnits(entry.expensesMinor),
+    currencyCode: entry.currencyCode,
+  }));
+
+  const earningsBySource = Object.fromEntries(
+    Object.entries(data.earningsBySource).map(([source, amountMinor]) => [
+      source,
+      fromMinorUnits(amountMinor),
+    ]),
+  );
+
+  return {
+    bands,
+    transactions,
+    investments,
+    loans,
     monthlyLedger,
     summary,
     earningsBySource,
+  };
+};
+
+export const useFinances = () => {
+  const { profileId } = useActiveProfile();
+  const query = useQuery({
+    queryKey: ["finance-command-center", profileId],
+    queryFn: () => fetchFinanceCommandCenter(250),
+    enabled: !!profileId,
+  });
+
+  const mapped = query.data ? mapCommandCenter(query.data) : null;
+  const summary = mapped?.summary ?? emptySummary();
+
+  return {
+    profile: query.data ? { cash: summary.cash } : null,
+    bands: mapped?.bands ?? [],
+    transactions: mapped?.transactions ?? [],
+    investments: mapped?.investments ?? [],
+    loans: mapped?.loans ?? [],
+    monthlyLedger: mapped?.monthlyLedger ?? [],
+    summary,
+    earningsBySource: mapped?.earningsBySource ?? {},
     loanOffers: LOAN_OFFERS,
     investmentOptions: INVESTMENT_OPTIONS,
-    isLoading: !profile,
+    banking: query.data?.banking ?? null,
+    otherCurrencyBalances: query.data?.otherCurrencyBalances ?? [],
+    isLoading: !!profileId && query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
   };
 };

--- a/src/lib/financeFormatting.ts
+++ b/src/lib/financeFormatting.ts
@@ -1,0 +1,23 @@
+export const fromMinorUnits = (amountMinor: number): number => amountMinor / 100;
+
+export const createCurrencyFormatter = (
+  currencyCode = "GBP",
+  maximumFractionDigits = 0,
+) =>
+  new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: currencyCode || "GBP",
+    maximumFractionDigits,
+  });
+
+export const formatMoney = (
+  amount: number,
+  currencyCode = "GBP",
+  maximumFractionDigits = 0,
+): string => createCurrencyFormatter(currencyCode, maximumFractionDigits).format(amount);
+
+export const formatMinorMoney = (
+  amountMinor: number,
+  currencyCode = "GBP",
+  maximumFractionDigits = 0,
+): string => formatMoney(fromMinorUnits(amountMinor), currencyCode, maximumFractionDigits);

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -1,6 +1,8 @@
 import { Link, useSearchParams } from "react-router-dom";
+import { AlertCircle, DollarSign, Loader2 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { useFinances } from "@/hooks/useFinances";
 import { FinanceSummaryCards } from "@/components/finance/FinanceSummaryCards";
 import { IncomeBreakdownChart } from "@/components/finance/IncomeBreakdownChart";
@@ -8,41 +10,56 @@ import { IncomeExpenseChart } from "@/components/finance/IncomeExpenseChart";
 import { SpendingCategoriesChart } from "@/components/finance/SpendingCategoriesChart";
 import { BandFinanceDetail } from "@/components/finance/BandFinanceDetail";
 import { PersonalFinanceBreakdown } from "@/components/finance/PersonalFinanceBreakdown";
-import { InvestmentsTab } from "@/components/finance/InvestmentsTab";
-import { LoansTab } from "@/components/finance/LoansTab";
 import { TransactionsList } from "@/components/finance/TransactionsList";
-import { CharityDonationsTab } from "@/components/finance/CharityDonationsTab";
 import { SponsorshipTypesPanel } from "@/components/finance/SponsorshipTypesPanel";
 import { CityTreasuryCard } from "@/components/finance/CityTreasuryCard";
 import { FinancialHistoryLedger } from "@/components/finance/FinancialHistoryLedger";
 import { PlayerFinanceHub } from "@/components/finance/PlayerFinanceHub";
-import { Loader2, DollarSign } from "lucide-react";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { FinancialObligationsPanel } from "@/components/finance/FinancialObligationsPanel";
-import { useActiveProfile } from "@/hooks/useActiveProfile";
+import {
+  CanonicalInvestmentsPanel,
+  CanonicalLoansPanel,
+  LegacyMutationNotice,
+  OtherCurrencyBalancesPanel,
+} from "@/components/finance/CanonicalFinanceHoldings";
 
 const Finances = () => {
   const [searchParams] = useSearchParams();
-  const { 
-    bands, 
-    transactions, 
-    investments, 
-    loans, 
+  const {
+    bands,
+    transactions,
+    investments,
+    loans,
     summary,
     earningsBySource,
     monthlyLedger,
-    loanOffers,
-    investmentOptions,
+    otherCurrencyBalances,
     isLoading,
+    error,
+    refetch,
   } = useFinances();
-  const { profileId } = useActiveProfile();
 
   if (isLoading) {
     return (
       <FMPageScaffold title="Financial Command Center" icon={DollarSign} backTo="/career">
-        <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex min-h-[400px] items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>
+      </FMPageScaffold>
+    );
+  }
+
+  if (error) {
+    return (
+      <FMPageScaffold title="Financial Command Center" icon={DollarSign} backTo="/career">
+        <Card className="border-destructive/40">
+          <CardContent className="flex min-h-[260px] flex-col items-center justify-center gap-3 text-center">
+            <AlertCircle className="h-8 w-8 text-destructive" />
+            <div><p className="font-semibold">Financial data could not be loaded</p><p className="text-sm text-muted-foreground">The canonical finance dashboard did not return successfully.</p></div>
+            <Button variant="outline" onClick={() => void refetch()}>Retry</Button>
+          </CardContent>
+        </Card>
       </FMPageScaffold>
     );
   }
@@ -50,16 +67,13 @@ const Finances = () => {
   return (
     <FMPageScaffold
       title="Financial Command Center"
-      subtitle="Monitor personal and band finances, track investments, and explore funding pathways."
+      subtitle="Canonical personal balances, cash flow, liabilities and separate band treasuries."
       icon={DollarSign}
       backTo="/career"
     >
-
-
-      {/* Summary Cards */}
       <FinanceSummaryCards summary={summary} />
+      <OtherCurrencyBalancesPanel balances={otherCurrencyBalances} />
 
-      {/* Main Tabs */}
       <Tabs defaultValue={searchParams.get("tab") || "overview"} className="space-y-6">
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -74,25 +88,20 @@ const Finances = () => {
           <TabsTrigger value="sponsorships">Sponsorships</TabsTrigger>
           <TabsTrigger value="city">City Treasury</TabsTrigger>
           <TabsTrigger value="transactions">Transactions</TabsTrigger>
-          <TabsTrigger value="ledger">Ledger</TabsTrigger>
+          <TabsTrigger value="ledger">Wallet Ledger</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview" className="space-y-6">
           <div className="grid gap-6 lg:grid-cols-2">
             <PersonalFinanceBreakdown summary={summary} />
-            <BandFinanceDetail bands={bands} transactions={transactions} />
+            <BandFinanceDetail bands={bands} />
           </div>
-
-          {/* Income vs Expenses trend */}
-          <IncomeExpenseChart data={monthlyLedger} />
-
+          <IncomeExpenseChart data={monthlyLedger} currencyCode={summary.currencyCode} />
           <div className="grid gap-6 lg:grid-cols-2">
-            <IncomeBreakdownChart earningsBySource={earningsBySource} />
-            <SpendingCategoriesChart transactions={transactions} />
+            <IncomeBreakdownChart earningsBySource={earningsBySource} currencyCode={summary.currencyCode} />
+            <SpendingCategoriesChart transactions={transactions} currencyCode={summary.currencyCode} />
           </div>
-
-          {/* Recent Transactions */}
-          <TransactionsList transactions={transactions.slice(0, 10)} />
+          <TransactionsList transactions={transactions.slice(0, 10)} currencyCode={summary.currencyCode} />
         </TabsContent>
 
         <TabsContent value="personal" className="space-y-6">
@@ -100,23 +109,15 @@ const Finances = () => {
         </TabsContent>
 
         <TabsContent value="bands" className="space-y-6">
-          <BandFinanceDetail bands={bands} transactions={transactions} />
+          <BandFinanceDetail bands={bands} />
         </TabsContent>
 
         <TabsContent value="investments" className="space-y-6">
-          <InvestmentsTab 
-            investments={investments} 
-            investmentOptions={investmentOptions}
-            cash={summary.cash}
-          />
+          <CanonicalInvestmentsPanel investments={investments} currencyCode={summary.currencyCode} />
         </TabsContent>
 
         <TabsContent value="loans" className="space-y-6">
-          <LoansTab 
-            loans={loans} 
-            loanOffers={loanOffers}
-            cash={summary.cash}
-          />
+          <CanonicalLoansPanel loans={loans} />
         </TabsContent>
 
         <TabsContent value="obligations" className="space-y-6">
@@ -124,7 +125,10 @@ const Finances = () => {
         </TabsContent>
 
         <TabsContent value="charity" className="space-y-6">
-          <CharityDonationsTab cash={summary.cash} />
+          <LegacyMutationNotice
+            title="Charity donations are temporarily read-only"
+            body="The previous donation flow deducted compatibility cash before recording the donation. It is disabled until the donation and reward update can post through one atomic ledger transaction."
+          />
         </TabsContent>
 
         <TabsContent value="sponsorships" className="space-y-6">
@@ -136,7 +140,7 @@ const Finances = () => {
         </TabsContent>
 
         <TabsContent value="transactions" className="space-y-6">
-          <TransactionsList transactions={transactions} />
+          <TransactionsList transactions={transactions} currencyCode={summary.currencyCode} />
         </TabsContent>
 
         <TabsContent value="ledger" className="space-y-6">

--- a/src/pages/finance/portfolio.tsx
+++ b/src/pages/finance/portfolio.tsx
@@ -39,32 +39,25 @@ const PortfolioPage = () => {
           fetchMonthlyLedger(DEMO_CHARACTER_ID, LEDGER_MONTHS),
         ]);
 
-        if (!isMounted) {
-          return;
-        }
+        if (!isMounted) return;
 
         setTransactions(txn);
         setPositions(investmentPositions);
         setLedger(ledgerData);
         setPerformance(calculatePortfolioPerformance(investmentPositions));
       } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
+        if (isMounted) setIsLoading(false);
       }
     };
 
     void loadData();
-
     return () => {
       isMounted = false;
     };
   }, []);
 
   const { monthlyIncome, monthlyExpenses } = useMemo(() => {
-    if (!ledger.length) {
-      return { monthlyIncome: 0, monthlyExpenses: 0 };
-    }
+    if (!ledger.length) return { monthlyIncome: 0, monthlyExpenses: 0 };
 
     const totalIncome = ledger.reduce((sum, item) => sum + item.income, 0);
     const totalExpenses = ledger.reduce((sum, item) => sum + item.expenses, 0);
@@ -77,7 +70,10 @@ const PortfolioPage = () => {
   }, [ledger]);
 
   const cashReserve = useMemo(
-    () => positions.filter((position) => position.category === "Cash").reduce((sum, position) => sum + position.currentValue, 0),
+    () =>
+      positions
+        .filter((position) => position.category === "Cash")
+        .reduce((sum, position) => sum + position.currentValue, 0),
     [positions],
   );
 
@@ -97,8 +93,6 @@ const PortfolioPage = () => {
       icon={Briefcase}
       backTo="/hub/career-business"
     >
-
-
       <PortfolioSummary
         netWorth={summary.totalCurrentValue}
         invested={summary.totalInvested}
@@ -110,7 +104,7 @@ const PortfolioPage = () => {
 
       <div className="grid gap-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <IncomeExpenseChart data={ledger} />
+          <IncomeExpenseChart data={ledger} currencyCode="GBP" />
         </div>
         <InvestmentAllocation positions={positions} />
       </div>
@@ -130,4 +124,3 @@ const PortfolioPage = () => {
 };
 
 export default PortfolioPage;
-


### PR DESCRIPTION
## What changed

- replaces the legacy `useFinances` queries with the merged `get_my_finance_command_center` RPC
- removes reads from `profiles.cash`, `bands.band_balance` and `band_earnings`
- maps canonical wallet, bank, savings, investment, loan, band treasury and transaction data into the existing page layout
- shows wallet-to-bank and savings movements as transfers rather than income or spending
- calculates charts and summaries from external cash flow only
- excludes band treasuries from personal net worth and removes the fictional equal member share
- shows each band treasury separately by currency
- lists non-primary-currency holdings separately without assuming an exchange rate
- adds shared `en-GB` currency formatting using the active character currency, with GBP as the fallback
- replaces the reachable Investments and Loans tabs with read-only canonical portfolio and contract views
- disables the reachable Charity mutation because its old flow deducted compatibility cash before inserting the donation
- retains the primary-wallet ledger tab but labels it clearly as wallet-only
- fixes the secondary portfolio chart call site after the currency prop became required
- repairs company share issuer, shareholder and recipient identity queries by using `public_profiles.display_name` instead of the nonexistent `profiles.stage_name`
- adds source, formatting and public-identity authority tests

## Root causes addressed

The Financial Command Center still used compatibility balance fields and the old earnings table even after Banking was migrated to canonical accounts and transactions. It could therefore disagree with Banking, omit bank and savings activity, count internal transfers as financial performance and add a share of band treasury money to personal wealth.

The Investments, Loans and Charity tabs could also immediately recreate balance drift because they directly updated `profiles.cash` and legacy tables.

The company share UI also queried a field that does not exist and attempted cross-player reads through the private `profiles` table. The public profile view is now used for those display-name lookups.

## Player impact

- Banking and the Financial Command Center now use the same personal balance authority
- GBP characters see GBP figures formatted for `en-GB`, rather than hardcoded USD
- account transfers remain visible but do not inflate earnings or expenses
- personal net worth includes personal accounts, investments and canonical liabilities only
- band money remains shared band money
- foreign currencies are disclosed separately rather than falsely converted
- unsafe legacy investment, loan and donation actions are temporarily unavailable until atomic ledger-backed RPCs replace them
- company share offers and recipient search can display other players through the authorised public identity view

## Validation

```bash
npm test -- src/hooks/__tests__/useFinances.authority.test.ts src/lib/api/__tests__/financeCommandCenter.database.test.ts src/hooks/__tests__/useCompanyShareOffers.authority.test.ts
npm run typecheck
```

### Observed workflow results

The first standard CI run identified the portfolio chart prop regression and the pre-existing `profiles.stage_name` share-offer errors; both have now been fixed on this branch.

Finance verification did not reach the changed finance migration or frontend checks because the repository bootstrap currently applies `086_band_member_locks.sql` before `public.bands` exists. That migration-order failure is outside this PR and occurs during `supabase db start`.

Fresh workflow runs have been triggered for the corrected head. The PR remains draft until the available checks are inspected.