### PR TITLE
Remove insecure default administrator seed

### DIFF
--- a/src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts
+++ b/src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const roleMigration = read(
+  "supabase/migrations/20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql",
+);
+const safetyMigration = read(
+  "supabase/migrations/20291218243100_neutralise_insecure_default_admin.sql",
+);
+
+describe("default administrator provisioning security", () => {
+  it("preserves the role model and normal signup role", () => {
+    expect(roleMigration).toContain("CREATE TYPE public.app_role");
+    expect(roleMigration).toContain("CREATE TABLE public.user_roles");
+    expect(roleMigration).toContain("CREATE OR REPLACE FUNCTION public.handle_new_user()");
+    expect(roleMigration).toContain("VALUES (NEW.id, 'user')");
+  });
+
+  it("does not create a known administrator credential", () => {
+    expect(roleMigration).not.toContain("INSERT INTO auth.users");
+    expect(roleMigration).not.toContain("encrypted_password");
+    expect(roleMigration).not.toContain("admin@rockmundo.com");
+    expect(roleMigration).toContain("Default admin account seed intentionally disabled");
+  });
+
+  it("neutralises only the recognisable legacy seeded account", () => {
+    expect(safetyMigration).toContain("lower(users.email) = 'admin@rockmundo.com'");
+    expect(safetyMigration).toContain("raw_user_meta_data->>'username'");
+    expect(safetyMigration).toContain("raw_user_meta_data->>'display_name'");
+    expect(safetyMigration).toContain("banned_until = 'infinity'::timestamptz");
+    expect(safetyMigration).toContain("seeded_default_admin_disabled");
+  });
+
+  it("revokes administrator authority without deleting game data", () => {
+    expect(safetyMigration).toContain("DELETE FROM public.user_roles");
+    expect(safetyMigration).toContain("role = 'admin'::public.app_role");
+    expect(safetyMigration).toContain("VALUES (v_seeded_admin_id, 'user'::public.app_role)");
+    expect(safetyMigration).not.toContain("DELETE FROM auth.users");
+    expect(safetyMigration).not.toContain("DELETE FROM public.profiles");
+  });
+});

--- a/supabase/migrations/20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql
+++ b/supabase/migrations/20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql
@@ -1,7 +1,7 @@
 -- Create enum for user roles
 CREATE TYPE public.app_role AS ENUM ('admin', 'moderator', 'user');
 
--- Create user_roles table  
+-- Create user_roles table
 CREATE TABLE public.user_roles (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
@@ -40,7 +40,7 @@ AS $$
   SELECT role
   FROM public.user_roles
   WHERE user_id = _user_id
-  ORDER BY 
+  ORDER BY
     CASE role
       WHEN 'admin' THEN 1
       WHEN 'moderator' THEN 2
@@ -65,7 +65,7 @@ ON public.user_roles
 FOR ALL
 USING (public.has_role(auth.uid(), 'admin'));
 
--- Update the handle_new_user function to assign default user role
+-- Update the handle_new_user function to assign the default user role.
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -73,111 +73,38 @@ SECURITY DEFINER
 SET search_path = 'public'
 AS $function$
 BEGIN
-  -- Create profile
   INSERT INTO public.profiles (user_id, username, display_name)
-  VALUES (NEW.id, 
-          COALESCE(NEW.raw_user_meta_data->>'username', 'Player' || substr(NEW.id::text, 1, 8)),
-          COALESCE(NEW.raw_user_meta_data->>'display_name', 'New Player'));
-  
-  -- Assign default user role
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'username', 'Player' || substr(NEW.id::text, 1, 8)),
+    COALESCE(NEW.raw_user_meta_data->>'display_name', 'New Player')
+  );
+
   INSERT INTO public.user_roles (user_id, role)
   VALUES (NEW.id, 'user');
-  
-  -- Create initial skills
+
   INSERT INTO public.player_skills (user_id)
   VALUES (NEW.id);
 
-  -- Create initial fan demographics
   INSERT INTO public.fan_demographics (user_id)
   VALUES (NEW.id);
 
-  -- Create initial activity
   INSERT INTO public.activity_feed (user_id, activity_type, message)
   VALUES (NEW.id, 'join', 'Welcome to Rockmundo! Your musical journey begins now.');
 
-  -- Grant "First Steps" achievement
   INSERT INTO public.player_achievements (user_id, achievement_id)
-  SELECT NEW.id, id FROM public.achievements WHERE name = 'First Steps';
+  SELECT NEW.id, id
+  FROM public.achievements
+  WHERE name = 'First Steps';
 
   RETURN NEW;
 END;
 $function$;
 
--- Create default admin user credentials (email: admin@rockmundo.com, password: admin123)
--- Note: This creates the auth user directly in the database
-INSERT INTO auth.users (
-  id,
-  instance_id,
-  aud,
-  role,
-  email,
-  encrypted_password,
-  email_confirmed_at,
-  confirmation_sent_at,
-  confirmation_token,
-  recovery_token,
-  email_change_token_new,
-  email_change,
-  raw_app_meta_data,
-  raw_user_meta_data,
-  is_super_admin,
-  created_at,
-  updated_at
-) VALUES (
-  gen_random_uuid(),
-  '00000000-0000-0000-0000-000000000000',
-  'authenticated',
-  'authenticated',
-  'admin@rockmundo.com',
-  crypt('admin123', gen_salt('bf')),
-  now(),
-  now(),
-  '',
-  '',
-  '',
-  '',
-  '{"provider": "email", "providers": ["email"]}',
-  '{"username": "admin", "display_name": "Admin User"}',
-  false,
-  now(),
-  now()
-) ON CONFLICT (email) DO NOTHING;
-
--- Get the admin user ID and create their profile and admin role
+-- Administrators must be provisioned through an authenticated, audited role
+-- assignment process. Never create a known credential inside a migration.
 DO $$
-DECLARE
-  admin_user_id UUID;
 BEGIN
-  -- Get the admin user ID
-  SELECT id INTO admin_user_id FROM auth.users WHERE email = 'admin@rockmundo.com';
-  
-  IF admin_user_id IS NOT NULL THEN
-    -- Create admin profile
-    INSERT INTO public.profiles (user_id, username, display_name, cash, fame, level, experience)
-    VALUES (admin_user_id, 'admin', 'Admin User', 1000000, 10000, 10, 5000)
-    ON CONFLICT (user_id) DO UPDATE SET
-      username = 'admin',
-      display_name = 'Admin User',
-      cash = 1000000,
-      fame = 10000,
-      level = 10,
-      experience = 5000;
-    
-    -- Assign admin role
-    INSERT INTO public.user_roles (user_id, role)
-    VALUES (admin_user_id, 'admin')
-    ON CONFLICT (user_id, role) DO NOTHING;
-    
-    -- Create admin skills
-    INSERT INTO public.player_skills (user_id, guitar, vocals, drums, bass, performance, songwriting)
-    VALUES (admin_user_id, 95, 95, 95, 95, 95, 95)
-    ON CONFLICT (user_id) DO UPDATE SET
-      guitar = 95, vocals = 95, drums = 95, bass = 95, performance = 95, songwriting = 95;
-    
-    -- Create admin fan demographics
-    INSERT INTO public.fan_demographics (user_id, total_fans, engagement_rate)
-    VALUES (admin_user_id, 50000, 85)
-    ON CONFLICT (user_id) DO UPDATE SET
-      total_fans = 50000, engagement_rate = 85;
-  END IF;
-END $$;
+  RAISE NOTICE 'Default admin account seed intentionally disabled';
+END
+$$;

--- a/supabase/migrations/20291218243100_neutralise_insecure_default_admin.sql
+++ b/supabase/migrations/20291218243100_neutralise_insecure_default_admin.sql
@@ -1,0 +1,39 @@
+-- Neutralise the historical default admin account without deleting its profile
+-- or cascading through game data. Any legitimate administrator must be granted
+-- access again through a secure, audited role-assignment process.
+DO $$
+DECLARE
+  v_seeded_admin_id uuid;
+BEGIN
+  SELECT users.id
+  INTO v_seeded_admin_id
+  FROM auth.users AS users
+  WHERE lower(users.email) = 'admin@rockmundo.com'
+    AND coalesce(users.raw_user_meta_data->>'username', '') = 'admin'
+    AND coalesce(users.raw_user_meta_data->>'display_name', '') = 'Admin User'
+  ORDER BY users.created_at
+  LIMIT 1;
+
+  IF v_seeded_admin_id IS NULL THEN
+    RAISE NOTICE 'No legacy seeded default admin account found';
+    RETURN;
+  END IF;
+
+  UPDATE auth.users
+  SET banned_until = 'infinity'::timestamptz,
+      raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb)
+        || jsonb_build_object('seeded_default_admin_disabled', true),
+      updated_at = now()
+  WHERE id = v_seeded_admin_id;
+
+  DELETE FROM public.user_roles
+  WHERE user_id = v_seeded_admin_id
+    AND role = 'admin'::public.app_role;
+
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (v_seeded_admin_id, 'user'::public.app_role)
+  ON CONFLICT (user_id, role) DO NOTHING;
+
+  RAISE WARNING 'Legacy seeded default admin account was banned and its admin role revoked';
+END
+$$;


### PR DESCRIPTION
## What changed

- removes automatic creation of the known `admin@rockmundo.com` administrator account from `20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql`
- preserves the `app_role` enum, `user_roles` table, role-check functions, RLS policies and normal user signup flow
- keeps new players assigned the standard `user` role
- adds `20291218243100_neutralise_insecure_default_admin.sql` for existing deployments
- identifies the legacy seeded account using its exact email and metadata fingerprint
- bans that account and revokes its `admin` role without deleting its profile or cascading through game data
- leaves secure administrator provisioning to an authenticated, audited role-assignment process
- adds a source-level security regression test

## Root cause

After PR #1416 retired the duplicate baseline seed migrations, fresh Finance verification progressed to:

```text
20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql
ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The immediate SQL failure came from `ON CONFLICT (email)` against `auth.users`, but the underlying migration was unsafe regardless: it embedded a fixed administrator email and password in source control and granted that account elevated cash, fame, skills, fans and the `admin` role.

## Existing deployments

The forward safety migration does not delete the account or profile. When it finds the unmistakable legacy seed fingerprint, it:

- sets `banned_until` to infinity
- marks the account metadata as disabled
- removes its `admin` role
- retains a standard `user` role

A legitimate administrator can then be provisioned through the secure role-management path.

## Validation

```bash
npm test -- src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts
supabase db start
supabase db reset
```

The branch is based on merged PR #1416, is zero commits behind `main`, and changes only the insecure historical role migration, one forward safety migration and one regression test. It remains a draft until Finance verification reports the next fresh-database result.