### PR TITLE
Restore atomic character charity donations

### DIFF
--- a/src/components/finance/CharityDonationsTab.tsx
+++ b/src/components/finance/CharityDonationsTab.tsx
@@ -81,14 +81,14 @@ export const CharityDonationsTab = ({ cash, currencyCode }: CharityDonationsTabP
     queryKey: ["charity-donations", profileId],
     queryFn: async () => {
       if (!profileId) return [];
-      const { data, error } = await (supabase as any)
+      const { data, error } = await supabase
         .from("charity_donations")
-        .select("id, charity_id, amount, amount_minor, currency_code, fame_gained, reputation_gained, created_at")
+        .select("*")
         .eq("profile_id", profileId)
         .order("created_at", { ascending: false })
         .limit(50);
       if (error) throw error;
-      return (data ?? []) as CharityDonation[];
+      return (data ?? []) as unknown as CharityDonation[];
     },
     enabled: !!profileId,
   });

--- a/src/components/finance/CharityDonationsTab.tsx
+++ b/src/components/finance/CharityDonationsTab.tsx
@@ -114,8 +114,9 @@ export const CharityDonationsTab = ({ cash, currencyCode }: CharityDonationsTabP
     onError: (error: Error) => toast.error(error.message),
   });
 
-  const amountMajor = Number.parseInt(donationAmount, 10);
-  const validAmount = Number.isInteger(amountMajor) && amountMajor > 0;
+  const amountText = donationAmount.trim();
+  const validAmount = /^\d+$/.test(amountText) && Number(amountText) > 0;
+  const amountMajor = validAmount ? Number(amountText) : 0;
 
   const handleDonate = () => {
     if (!selectedCharity || !validAmount) {

--- a/src/components/finance/CharityDonationsTab.tsx
+++ b/src/components/finance/CharityDonationsTab.tsx
@@ -1,17 +1,18 @@
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { useActiveProfile } from "@/hooks/useActiveProfile";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Heart, Star, Shield, Leaf, Music, Palette } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Heart, Leaf, Music, Palette, Shield, Star } from "lucide-react";
 import { toast } from "sonner";
 
-const fmt = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { useActiveProfile } from "@/hooks/useActiveProfile";
+import { supabase } from "@/integrations/supabase/client";
+import { makeCharityDonation } from "@/lib/api/charityDonations";
+import { formatMinorMoney, formatMoney } from "@/lib/financeFormatting";
 
 const categoryIcons: Record<string, typeof Heart> = {
   music_education: Music,
@@ -21,7 +22,7 @@ const categoryIcons: Record<string, typeof Heart> = {
   arts: Palette,
 };
 
-const categoryColors: Record<string, string> = {
+const categoryColours: Record<string, string> = {
   music_education: "bg-blue-500/10 text-blue-500",
   health: "bg-red-500/10 text-red-500",
   environment: "bg-green-500/10 text-green-500",
@@ -29,7 +30,7 @@ const categoryColors: Record<string, string> = {
   arts: "bg-purple-500/10 text-purple-500",
 };
 
-interface CharityOrg {
+interface CharityOrganisation {
   id: string;
   name: string;
   category: string;
@@ -43,15 +44,22 @@ interface CharityDonation {
   id: string;
   charity_id: string;
   amount: number;
+  amount_minor: number;
+  currency_code: string;
   fame_gained: number;
   reputation_gained: number;
   created_at: string;
 }
 
-export const CharityDonationsTab = ({ cash }: { cash: number }) => {
+interface CharityDonationsTabProps {
+  cash: number;
+  currencyCode: string;
+}
+
+export const CharityDonationsTab = ({ cash, currencyCode }: CharityDonationsTabProps) => {
   const { profileId } = useActiveProfile();
   const queryClient = useQueryClient();
-  const [selectedCharity, setSelectedCharity] = useState<CharityOrg | null>(null);
+  const [selectedCharity, setSelectedCharity] = useState<CharityOrganisation | null>(null);
   const [donationAmount, setDonationAmount] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
@@ -61,11 +69,11 @@ export const CharityDonationsTab = ({ cash }: { cash: number }) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("charity_organizations")
-        .select("*")
+        .select("id, name, category, description, fame_bonus_pct, reputation_boost, tax_deduction_pct")
         .eq("is_active", true)
         .order("name");
       if (error) throw error;
-      return data as CharityOrg[];
+      return data as CharityOrganisation[];
     },
   });
 
@@ -73,87 +81,101 @@ export const CharityDonationsTab = ({ cash }: { cash: number }) => {
     queryKey: ["charity-donations", profileId],
     queryFn: async () => {
       if (!profileId) return [];
-      const { data, error } = await supabase
+      const { data, error } = await (supabase as any)
         .from("charity_donations")
-        .select("*")
+        .select("id, charity_id, amount, amount_minor, currency_code, fame_gained, reputation_gained, created_at")
         .eq("profile_id", profileId)
         .order("created_at", { ascending: false })
-        .limit(20);
+        .limit(50);
       if (error) throw error;
-      return data as CharityDonation[];
+      return (data ?? []) as CharityDonation[];
     },
     enabled: !!profileId,
   });
 
   const donateMutation = useMutation({
-    mutationFn: async ({ charityId, amount, fameGained, repGained }: { charityId: string; amount: number; fameGained: number; repGained: number }) => {
-      if (!profileId) throw new Error("No profile");
-
-      // Deduct cash
-      const { error: cashErr } = await supabase
-        .from("profiles")
-        .update({ cash: cash - amount })
-        .eq("id", profileId);
-      if (cashErr) throw cashErr;
-
-      // Record donation
-      const { error: donErr } = await supabase
-        .from("charity_donations")
-        .insert({ profile_id: profileId, charity_id: charityId, amount, fame_gained: fameGained, reputation_gained: repGained });
-      if (donErr) throw donErr;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["profile-cash"] });
-      queryClient.invalidateQueries({ queryKey: ["charity-donations"] });
-      toast.success("Donation made! You gained fame and reputation.");
+    mutationFn: ({ charityId, amountMinor, idempotencyKey }: { charityId: string; amountMinor: number; idempotencyKey: string }) =>
+      makeCharityDonation(charityId, amountMinor, idempotencyKey),
+    onSuccess: (result) => {
+      for (const queryKey of [
+        ["charity-donations", profileId],
+        ["finance-command-center", profileId],
+        ["financial-ledger-history"],
+        ["profile"],
+      ]) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+      toast.success(
+        `Donated ${formatMinorMoney(result.amountMinor, result.currencyCode)} · +${result.fameGained} fame · +${result.reputationGained} attitude`,
+      );
       setDialogOpen(false);
       setDonationAmount("");
     },
-    onError: () => toast.error("Failed to process donation"),
+    onError: (error: Error) => toast.error(error.message),
   });
 
+  const amountMajor = Number.parseInt(donationAmount, 10);
+  const validAmount = Number.isInteger(amountMajor) && amountMajor > 0;
+
   const handleDonate = () => {
-    if (!selectedCharity) return;
-    const amount = parseInt(donationAmount);
-    if (isNaN(amount) || amount <= 0) return toast.error("Enter a valid amount");
-    if (amount > cash) return toast.error("Not enough cash");
-    const fameGained = Math.floor(amount * (selectedCharity.fame_bonus_pct / 100));
-    const repGained = Math.floor((amount / 100) * selectedCharity.reputation_boost);
-    donateMutation.mutate({ charityId: selectedCharity.id, amount, fameGained, repGained });
+    if (!selectedCharity || !validAmount) {
+      toast.error("Enter a whole-number donation amount");
+      return;
+    }
+    if (amountMajor > cash) {
+      toast.error("Not enough available wallet funds");
+      return;
+    }
+
+    donateMutation.mutate({
+      charityId: selectedCharity.id,
+      amountMinor: amountMajor * 100,
+      idempotencyKey: `charity:${profileId ?? "unknown"}:${crypto.randomUUID()}`,
+    });
   };
 
-  const categories = [...new Set(charities.map((c) => c.category))];
-  const filtered = categoryFilter ? charities.filter((c) => c.category === categoryFilter) : charities;
-  const totalDonated = donations.reduce((s, d) => s + d.amount, 0);
+  const categories = [...new Set(charities.map((charity) => charity.category))];
+  const filtered = categoryFilter
+    ? charities.filter((charity) => charity.category === categoryFilter)
+    : charities;
+  const currentCurrencyDonatedMinor = donations
+    .filter((donation) => donation.currency_code === currencyCode)
+    .reduce((sum, donation) => sum + donation.amount_minor, 0);
+  const previewFame = selectedCharity && validAmount
+    ? Math.floor((amountMajor * selectedCharity.fame_bonus_pct) / 100)
+    : 0;
+  const previewReputation = selectedCharity && validAmount
+    ? Math.floor((amountMajor * selectedCharity.reputation_boost) / 100)
+    : 0;
 
   return (
     <div className="space-y-6">
-      {/* Summary */}
       <div className="grid gap-4 sm:grid-cols-3">
         <Card>
           <CardContent className="p-4 text-center">
-            <p className="text-sm text-muted-foreground">Total Donated</p>
-            <p className="text-2xl font-bold text-pink-500">{fmt.format(totalDonated)}</p>
+            <p className="text-sm text-muted-foreground">Donated in {currencyCode}</p>
+            <p className="text-2xl font-bold text-pink-500">
+              {formatMinorMoney(currentCurrencyDonatedMinor, currencyCode)}
+            </p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4 text-center">
-            <p className="text-sm text-muted-foreground">Donations Made</p>
+            <p className="text-sm text-muted-foreground">Donations made</p>
             <p className="text-2xl font-bold text-primary">{donations.length}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4 text-center">
-            <p className="text-sm text-muted-foreground">Fame Earned</p>
+            <p className="text-sm text-muted-foreground">Fame earned</p>
             <p className="text-2xl font-bold text-amber-500">
-              <Star className="inline h-5 w-5 mr-1" />
-              {donations.reduce((s, d) => s + d.fame_gained, 0)}
+              <Star className="mr-1 inline h-5 w-5" />
+              {donations.reduce((sum, donation) => sum + donation.fame_gained, 0)}
             </p>
           </CardContent>
         </Card>
       </div>
 
-      {/* Category filters */}
       <div className="flex flex-wrap gap-2">
         <Badge
           variant={categoryFilter === null ? "default" : "outline"}
@@ -162,74 +184,74 @@ export const CharityDonationsTab = ({ cash }: { cash: number }) => {
         >
           All
         </Badge>
-        {categories.map((cat) => (
+        {categories.map((category) => (
           <Badge
-            key={cat}
-            variant={categoryFilter === cat ? "default" : "outline"}
+            key={category}
+            variant={categoryFilter === category ? "default" : "outline"}
             className="cursor-pointer capitalize"
-            onClick={() => setCategoryFilter(cat === categoryFilter ? null : cat)}
+            onClick={() => setCategoryFilter(category === categoryFilter ? null : category)}
           >
-            {cat.replace("_", " ")}
+            {category.replaceAll("_", " ")}
           </Badge>
         ))}
       </div>
 
-      {/* Charity grid */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {filtered.map((charity) => {
           const Icon = categoryIcons[charity.category] || Heart;
-          const color = categoryColors[charity.category] || "bg-muted text-muted-foreground";
+          const colour = categoryColours[charity.category] || "bg-muted text-muted-foreground";
           return (
             <Card key={charity.id} className="flex flex-col">
               <CardHeader className="pb-2">
                 <div className="flex items-start justify-between">
-                  <div className={`rounded-lg p-2 ${color}`}>
-                    <Icon className="h-5 w-5" />
-                  </div>
-                  <Badge variant="outline" className="capitalize text-xs">
-                    {charity.category.replace("_", " ")}
-                  </Badge>
+                  <div className={`rounded-lg p-2 ${colour}`}><Icon className="h-5 w-5" /></div>
+                  <Badge variant="outline" className="text-xs capitalize">{charity.category.replaceAll("_", " ")}</Badge>
                 </div>
-                <CardTitle className="text-base mt-2">{charity.name}</CardTitle>
-                <CardDescription className="text-xs line-clamp-2">{charity.description}</CardDescription>
+                <CardTitle className="mt-2 text-base">{charity.name}</CardTitle>
+                <CardDescription className="line-clamp-2 text-xs">{charity.description}</CardDescription>
               </CardHeader>
               <CardContent className="mt-auto space-y-3">
                 <div className="flex flex-wrap gap-2 text-xs">
-                  <Badge variant="secondary">Fame +{charity.fame_bonus_pct}%</Badge>
-                  <Badge variant="secondary">Rep +{charity.reputation_boost}</Badge>
-                  <Badge variant="secondary">Tax -{charity.tax_deduction_pct}%</Badge>
+                  <Badge variant="secondary">Fame rate {charity.fame_bonus_pct}%</Badge>
+                  <Badge variant="secondary">Attitude rate {charity.reputation_boost}%</Badge>
+                  <Badge variant="secondary">Tax record {charity.tax_deduction_pct}%</Badge>
                 </div>
-                <Dialog open={dialogOpen && selectedCharity?.id === charity.id} onOpenChange={(open) => {
-                  setDialogOpen(open);
-                  if (open) setSelectedCharity(charity);
-                }}>
+                <Dialog
+                  open={dialogOpen && selectedCharity?.id === charity.id}
+                  onOpenChange={(open) => {
+                    setDialogOpen(open);
+                    setSelectedCharity(open ? charity : null);
+                    if (!open) setDonationAmount("");
+                  }}
+                >
                   <DialogTrigger asChild>
-                    <Button size="sm" className="w-full" variant="outline">
-                      <Heart className="h-3 w-3 mr-1" /> Donate
+                    <Button size="sm" className="w-full" variant="outline" disabled={cash < 1}>
+                      <Heart className="mr-1 h-3 w-3" /> Donate
                     </Button>
                   </DialogTrigger>
                   <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>Donate to {charity.name}</DialogTitle>
-                    </DialogHeader>
+                    <DialogHeader><DialogTitle>Donate to {charity.name}</DialogTitle></DialogHeader>
                     <div className="space-y-4 pt-2">
-                      <p className="text-sm text-muted-foreground">Available: {fmt.format(cash)}</p>
+                      <p className="text-sm text-muted-foreground">Wallet available: {formatMoney(cash, currencyCode)}</p>
                       <Input
                         type="number"
-                        placeholder="Amount ($)"
+                        inputMode="numeric"
+                        placeholder={`Amount (${currencyCode})`}
                         value={donationAmount}
-                        onChange={(e) => setDonationAmount(e.target.value)}
+                        onChange={(event) => setDonationAmount(event.target.value)}
                         min={1}
-                        max={cash}
+                        max={Math.floor(cash)}
+                        step={1}
                       />
-                      {donationAmount && parseInt(donationAmount) > 0 && (
-                        <div className="rounded-md bg-muted p-3 text-sm space-y-1">
-                          <p>Fame gained: <span className="font-semibold text-amber-500">+{Math.floor(parseInt(donationAmount) * (charity.fame_bonus_pct / 100))}</span></p>
-                          <p>Reputation: <span className="font-semibold text-blue-500">+{Math.floor((parseInt(donationAmount) / 100) * charity.reputation_boost)}</span></p>
+                      {validAmount && (
+                        <div className="space-y-1 rounded-md bg-muted p-3 text-sm">
+                          <p>Estimated fame: <span className="font-semibold text-amber-500">+{previewFame}</span></p>
+                          <p>Estimated attitude reputation: <span className="font-semibold text-blue-500">+{previewReputation}</span></p>
+                          <p className="text-xs text-muted-foreground">The server calculates the final rewards and caps attitude at 100.</p>
                         </div>
                       )}
-                      <Button onClick={handleDonate} disabled={donateMutation.isPending} className="w-full">
-                        {donateMutation.isPending ? "Processing..." : "Confirm Donation"}
+                      <Button onClick={handleDonate} disabled={donateMutation.isPending || !validAmount} className="w-full">
+                        {donateMutation.isPending ? "Processing…" : `Donate ${validAmount ? formatMoney(amountMajor, currencyCode) : ""}`}
                       </Button>
                     </div>
                   </DialogContent>
@@ -240,33 +262,25 @@ export const CharityDonationsTab = ({ cash }: { cash: number }) => {
         })}
       </div>
 
-      {/* Donation history */}
       {donations.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Donation History</CardTitle>
+            <CardTitle className="text-lg">Donation history</CardTitle>
+            <CardDescription>Each completed donation is linked to an immutable ledger transaction.</CardDescription>
           </CardHeader>
           <CardContent>
             <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Charity</TableHead>
-                  <TableHead className="text-right">Amount</TableHead>
-                  <TableHead className="text-right">Fame</TableHead>
-                  <TableHead className="text-right">Date</TableHead>
-                </TableRow>
-              </TableHeader>
+              <TableHeader><TableRow><TableHead>Charity</TableHead><TableHead className="text-right">Amount</TableHead><TableHead className="text-right">Fame</TableHead><TableHead className="text-right">Attitude</TableHead><TableHead className="text-right">Date</TableHead></TableRow></TableHeader>
               <TableBody>
-                {donations.map((d) => {
-                  const charity = charities.find((c) => c.id === d.charity_id);
+                {donations.map((donation) => {
+                  const charity = charities.find((item) => item.id === donation.charity_id);
                   return (
-                    <TableRow key={d.id}>
-                      <TableCell className="font-medium">{charity?.name || "Unknown"}</TableCell>
-                      <TableCell className="text-right text-pink-500">{fmt.format(d.amount)}</TableCell>
-                      <TableCell className="text-right text-amber-500">+{d.fame_gained}</TableCell>
-                      <TableCell className="text-right text-muted-foreground text-xs">
-                        {new Date(d.created_at).toLocaleDateString()}
-                      </TableCell>
+                    <TableRow key={donation.id}>
+                      <TableCell className="font-medium">{charity?.name || "Unknown charity"}</TableCell>
+                      <TableCell className="text-right text-pink-500">{formatMinorMoney(donation.amount_minor, donation.currency_code)}</TableCell>
+                      <TableCell className="text-right text-amber-500">+{donation.fame_gained}</TableCell>
+                      <TableCell className="text-right text-blue-500">+{donation.reputation_gained}</TableCell>
+                      <TableCell className="text-right text-xs text-muted-foreground">{new Date(donation.created_at).toLocaleDateString("en-GB")}</TableCell>
                     </TableRow>
                   );
                 })}

--- a/src/hooks/__tests__/useFinances.authority.test.ts
+++ b/src/hooks/__tests__/useFinances.authority.test.ts
@@ -8,6 +8,8 @@ const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
 const hookSource = read("src/hooks/useFinances.ts");
 const pageSource = read("src/pages/Finances.tsx");
 const holdingsSource = read("src/components/finance/CanonicalFinanceHoldings.tsx");
+const charitySource = read("src/components/finance/CharityDonationsTab.tsx");
+const charityApiSource = read("src/lib/api/charityDonations.ts");
 const transactionSource = read("src/components/finance/TransactionsList.tsx");
 const summarySource = read("src/components/finance/FinanceSummaryCards.tsx");
 const personalSource = read("src/components/finance/PersonalFinanceBreakdown.tsx");
@@ -17,6 +19,7 @@ const formattingSource = read("src/lib/financeFormatting.ts");
 const migratedUiSources = [
   pageSource,
   holdingsSource,
+  charitySource,
   transactionSource,
   summarySource,
   personalSource,
@@ -59,14 +62,17 @@ describe("canonical Financial Command Center UI", () => {
     expect(fromMinorUnits(12345)).toBe(123.45);
   });
 
-  it("removes unsafe legacy cash mutations from reachable finance tabs", () => {
+  it("keeps unsafe legacy mutations out of reachable finance tabs", () => {
     expect(pageSource).not.toContain("InvestmentsTab");
     expect(pageSource).not.toContain("LoansTab");
-    expect(pageSource).not.toContain("CharityDonationsTab");
+    expect(pageSource).toContain("CharityDonationsTab");
     expect(pageSource).toContain("CanonicalInvestmentsPanel");
     expect(pageSource).toContain("CanonicalLoansPanel");
     expect(holdingsSource).not.toContain("supabase");
     expect(holdingsSource).toContain("temporarily read-only");
+    expect(charitySource).not.toContain('.from("profiles")');
+    expect(charitySource).not.toContain('.from("charity_donations").insert');
+    expect(charityApiSource).toContain('"make_my_charity_donation"');
   });
 
   it("discloses other currencies without fake conversion", () => {

--- a/src/lib/api/__tests__/charityDonations.database.test.ts
+++ b/src/lib/api/__tests__/charityDonations.database.test.ts
@@ -7,6 +7,9 @@ const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
 const categoryMigration = read(
   "supabase/migrations/20291218242500_add_charity_donation_transaction_category.sql",
 );
+const movementMigration = read(
+  "supabase/migrations/20291218242550_repair_financial_move_currency_entries.sql",
+);
 const migration = read(
   "supabase/migrations/20291218242600_atomic_charity_donations.sql",
 );
@@ -19,6 +22,16 @@ describe("atomic character charity donations", () => {
     expect(migration).toContain("public._move_financial_account_money(");
     expect(migration).toContain("'charity_donation'");
     expect(migration).toContain("'charity_clearing'");
+  });
+
+  it("repairs the canonical movement primitive for required currency columns", () => {
+    expect(movementMigration).toContain("transaction_currency char(3)");
+    expect(movementMigration).toContain("source_currency_code");
+    expect(movementMigration).toContain("destination_currency_code");
+    expect(movementMigration).toContain("INSERT INTO public.financial_ledger_entries");
+    expect(movementMigration).toContain("currency_code");
+    expect(movementMigration).toContain("pg_advisory_xact_lock");
+    expect(movementMigration).toContain("idempotency_key_conflict");
   });
 
   it("derives authority, wallet and currency on the server", () => {

--- a/src/lib/api/__tests__/charityDonations.database.test.ts
+++ b/src/lib/api/__tests__/charityDonations.database.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const categoryMigration = read(
+  "supabase/migrations/20291218242500_add_charity_donation_transaction_category.sql",
+);
+const migration = read(
+  "supabase/migrations/20291218242600_atomic_charity_donations.sql",
+);
+const apiSource = read("src/lib/api/charityDonations.ts");
+const componentSource = read("src/components/finance/CharityDonationsTab.tsx");
+
+describe("atomic character charity donations", () => {
+  it("uses a dedicated canonical transaction category", () => {
+    expect(categoryMigration).toContain("ADD VALUE IF NOT EXISTS 'charity_donation'");
+    expect(migration).toContain("public._move_financial_account_money(");
+    expect(migration).toContain("'charity_donation'");
+    expect(migration).toContain("'charity_clearing'");
+  });
+
+  it("derives authority, wallet and currency on the server", () => {
+    expect(migration).toContain("public.current_active_player_profile_id()");
+    expect(migration).toContain("owner_type = 'player'");
+    expect(migration).toContain("AND is_primary");
+    expect(migration).toContain("COALESCE(wallet.currency_code, wallet.default_currency_code)");
+    expect(migration).toContain("donation_amount_must_be_whole_major_units");
+  });
+
+  it("is idempotent and links every canonical donation to the ledger", () => {
+    expect(migration).toContain("pg_advisory_xact_lock");
+    expect(migration).toContain("charity_donations_idempotency_unique_idx");
+    expect(migration).toContain("financial_transaction_id");
+    expect(migration).toContain("idempotency_key_conflict");
+    expect(migration).toContain("'idempotent', true");
+  });
+
+  it("calculates and applies rewards in the same transaction", () => {
+    expect(migration).toContain("charity.fame_bonus_pct");
+    expect(migration).toContain("charity.reputation_boost");
+    expect(migration).toContain("fame = COALESCE(fame, 0) + fame_reward");
+    expect(migration).toContain("attitude_score = new_attitude");
+    expect(migration).toContain("INSERT INTO public.reputation_events");
+    expect(migration).toContain("LEAST(100");
+  });
+
+  it("prevents the old direct donation write path", () => {
+    expect(migration).toContain('DROP POLICY IF EXISTS "Users can insert own donations"');
+    expect(migration).toContain("REVOKE INSERT, UPDATE, DELETE");
+    expect(componentSource).not.toContain('.from("profiles")');
+    expect(componentSource).not.toContain('.from("charity_donations").insert');
+    expect(componentSource).toContain("makeCharityDonation");
+  });
+
+  it("exposes one typed RPC using minor units and a caller idempotency key", () => {
+    expect(apiSource).toContain('"make_my_charity_donation"');
+    expect(apiSource).toContain("p_amount_minor: amountMinor");
+    expect(apiSource).toContain("p_idempotency_key: idempotencyKey");
+    expect(apiSource).toContain("CharityDonationResult");
+  });
+});

--- a/src/lib/api/charityDonations.ts
+++ b/src/lib/api/charityDonations.ts
@@ -1,0 +1,36 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface CharityDonationResult {
+  donationId: string;
+  transactionId: string;
+  charityId: string;
+  charityName?: string;
+  currencyCode: string;
+  amountMinor: number;
+  walletBalanceMinor: number;
+  fameGained: number;
+  reputationGained: number;
+  requestedReputationGained?: number;
+  idempotent: boolean;
+}
+
+export async function makeCharityDonation(
+  charityId: string,
+  amountMinor: number,
+  idempotencyKey: string,
+): Promise<CharityDonationResult> {
+  const { data, error } = await (supabase as any).rpc("make_my_charity_donation", {
+    p_charity_id: charityId,
+    p_amount_minor: amountMinor,
+    p_idempotency_key: idempotencyKey,
+  });
+
+  if (error) {
+    throw new Error(`Charity donation failed: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error("Charity donation failed: no result returned");
+  }
+
+  return data as CharityDonationResult;
+}

--- a/src/lib/api/charityDonations.ts
+++ b/src/lib/api/charityDonations.ts
@@ -14,12 +14,24 @@ export interface CharityDonationResult {
   idempotent: boolean;
 }
 
+interface CharityDonationRpcClient {
+  rpc: (
+    functionName: string,
+    parameters: Record<string, unknown>,
+  ) => Promise<{
+    data: unknown;
+    error: { message: string } | null;
+  }>;
+}
+
+const charityDonationRpcClient = supabase as unknown as CharityDonationRpcClient;
+
 export async function makeCharityDonation(
   charityId: string,
   amountMinor: number,
   idempotencyKey: string,
 ): Promise<CharityDonationResult> {
-  const { data, error } = await (supabase as any).rpc("make_my_charity_donation", {
+  const { data, error } = await charityDonationRpcClient.rpc("make_my_charity_donation", {
     p_charity_id: charityId,
     p_amount_minor: amountMinor,
     p_idempotency_key: idempotencyKey,

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -15,12 +15,12 @@ import { SponsorshipTypesPanel } from "@/components/finance/SponsorshipTypesPane
 import { CityTreasuryCard } from "@/components/finance/CityTreasuryCard";
 import { FinancialHistoryLedger } from "@/components/finance/FinancialHistoryLedger";
 import { PlayerFinanceHub } from "@/components/finance/PlayerFinanceHub";
+import { CharityDonationsTab } from "@/components/finance/CharityDonationsTab";
 import { FMPageScaffold } from "@/components/fm/FMPageScaffold";
 import { FinancialObligationsPanel } from "@/components/finance/FinancialObligationsPanel";
 import {
   CanonicalInvestmentsPanel,
   CanonicalLoansPanel,
-  LegacyMutationNotice,
   OtherCurrencyBalancesPanel,
 } from "@/components/finance/CanonicalFinanceHoldings";
 
@@ -125,10 +125,7 @@ const Finances = () => {
         </TabsContent>
 
         <TabsContent value="charity" className="space-y-6">
-          <LegacyMutationNotice
-            title="Charity donations are temporarily read-only"
-            body="The previous donation flow deducted compatibility cash before recording the donation. It is disabled until the donation and reward update can post through one atomic ledger transaction."
-          />
+          <CharityDonationsTab cash={summary.cash} currencyCode={summary.currencyCode} />
         </TabsContent>
 
         <TabsContent value="sponsorships" className="space-y-6">

--- a/supabase/migrations/20291218242500_add_charity_donation_transaction_category.sql
+++ b/supabase/migrations/20291218242500_add_charity_donation_transaction_category.sql
@@ -1,0 +1,4 @@
+-- Add the dedicated category in its own migration so PostgreSQL can commit the
+-- enum value before later functions reference it.
+ALTER TYPE public.financial_transaction_category
+  ADD VALUE IF NOT EXISTS 'charity_donation';

--- a/supabase/migrations/20291218242550_repair_financial_move_currency_entries.sql
+++ b/supabase/migrations/20291218242550_repair_financial_move_currency_entries.sql
@@ -1,0 +1,183 @@
+-- The hardened movement primitive pre-dated the final NOT NULL currency column
+-- on financial_ledger_entries. Preserve its idempotency guarantees while
+-- writing complete multi-currency transaction and ledger data.
+
+CREATE OR REPLACE FUNCTION public._move_financial_account_money(
+  p_source uuid,
+  p_destination uuid,
+  p_amount bigint,
+  p_category public.financial_transaction_category,
+  p_description text,
+  p_key text,
+  p_profile uuid,
+  p_related_type text DEFAULT NULL,
+  p_related_id uuid DEFAULT NULL,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  source_account public.financial_accounts%ROWTYPE;
+  destination_account public.financial_accounts%ROWTYPE;
+  existing_transaction public.financial_transactions%ROWTYPE;
+  transaction_id uuid;
+  transaction_currency char(3);
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_key IS NULL OR length(btrim(p_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_key, 0));
+
+  SELECT * INTO existing_transaction
+  FROM public.financial_transactions
+  WHERE idempotency_key = p_key;
+
+  IF existing_transaction.id IS NOT NULL THEN
+    IF existing_transaction.status <> 'completed'
+      OR existing_transaction.created_by_profile_id IS DISTINCT FROM p_profile
+      OR existing_transaction.source_account_id IS DISTINCT FROM p_source
+      OR existing_transaction.destination_account_id IS DISTINCT FROM p_destination
+      OR existing_transaction.net_amount_minor IS DISTINCT FROM p_amount THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+    RETURN existing_transaction.id;
+  END IF;
+
+  PERFORM 1
+  FROM public.financial_accounts
+  WHERE id IN (p_source, p_destination)
+  ORDER BY id
+  FOR UPDATE;
+
+  SELECT * INTO source_account
+  FROM public.financial_accounts
+  WHERE id = p_source;
+
+  SELECT * INTO destination_account
+  FROM public.financial_accounts
+  WHERE id = p_destination;
+
+  IF source_account.id IS NULL
+    OR destination_account.id IS NULL
+    OR source_account.id = destination_account.id THEN
+    RAISE EXCEPTION 'account_invalid' USING ERRCODE = 'P0001';
+  END IF;
+  IF source_account.account_status <> 'active'
+    OR destination_account.account_status <> 'active' THEN
+    RAISE EXCEPTION 'account_not_active' USING ERRCODE = 'P0001';
+  END IF;
+
+  transaction_currency := COALESCE(source_account.currency_code, source_account.default_currency_code);
+  IF transaction_currency IS DISTINCT FROM
+    COALESCE(destination_account.currency_code, destination_account.default_currency_code) THEN
+    RAISE EXCEPTION 'currency_mismatch_no_conversion' USING ERRCODE = 'P0001';
+  END IF;
+  IF source_account.available_balance_minor < p_amount THEN
+    RAISE EXCEPTION 'insufficient_funds' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.financial_transactions (
+    transaction_category,
+    status,
+    currency_code,
+    gross_amount_minor,
+    net_amount_minor,
+    source_account_id,
+    destination_account_id,
+    related_entity_type,
+    related_entity_id,
+    description,
+    idempotency_key,
+    created_by_user_id,
+    created_by_profile_id,
+    created_by_actor,
+    completed_at,
+    source_currency_code,
+    destination_currency_code,
+    source_amount_minor,
+    destination_amount_minor,
+    metadata
+  ) VALUES (
+    p_category,
+    'completed',
+    transaction_currency,
+    p_amount,
+    p_amount,
+    source_account.id,
+    destination_account.id,
+    p_related_type,
+    p_related_id,
+    p_description,
+    p_key,
+    auth.uid(),
+    p_profile,
+    COALESCE(auth.uid()::text, 'system'),
+    now(),
+    transaction_currency,
+    transaction_currency,
+    p_amount,
+    p_amount,
+    COALESCE(p_metadata, '{}'::jsonb)
+  )
+  RETURNING id INTO transaction_id;
+
+  UPDATE public.financial_accounts
+  SET current_balance_minor = current_balance_minor - p_amount,
+      updated_at = now()
+  WHERE id = source_account.id;
+
+  UPDATE public.financial_accounts
+  SET current_balance_minor = current_balance_minor + p_amount,
+      updated_at = now()
+  WHERE id = destination_account.id;
+
+  INSERT INTO public.financial_ledger_entries (
+    transaction_id,
+    account_id,
+    entry_direction,
+    amount_minor,
+    balance_before_minor,
+    balance_after_minor,
+    currency_code
+  ) VALUES
+    (
+      transaction_id,
+      source_account.id,
+      'debit',
+      p_amount,
+      source_account.current_balance_minor,
+      source_account.current_balance_minor - p_amount,
+      transaction_currency
+    ),
+    (
+      transaction_id,
+      destination_account.id,
+      'credit',
+      p_amount,
+      destination_account.current_balance_minor,
+      destination_account.current_balance_minor + p_amount,
+      transaction_currency
+    );
+
+  RETURN transaction_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._move_financial_account_money(
+  uuid, uuid, bigint, public.financial_transaction_category, text, text,
+  uuid, text, uuid, jsonb
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public._move_financial_account_money(
+  uuid, uuid, bigint, public.financial_transaction_category, text, text,
+  uuid, text, uuid, jsonb
+) TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218242600_atomic_charity_donations.sql
+++ b/supabase/migrations/20291218242600_atomic_charity_donations.sql
@@ -1,0 +1,330 @@
+-- Restore character charity donations through the canonical financial ledger.
+-- The browser may choose a charity and amount, but profile authority, wallet,
+-- currency and rewards are all resolved and applied in one database transaction.
+
+ALTER TABLE public.charity_donations
+  ADD COLUMN IF NOT EXISTS amount_minor bigint,
+  ADD COLUMN IF NOT EXISTS currency_code char(3),
+  ADD COLUMN IF NOT EXISTS financial_transaction_id uuid REFERENCES public.financial_transactions(id),
+  ADD COLUMN IF NOT EXISTS idempotency_key text,
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE public.charity_donations
+SET amount_minor = COALESCE(amount_minor, GREATEST(amount, 0)::bigint * 100),
+    currency_code = COALESCE(currency_code, 'USD'),
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'legacy_projection', true,
+      'legacy_amount_major', amount
+    )
+WHERE amount_minor IS NULL OR currency_code IS NULL;
+
+ALTER TABLE public.charity_donations
+  ALTER COLUMN amount_minor SET NOT NULL,
+  ALTER COLUMN currency_code SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE public.charity_donations
+    ADD CONSTRAINT charity_donations_currency_format
+    CHECK (currency_code ~ '^[A-Z]{3}$');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS charity_donations_transaction_unique_idx
+  ON public.charity_donations(financial_transaction_id)
+  WHERE financial_transaction_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS charity_donations_idempotency_unique_idx
+  ON public.charity_donations(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+DROP POLICY IF EXISTS "Users can insert own donations" ON public.charity_donations;
+REVOKE INSERT, UPDATE, DELETE ON public.charity_donations FROM anon, authenticated;
+GRANT SELECT ON public.charity_donations TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.make_my_charity_donation(
+  p_charity_id uuid,
+  p_amount_minor bigint,
+  p_idempotency_key text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  profile_id uuid := public.current_active_player_profile_id();
+  charity public.charity_organizations%ROWTYPE;
+  wallet public.financial_accounts%ROWTYPE;
+  charity_account public.financial_accounts%ROWTYPE;
+  existing_donation public.charity_donations%ROWTYPE;
+  reputation public.player_reputation%ROWTYPE;
+  transaction_id uuid;
+  donation_id uuid;
+  currency char(3);
+  amount_major bigint;
+  fame_reward integer;
+  requested_reputation_reward integer;
+  applied_reputation_reward integer;
+  previous_attitude integer;
+  new_attitude integer;
+  wallet_balance_minor bigint;
+BEGIN
+  IF profile_id IS NULL THEN
+    RAISE EXCEPTION 'active_profile_required' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_amount_minor IS NULL OR p_amount_minor <= 0 THEN
+    RAISE EXCEPTION 'amount_must_be_positive' USING ERRCODE = 'P0001';
+  END IF;
+  IF mod(p_amount_minor, 100) <> 0 THEN
+    RAISE EXCEPTION 'donation_amount_must_be_whole_major_units' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_idempotency_key IS NULL OR length(btrim(p_idempotency_key)) < 8 THEN
+    RAISE EXCEPTION 'idempotency_key_invalid' USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key, 0));
+
+  SELECT * INTO existing_donation
+  FROM public.charity_donations
+  WHERE idempotency_key = p_idempotency_key;
+
+  IF existing_donation.id IS NOT NULL THEN
+    IF existing_donation.profile_id IS DISTINCT FROM profile_id
+      OR existing_donation.charity_id IS DISTINCT FROM p_charity_id
+      OR existing_donation.amount_minor IS DISTINCT FROM p_amount_minor THEN
+      RAISE EXCEPTION 'idempotency_key_conflict' USING ERRCODE = 'P0001';
+    END IF;
+
+    SELECT current_balance_minor INTO wallet_balance_minor
+    FROM public.financial_accounts
+    WHERE owner_type = 'player'
+      AND owner_id = profile_id
+      AND is_primary
+      AND account_status = 'active'
+    ORDER BY created_at
+    LIMIT 1;
+
+    RETURN jsonb_build_object(
+      'donationId', existing_donation.id,
+      'transactionId', existing_donation.financial_transaction_id,
+      'charityId', existing_donation.charity_id,
+      'currencyCode', existing_donation.currency_code,
+      'amountMinor', existing_donation.amount_minor,
+      'walletBalanceMinor', COALESCE(wallet_balance_minor, 0),
+      'fameGained', existing_donation.fame_gained,
+      'reputationGained', existing_donation.reputation_gained,
+      'idempotent', true
+    );
+  END IF;
+
+  SELECT * INTO charity
+  FROM public.charity_organizations
+  WHERE id = p_charity_id
+    AND is_active
+  FOR SHARE;
+
+  IF charity.id IS NULL THEN
+    RAISE EXCEPTION 'charity_not_found_or_inactive' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO wallet
+  FROM public.financial_accounts
+  WHERE owner_type = 'player'
+    AND owner_id = profile_id
+    AND is_primary
+    AND account_status = 'active'
+  ORDER BY created_at
+  LIMIT 1;
+
+  IF wallet.id IS NULL THEN
+    RAISE EXCEPTION 'character_wallet_missing' USING ERRCODE = 'P0001';
+  END IF;
+
+  currency := COALESCE(wallet.currency_code, wallet.default_currency_code);
+  IF wallet.available_balance_minor < p_amount_minor THEN
+    RAISE EXCEPTION 'insufficient_funds' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.financial_accounts(
+    owner_type,
+    owner_id,
+    account_name,
+    account_status,
+    current_balance_minor,
+    reserved_balance_minor,
+    default_currency_code,
+    currency_code,
+    account_purpose,
+    is_primary,
+    metadata
+  ) VALUES (
+    'system',
+    NULL,
+    'Charity clearing ' || currency,
+    'active',
+    0,
+    0,
+    currency,
+    currency,
+    'charity_clearing',
+    false,
+    jsonb_build_object('account_role', 'charity_clearing', 'currency_code', currency)
+  )
+  ON CONFLICT DO NOTHING;
+
+  SELECT * INTO charity_account
+  FROM public.financial_accounts
+  WHERE owner_type = 'system'
+    AND account_status = 'active'
+    AND account_name = 'Charity clearing ' || currency
+    AND currency_code = currency
+    AND account_purpose = 'charity_clearing'
+  ORDER BY created_at
+  LIMIT 1;
+
+  IF charity_account.id IS NULL THEN
+    RAISE EXCEPTION 'charity_clearing_account_missing' USING ERRCODE = 'P0001';
+  END IF;
+
+  amount_major := p_amount_minor / 100;
+  fame_reward := GREATEST(0, floor((amount_major::numeric * charity.fame_bonus_pct) / 100)::integer);
+  requested_reputation_reward := GREATEST(
+    0,
+    floor((amount_major::numeric * charity.reputation_boost) / 100)::integer
+  );
+
+  INSERT INTO public.player_reputation(profile_id)
+  VALUES (profile_id)
+  ON CONFLICT (profile_id) DO NOTHING;
+
+  SELECT * INTO reputation
+  FROM public.player_reputation
+  WHERE player_reputation.profile_id = make_my_charity_donation.profile_id
+  FOR UPDATE;
+
+  previous_attitude := reputation.attitude_score;
+  new_attitude := LEAST(100, previous_attitude + requested_reputation_reward);
+  applied_reputation_reward := new_attitude - previous_attitude;
+
+  transaction_id := public._move_financial_account_money(
+    wallet.id,
+    charity_account.id,
+    p_amount_minor,
+    'charity_donation',
+    'Donation to ' || charity.name,
+    p_idempotency_key,
+    profile_id,
+    'charity_organization',
+    charity.id,
+    jsonb_build_object(
+      'classification', 'charity_donation',
+      'charity_name', charity.name,
+      'charity_category', charity.category,
+      'commercial_revenue', false,
+      'tax_deduction_pct', charity.tax_deduction_pct
+    )
+  );
+
+  UPDATE public.profiles
+  SET cash = (
+        SELECT current_balance_minor / 100
+        FROM public.financial_accounts
+        WHERE id = wallet.id
+      ),
+      fame = COALESCE(fame, 0) + fame_reward,
+      updated_at = now()
+  WHERE id = profile_id;
+
+  UPDATE public.player_reputation
+  SET attitude_score = new_attitude,
+      last_updated_at = now()
+  WHERE player_reputation.profile_id = make_my_charity_donation.profile_id;
+
+  IF applied_reputation_reward > 0 THEN
+    INSERT INTO public.reputation_events(
+      profile_id,
+      event_type,
+      event_source,
+      source_id,
+      axis,
+      change_amount,
+      previous_value,
+      new_value,
+      reason,
+      metadata
+    ) VALUES (
+      profile_id,
+      'charity_donation',
+      'charity',
+      charity.id,
+      'attitude',
+      applied_reputation_reward,
+      previous_attitude,
+      new_attitude,
+      'Supported ' || charity.name,
+      jsonb_build_object(
+        'fame_delta', fame_reward,
+        'requested_reputation_delta', requested_reputation_reward,
+        'amount_minor', p_amount_minor,
+        'currency_code', currency,
+        'transaction_id', transaction_id
+      )
+    );
+  END IF;
+
+  INSERT INTO public.charity_donations(
+    profile_id,
+    charity_id,
+    amount,
+    amount_minor,
+    currency_code,
+    fame_gained,
+    reputation_gained,
+    financial_transaction_id,
+    idempotency_key,
+    metadata
+  ) VALUES (
+    profile_id,
+    charity.id,
+    amount_major::integer,
+    p_amount_minor,
+    currency,
+    fame_reward,
+    applied_reputation_reward,
+    transaction_id,
+    p_idempotency_key,
+    jsonb_build_object(
+      'reward_axis', 'attitude',
+      'requested_reputation_gained', requested_reputation_reward,
+      'tax_deduction_pct', charity.tax_deduction_pct
+    )
+  )
+  RETURNING id INTO donation_id;
+
+  SELECT current_balance_minor INTO wallet_balance_minor
+  FROM public.financial_accounts
+  WHERE id = wallet.id;
+
+  RETURN jsonb_build_object(
+    'donationId', donation_id,
+    'transactionId', transaction_id,
+    'charityId', charity.id,
+    'charityName', charity.name,
+    'currencyCode', currency,
+    'amountMinor', p_amount_minor,
+    'walletBalanceMinor', wallet_balance_minor,
+    'fameGained', fame_reward,
+    'reputationGained', applied_reputation_reward,
+    'requestedReputationGained', requested_reputation_reward,
+    'idempotent', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.make_my_charity_donation(uuid, bigint, text)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.make_my_charity_donation(uuid, bigint, text)
+  TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- restores the Charity tab in the Financial Command Center
- adds the authenticated `make_my_charity_donation` RPC
- resolves the active character and primary wallet on the server
- accepts digits-only whole major-currency amounts; fractional entries are rejected rather than truncated
- posts each donation as a balanced same-currency transfer to a system charity clearing account
- adds a dedicated `charity_donation` financial transaction category
- links every new `charity_donations` row to its immutable financial transaction and idempotency key
- calculates fame and reputation rewards on the server
- applies fame to the character profile
- applies charitable reputation to the existing attitude/humility reputation axis, capped at 100
- records the applied reputation change in `reputation_events`
- preserves legacy donation records with their original USD classification instead of relabelling them as the active character currency
- removes the old authenticated direct-insert policy for charity donations
- adds a typed frontend API and currency-aware en-GB UI
- keeps the changed Charity files free of explicit `any` casts
- updates the Financial Command Center authority test now that Charity is no longer temporarily disabled

## Shared ledger repair

The audit found that the final `_move_financial_account_money` implementation did not include the required `currency_code` when inserting `financial_ledger_entries`. This PR repairs that primitive while preserving its advisory-lock and idempotency-conflict guarantees. The transaction now also records source/destination currencies and amounts.

This repair supports Charity and prevents the same hidden multi-currency insert failure in existing canonical Banking and Savings movements.

## Root cause

The previous Charity flow performed two independent browser writes:

1. decrement `profiles.cash`
2. insert `charity_donations`

A failed second write could permanently remove the character's money without recording the donation. Fame and reputation were calculated by the browser, written only as donation metadata, and were not reliably applied to the character.

## Player impact

- players can donate from their real character wallet again
- GBP characters see pounds using en-GB formatting; other character currencies remain separate
- donations appear as genuine external expenses in the Financial Command Center
- repeated requests cannot charge the player twice
- donation history shows its actual recorded currency
- fame and attitude reputation rewards are genuinely awarded
- very large reputation rewards stop at the existing attitude cap instead of exceeding it
- invalid fractional input is not silently changed to a smaller donation

## Validation

```bash
npm test -- src/lib/api/__tests__/charityDonations.database.test.ts src/hooks/__tests__/useFinances.authority.test.ts
npm run typecheck
```

### Observed workflow results

- Finance verification installs dependencies successfully but fails during `supabase db start` before reaching these migrations. The repository applies `085_jam_sessions_core.sql` and then `086_band_member_locks.sql`; migration `086` references `public.bands` before the timestamped base schema creates it.
- Festival runtime lint fails on the repository's existing global lint backlog across many unrelated files. An explicit-`any` finding originally reported in the new Charity component has been removed; fresh runs still encounter the wider baseline.
- Standard CI is currently executing TypeScript compilation for the latest head. No success is claimed until that run completes.

The branch is based on merged PR #1410, remains zero commits behind `main`, and is intentionally still a draft.