### PR TITLE
Repair jam and activity compatibility migration

### DIFF
--- a/src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("jam and activity compatibility migration", () => {
+  it("keeps profile activity status compatibility fields", () => {
+    expect(migration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_activity_statuses",
+    );
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS activity_type");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS completed_at");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS metadata");
+  });
+
+  it("makes activity policies and its temporary trigger replay-safe", () => {
+    expect(migration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own activity statuses"',
+    );
+    expect(migration).toContain(
+      "DROP TRIGGER IF EXISTS update_profile_activity_statuses_updated_at",
+    );
+  });
+
+  it("does not recreate or redefine the authoritative jam system", () => {
+    expect(migration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.jam_sessions",
+    );
+    expect(migration).not.toContain("CREATE POLICY \"Jam sessions");
+    expect(migration).not.toContain(
+      "CREATE TRIGGER update_jam_sessions_updated_at",
+    );
+    expect(migration).not.toContain(
+      "EXECUTE FUNCTION public.update_updated_at_column();\n\n-- The 20250916153000 bundle owns",
+    );
+  });
+
+  it("adds only the missing jam status field", () => {
+    expect(migration).toContain("ALTER TABLE public.jam_sessions");
+    expect(migration).toContain(
+      "ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active'",
+    );
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active'",
+    );
+  });
+
+  it("does not rewrite deployed jam or activity rows", () => {
+    expect(forwardMigration).not.toContain("UPDATE public.jam_sessions");
+    expect(forwardMigration).not.toContain(
+      "DELETE FROM public.profile_activity_statuses",
+    );
+    expect(forwardMigration).not.toContain("CREATE POLICY");
+    expect(forwardMigration).not.toContain("CREATE TRIGGER");
+  });
+});

--- a/supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql
+++ b/supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql
@@ -1,91 +1,97 @@
--- Create profile_activity_statuses table
+-- Activity-status compatibility before the timer-focused follow-up migration.
 CREATE TABLE IF NOT EXISTS public.profile_activity_statuses (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  activity_type character varying NOT NULL,
-  status character varying NOT NULL DEFAULT 'active',
-  started_at timestamp with time zone NOT NULL DEFAULT now(),
-  completed_at timestamp with time zone,
+  activity_type varchar NOT NULL,
+  status varchar NOT NULL DEFAULT 'active',
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
   metadata jsonb DEFAULT '{}'::jsonb,
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
   UNIQUE(profile_id)
 );
 
--- Enable RLS
+ALTER TABLE public.profile_activity_statuses
+  ADD COLUMN IF NOT EXISTS activity_type varchar,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
 ALTER TABLE public.profile_activity_statuses ENABLE ROW LEVEL SECURITY;
 
--- Create policies
+DROP POLICY IF EXISTS "Users can view their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can view their own activity statuses"
   ON public.profile_activity_statuses
   FOR SELECT
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can insert their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can insert their own activity statuses"
   ON public.profile_activity_statuses
   FOR INSERT
-  WITH CHECK (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can update their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can update their own activity statuses"
   ON public.profile_activity_statuses
   FOR UPDATE
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can delete their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can delete their own activity statuses"
   ON public.profile_activity_statuses
   FOR DELETE
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
--- Create jam_sessions table
-CREATE TABLE IF NOT EXISTS public.jam_sessions (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  host_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  name character varying NOT NULL,
-  description text,
-  genre character varying NOT NULL,
-  tempo integer NOT NULL DEFAULT 120,
-  max_participants integer NOT NULL DEFAULT 4,
-  current_participants integer NOT NULL DEFAULT 1,
-  skill_requirement integer NOT NULL DEFAULT 1,
-  is_private boolean NOT NULL DEFAULT false,
-  access_code character varying,
-  status character varying NOT NULL DEFAULT 'active',
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now()
-);
-
--- Enable RLS
-ALTER TABLE public.jam_sessions ENABLE ROW LEVEL SECURITY;
-
--- Create policies
-CREATE POLICY "Jam sessions are viewable by everyone"
-  ON public.jam_sessions
-  FOR SELECT
-  USING (true);
-
-CREATE POLICY "Users can create jam sessions"
-  ON public.jam_sessions
-  FOR INSERT
-  WITH CHECK (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Hosts can update their own jam sessions"
-  ON public.jam_sessions
-  FOR UPDATE
-  USING (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Hosts can delete their own jam sessions"
-  ON public.jam_sessions
-  FOR DELETE
-  USING (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
--- Create updated_at trigger for profile_activity_statuses
+DROP TRIGGER IF EXISTS update_profile_activity_statuses_updated_at
+  ON public.profile_activity_statuses;
 CREATE TRIGGER update_profile_activity_statuses_updated_at
   BEFORE UPDATE ON public.profile_activity_statuses
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
--- Create updated_at trigger for jam_sessions
-CREATE TRIGGER update_jam_sessions_updated_at
-  BEFORE UPDATE ON public.jam_sessions
-  FOR EACH ROW
-  EXECUTE FUNCTION public.update_updated_at_column();
+-- The 20250916153000 bundle owns the jam-session table, participant arrays,
+-- ownership policies, join function, and updated-at trigger. This migration
+-- contributes only the later compatibility status field.
+ALTER TABLE public.jam_sessions
+  ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active';

--- a/supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql
+++ b/supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql
@@ -1,0 +1,11 @@
+-- Restore compatibility columns that may have been skipped when the historical
+-- migration collided with the authoritative jam-session trigger. Later
+-- migrations own the final activity policies and timer triggers.
+
+ALTER TABLE public.profile_activity_statuses
+  ADD COLUMN IF NOT EXISTS activity_type varchar,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.jam_sessions
+  ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active';


### PR DESCRIPTION
## What changed

- keeps the profile activity-status compatibility table and its missing fields
- makes the temporary activity policies and updated-at trigger replay-safe
- stops recreating the authoritative jam-session table
- stops adding conflicting jam ownership policies
- stops replacing the established jam updated-at trigger and join behaviour
- adds only the missing jam `status` compatibility field
- adds a conservative forward repair for deployed databases
- adds regression coverage for table ownership and data preservation

## Root cause

PR #1425 successfully advanced Finance verification beyond the university class-hours migration. Fresh bootstrap then stopped at:

```text
20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql
ERROR: trigger "update_jam_sessions_updated_at" for relation "jam_sessions" already exists
```

The jam table, participant array, ownership policies, join function and updated-at trigger are already owned by the consolidated `20250916153000` migration. This later compatibility file attempted to redefine them using a different host identity model.

## Safety

No jam session or activity-status data is deleted. The authoritative auth-user jam ownership model remains intact. The compatibility file contributes only its genuinely new `status` field, while the next timer migration remains responsible for final activity policies and timing triggers.

## Validation

```bash
npm test -- src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts
supabase db start
supabase db reset
```

This is a stacked draft based on PR #1425 and contains only three focused files. It will be retargeted after its parent PRs merge.