### PR TITLE
Repair duplicate role and destructive song migrations

### DIFF
--- a/src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts
+++ b/src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts
@@ -7,6 +7,9 @@ const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
 const roleMigration = read(
   "supabase/migrations/20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql",
 );
+const duplicateRoleMigration = read(
+  "supabase/migrations/20250916092648_ab238d3f-a45d-4b44-a477-803eaa1cdd54.sql",
+);
 const safetyMigration = read(
   "supabase/migrations/20291218243100_neutralise_insecure_default_admin.sql",
 );
@@ -24,6 +27,14 @@ describe("default administrator provisioning security", () => {
     expect(roleMigration).not.toContain("encrypted_password");
     expect(roleMigration).not.toContain("admin@rockmundo.com");
     expect(roleMigration).toContain("Default admin account seed intentionally disabled");
+  });
+
+  it("retires the duplicate role schema timestamp", () => {
+    expect(duplicateRoleMigration).toContain("Duplicate role schema migration intentionally skipped");
+    expect(duplicateRoleMigration).not.toContain("CREATE TYPE public.app_role");
+    expect(duplicateRoleMigration).not.toContain("CREATE TABLE public.user_roles");
+    expect(duplicateRoleMigration).not.toContain("CREATE POLICY");
+    expect(duplicateRoleMigration).not.toContain("CREATE OR REPLACE FUNCTION public.handle_new_user()");
   });
 
   it("neutralises only the recognisable legacy seeded account", () => {

--- a/src/lib/api/__tests__/songSchemaMigrationSafety.database.test.ts
+++ b/src/lib/api/__tests__/songSchemaMigrationSafety.database.test.ts
@@ -22,18 +22,18 @@ describe("song schema migration safety", () => {
     expect(baseSchema).toContain("auth.uid() = artist_id");
   });
 
-  it("extends songs without adding an incompatible user owner", () => {
+  it("extends songs without adding an incompatible song owner", () => {
     expect(compatibilityMigration).toContain("canonical_song_artist_id_missing");
     expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS lyrics");
     expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS streams");
     expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS revenue");
     expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS chart_position");
-    expect(compatibilityMigration).not.toContain("user_id UUID NOT NULL");
-    expect(compatibilityMigration).not.toContain("auth.uid() = user_id");
+    expect(compatibilityMigration).not.toContain('CREATE POLICY "Users can view their own songs"');
+    expect(compatibilityMigration).not.toContain('CREATE POLICY "Users can create their own songs"');
   });
 
   it("does not replace the base song policy or updated-at trigger", () => {
-    expect(compatibilityMigration).not.toContain('CREATE POLICY "Users can view their own songs"');
+    expect(compatibilityMigration).not.toContain('ON public.songs\n  FOR SELECT\n  USING (auth.uid() = user_id)');
     expect(compatibilityMigration).not.toContain("CREATE TRIGGER update_songs_updated_at");
     expect(compatibilityMigration).not.toContain("CREATE OR REPLACE FUNCTION public.update_songs_updated_at");
   });
@@ -44,10 +44,9 @@ describe("song schema migration safety", () => {
     expect(compatibilityMigration).not.toContain("ALTER TABLE public.player_profiles");
   });
 
-  it("retires the migration that dropped songs and dependencies", () => {
+  it("retires executable song deletion and recreation", () => {
     expect(retiredRebuild).toContain("Destructive duplicate song rebuild intentionally skipped");
     expect(retiredRebuild).not.toContain("DROP TABLE IF EXISTS public.songs");
     expect(retiredRebuild).not.toContain("CREATE TABLE public.songs");
-    expect(retiredRebuild).not.toContain("CASCADE");
   });
 });

--- a/src/lib/api/__tests__/songSchemaMigrationSafety.database.test.ts
+++ b/src/lib/api/__tests__/songSchemaMigrationSafety.database.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (file: string) => fs.readFileSync(path.resolve(file), "utf8");
+
+const baseSchema = read(
+  "supabase/migrations/20250916075501_1adc3330-58fe-4fde-85d0-b13e1e788c85.sql",
+);
+const compatibilityMigration = read(
+  "supabase/migrations/20250916114856_899eb480-3462-41e8-b937-a367711419a9.sql",
+);
+const retiredRebuild = read(
+  "supabase/migrations/20250916114927_73d634ec-2e82-4c77-8cee-e8eb53e13f4d.sql",
+);
+
+describe("song schema migration safety", () => {
+  it("keeps the base artist-owned song contract", () => {
+    expect(baseSchema).toContain("artist_id uuid NOT NULL REFERENCES auth.users(id)");
+    expect(baseSchema).toContain("Songs are viewable by everyone");
+    expect(baseSchema).toContain("Artists can manage their songs");
+    expect(baseSchema).toContain("auth.uid() = artist_id");
+  });
+
+  it("extends songs without adding an incompatible user owner", () => {
+    expect(compatibilityMigration).toContain("canonical_song_artist_id_missing");
+    expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS lyrics");
+    expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS streams");
+    expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS revenue");
+    expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS chart_position");
+    expect(compatibilityMigration).not.toContain("user_id UUID NOT NULL");
+    expect(compatibilityMigration).not.toContain("auth.uid() = user_id");
+  });
+
+  it("does not replace the base song policy or updated-at trigger", () => {
+    expect(compatibilityMigration).not.toContain('CREATE POLICY "Users can view their own songs"');
+    expect(compatibilityMigration).not.toContain("CREATE TRIGGER update_songs_updated_at");
+    expect(compatibilityMigration).not.toContain("CREATE OR REPLACE FUNCTION public.update_songs_updated_at");
+  });
+
+  it("uses the real character table for the legacy fans field", () => {
+    expect(compatibilityMigration).toContain("ALTER TABLE public.profiles");
+    expect(compatibilityMigration).toContain("ADD COLUMN IF NOT EXISTS fans");
+    expect(compatibilityMigration).not.toContain("ALTER TABLE public.player_profiles");
+  });
+
+  it("retires the migration that dropped songs and dependencies", () => {
+    expect(retiredRebuild).toContain("Destructive duplicate song rebuild intentionally skipped");
+    expect(retiredRebuild).not.toContain("DROP TABLE IF EXISTS public.songs");
+    expect(retiredRebuild).not.toContain("CREATE TABLE public.songs");
+    expect(retiredRebuild).not.toContain("CASCADE");
+  });
+});

--- a/supabase/migrations/20250916092648_ab238d3f-a45d-4b44-a477-803eaa1cdd54.sql
+++ b/supabase/migrations/20250916092648_ab238d3f-a45d-4b44-a477-803eaa1cdd54.sql
@@ -1,104 +1,11 @@
--- Create enum for user roles
-CREATE TYPE public.app_role AS ENUM ('admin', 'moderator', 'user');
-
--- Create user_roles table  
-CREATE TABLE public.user_roles (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
-    role app_role NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
-    UNIQUE (user_id, role)
-);
-
--- Enable RLS on user_roles
-ALTER TABLE public.user_roles ENABLE ROW LEVEL SECURITY;
-
--- Create security definer function to check roles (prevents RLS recursion)
-CREATE OR REPLACE FUNCTION public.has_role(_user_id UUID, _role app_role)
-RETURNS BOOLEAN
-LANGUAGE SQL
-STABLE
-SECURITY DEFINER
-SET search_path = public
-AS $$
-  SELECT EXISTS (
-    SELECT 1
-    FROM public.user_roles
-    WHERE user_id = _user_id
-      AND role = _role
-  )
-$$;
-
--- Create function to get user role
-CREATE OR REPLACE FUNCTION public.get_user_role(_user_id UUID)
-RETURNS app_role
-LANGUAGE SQL
-STABLE
-SECURITY DEFINER
-SET search_path = public
-AS $$
-  SELECT role
-  FROM public.user_roles
-  WHERE user_id = _user_id
-  ORDER BY 
-    CASE role
-      WHEN 'admin' THEN 1
-      WHEN 'moderator' THEN 2
-      WHEN 'user' THEN 3
-    END
-  LIMIT 1
-$$;
-
--- RLS policies for user_roles
-CREATE POLICY "Users can view their own roles"
-ON public.user_roles
-FOR SELECT
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Admins can view all roles"
-ON public.user_roles
-FOR SELECT
-USING (public.has_role(auth.uid(), 'admin'));
-
-CREATE POLICY "Admins can manage all roles"
-ON public.user_roles
-FOR ALL
-USING (public.has_role(auth.uid(), 'admin'));
-
--- Update the handle_new_user function to assign default user role
-CREATE OR REPLACE FUNCTION public.handle_new_user()
-RETURNS TRIGGER
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = 'public'
-AS $function$
+-- This migration duplicates the app_role enum, user_roles table, role helpers,
+-- RLS policies and handle_new_user() definition owned by
+-- 20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql.
+--
+-- Keeping this timestamp as an explicit no-op preserves migration history while
+-- preventing duplicate type, table and policy creation on fresh databases.
+DO $$
 BEGIN
-  -- Create profile
-  INSERT INTO public.profiles (user_id, username, display_name)
-  VALUES (NEW.id, 
-          COALESCE(NEW.raw_user_meta_data->>'username', 'Player' || substr(NEW.id::text, 1, 8)),
-          COALESCE(NEW.raw_user_meta_data->>'display_name', 'New Player'));
-  
-  -- Assign default user role
-  INSERT INTO public.user_roles (user_id, role)
-  VALUES (NEW.id, 'user');
-  
-  -- Create initial skills
-  INSERT INTO public.player_skills (user_id)
-  VALUES (NEW.id);
-
-  -- Create initial fan demographics
-  INSERT INTO public.fan_demographics (user_id)
-  VALUES (NEW.id);
-
-  -- Create initial activity
-  INSERT INTO public.activity_feed (user_id, activity_type, message)
-  VALUES (NEW.id, 'join', 'Welcome to Rockmundo! Your musical journey begins now.');
-
-  -- Grant "First Steps" achievement
-  INSERT INTO public.player_achievements (user_id, achievement_id)
-  SELECT NEW.id, id FROM public.achievements WHERE name = 'First Steps';
-
-  RETURN NEW;
-END;
-$function$;
+  RAISE NOTICE 'Duplicate role schema migration intentionally skipped';
+END
+$$;

--- a/supabase/migrations/20250916114856_899eb480-3462-41e8-b937-a367711419a9.sql
+++ b/supabase/migrations/20250916114856_899eb480-3462-41e8-b937-a367711419a9.sql
@@ -1,101 +1,85 @@
--- Create songs table with proper structure
-CREATE TABLE IF NOT EXISTS public.songs (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  title TEXT NOT NULL,
-  genre TEXT NOT NULL,
-  lyrics TEXT,
-  quality_score INTEGER NOT NULL DEFAULT 50,
-  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'recorded', 'released')),
-  streams INTEGER NOT NULL DEFAULT 0,
-  revenue DECIMAL(10,2) NOT NULL DEFAULT 0.00,
-  chart_position INTEGER,
-  release_date TIMESTAMP WITH TIME ZONE,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
+-- Extend the established artist-owned songs schema without replacing it.
+-- The base schema creates public.songs with artist_id ownership, public-read RLS
+-- and an updated_at trigger. Preserve those contracts and add only missing
+-- compatibility fields used by later features.
+DO $$
+BEGIN
+  IF to_regclass('public.songs') IS NULL THEN
+    RAISE EXCEPTION 'songs_missing_before_legacy_compatibility_migration';
+  END IF;
 
--- Enable RLS
-ALTER TABLE public.songs ENABLE ROW LEVEL SECURITY;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'songs'
+      AND column_name = 'artist_id'
+  ) THEN
+    RAISE EXCEPTION 'canonical_song_artist_id_missing';
+  END IF;
+END
+$$;
 
--- Create policies for songs
-CREATE POLICY "Users can view their own songs" 
-ON public.songs 
-FOR SELECT 
-USING (auth.uid() = user_id);
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS lyrics text,
+  ADD COLUMN IF NOT EXISTS quality_score integer NOT NULL DEFAULT 50,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'draft',
+  ADD COLUMN IF NOT EXISTS streams bigint NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS revenue numeric(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS chart_position integer;
 
-CREATE POLICY "Users can create their own songs" 
-ON public.songs 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
+-- Retain compatibility fields expected by the original equipment UI.
+ALTER TABLE public.player_equipment
+  ADD COLUMN IF NOT EXISTS equipped boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS condition integer NOT NULL DEFAULT 100,
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
 
-CREATE POLICY "Users can update their own songs" 
-ON public.songs 
-FOR UPDATE 
-USING (auth.uid() = user_id);
+UPDATE public.player_equipment
+SET equipped = coalesce(equipped, is_equipped, false),
+    condition = coalesce(condition, 100),
+    created_at = coalesce(created_at, purchased_at, now())
+WHERE equipped IS NULL
+   OR condition IS NULL
+   OR created_at IS NULL;
 
-CREATE POLICY "Users can delete their own songs" 
-ON public.songs 
-FOR DELETE 
-USING (auth.uid() = user_id);
+-- The main character table is public.profiles. public.player_profiles is a much
+-- later social projection and must not be referenced here.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS fans integer NOT NULL DEFAULT 0;
 
--- Fix player_equipment table structure to match what the code expects
-ALTER TABLE public.player_equipment 
-ADD COLUMN IF NOT EXISTS equipped BOOLEAN DEFAULT false,
-ADD COLUMN IF NOT EXISTS condition INTEGER DEFAULT 100;
-
--- Update existing player_equipment records to have default values
-UPDATE public.player_equipment 
-SET equipped = COALESCE(is_equipped, false), 
-    condition = 100 
-WHERE equipped IS NULL OR condition IS NULL;
-
--- Add fans column to player_profiles if it doesn't exist
-ALTER TABLE public.player_profiles 
-ADD COLUMN IF NOT EXISTS fans INTEGER DEFAULT 0;
-
--- Add gig_performances table for tracking gig history
+-- Preserve the legacy gig history table without touching the canonical gigs.
 CREATE TABLE IF NOT EXISTS public.gig_performances (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  gig_id UUID,
-  performance_score INTEGER,
-  earnings DECIMAL(10,2),
-  performed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  gig_id uuid REFERENCES public.gigs(id) ON DELETE SET NULL,
+  performance_score integer,
+  earnings numeric(12,2),
+  performed_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS for gig_performances
 ALTER TABLE public.gig_performances ENABLE ROW LEVEL SECURITY;
 
--- Create policies for gig_performances
-CREATE POLICY "Users can view their own gig performances" 
-ON public.gig_performances 
-FOR SELECT 
-USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can view their own gig performances"
+  ON public.gig_performances;
+CREATE POLICY "Users can view their own gig performances"
+  ON public.gig_performances
+  FOR SELECT
+  USING (auth.uid() = user_id);
 
-CREATE POLICY "Users can create their own gig performances" 
-ON public.gig_performances 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can create their own gig performances"
+  ON public.gig_performances;
+CREATE POLICY "Users can create their own gig performances"
+  ON public.gig_performances
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
 
--- Add missing skill columns to player_skills
-ALTER TABLE public.player_skills 
-ADD COLUMN IF NOT EXISTS creativity INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS technical INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS business INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS marketing INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS composition INTEGER DEFAULT 10;
+-- Add the legacy skill aliases without resetting any existing progression.
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer NOT NULL DEFAULT 10,
+  ADD COLUMN IF NOT EXISTS technical integer NOT NULL DEFAULT 10,
+  ADD COLUMN IF NOT EXISTS business integer NOT NULL DEFAULT 10,
+  ADD COLUMN IF NOT EXISTS marketing integer NOT NULL DEFAULT 10,
+  ADD COLUMN IF NOT EXISTS composition integer NOT NULL DEFAULT 10;
 
--- Create trigger for updating songs updated_at
-CREATE OR REPLACE FUNCTION public.update_songs_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-NEW.updated_at = now();
-RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER update_songs_updated_at
-BEFORE UPDATE ON public.songs
-FOR EACH ROW
-EXECUTE FUNCTION public.update_songs_updated_at();
+-- Song ownership policies and the updated_at trigger remain owned by the base
+-- schema. Do not create user_id policies or a second trigger here.

--- a/supabase/migrations/20250916114927_73d634ec-2e82-4c77-8cee-e8eb53e13f4d.sql
+++ b/supabase/migrations/20250916114927_73d634ec-2e82-4c77-8cee-e8eb53e13f4d.sql
@@ -1,106 +1,11 @@
--- First, check if we have existing songs table and handle it
-DROP TABLE IF EXISTS public.songs CASCADE;
-
--- Create songs table with proper structure
-CREATE TABLE public.songs (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  title TEXT NOT NULL,
-  genre TEXT NOT NULL,
-  lyrics TEXT,
-  quality_score INTEGER NOT NULL DEFAULT 50,
-  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'recorded', 'released')),
-  streams INTEGER NOT NULL DEFAULT 0,
-  revenue DECIMAL(10,2) NOT NULL DEFAULT 0.00,
-  chart_position INTEGER,
-  release_date TIMESTAMP WITH TIME ZONE,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Enable RLS
-ALTER TABLE public.songs ENABLE ROW LEVEL SECURITY;
-
--- Create policies for songs
-CREATE POLICY "Users can view their own songs" 
-ON public.songs 
-FOR SELECT 
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can create their own songs" 
-ON public.songs 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own songs" 
-ON public.songs 
-FOR UPDATE 
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can delete their own songs" 
-ON public.songs 
-FOR DELETE 
-USING (auth.uid() = user_id);
-
--- Fix player_equipment table structure
-ALTER TABLE public.player_equipment 
-ADD COLUMN IF NOT EXISTS equipped BOOLEAN DEFAULT false,
-ADD COLUMN IF NOT EXISTS condition INTEGER DEFAULT 100,
-ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE DEFAULT now();
-
--- Update existing records
-UPDATE public.player_equipment 
-SET equipped = COALESCE(is_equipped, false), 
-    condition = 100,
-    created_at = COALESCE(created_at, now())
-WHERE equipped IS NULL OR condition IS NULL OR created_at IS NULL;
-
--- Add fans column to profiles table
-ALTER TABLE public.profiles 
-ADD COLUMN IF NOT EXISTS fans INTEGER DEFAULT 0;
-
--- Add gig_performances table
-CREATE TABLE IF NOT EXISTS public.gig_performances (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  gig_id UUID,
-  performance_score INTEGER,
-  earnings DECIMAL(10,2),
-  performed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Enable RLS for gig_performances
-ALTER TABLE public.gig_performances ENABLE ROW LEVEL SECURITY;
-
--- Create policies for gig_performances
-CREATE POLICY "Users can view their own gig performances" 
-ON public.gig_performances 
-FOR SELECT 
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can create their own gig performances" 
-ON public.gig_performances 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
--- Add missing skill columns
-ALTER TABLE public.player_skills 
-ADD COLUMN IF NOT EXISTS creativity INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS technical INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS business INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS marketing INTEGER DEFAULT 10,
-ADD COLUMN IF NOT EXISTS composition INTEGER DEFAULT 10;
-
--- Create trigger for songs
-CREATE OR REPLACE FUNCTION public.update_songs_updated_at()
-RETURNS TRIGGER AS $$
+-- This migration attempted to DROP public.songs CASCADE and recreate it with an
+-- incompatible user_id ownership model. The preceding compatibility migration
+-- now adds the intended fields safely to the established artist_id schema.
+--
+-- Keeping this timestamp as an explicit no-op preserves migration history while
+-- protecting written songs, chart entries and all dependent relationships.
+DO $$
 BEGIN
-NEW.updated_at = now();
-RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER update_songs_updated_at
-BEFORE UPDATE ON public.songs
-FOR EACH ROW
-EXECUTE FUNCTION public.update_songs_updated_at();
+  RAISE NOTICE 'Destructive duplicate song rebuild intentionally skipped';
+END
+$$;


### PR DESCRIPTION
## What changed

- converts `20250916092648_ab238d3f-a45d-4b44-a477-803eaa1cdd54.sql` into an explicit no-op
- preserves role-schema ownership in `20250916092537_a7a97757-8b10-4046-b558-dd22f45d296c.sql`
- prevents duplicate creation of the `app_role` enum, `user_roles` table, RLS policies and `handle_new_user()` function
- rewrites `20250916114856_899eb480-3462-41e8-b937-a367711419a9.sql` as additive compatibility work against the established `songs.artist_id` schema
- retains existing songs, public-read and artist-management policies, chart foreign keys and the base updated-at trigger
- adds only missing song, equipment, profile, gig-history and skill compatibility fields
- converts `20250916114927_73d634ec-2e82-4c77-8cee-e8eb53e13f4d.sql` into an explicit no-op instead of dropping `public.songs CASCADE`
- adds regression coverage for role ownership and non-destructive song migrations

## Root cause

PR #1417 removed the insecure default administrator account and made the authoritative role migration apply successfully. Fresh Finance verification then exposed two consecutive migration problems.

First:

```text
20250916092648_ab238d3f-a45d-4b44-a477-803eaa1cdd54.sql
ERROR: type "app_role" already exists
```

That file was a complete duplicate of the preceding role schema.

After retiring it, Finance verification progressed to:

```text
20250916114856_899eb480-3462-41e8-b937-a367711419a9.sql
ERROR: column "user_id" does not exist
```

The base schema already creates `public.songs` with `artist_id` ownership. The legacy migration used `CREATE TABLE IF NOT EXISTS`, which skipped its incompatible table definition and then tried to create policies against the nonexistent `user_id` column. The next timestamp was even more dangerous: it dropped the established songs table with `CASCADE` and recreated a different schema.

## Behaviour

Written songs and every dependent chart or gameplay relationship remain intact. The compatibility migration now adds only missing fields and leaves ownership and update authority with the base schema.

## Validation

```bash
npm test -- src/lib/api/__tests__/defaultAdminSeedSecurity.database.test.ts src/lib/api/__tests__/songSchemaMigrationSafety.database.test.ts
supabase db start
supabase db reset
```

The branch is based on merged PR #1417, is zero commits behind `main`, and changes only three defective historical migrations plus two authority tests. It remains a draft until Finance verification reports the next fresh-database result.