### PR TITLE
Repair duplicate auth trigger and seed migrations

### DIFF
--- a/src/lib/api/__tests__/authSignupTriggerMigrationOrder.database.test.ts
+++ b/src/lib/api/__tests__/authSignupTriggerMigrationOrder.database.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const baseSchema = read(
+  "supabase/migrations/20250916075501_1adc3330-58fe-4fde-85d0-b13e1e788c85.sql",
+);
+const compatibilityMigration = read(
+  "supabase/migrations/20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql",
+);
+const duplicateMigration = read(
+  "supabase/migrations/20250916085517_f5f55449-6b35-4479-93e8-09fa35807472.sql",
+);
+const finalReconciliation = read(
+  "supabase/migrations/20291218243000_reconcile_auth_signup_trigger.sql",
+);
+
+describe("auth signup trigger migration authority", () => {
+  it("confirms the base schema owns the original trigger", () => {
+    expect(baseSchema).toContain("CREATE TRIGGER on_auth_user_created");
+    expect(baseSchema).toContain("EXECUTE FUNCTION public.handle_new_user()");
+  });
+
+  it("makes the compatibility trigger creation conditional", () => {
+    expect(compatibilityMigration).toContain("FROM pg_trigger");
+    expect(compatibilityMigration).toContain("tgname = 'on_auth_user_created'");
+    expect(compatibilityMigration).toContain("IF NOT EXISTS");
+    expect(compatibilityMigration).toContain("CREATE TRIGGER on_auth_user_created");
+  });
+
+  it("adds only missing baseline catalogue rows", () => {
+    expect(compatibilityMigration).toContain("FROM public.achievements existing");
+    expect(compatibilityMigration).toContain("FROM public.equipment_items existing");
+    expect(compatibilityMigration).toContain("FROM public.venues existing");
+    expect(compatibilityMigration).toContain("FROM public.streaming_platforms existing");
+    expect(compatibilityMigration.match(/WHERE NOT EXISTS/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("keeps the accidental duplicate timestamp as a no-op", () => {
+    expect(duplicateMigration).toContain("accidental byte-for-byte duplicate");
+    expect(duplicateMigration).not.toContain("CREATE TRIGGER on_auth_user_created");
+    expect(duplicateMigration).not.toContain("INSERT INTO public.achievements");
+    expect(duplicateMigration).not.toContain("INSERT INTO public.equipment_items");
+  });
+
+  it("rebinds exactly one final trigger to the latest function", () => {
+    expect(finalReconciliation).toContain(
+      "DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users",
+    );
+    expect(finalReconciliation).toContain("CREATE TRIGGER on_auth_user_created");
+    expect(finalReconciliation).toContain("EXECUTE FUNCTION public.handle_new_user()");
+    expect(finalReconciliation).toContain("to_regprocedure('public.handle_new_user()')");
+  });
+});

--- a/src/lib/api/__tests__/authSignupTriggerMigrationOrder.database.test.ts
+++ b/src/lib/api/__tests__/authSignupTriggerMigrationOrder.database.test.ts
@@ -35,7 +35,7 @@ describe("auth signup trigger migration authority", () => {
     expect(compatibilityMigration).toContain("FROM public.equipment_items existing");
     expect(compatibilityMigration).toContain("FROM public.venues existing");
     expect(compatibilityMigration).toContain("FROM public.streaming_platforms existing");
-    expect(compatibilityMigration.match(/WHERE NOT EXISTS/g)?.length).toBeGreaterThanOrEqual(5);
+    expect(compatibilityMigration.match(/WHERE NOT EXISTS/g)?.length).toBeGreaterThanOrEqual(4);
   });
 
   it("keeps the accidental duplicate timestamp as a no-op", () => {

--- a/supabase/migrations/20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql
+++ b/supabase/migrations/20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql
@@ -1,57 +1,99 @@
--- Add the missing trigger to connect handle_new_user() function to user signup
-CREATE TRIGGER on_auth_user_created
-  AFTER INSERT ON auth.users
-  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+-- Reconcile the auth signup trigger and add only baseline rows that are still missing.
+-- The base schema already creates public.handle_new_user() and normally installs this trigger.
+DO $$
+BEGIN
+  IF to_regprocedure('public.handle_new_user()') IS NULL THEN
+    RAISE EXCEPTION 'handle_new_user_missing_before_auth_signup_trigger';
+  END IF;
 
--- Seed initial achievements data
-INSERT INTO public.achievements (name, description, category, rarity, icon, requirements, rewards) VALUES
-('First Steps', 'Welcome to RockMundo! Your musical journey begins.', 'career', 'common', '🎵', '{}', '{"experience": 100}'),
-('First Song', 'Create your first original song.', 'music', 'common', '🎤', '{"songs_created": 1}', '{"experience": 250, "cash": 500}'),
-('First Performance', 'Complete your first live performance.', 'performance', 'common', '🎪', '{"gigs_completed": 1}', '{"experience": 300, "fame": 50}'),
-('Band Leader', 'Form your first band and recruit members.', 'social', 'uncommon', '👥', '{"bands_created": 1}', '{"experience": 500, "fame": 100}'),
-('Rising Star', 'Gain 1000 fame points.', 'fame', 'uncommon', '⭐', '{"fame": 1000}', '{"experience": 750, "cash": 2000}'),
-('Skill Master', 'Reach level 80 in any skill.', 'skill', 'rare', '🏆', '{"max_skill": 80}', '{"experience": 1000, "cash": 5000}'),
-('Chart Topper', 'Get a song into the top 10 charts.', 'success', 'epic', '📈', '{"chart_position": 10}', '{"experience": 2000, "fame": 1000, "cash": 10000}'),
-('Legend', 'Reach level 50 overall.', 'career', 'legendary', '👑', '{"level": 50}', '{"experience": 5000, "fame": 2000, "cash": 25000}');
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'on_auth_user_created'
+      AND tgrelid = 'auth.users'::regclass
+      AND NOT tgisinternal
+  ) THEN
+    CREATE TRIGGER on_auth_user_created
+      AFTER INSERT ON auth.users
+      FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+  END IF;
+END
+$$;
 
--- Seed equipment items
-INSERT INTO public.equipment_items (name, category, subcategory, description, price, rarity, stat_boosts, image_url) VALUES
--- Guitars
-('Starter Acoustic Guitar', 'instrument', 'guitar', 'A basic acoustic guitar perfect for beginners.', 500, 'common', '{"guitar": 5}', NULL),
-('Electric Guitar Pro', 'instrument', 'guitar', 'Professional electric guitar with excellent tone.', 2500, 'uncommon', '{"guitar": 15, "performance": 5}', NULL),
-('Vintage Les Paul', 'instrument', 'guitar', 'Legendary guitar used by rock icons.', 8000, 'rare', '{"guitar": 25, "performance": 15, "songwriting": 10}', NULL),
-('Custom Master Guitar', 'instrument', 'guitar', 'Hand-crafted masterpiece with perfect sound.', 25000, 'epic', '{"guitar": 40, "performance": 25, "songwriting": 15}', NULL),
+-- Seed initial achievements without duplicating rows already supplied by the base schema.
+INSERT INTO public.achievements (name, description, category, rarity, icon, requirements, rewards)
+SELECT seed.name, seed.description, seed.category, seed.rarity, seed.icon, seed.requirements::jsonb, seed.rewards::jsonb
+FROM (VALUES
+  ('First Steps', 'Welcome to RockMundo! Your musical journey begins.', 'career', 'common', '🎵', '{}', '{"experience": 100}'),
+  ('First Song', 'Create your first original song.', 'music', 'common', '🎤', '{"songs_created": 1}', '{"experience": 250, "cash": 500}'),
+  ('First Performance', 'Complete your first live performance.', 'performance', 'common', '🎪', '{"gigs_completed": 1}', '{"experience": 300, "fame": 50}'),
+  ('Band Leader', 'Form your first band and recruit members.', 'social', 'uncommon', '👥', '{"bands_created": 1}', '{"experience": 500, "fame": 100}'),
+  ('Rising Star', 'Gain 1000 fame points.', 'fame', 'uncommon', '⭐', '{"fame": 1000}', '{"experience": 750, "cash": 2000}'),
+  ('Skill Master', 'Reach level 80 in any skill.', 'skill', 'rare', '🏆', '{"max_skill": 80}', '{"experience": 1000, "cash": 5000}'),
+  ('Chart Topper', 'Get a song into the top 10 charts.', 'success', 'epic', '📈', '{"chart_position": 10}', '{"experience": 2000, "fame": 1000, "cash": 10000}'),
+  ('Legend', 'Reach level 50 overall.', 'career', 'legendary', '👑', '{"level": 50}', '{"experience": 5000, "fame": 2000, "cash": 25000}')
+) AS seed(name, description, category, rarity, icon, requirements, rewards)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.achievements existing
+  WHERE lower(existing.name) = lower(seed.name)
+);
 
--- Microphones
-('Basic Mic', 'equipment', 'microphone', 'Standard microphone for practice sessions.', 200, 'common', '{"vocals": 5}', NULL),
-('Studio Condenser Mic', 'equipment', 'microphone', 'Professional recording microphone.', 1500, 'uncommon', '{"vocals": 15, "songwriting": 5}', NULL),
-('Vintage Tube Mic', 'equipment', 'microphone', 'Classic microphone with warm, rich tone.', 5000, 'rare', '{"vocals": 25, "performance": 10}', NULL),
+-- Seed equipment without duplicating names already present.
+INSERT INTO public.equipment_items (name, category, subcategory, description, price, rarity, stat_boosts, image_url)
+SELECT seed.name, seed.category, seed.subcategory, seed.description, seed.price, seed.rarity, seed.stat_boosts::jsonb, NULL
+FROM (VALUES
+  ('Starter Acoustic Guitar', 'instrument', 'guitar', 'A basic acoustic guitar perfect for beginners.', 500, 'common', '{"guitar": 5}'),
+  ('Electric Guitar Pro', 'instrument', 'guitar', 'Professional electric guitar with excellent tone.', 2500, 'uncommon', '{"guitar": 15, "performance": 5}'),
+  ('Vintage Les Paul', 'instrument', 'guitar', 'Legendary guitar used by rock icons.', 8000, 'rare', '{"guitar": 25, "performance": 15, "songwriting": 10}'),
+  ('Custom Master Guitar', 'instrument', 'guitar', 'Hand-crafted masterpiece with perfect sound.', 25000, 'epic', '{"guitar": 40, "performance": 25, "songwriting": 15}'),
+  ('Basic Mic', 'equipment', 'microphone', 'Standard microphone for practice sessions.', 200, 'common', '{"vocals": 5}'),
+  ('Studio Condenser Mic', 'equipment', 'microphone', 'Professional recording microphone.', 1500, 'uncommon', '{"vocals": 15, "songwriting": 5}'),
+  ('Vintage Tube Mic', 'equipment', 'microphone', 'Classic microphone with warm, rich tone.', 5000, 'rare', '{"vocals": 25, "performance": 10}'),
+  ('Practice Amp', 'equipment', 'amplifier', 'Small amp perfect for home practice.', 300, 'common', '{"performance": 3}'),
+  ('Stage Amp', 'equipment', 'amplifier', 'Powerful amplifier for live performances.', 1800, 'uncommon', '{"performance": 12, "guitar": 8}'),
+  ('Stadium Stack', 'equipment', 'amplifier', 'Massive amplifier system for large venues.', 12000, 'epic', '{"performance": 30, "guitar": 20, "bass": 15}'),
+  ('Guitar Pick Set', 'accessory', 'picks', 'High-quality guitar picks for better control.', 50, 'common', '{"guitar": 2}'),
+  ('Stage Outfit', 'clothing', 'outfit', 'Stylish outfit that makes you stand out on stage.', 800, 'uncommon', '{"performance": 8, "fame": 5}'),
+  ('Lucky Charm', 'accessory', 'charm', 'A mysterious charm that brings good fortune.', 2000, 'rare', '{"performance": 5, "songwriting": 5, "vocals": 5}')
+) AS seed(name, category, subcategory, description, price, rarity, stat_boosts)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.equipment_items existing
+  WHERE lower(existing.name) = lower(seed.name)
+);
 
--- Amplifiers
-('Practice Amp', 'equipment', 'amplifier', 'Small amp perfect for home practice.', 300, 'common', '{"performance": 3}', NULL),
-('Stage Amp', 'equipment', 'amplifier', 'Powerful amplifier for live performances.', 1800, 'uncommon', '{"performance": 12, "guitar": 8}', NULL),
-('Stadium Stack', 'equipment', 'amplifier', 'Massive amplifier system for large venues.', 12000, 'epic', '{"performance": 30, "guitar": 20, "bass": 15}', NULL),
+-- Seed venues without duplicating an existing venue name.
+INSERT INTO public.venues (name, location, venue_type, capacity, base_payment, prestige_level, requirements)
+SELECT seed.name, seed.location, seed.venue_type, seed.capacity, seed.base_payment, seed.prestige_level, seed.requirements::jsonb
+FROM (VALUES
+  ('Local Coffee Shop', 'Downtown', 'cafe', 50, 200, 1, '{}'),
+  ('Community Center', 'Suburbs', 'community', 150, 500, 1, '{}'),
+  ('The Underground', 'Arts District', 'club', 300, 1000, 2, '{"fame": 100}'),
+  ('City Music Hall', 'Uptown', 'theater', 800, 2500, 3, '{"fame": 500, "performance": 60}'),
+  ('The Arena', 'Sports District', 'arena', 2000, 8000, 4, '{"fame": 2000, "performance": 80}'),
+  ('Festival Grounds', 'Outskirts', 'festival', 5000, 15000, 4, '{"fame": 3000, "band_members": 3}'),
+  ('Stadium', 'Central', 'stadium', 50000, 100000, 5, '{"fame": 10000, "performance": 95, "chart_position": 20}')
+) AS seed(name, location, venue_type, capacity, base_payment, prestige_level, requirements)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.venues existing
+  WHERE lower(existing.name) = lower(seed.name)
+);
 
--- Accessories
-('Guitar Pick Set', 'accessory', 'picks', 'High-quality guitar picks for better control.', 50, 'common', '{"guitar": 2}', NULL),
-('Stage Outfit', 'clothing', 'outfit', 'Stylish outfit that makes you stand out on stage.', 800, 'uncommon', '{"performance": 8, "fame": 5}', NULL),
-('Lucky Charm', 'accessory', 'charm', 'A mysterious charm that brings good fortune.', 2000, 'rare', '{"performance": 5, "songwriting": 5, "vocals": 5}', NULL);
-
--- Seed venues
-INSERT INTO public.venues (name, location, venue_type, capacity, base_payment, prestige_level, requirements) VALUES
-('Local Coffee Shop', 'Downtown', 'cafe', 50, 200, 1, '{}'),
-('Community Center', 'Suburbs', 'community', 150, 500, 1, '{}'),
-('The Underground', 'Arts District', 'club', 300, 1000, 2, '{"fame": 100}'),
-('City Music Hall', 'Uptown', 'theater', 800, 2500, 3, '{"fame": 500, "performance": 60}'),
-('The Arena', 'Sports District', 'arena', 2000, 8000, 4, '{"fame": 2000, "performance": 80}'),
-('Festival Grounds', 'Outskirts', 'festival', 5000, 15000, 4, '{"fame": 3000, "band_members": 3}'),
-('Stadium', 'Central', 'stadium', 50000, 100000, 5, '{"fame": 10000, "performance": 95, "chart_position": 20}');
-
--- Seed streaming platforms
-INSERT INTO public.streaming_platforms (name, description, min_followers, revenue_per_play, icon) VALUES
-('SoundStream', 'Popular music streaming platform with millions of users.', 0, 0.003, '🎵'),
-('MusicFlow', 'Artist-friendly platform with higher payouts.', 100, 0.005, '🎶'),
-('BeatWave', 'Platform focused on emerging artists and discovery.', 50, 0.004, '🌊'),
-('RhythmLink', 'Social music platform with community features.', 500, 0.006, '🔗'),
-('SonicHub', 'Premium platform for established artists.', 1000, 0.008, '⚡'),
-('GlobalTunes', 'Worldwide platform with massive reach.', 2000, 0.007, '🌍');
+-- Seed streaming platforms without duplicating existing names.
+INSERT INTO public.streaming_platforms (name, description, min_followers, revenue_per_play, icon)
+SELECT seed.name, seed.description, seed.min_followers, seed.revenue_per_play, seed.icon
+FROM (VALUES
+  ('SoundStream', 'Popular music streaming platform with millions of users.', 0, 0.003::numeric, '🎵'),
+  ('MusicFlow', 'Artist-friendly platform with higher payouts.', 100, 0.005::numeric, '🎶'),
+  ('BeatWave', 'Platform focused on emerging artists and discovery.', 50, 0.004::numeric, '🌊'),
+  ('RhythmLink', 'Social music platform with community features.', 500, 0.006::numeric, '🔗'),
+  ('SonicHub', 'Premium platform for established artists.', 1000, 0.008::numeric, '⚡'),
+  ('GlobalTunes', 'Worldwide platform with massive reach.', 2000, 0.007::numeric, '🌍')
+) AS seed(name, description, min_followers, revenue_per_play, icon)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.streaming_platforms existing
+  WHERE lower(existing.name) = lower(seed.name)
+);

--- a/supabase/migrations/20250916085517_f5f55449-6b35-4479-93e8-09fa35807472.sql
+++ b/supabase/migrations/20250916085517_f5f55449-6b35-4479-93e8-09fa35807472.sql
@@ -1,57 +1,11 @@
--- Add the missing trigger to connect handle_new_user() function to user signup
-CREATE TRIGGER on_auth_user_created
-  AFTER INSERT ON auth.users
-  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
-
--- Seed initial achievements data
-INSERT INTO public.achievements (name, description, category, rarity, icon, requirements, rewards) VALUES
-('First Steps', 'Welcome to RockMundo! Your musical journey begins.', 'career', 'common', '🎵', '{}', '{"experience": 100}'),
-('First Song', 'Create your first original song.', 'music', 'common', '🎤', '{"songs_created": 1}', '{"experience": 250, "cash": 500}'),
-('First Performance', 'Complete your first live performance.', 'performance', 'common', '🎪', '{"gigs_completed": 1}', '{"experience": 300, "fame": 50}'),
-('Band Leader', 'Form your first band and recruit members.', 'social', 'uncommon', '👥', '{"bands_created": 1}', '{"experience": 500, "fame": 100}'),
-('Rising Star', 'Gain 1000 fame points.', 'fame', 'uncommon', '⭐', '{"fame": 1000}', '{"experience": 750, "cash": 2000}'),
-('Skill Master', 'Reach level 80 in any skill.', 'skill', 'rare', '🏆', '{"max_skill": 80}', '{"experience": 1000, "cash": 5000}'),
-('Chart Topper', 'Get a song into the top 10 charts.', 'success', 'epic', '📈', '{"chart_position": 10}', '{"experience": 2000, "fame": 1000, "cash": 10000}'),
-('Legend', 'Reach level 50 overall.', 'career', 'legendary', '👑', '{"level": 50}', '{"experience": 5000, "fame": 2000, "cash": 25000}');
-
--- Seed equipment items
-INSERT INTO public.equipment_items (name, category, subcategory, description, price, rarity, stat_boosts, image_url) VALUES
--- Guitars
-('Starter Acoustic Guitar', 'instrument', 'guitar', 'A basic acoustic guitar perfect for beginners.', 500, 'common', '{"guitar": 5}', NULL),
-('Electric Guitar Pro', 'instrument', 'guitar', 'Professional electric guitar with excellent tone.', 2500, 'uncommon', '{"guitar": 15, "performance": 5}', NULL),
-('Vintage Les Paul', 'instrument', 'guitar', 'Legendary guitar used by rock icons.', 8000, 'rare', '{"guitar": 25, "performance": 15, "songwriting": 10}', NULL),
-('Custom Master Guitar', 'instrument', 'guitar', 'Hand-crafted masterpiece with perfect sound.', 25000, 'epic', '{"guitar": 40, "performance": 25, "songwriting": 15}', NULL),
-
--- Microphones
-('Basic Mic', 'equipment', 'microphone', 'Standard microphone for practice sessions.', 200, 'common', '{"vocals": 5}', NULL),
-('Studio Condenser Mic', 'equipment', 'microphone', 'Professional recording microphone.', 1500, 'uncommon', '{"vocals": 15, "songwriting": 5}', NULL),
-('Vintage Tube Mic', 'equipment', 'microphone', 'Classic microphone with warm, rich tone.', 5000, 'rare', '{"vocals": 25, "performance": 10}', NULL),
-
--- Amplifiers
-('Practice Amp', 'equipment', 'amplifier', 'Small amp perfect for home practice.', 300, 'common', '{"performance": 3}', NULL),
-('Stage Amp', 'equipment', 'amplifier', 'Powerful amplifier for live performances.', 1800, 'uncommon', '{"performance": 12, "guitar": 8}', NULL),
-('Stadium Stack', 'equipment', 'amplifier', 'Massive amplifier system for large venues.', 12000, 'epic', '{"performance": 30, "guitar": 20, "bass": 15}', NULL),
-
--- Accessories
-('Guitar Pick Set', 'accessory', 'picks', 'High-quality guitar picks for better control.', 50, 'common', '{"guitar": 2}', NULL),
-('Stage Outfit', 'clothing', 'outfit', 'Stylish outfit that makes you stand out on stage.', 800, 'uncommon', '{"performance": 8, "fame": 5}', NULL),
-('Lucky Charm', 'accessory', 'charm', 'A mysterious charm that brings good fortune.', 2000, 'rare', '{"performance": 5, "songwriting": 5, "vocals": 5}', NULL);
-
--- Seed venues
-INSERT INTO public.venues (name, location, venue_type, capacity, base_payment, prestige_level, requirements) VALUES
-('Local Coffee Shop', 'Downtown', 'cafe', 50, 200, 1, '{}'),
-('Community Center', 'Suburbs', 'community', 150, 500, 1, '{}'),
-('The Underground', 'Arts District', 'club', 300, 1000, 2, '{"fame": 100}'),
-('City Music Hall', 'Uptown', 'theater', 800, 2500, 3, '{"fame": 500, "performance": 60}'),
-('The Arena', 'Sports District', 'arena', 2000, 8000, 4, '{"fame": 2000, "performance": 80}'),
-('Festival Grounds', 'Outskirts', 'festival', 5000, 15000, 4, '{"fame": 3000, "band_members": 3}'),
-('Stadium', 'Central', 'stadium', 50000, 100000, 5, '{"fame": 10000, "performance": 95, "chart_position": 20}');
-
--- Seed streaming platforms
-INSERT INTO public.streaming_platforms (name, description, min_followers, revenue_per_play, icon) VALUES
-('SoundStream', 'Popular music streaming platform with millions of users.', 0, 0.003, '🎵'),
-('MusicFlow', 'Artist-friendly platform with higher payouts.', 100, 0.005, '🎶'),
-('BeatWave', 'Platform focused on emerging artists and discovery.', 50, 0.004, '🌊'),
-('RhythmLink', 'Social music platform with community features.', 500, 0.006, '🔗'),
-('SonicHub', 'Premium platform for established artists.', 1000, 0.008, '⚡'),
-('GlobalTunes', 'Worldwide platform with massive reach.', 2000, 0.007, '🌍');
+-- This migration was an accidental byte-for-byte duplicate of
+-- 20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql.
+--
+-- Trigger reconciliation and missing baseline seeds are owned by the earlier
+-- migration. Keeping this timestamp as an explicit no-op preserves migration
+-- history without creating duplicate triggers or duplicate catalogue rows.
+DO $$
+BEGIN
+  RAISE NOTICE 'Duplicate auth trigger and seed migration intentionally skipped';
+END
+$$;

--- a/supabase/migrations/20291218243000_reconcile_auth_signup_trigger.sql
+++ b/supabase/migrations/20291218243000_reconcile_auth_signup_trigger.sql
@@ -1,0 +1,15 @@
+-- Ensure existing deployments finish with exactly one signup trigger bound to
+-- the latest public.handle_new_user() implementation.
+DO $$
+BEGIN
+  IF to_regprocedure('public.handle_new_user()') IS NULL THEN
+    RAISE EXCEPTION 'handle_new_user_missing_before_final_auth_trigger_reconciliation';
+  END IF;
+END
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## What changed

- makes `20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql` idempotent
- creates `on_auth_user_created` only when the base schema has not already installed it
- verifies `public.handle_new_user()` exists before trigger reconciliation
- inserts only missing achievements, equipment, venues and streaming platforms by case-insensitive name
- converts the byte-for-byte duplicate migration `20250916085517_f5f55449-6b35-4479-93e8-09fa35807472.sql` into an explicit no-op
- adds `20291218243000_reconcile_auth_signup_trigger.sql` so existing databases finish with exactly one trigger bound to the latest `handle_new_user()` implementation
- adds a source-level migration ownership and idempotency test

## Root cause

After PR #1414 repaired the premature tour-venue cost migration, fresh Finance verification reached the September 2025 schema and failed at:

```text
20250916085440_446206dd-4681-4653-9198-bcc512ebdd45.sql
ERROR: trigger "on_auth_user_created" for relation "users" already exists
```

The base migration `20250916075501_1adc3330-58fe-4fde-85d0-b13e1e788c85.sql` already creates that trigger. The immediately following migration `20250916085517_f5f55449-6b35-4479-93e8-09fa35807472.sql` was also an exact duplicate of the failing migration, including every seed insert.

## Behaviour

Fresh databases retain one signup trigger and receive each baseline catalogue row at most once by name. Existing databases receive a final forward reconciliation that rebinds the trigger to the latest function definition without rewriting player data.

## Validation

```bash
npm test -- src/lib/api/__tests__/authSignupTriggerMigrationOrder.database.test.ts
supabase db start
supabase db reset
```

The branch is based on merged PR #1414, is zero commits behind `main`, and changes only the two duplicate historical migrations, one forward trigger reconciliation migration and one regression test. It remains a draft until Finance verification reports the next fresh-database result.