### PR TITLE
Repair duplicate player skills compatibility migration

### DIFF
--- a/src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("player skills compatibility migration", () => {
+  it("does not recreate the authoritative player skills table", () => {
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE public.player_skills",
+    );
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.player_skills",
+    );
+    expect(historicalMigration).toContain("ALTER TABLE public.player_skills");
+  });
+
+  it("retains all intended skill extensions", () => {
+    for (const column of [
+      "creativity",
+      "technical",
+      "business",
+      "marketing",
+      "composition",
+    ]) {
+      expect(historicalMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+      expect(forwardMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+  });
+
+  it("preserves the daily XP and education resource systems", () => {
+    expect(historicalMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.education_youtube_resources",
+    );
+    expect(historicalMigration).toContain(
+      "profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE",
+    );
+    expect(forwardMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants",
+    );
+    expect(forwardMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.education_youtube_resources",
+    );
+  });
+
+  it("recreates policies and triggers safely", () => {
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own XP grants"',
+    );
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"',
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_player_skills_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at",
+    );
+  });
+
+  it("adds current city without failing when it already exists", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS current_city_id uuid",
+    );
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS current_city_id uuid",
+    );
+  });
+});

--- a/supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql
+++ b/supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql
@@ -1,101 +1,93 @@
--- Create missing player_skills table
-CREATE TABLE public.player_skills (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  vocals INTEGER NOT NULL DEFAULT 1,
-  guitar INTEGER NOT NULL DEFAULT 1,
-  bass INTEGER NOT NULL DEFAULT 1,
-  drums INTEGER NOT NULL DEFAULT 1,
-  songwriting INTEGER NOT NULL DEFAULT 1,
-  performance INTEGER NOT NULL DEFAULT 1,
-  creativity INTEGER NOT NULL DEFAULT 1,
-  technical INTEGER NOT NULL DEFAULT 1,
-  business INTEGER NOT NULL DEFAULT 1,
-  marketing INTEGER NOT NULL DEFAULT 1,
-  composition INTEGER NOT NULL DEFAULT 1,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
+-- Additive compatibility for skills, daily XP history, education resources,
+-- and profile location. The base schema already owns public.player_skills.
 
--- Enable RLS for player_skills
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
 ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for player_skills
-CREATE POLICY "Users can view their own skills" 
-ON public.player_skills 
-FOR SELECT 
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can insert their own skills" 
-ON public.player_skills 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own skills" 
-ON public.player_skills 
-FOR UPDATE 
-USING (auth.uid() = user_id);
-
--- Create missing profile_daily_xp_grants table
-CREATE TABLE public.profile_daily_xp_grants (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  profile_id UUID NOT NULL,
-  grant_date DATE NOT NULL DEFAULT CURRENT_DATE,
-  xp_amount INTEGER NOT NULL DEFAULT 0,
-  source VARCHAR NOT NULL,
-  metadata JSONB DEFAULT '{}',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  grant_date date NOT NULL DEFAULT current_date,
+  xp_amount integer NOT NULL DEFAULT 0,
+  source varchar NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS for profile_daily_xp_grants
+CREATE INDEX IF NOT EXISTS profile_daily_xp_grants_profile_date_idx
+  ON public.profile_daily_xp_grants(profile_id, grant_date DESC);
+
 ALTER TABLE public.profile_daily_xp_grants ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for profile_daily_xp_grants
-CREATE POLICY "Users can view their own XP grants" 
-ON public.profile_daily_xp_grants 
-FOR SELECT 
-USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_daily_xp_grants.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
-CREATE POLICY "Users can insert their own XP grants" 
-ON public.profile_daily_xp_grants 
-FOR INSERT 
-WITH CHECK (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_daily_xp_grants.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
--- Create missing education_youtube_resources table
-CREATE TABLE public.education_youtube_resources (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  title VARCHAR NOT NULL,
-  description TEXT,
-  video_url VARCHAR NOT NULL,
-  category VARCHAR,
-  difficulty_level INTEGER DEFAULT 1,
-  duration_minutes INTEGER,
-  tags TEXT[],
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS public.education_youtube_resources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title varchar NOT NULL,
+  description text,
+  video_url varchar NOT NULL,
+  category varchar,
+  difficulty_level integer DEFAULT 1,
+  duration_minutes integer,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS for education_youtube_resources
 ALTER TABLE public.education_youtube_resources ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policy for education_youtube_resources (viewable by everyone)
-CREATE POLICY "YouTube resources are viewable by everyone" 
-ON public.education_youtube_resources 
-FOR SELECT 
-USING (true);
+DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources;
+CREATE POLICY "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources
+  FOR SELECT
+  USING (true);
 
--- Add missing current_city_id column to profiles table
-ALTER TABLE public.profiles 
-ADD COLUMN current_city_id UUID;
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_city_id uuid;
 
--- Create trigger for player_skills updated_at
+DROP TRIGGER IF EXISTS update_player_skills_updated_at
+  ON public.player_skills;
 CREATE TRIGGER update_player_skills_updated_at
-BEFORE UPDATE ON public.player_skills
-FOR EACH ROW
-EXECUTE FUNCTION public.update_updated_at_column();
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
 
--- Create trigger for education_youtube_resources updated_at  
+DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at
+  ON public.education_youtube_resources;
 CREATE TRIGGER update_education_youtube_resources_updated_at
-BEFORE UPDATE ON public.education_youtube_resources
-FOR EACH ROW
-EXECUTE FUNCTION public.update_updated_at_column();
+  BEFORE UPDATE ON public.education_youtube_resources
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql
+++ b/supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql
@@ -1,0 +1,68 @@
+-- Reconcile databases where the historical migration failed while recreating
+-- public.player_skills. All operations are additive and replay-safe.
+
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
+CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  grant_date date NOT NULL DEFAULT current_date,
+  xp_amount integer NOT NULL DEFAULT 0,
+  source varchar NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS profile_daily_xp_grants_profile_date_idx
+  ON public.profile_daily_xp_grants(profile_id, grant_date DESC);
+ALTER TABLE public.profile_daily_xp_grants ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users can view their own XP grants" ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = profile_daily_xp_grants.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
+DROP POLICY IF EXISTS "Users can insert their own XP grants" ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants FOR INSERT
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = profile_daily_xp_grants.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
+
+CREATE TABLE IF NOT EXISTS public.education_youtube_resources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title varchar NOT NULL,
+  description text,
+  video_url varchar NOT NULL,
+  category varchar,
+  difficulty_level integer DEFAULT 1,
+  duration_minutes integer,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.education_youtube_resources ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources;
+CREATE POLICY "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources FOR SELECT USING (true);
+
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS current_city_id uuid;
+
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
+CREATE TRIGGER update_player_skills_updated_at
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at
+  ON public.education_youtube_resources;
+CREATE TRIGGER update_education_youtube_resources_updated_at
+  BEFORE UPDATE ON public.education_youtube_resources
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## What changed

- converts `20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql` from a duplicate `player_skills` creator into additive compatibility work
- preserves the five intended skill columns through `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
- preserves the daily profile XP grant table and adds profile ownership integrity
- preserves education YouTube resources and public-read access
- makes XP/resource policies and updated-at triggers replay-safe
- adds `current_city_id` idempotently
- adds a forward reconciliation for databases where the historical migration stopped at the duplicate table
- adds regression coverage for table authority, missing systems and replay safety

## Root cause

PR #1423 successfully advanced fresh Finance verification beyond the social compatibility bundle. The next failure was:

```text
20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql
ERROR: relation "player_skills" already exists
```

The base schema already owns `public.player_skills`. Recreating it also prevented the remaining XP history, education resource and location schema from ever being applied.

## Safety

No skill, XP, profile or education data is deleted. The authoritative skills table is retained, missing columns are additive, and both otherwise-skipped tables are restored idempotently.

## Validation

```bash
npm test -- src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts
supabase db start
supabase db reset
```

This is a stacked draft based on PR #1423 and contains only three focused files. It will be retargeted after its parent PRs merge.