### PR TITLE
Repair fresh database numeric band migration order

### DIFF
--- a/src/lib/api/__tests__/bandMemberLocksMigrationOrder.database.test.ts
+++ b/src/lib/api/__tests__/bandMemberLocksMigrationOrder.database.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const earlyMigration = read("supabase/migrations/086_band_member_locks.sql");
+const baseSchema = read(
+  "supabase/migrations/20250916075501_1adc3330-58fe-4fde-85d0-b13e1e788c85.sql",
+);
+const completionMigration = read(
+  "supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql",
+);
+
+describe("band member lock migration order", () => {
+  it("does not reference the timestamped bands table from numeric migration 086", () => {
+    expect(earlyMigration).toContain("CREATE TABLE IF NOT EXISTS public.band_member_locks");
+    expect(earlyMigration).toContain("band_id uuid NOT NULL");
+    expect(earlyMigration).not.toContain("REFERENCES public.bands");
+  });
+
+  it("keeps the activity type and lock integrity constraints in the early table", () => {
+    expect(earlyMigration).toContain("CREATE TYPE public.band_member_activity_type");
+    expect(earlyMigration).toContain("CHECK (lock_end_at > lock_start_at)");
+    expect(earlyMigration).toContain("UNIQUE (user_id, activity_type)");
+    expect(earlyMigration).toContain("idx_band_member_locks_band");
+  });
+
+  it("confirms the base timestamped schema creates bands", () => {
+    expect(baseSchema).toContain("CREATE TABLE public.bands");
+    expect(baseSchema).toContain("id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY");
+  });
+
+  it("adds and validates the deferred cascade foreign key idempotently", () => {
+    expect(completionMigration).toContain("to_regclass('public.bands')");
+    expect(completionMigration).toContain("band_member_locks_band_id_fkey");
+    expect(completionMigration).toContain("FOREIGN KEY (band_id)");
+    expect(completionMigration).toContain("REFERENCES public.bands(id)");
+    expect(completionMigration).toContain("ON DELETE CASCADE");
+    expect(completionMigration).toContain("NOT VALID");
+    expect(completionMigration).toContain("VALIDATE CONSTRAINT");
+  });
+});

--- a/src/lib/api/__tests__/bandMemberLocksMigrationOrder.database.test.ts
+++ b/src/lib/api/__tests__/bandMemberLocksMigrationOrder.database.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from "vitest";
 
 const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
 
-const earlyMigration = read("supabase/migrations/086_band_member_locks.sql");
+const lockMigration = read("supabase/migrations/086_band_member_locks.sql");
+const progressionMigration = read(
+  "supabase/migrations/087_bands_add_chemistry_cohesion.sql",
+);
 const baseSchema = read(
   "supabase/migrations/20250916075501_1adc3330-58fe-4fde-85d0-b13e1e788c85.sql",
 );
@@ -12,23 +15,38 @@ const completionMigration = read(
   "supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql",
 );
 
-describe("band member lock migration order", () => {
+describe("numeric band migration order", () => {
   it("does not reference the timestamped bands table from numeric migration 086", () => {
-    expect(earlyMigration).toContain("CREATE TABLE IF NOT EXISTS public.band_member_locks");
-    expect(earlyMigration).toContain("band_id uuid NOT NULL");
-    expect(earlyMigration).not.toContain("REFERENCES public.bands");
+    expect(lockMigration).toContain("CREATE TABLE IF NOT EXISTS public.band_member_locks");
+    expect(lockMigration).toContain("band_id uuid NOT NULL");
+    expect(lockMigration).not.toContain("REFERENCES public.bands");
   });
 
   it("keeps the activity type and lock integrity constraints in the early table", () => {
-    expect(earlyMigration).toContain("CREATE TYPE public.band_member_activity_type");
-    expect(earlyMigration).toContain("CHECK (lock_end_at > lock_start_at)");
-    expect(earlyMigration).toContain("UNIQUE (user_id, activity_type)");
-    expect(earlyMigration).toContain("idx_band_member_locks_band");
+    expect(lockMigration).toContain("CREATE TYPE public.band_member_activity_type");
+    expect(lockMigration).toContain("CHECK (lock_end_at > lock_start_at)");
+    expect(lockMigration).toContain("UNIQUE (user_id, activity_type)");
+    expect(lockMigration).toContain("idx_band_member_locks_band");
+  });
+
+  it("makes numeric migration 087 safe when bands do not exist yet", () => {
+    expect(progressionMigration).toContain("to_regclass('public.bands') IS NOT NULL");
+    expect(progressionMigration).toContain("ADD COLUMN IF NOT EXISTS chemistry");
+    expect(progressionMigration).toContain("ADD COLUMN IF NOT EXISTS cohesion");
+    expect(progressionMigration).toContain("bands_chemistry_range");
+    expect(progressionMigration).toContain("bands_cohesion_range");
   });
 
   it("confirms the base timestamped schema creates bands", () => {
     expect(baseSchema).toContain("CREATE TABLE public.bands");
     expect(baseSchema).toContain("id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY");
+  });
+
+  it("completes the deferred band columns and constraints idempotently", () => {
+    expect(completionMigration).toContain("ADD COLUMN IF NOT EXISTS chemistry");
+    expect(completionMigration).toContain("ADD COLUMN IF NOT EXISTS cohesion");
+    expect(completionMigration).toContain("CHECK (chemistry BETWEEN 0 AND 100)");
+    expect(completionMigration).toContain("CHECK (cohesion BETWEEN 0 AND 100)");
   });
 
   it("adds and validates the deferred cascade foreign key idempotently", () => {

--- a/supabase/migrations/086_band_member_locks.sql
+++ b/supabase/migrations/086_band_member_locks.sql
@@ -1,12 +1,28 @@
 -- Migration 086: Band member lock windows for activities
+--
+-- Numeric migrations run before the timestamped base schema. Keep the early
+-- lock table available to later migrations, but defer the public.bands foreign
+-- key until the timestamped migration sequence has created that table.
 
-CREATE TYPE public.band_member_activity_type AS ENUM ('jam', 'gig', 'tour', 'recording', 'other');
+DO $$
+BEGIN
+  CREATE TYPE public.band_member_activity_type AS ENUM (
+    'jam',
+    'gig',
+    'tour',
+    'recording',
+    'other'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
 
-CREATE TABLE public.band_member_locks (
+CREATE TABLE IF NOT EXISTS public.band_member_locks (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   activity_type public.band_member_activity_type NOT NULL,
-  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL,
   lock_start_at timestamptz NOT NULL,
   lock_end_at timestamptz NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
@@ -15,6 +31,9 @@ CREATE TABLE public.band_member_locks (
   UNIQUE (user_id, activity_type)
 );
 
-CREATE INDEX IF NOT EXISTS idx_band_member_locks_user ON public.band_member_locks(user_id);
-CREATE INDEX IF NOT EXISTS idx_band_member_locks_band ON public.band_member_locks(band_id);
-CREATE INDEX IF NOT EXISTS idx_band_member_locks_window ON public.band_member_locks(lock_start_at, lock_end_at);
+CREATE INDEX IF NOT EXISTS idx_band_member_locks_user
+  ON public.band_member_locks(user_id);
+CREATE INDEX IF NOT EXISTS idx_band_member_locks_band
+  ON public.band_member_locks(band_id);
+CREATE INDEX IF NOT EXISTS idx_band_member_locks_window
+  ON public.band_member_locks(lock_start_at, lock_end_at);

--- a/supabase/migrations/087_bands_add_chemistry_cohesion.sql
+++ b/supabase/migrations/087_bands_add_chemistry_cohesion.sql
@@ -1,9 +1,38 @@
 -- Migration 087: Add chemistry and cohesion attributes to bands
+--
+-- Numeric migrations run before the timestamped base schema. Existing
+-- deployments may already have public.bands here, but fresh databases do not.
+-- Apply immediately when possible and otherwise let the completion migration
+-- add the same columns and checks after the base schema has run.
 
-ALTER TABLE public.bands
-  ADD COLUMN chemistry integer NOT NULL DEFAULT 20,
-  ADD COLUMN cohesion integer NOT NULL DEFAULT 20;
+DO $$
+BEGIN
+  IF to_regclass('public.bands') IS NOT NULL THEN
+    ALTER TABLE public.bands
+      ADD COLUMN IF NOT EXISTS chemistry integer NOT NULL DEFAULT 20,
+      ADD COLUMN IF NOT EXISTS cohesion integer NOT NULL DEFAULT 20;
 
-ALTER TABLE public.bands
-  ADD CONSTRAINT bands_chemistry_range CHECK (chemistry BETWEEN 0 AND 100),
-  ADD CONSTRAINT bands_cohesion_range CHECK (cohesion BETWEEN 0 AND 100);
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'bands_chemistry_range'
+        AND conrelid = 'public.bands'::regclass
+    ) THEN
+      ALTER TABLE public.bands
+        ADD CONSTRAINT bands_chemistry_range
+        CHECK (chemistry BETWEEN 0 AND 100);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'bands_cohesion_range'
+        AND conrelid = 'public.bands'::regclass
+    ) THEN
+      ALTER TABLE public.bands
+        ADD CONSTRAINT bands_cohesion_range
+        CHECK (cohesion BETWEEN 0 AND 100);
+    END IF;
+  END IF;
+END
+$$;

--- a/supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql
+++ b/supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql
@@ -1,14 +1,40 @@
--- Complete the relationship deferred by numeric migration 086 after the
--- timestamped base schema has created public.bands.
+-- Complete the band schema work deferred by numeric migrations 086 and 087
+-- after the timestamped base schema has created public.bands.
 
 DO $$
 BEGIN
   IF to_regclass('public.band_member_locks') IS NULL THEN
-    RAISE EXCEPTION 'band_member_locks_missing_before_foreign_key';
+    RAISE EXCEPTION 'band_member_locks_missing_before_completion';
   END IF;
 
   IF to_regclass('public.bands') IS NULL THEN
-    RAISE EXCEPTION 'bands_missing_before_band_member_lock_foreign_key';
+    RAISE EXCEPTION 'bands_missing_before_numeric_migration_completion';
+  END IF;
+
+  ALTER TABLE public.bands
+    ADD COLUMN IF NOT EXISTS chemistry integer NOT NULL DEFAULT 20,
+    ADD COLUMN IF NOT EXISTS cohesion integer NOT NULL DEFAULT 20;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'bands_chemistry_range'
+      AND conrelid = 'public.bands'::regclass
+  ) THEN
+    ALTER TABLE public.bands
+      ADD CONSTRAINT bands_chemistry_range
+      CHECK (chemistry BETWEEN 0 AND 100);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'bands_cohesion_range'
+      AND conrelid = 'public.bands'::regclass
+  ) THEN
+    ALTER TABLE public.bands
+      ADD CONSTRAINT bands_cohesion_range
+      CHECK (cohesion BETWEEN 0 AND 100);
   END IF;
 
   IF NOT EXISTS (

--- a/supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql
+++ b/supabase/migrations/20291218242700_complete_band_member_lock_foreign_key.sql
@@ -1,0 +1,32 @@
+-- Complete the relationship deferred by numeric migration 086 after the
+-- timestamped base schema has created public.bands.
+
+DO $$
+BEGIN
+  IF to_regclass('public.band_member_locks') IS NULL THEN
+    RAISE EXCEPTION 'band_member_locks_missing_before_foreign_key';
+  END IF;
+
+  IF to_regclass('public.bands') IS NULL THEN
+    RAISE EXCEPTION 'bands_missing_before_band_member_lock_foreign_key';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'band_member_locks_band_id_fkey'
+      AND conrelid = 'public.band_member_locks'::regclass
+      AND contype = 'f'
+  ) THEN
+    ALTER TABLE public.band_member_locks
+      ADD CONSTRAINT band_member_locks_band_id_fkey
+      FOREIGN KEY (band_id)
+      REFERENCES public.bands(id)
+      ON DELETE CASCADE
+      NOT VALID;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.band_member_locks
+  VALIDATE CONSTRAINT band_member_locks_band_id_fkey;


### PR DESCRIPTION
## What changed

- repairs the fresh Supabase bootstrap failures in numeric migrations `086_band_member_locks.sql` and `087_bands_add_chemistry_cohesion.sql`
- keeps the band-member lock table, enum, time-window check, unique lock rule and indexes in the early numeric sequence
- defers only the `band_id -> bands.id` foreign key because `public.bands` is created later by the timestamped base schema
- makes the early enum and table creation safe to repeat
- makes migration `087` conditional when `public.bands` does not yet exist
- preserves immediate chemistry/cohesion setup for environments where the table already exists
- expands migration `20291218242700_complete_band_member_lock_foreign_key.sql` to complete all deferred band work
- adds chemistry and cohesion with defaults of 20
- restores both 0–100 range constraints
- adds and validates the deferred band-lock foreign key with `ON DELETE CASCADE`
- handles already-deployed databases idempotently by checking existing columns and constraints
- adds a source-level migration-order regression test

## Root cause

Supabase orders the repository's numeric migrations before its timestamped migrations. The broken sequence was:

1. `085_jam_sessions_core.sql`
2. `086_band_member_locks.sql`, which referenced `public.bands`
3. `087_bands_add_chemistry_cohesion.sql`, which altered `public.bands`
4. timestamped migrations, including the base schema that finally creates `public.bands`

Migration `086` caused every fresh `supabase db start` and Finance verification run to stop immediately. Once that reference was deferred, migration `087` was the next guaranteed failure for the same ordering reason.

## Why the schema work is deferred

Creating the lock table early preserves compatibility for later migrations that may reference it. The numeric progression migration now applies immediately only when `bands` already exists. The completion migration runs after the full current timestamped schema and restores the exact intended columns, checks and foreign key.

Existing deployed databases are safe: `ADD COLUMN IF NOT EXISTS` and constraint checks make the completion migration idempotent, while an existing original foreign key is detected and only validated.

## Validation

```bash
npm test -- src/lib/api/__tests__/bandMemberLocksMigrationOrder.database.test.ts
supabase db start
supabase db reset
```

This branch is based on merged PR #1411, is zero commits behind `main`, and changes only the two broken historical numeric migrations, their deferred completion migration and one regression test.