### PR TITLE
Repair song collaborator split constraints

### DIFF
--- a/src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts
+++ b/src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250917104500_add_song_collaborators.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql",
+  ),
+  "utf8",
+);
+
+describe("song collaborator split constraints", () => {
+  it("moves array aggregation out of the check expression", () => {
+    expect(historicalMigration).toContain(
+      "CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid",
+    );
+    expect(historicalMigration).toContain("IMMUTABLE");
+    expect(historicalMigration).toContain(
+      "CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages))",
+    );
+    expect(historicalMigration).not.toContain(
+      "CHECK (\n        COALESCE((SELECT SUM",
+    );
+  });
+
+  it("requires aligned arrays and safe percentage values", () => {
+    expect(historicalMigration).toContain(
+      "cardinality(p_co_writers) = cardinality(p_split_percentages)",
+    );
+    expect(historicalMigration).toContain(
+      "WHERE split.value < 0 OR split.value > 100",
+    );
+    expect(historicalMigration).toContain(
+      "FROM unnest(p_split_percentages) AS split(value)",
+    );
+    expect(historicalMigration).toContain("), 0) <= 100");
+  });
+
+  it("removes both invalid legacy constraints", () => {
+    expect(historicalMigration).toContain(
+      "DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match",
+    );
+    expect(historicalMigration).toContain(
+      "DROP CONSTRAINT IF EXISTS songs_split_percentages_total",
+    );
+  });
+
+  it("repairs deployed databases without rewriting collaborator data", () => {
+    expect(forwardMigration).toContain("NOT VALID");
+    expect(forwardMigration).toContain(
+      "Existing legacy rows remain unvalidated until reviewed",
+    );
+    expect(forwardMigration).not.toContain("UPDATE public.songs");
+    expect(forwardMigration).not.toContain("DELETE FROM public.songs");
+  });
+});

--- a/supabase/migrations/20250917104500_add_song_collaborators.sql
+++ b/supabase/migrations/20250917104500_add_song_collaborators.sql
@@ -1,36 +1,38 @@
--- Add collaborator and split columns to songs
+-- Add collaborator and split columns to songs.
 ALTER TABLE public.songs
   ADD COLUMN IF NOT EXISTS co_writers text[] NOT NULL DEFAULT '{}'::text[],
   ADD COLUMN IF NOT EXISTS split_percentages numeric[] NOT NULL DEFAULT '{}'::numeric[];
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'songs_collaborator_splits_match'
-      AND conrelid = 'public.songs'::regclass
-  ) THEN
-    ALTER TABLE public.songs
-      ADD CONSTRAINT songs_collaborator_splits_match
-      CHECK (
-        COALESCE(array_length(co_writers, 1), 0) = COALESCE(array_length(split_percentages, 1), 0)
-      );
-  END IF;
-END
+-- PostgreSQL check constraints cannot contain subqueries. Keep the array
+-- inspection inside an immutable helper and let the constraint call it.
+CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid(
+  p_co_writers text[],
+  p_split_percentages numeric[]
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    cardinality(p_co_writers) = cardinality(p_split_percentages)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(p_split_percentages) AS split(value)
+      WHERE split.value < 0 OR split.value > 100
+    )
+    AND COALESCE((
+      SELECT SUM(split.value)
+      FROM unnest(p_split_percentages) AS split(value)
+    ), 0) <= 100;
 $$;
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'songs_split_percentages_total'
-      AND conrelid = 'public.songs'::regclass
-  ) THEN
-    ALTER TABLE public.songs
-      ADD CONSTRAINT songs_split_percentages_total
-      CHECK (
-        COALESCE((SELECT SUM(value) FROM unnest(split_percentages) AS value), 0) <= 100
-      );
-  END IF;
-END
-$$;
+ALTER TABLE public.songs
+  DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match,
+  DROP CONSTRAINT IF EXISTS songs_split_percentages_total,
+  DROP CONSTRAINT IF EXISTS songs_collaborator_splits_valid;
+
+ALTER TABLE public.songs
+  ADD CONSTRAINT songs_collaborator_splits_valid
+  CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages));

--- a/supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql
+++ b/supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql
@@ -1,0 +1,50 @@
+-- Repair deployed collaborator constraints without rewriting existing song data.
+CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid(
+  p_co_writers text[],
+  p_split_percentages numeric[]
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    cardinality(p_co_writers) = cardinality(p_split_percentages)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(p_split_percentages) AS split(value)
+      WHERE split.value < 0 OR split.value > 100
+    )
+    AND COALESCE((
+      SELECT SUM(split.value)
+      FROM unnest(p_split_percentages) AS split(value)
+    ), 0) <= 100;
+$$;
+
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS co_writers text[] NOT NULL DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS split_percentages numeric[] NOT NULL DEFAULT '{}'::numeric[];
+
+DO $$
+BEGIN
+  ALTER TABLE public.songs
+    DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match,
+    DROP CONSTRAINT IF EXISTS songs_split_percentages_total;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.songs'::regclass
+      AND conname = 'songs_collaborator_splits_valid'
+  ) THEN
+    ALTER TABLE public.songs
+      ADD CONSTRAINT songs_collaborator_splits_valid
+      CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages))
+      NOT VALID;
+  END IF;
+END
+$$;
+
+COMMENT ON CONSTRAINT songs_collaborator_splits_valid ON public.songs IS
+  'Collaborator names and shares must align; each share is 0-100 and the total is at most 100. Existing legacy rows remain unvalidated until reviewed.';


### PR DESCRIPTION
## What changed

- replaces the invalid subquery-based song split check with an immutable validation function
- keeps collaborator names and percentage arrays the same length
- rejects negative percentages and individual values above 100
- keeps the combined collaborator allocation at or below 100
- removes both legacy constraints before installing the authoritative rule
- adds a forward repair for databases where the historical migration already ran
- preserves existing collaboration data by installing the forward constraint as `NOT VALID`
- adds regression coverage for PostgreSQL-compatible checks and data preservation

## Root cause

PR #1421 successfully advanced fresh Finance verification beyond the consolidated label migration. The next failure was:

```text
20250917104500_add_song_collaborators.sql
ERROR: cannot use subquery in check constraint
```

The migration attempted to call `SELECT SUM(...) FROM unnest(...)` directly inside a table check constraint, which PostgreSQL does not allow.

## Safety

No song or collaboration data is rewritten or deleted. Fresh databases receive a fully validated constraint. Existing databases receive the same rule as `NOT VALID`, so all future writes are protected while legacy rows can be reviewed separately.

## Validation

```bash
npm test -- src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts
supabase db start
supabase db reset
```

This is a stacked draft based on PR #1421 and contains only three focused files. It will be retargeted to `main` after the parent PR merges.