### PR TITLE
Repair social compatibility migration

### DIFF
--- a/src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("social compatibility migration", () => {
+  it("creates legacy enums safely", () => {
+    expect(historicalMigration).toContain(
+      "CREATE TYPE public.friendship_status AS ENUM",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE TYPE public.chat_participant_status AS ENUM",
+    );
+    expect(historicalMigration.match(/WHEN duplicate_object THEN NULL/g)).toHaveLength(2);
+  });
+
+  it("extends the authoritative player skills table", () => {
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.player_skills",
+    );
+    expect(historicalMigration).toContain("ALTER TABLE public.player_skills");
+    for (const column of [
+      "creativity",
+      "technical",
+      "business",
+      "marketing",
+      "composition",
+    ]) {
+      expect(historicalMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+      expect(forwardMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+  });
+
+  it("recreates named policies and triggers idempotently", () => {
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own friendships"',
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_friendships_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_chat_participants_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_player_skills_updated_at",
+    );
+  });
+
+  it("keeps the forward repair away from obsolete friendship columns", () => {
+    expect(forwardMigration).toContain("ALTER TABLE public.player_skills");
+    expect(forwardMigration).toContain("ALTER TABLE public.profiles");
+    expect(forwardMigration).not.toContain("friend_user_id");
+    expect(forwardMigration).not.toContain("user_profile_id");
+    expect(forwardMigration).not.toContain("CREATE POLICY");
+  });
+});

--- a/supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql
+++ b/supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql
@@ -1,143 +1,140 @@
--- Create missing enums
-CREATE TYPE friendship_status AS ENUM ('pending', 'accepted', 'declined', 'blocked');
-CREATE TYPE chat_participant_status AS ENUM ('online', 'offline', 'typing', 'away');
+-- Social and progression compatibility bundle.
+-- The base schema already owns player_skills, so this migration extends it
+-- instead of relying on CREATE TABLE IF NOT EXISTS to apply missing columns.
 
--- Add missing columns to profiles table
-ALTER TABLE public.profiles 
-ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
-ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
-ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamp with time zone,
-ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
-ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+DO $$
+BEGIN
+  CREATE TYPE public.friendship_status AS ENUM (
+    'pending', 'accepted', 'declined', 'blocked'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
 
--- Create friendships table
+DO $$
+BEGIN
+  CREATE TYPE public.chat_participant_status AS ENUM (
+    'online', 'offline', 'typing', 'away'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamptz,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+
 CREATE TABLE IF NOT EXISTS public.friendships (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  friend_user_id uuid NOT NULL,
-  user_profile_id uuid,
-  friend_profile_id uuid,
-  status friendship_status NOT NULL DEFAULT 'pending',
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
-  UNIQUE(user_id, friend_user_id)
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  friend_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  friend_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  status public.friendship_status NOT NULL DEFAULT 'pending',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, friend_user_id),
+  CHECK (user_id <> friend_user_id)
 );
 
--- Enable RLS on friendships
-ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
-
--- Create RLS policies for friendships
-CREATE POLICY "Users can view their own friendships" 
-ON public.friendships 
-FOR SELECT 
-USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
-
-CREATE POLICY "Users can create friendships" 
-ON public.friendships 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their friendships" 
-ON public.friendships 
-FOR UPDATE 
-USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
-
--- Create chat_participants table
 CREATE TABLE IF NOT EXISTS public.chat_participants (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   channel text NOT NULL DEFAULT 'general',
-  status chat_participant_status NOT NULL DEFAULT 'offline',
-  last_seen timestamp with time zone DEFAULT now(),
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
+  status public.chat_participant_status NOT NULL DEFAULT 'offline',
+  last_seen timestamptz DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
   UNIQUE(user_id, channel)
 );
 
--- Enable RLS on chat_participants
-ALTER TABLE public.chat_participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
 
--- Create RLS policies for chat_participants
-CREATE POLICY "Chat participants are viewable by everyone" 
-ON public.chat_participants 
-FOR SELECT 
-USING (true);
-
-CREATE POLICY "Users can manage their own participation" 
-ON public.chat_participants 
-FOR ALL 
-USING (auth.uid() = user_id);
-
--- Create player_skills table
-CREATE TABLE IF NOT EXISTS public.player_skills (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  vocals integer DEFAULT 1,
-  guitar integer DEFAULT 1,
-  bass integer DEFAULT 1,
-  drums integer DEFAULT 1,
-  songwriting integer DEFAULT 1,
-  performance integer DEFAULT 1,
-  creativity integer DEFAULT 1,
-  technical integer DEFAULT 1,
-  business integer DEFAULT 1,
-  marketing integer DEFAULT 1,
-  composition integer DEFAULT 1,
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now()
-);
-
--- Enable RLS on player_skills
-ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
-
--- Create RLS policies for player_skills
-CREATE POLICY "Users can view all player skills" 
-ON public.player_skills 
-FOR SELECT 
-USING (true);
-
-CREATE POLICY "Users can manage their own skills" 
-ON public.player_skills 
-FOR ALL 
-USING (auth.uid() = user_id);
-
--- Create experience_ledger table
 CREATE TABLE IF NOT EXISTS public.experience_ledger (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  profile_id uuid,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
   activity_type text NOT NULL,
   xp_amount integer NOT NULL DEFAULT 0,
   skill_slug text,
   metadata jsonb DEFAULT '{}'::jsonb,
-  created_at timestamp with time zone DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS on experience_ledger
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.experience_ledger ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for experience_ledger
-CREATE POLICY "Users can view their own experience" 
-ON public.experience_ledger 
-FOR SELECT 
-USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can view their own friendships" ON public.friendships;
+CREATE POLICY "Users can view their own friendships"
+  ON public.friendships FOR SELECT
+  USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
 
-CREATE POLICY "Users can create their own experience entries" 
-ON public.experience_ledger 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can create friendships" ON public.friendships;
+CREATE POLICY "Users can create friendships"
+  ON public.friendships FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
 
--- Create triggers for updated_at columns
+DROP POLICY IF EXISTS "Users can update their friendships" ON public.friendships;
+CREATE POLICY "Users can update their friendships"
+  ON public.friendships FOR UPDATE
+  USING (auth.uid() = user_id OR auth.uid() = friend_user_id)
+  WITH CHECK (auth.uid() = user_id OR auth.uid() = friend_user_id);
+
+DROP POLICY IF EXISTS "Chat participants are viewable by everyone" ON public.chat_participants;
+CREATE POLICY "Chat participants are viewable by everyone"
+  ON public.chat_participants FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Users can manage their own participation" ON public.chat_participants;
+CREATE POLICY "Users can manage their own participation"
+  ON public.chat_participants FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can view all player skills" ON public.player_skills;
+CREATE POLICY "Users can view all player skills"
+  ON public.player_skills FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Users can manage their own skills" ON public.player_skills;
+CREATE POLICY "Users can manage their own skills"
+  ON public.player_skills FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can view their own experience" ON public.experience_ledger;
+CREATE POLICY "Users can view their own experience"
+  ON public.experience_ledger FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can create their own experience entries" ON public.experience_ledger;
+CREATE POLICY "Users can create their own experience entries"
+  ON public.experience_ledger FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_friendships_updated_at ON public.friendships;
 CREATE TRIGGER update_friendships_updated_at
   BEFORE UPDATE ON public.friendships
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_chat_participants_updated_at ON public.chat_participants;
 CREATE TRIGGER update_chat_participants_updated_at
   BEFORE UPDATE ON public.chat_participants
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
 CREATE TRIGGER update_player_skills_updated_at
   BEFORE UPDATE ON public.player_skills
   FOR EACH ROW

--- a/supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql
+++ b/supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql
@@ -1,0 +1,24 @@
+-- Restore fields silently skipped when the historical compatibility migration
+-- encountered an already-existing player_skills table. Later friendship and chat
+-- migrations own their deployed schemas, so this forward repair does not replay
+-- obsolete social policies or column names.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamptz,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
+CREATE TRIGGER update_player_skills_updated_at
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## What changed

- makes the friendship and chat presence enum creation safe on replay
- preserves the historical friendship shape required by the later October 2025 rename migration
- adds foreign keys and a self-friendship guard for fresh databases
- makes friendship, chat, skill and experience policies idempotent
- drops and recreates all three updated-at triggers safely
- stops trying to recreate the authoritative `player_skills` table
- adds the five intended skill columns with `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
- adds a conservative forward repair for deployed profile bonus and skill fields
- avoids replaying obsolete friendship policies against later profile-based schemas
- adds regression coverage for enums, skill columns, policies and triggers

## Root cause

PR #1422 successfully advanced Finance verification beyond the song collaborator migration. Fresh bootstrap then stopped at:

```text
20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql
ERROR: trigger "update_player_skills_updated_at" for relation "player_skills" already exists
```

The same migration also used `CREATE TABLE IF NOT EXISTS public.player_skills` to introduce five new skill columns. Because the base table already existed, PostgreSQL skipped the entire definition and never added those columns.

## Safety

No friendship, chat, skill or XP data is deleted. The historical friendship columns remain intact because a subsequent migration explicitly renames them. The forward repair is deliberately limited to profile and skill fields so it cannot reintroduce obsolete social policies on upgraded databases.

## Validation

```bash
npm test -- src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts
supabase db start
supabase db reset
```

This is a stacked draft based on PR #1422 and contains only three focused files. It will be retargeted after its parent PRs merge.