### PR TITLE
Repair tour venue cost migration order

### DIFF
--- a/src/lib/api/__tests__/tourVenueCostsMigrationOrder.database.test.ts
+++ b/src/lib/api/__tests__/tourVenueCostsMigrationOrder.database.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const prematureMigration = read(
+  "supabase/migrations/20250214120000_add_costs_to_tour_venues.sql",
+);
+const tourSchemaMigration = read(
+  "supabase/migrations/20250916081629_c5c74efe-b5cd-4bd7-9b25-0cda3f8be4d6.sql",
+);
+const completionMigration = read(
+  "supabase/migrations/20291218242900_complete_tour_venue_cost_fields.sql",
+);
+
+describe("tour venue cost migration order", () => {
+  it("keeps the pre-table February migration dependency-free", () => {
+    expect(prematureMigration).toContain("explicit no-op");
+    expect(prematureMigration).not.toContain("ALTER TABLE public.tour_venues");
+    expect(prematureMigration).toContain("Deferred tour venue cost fields");
+  });
+
+  it("confirms tour venues are created by the later MMO schema", () => {
+    expect(tourSchemaMigration).toContain("CREATE TABLE public.tour_venues");
+    expect(tourSchemaMigration).toContain("tour_id uuid NOT NULL REFERENCES public.tours(id)");
+    expect(tourSchemaMigration).toContain("venue_id uuid NOT NULL REFERENCES public.venues(id)");
+  });
+
+  it("adds all cost fields idempotently after table creation", () => {
+    expect(completionMigration).toContain("to_regclass('public.tour_venues')");
+    expect(completionMigration).toContain("ADD COLUMN IF NOT EXISTS travel_cost integer NOT NULL DEFAULT 0");
+    expect(completionMigration).toContain("ADD COLUMN IF NOT EXISTS lodging_cost integer NOT NULL DEFAULT 0");
+    expect(completionMigration).toContain("ADD COLUMN IF NOT EXISTS misc_cost integer NOT NULL DEFAULT 0");
+    expect(completionMigration).toContain("UPDATE public.tour_venues");
+  });
+
+  it("protects every tour cost from negative values", () => {
+    expect(completionMigration).toContain("tour_venues_travel_cost_nonnegative");
+    expect(completionMigration).toContain("tour_venues_lodging_cost_nonnegative");
+    expect(completionMigration).toContain("tour_venues_misc_cost_nonnegative");
+    expect(completionMigration).toContain("CHECK (travel_cost >= 0) NOT VALID");
+    expect(completionMigration).toContain("VALIDATE CONSTRAINT tour_venues_misc_cost_nonnegative");
+  });
+});

--- a/supabase/migrations/20250214120000_add_costs_to_tour_venues.sql
+++ b/supabase/migrations/20250214120000_add_costs_to_tour_venues.sql
@@ -1,5 +1,10 @@
--- Add cost tracking fields to tour_venues
-ALTER TABLE public.tour_venues
-  ADD COLUMN travel_cost integer DEFAULT 0,
-  ADD COLUMN lodging_cost integer DEFAULT 0,
-  ADD COLUMN misc_cost integer DEFAULT 0;
+-- This migration sorts before public.tour_venues is created by the September
+-- 2025 MMO schema migration. Keep the historical version as an explicit no-op
+-- and add the columns in the dependency-safe compatibility migration
+-- 20291218242900_complete_tour_venue_cost_fields.sql.
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Deferred tour venue cost fields until public.tour_venues exists';
+END
+$$;

--- a/supabase/migrations/20291218242900_complete_tour_venue_cost_fields.sql
+++ b/supabase/migrations/20291218242900_complete_tour_venue_cost_fields.sql
@@ -1,0 +1,71 @@
+-- Complete the tour venue cost fields after public.tour_venues has been created.
+-- The original February 2025 migration sorted before the table existed.
+
+DO $$
+BEGIN
+  IF to_regclass('public.tour_venues') IS NULL THEN
+    RAISE EXCEPTION 'tour_venues_missing_before_cost_field_completion';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.tour_venues
+  ADD COLUMN IF NOT EXISTS travel_cost integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS lodging_cost integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS misc_cost integer NOT NULL DEFAULT 0;
+
+UPDATE public.tour_venues
+SET
+  travel_cost = COALESCE(travel_cost, 0),
+  lodging_cost = COALESCE(lodging_cost, 0),
+  misc_cost = COALESCE(misc_cost, 0)
+WHERE
+  travel_cost IS NULL
+  OR lodging_cost IS NULL
+  OR misc_cost IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'tour_venues_travel_cost_nonnegative'
+      AND conrelid = 'public.tour_venues'::regclass
+  ) THEN
+    ALTER TABLE public.tour_venues
+      ADD CONSTRAINT tour_venues_travel_cost_nonnegative
+      CHECK (travel_cost >= 0) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'tour_venues_lodging_cost_nonnegative'
+      AND conrelid = 'public.tour_venues'::regclass
+  ) THEN
+    ALTER TABLE public.tour_venues
+      ADD CONSTRAINT tour_venues_lodging_cost_nonnegative
+      CHECK (lodging_cost >= 0) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'tour_venues_misc_cost_nonnegative'
+      AND conrelid = 'public.tour_venues'::regclass
+  ) THEN
+    ALTER TABLE public.tour_venues
+      ADD CONSTRAINT tour_venues_misc_cost_nonnegative
+      CHECK (misc_cost >= 0) NOT VALID;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.tour_venues
+  VALIDATE CONSTRAINT tour_venues_travel_cost_nonnegative;
+ALTER TABLE public.tour_venues
+  VALIDATE CONSTRAINT tour_venues_lodging_cost_nonnegative;
+ALTER TABLE public.tour_venues
+  VALIDATE CONSTRAINT tour_venues_misc_cost_nonnegative;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- converts `20250214120000_add_costs_to_tour_venues.sql` into a dependency-free historical no-op
- adds `20291218242900_complete_tour_venue_cost_fields.sql` after the September 2025 schema has created `public.tour_venues`
- restores `travel_cost`, `lodging_cost` and `misc_cost` with `NOT NULL DEFAULT 0`
- backfills any legacy null values
- adds idempotent non-negative constraints for all three costs
- validates the constraints after existing rows have been normalised
- adds a migration-order regression test

## Root cause

After PR #1413 repaired profile activity bootstrap ordering, fresh Finance verification successfully applied the deferred 2024 migration and then failed at:

```text
20250214120000_add_costs_to_tour_venues.sql
ERROR: relation "public.tour_venues" does not exist
```

`public.tour_venues` is created later by `20250916081629_c5c74efe-b5cd-4bd7-9b25-0cda3f8be4d6.sql`, so the February migration could never work on a fresh database.

## Why the fields are completed late

No migration or source file uses these three columns between the broken February migration and the final compatibility sequence. Deferring them therefore preserves behaviour while supporting both:

- fresh databases, where the table must exist first
- deployed databases, where the columns may already exist

The completion migration is idempotent and refuses to silently continue if `tour_venues` is still missing.

## Validation

```bash
npm test -- src/lib/api/__tests__/tourVenueCostsMigrationOrder.database.test.ts
supabase db start
supabase db reset
```

This branch is based on merged PR #1413, is zero commits behind `main`, and changes only the broken historical migration, its dependency-safe completion migration and one regression test. It remains a draft until Finance verification identifies the next fresh-database result.