### PR TITLE
Land validated migration compatibility repairs on main

### DIFF
--- a/src/lib/api/__tests__/activityStatusSongCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/activityStatusSongCompatibilityMigration.database.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251006052802_4b82ad0e-e2a8-49b5-a82f-9cca1bc0d525.sql",
+  ),
+  "utf8",
+);
+
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243510_reconcile_activity_status_song_link.sql",
+  ),
+  "utf8",
+);
+
+describe("activity status song compatibility migration", () => {
+  it("adds song_id before creating its index", () => {
+    const addColumnPosition = historicalMigration.indexOf(
+      "ADD COLUMN IF NOT EXISTS song_id uuid REFERENCES public.songs(id)",
+    );
+    const indexPosition = historicalMigration.indexOf(
+      "CREATE INDEX IF NOT EXISTS profile_activity_statuses_song_id_idx",
+    );
+
+    expect(addColumnPosition).toBeGreaterThan(-1);
+    expect(indexPosition).toBeGreaterThan(addColumnPosition);
+  });
+
+  it("restores timer fields when a smaller compatibility table already exists", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS duration_minutes integer",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS ends_at timestamptz",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS metadata jsonb",
+    );
+    expect(historicalMigration).toContain(
+      "profile_activity_statuses_duration_check",
+    );
+  });
+
+  it("reconciles deployed databases without rewriting activity rows", () => {
+    expect(reconciliationMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS song_id uuid REFERENCES public.songs(id)",
+    );
+    expect(reconciliationMigration).toContain(
+      "CREATE INDEX IF NOT EXISTS profile_activity_statuses_song_id_idx",
+    );
+    expect(reconciliationMigration).toContain("NOT VALID");
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("jam and activity compatibility migration", () => {
+  it("keeps profile activity status compatibility fields", () => {
+    expect(migration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_activity_statuses",
+    );
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS activity_type");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS completed_at");
+    expect(migration).toContain("ADD COLUMN IF NOT EXISTS metadata");
+  });
+
+  it("makes activity policies and its temporary trigger replay-safe", () => {
+    expect(migration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own activity statuses"',
+    );
+    expect(migration).toContain(
+      "DROP TRIGGER IF EXISTS update_profile_activity_statuses_updated_at",
+    );
+  });
+
+  it("does not recreate or redefine the authoritative jam system", () => {
+    expect(migration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.jam_sessions",
+    );
+    expect(migration).not.toContain("CREATE POLICY \"Jam sessions");
+    expect(migration).not.toContain(
+      "CREATE TRIGGER update_jam_sessions_updated_at",
+    );
+    expect(migration).not.toContain(
+      "EXECUTE FUNCTION public.update_updated_at_column();\n\n-- The 20250916153000 bundle owns",
+    );
+  });
+
+  it("adds only the missing jam status field", () => {
+    expect(migration).toContain("ALTER TABLE public.jam_sessions");
+    expect(migration).toContain(
+      "ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active'",
+    );
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active'",
+    );
+  });
+
+  it("does not rewrite deployed jam or activity rows", () => {
+    expect(forwardMigration).not.toContain("UPDATE public.jam_sessions");
+    expect(forwardMigration).not.toContain(
+      "DELETE FROM public.profile_activity_statuses",
+    );
+    expect(forwardMigration).not.toContain("CREATE POLICY");
+    expect(forwardMigration).not.toContain("CREATE TRIGGER");
+  });
+});

--- a/src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("player skills compatibility migration", () => {
+  it("does not recreate the authoritative player skills table", () => {
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE public.player_skills",
+    );
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.player_skills",
+    );
+    expect(historicalMigration).toContain("ALTER TABLE public.player_skills");
+  });
+
+  it("retains all intended skill extensions", () => {
+    for (const column of [
+      "creativity",
+      "technical",
+      "business",
+      "marketing",
+      "composition",
+    ]) {
+      expect(historicalMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+      expect(forwardMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+  });
+
+  it("preserves the daily XP and education resource systems", () => {
+    expect(historicalMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.education_youtube_resources",
+    );
+    expect(historicalMigration).toContain(
+      "profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE",
+    );
+    expect(forwardMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants",
+    );
+    expect(forwardMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.education_youtube_resources",
+    );
+  });
+
+  it("recreates policies and triggers safely", () => {
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own XP grants"',
+    );
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"',
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_player_skills_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at",
+    );
+  });
+
+  it("adds current city without failing when it already exists", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS current_city_id uuid",
+    );
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS current_city_id uuid",
+    );
+  });
+});

--- a/src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql",
+  ),
+  "utf8",
+);
+
+describe("social compatibility migration", () => {
+  it("creates legacy enums safely", () => {
+    expect(historicalMigration).toContain(
+      "CREATE TYPE public.friendship_status AS ENUM",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE TYPE public.chat_participant_status AS ENUM",
+    );
+    expect(historicalMigration.match(/WHEN duplicate_object THEN NULL/g)).toHaveLength(2);
+  });
+
+  it("extends the authoritative player skills table", () => {
+    expect(historicalMigration).not.toContain(
+      "CREATE TABLE IF NOT EXISTS public.player_skills",
+    );
+    expect(historicalMigration).toContain("ALTER TABLE public.player_skills");
+    for (const column of [
+      "creativity",
+      "technical",
+      "business",
+      "marketing",
+      "composition",
+    ]) {
+      expect(historicalMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+      expect(forwardMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+  });
+
+  it("recreates named policies and triggers idempotently", () => {
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Users can view their own friendships"',
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_friendships_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_chat_participants_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_player_skills_updated_at",
+    );
+  });
+
+  it("keeps the forward repair away from obsolete friendship columns", () => {
+    expect(forwardMigration).toContain("ALTER TABLE public.player_skills");
+    expect(forwardMigration).toContain("ALTER TABLE public.profiles");
+    expect(forwardMigration).not.toContain("friend_user_id");
+    expect(forwardMigration).not.toContain("user_profile_id");
+    expect(forwardMigration).not.toContain("CREATE POLICY");
+  });
+});

--- a/src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts
+++ b/src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250917104500_add_song_collaborators.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql",
+  ),
+  "utf8",
+);
+
+describe("song collaborator split constraints", () => {
+  it("moves array aggregation out of the check expression", () => {
+    expect(historicalMigration).toContain(
+      "CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid",
+    );
+    expect(historicalMigration).toContain("IMMUTABLE");
+    expect(historicalMigration).toContain(
+      "CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages))",
+    );
+    expect(historicalMigration).not.toContain(
+      "CHECK (\n        COALESCE((SELECT SUM",
+    );
+  });
+
+  it("requires aligned arrays and safe percentage values", () => {
+    expect(historicalMigration).toContain(
+      "cardinality(p_co_writers) = cardinality(p_split_percentages)",
+    );
+    expect(historicalMigration).toContain(
+      "WHERE split.value < 0 OR split.value > 100",
+    );
+    expect(historicalMigration).toContain(
+      "FROM unnest(p_split_percentages) AS split(value)",
+    );
+    expect(historicalMigration).toContain("), 0) <= 100");
+  });
+
+  it("removes both invalid legacy constraints", () => {
+    expect(historicalMigration).toContain(
+      "DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match",
+    );
+    expect(historicalMigration).toContain(
+      "DROP CONSTRAINT IF EXISTS songs_split_percentages_total",
+    );
+  });
+
+  it("repairs deployed databases without rewriting collaborator data", () => {
+    expect(forwardMigration).toContain("NOT VALID");
+    expect(forwardMigration).toContain(
+      "Existing legacy rows remain unvalidated until reviewed",
+    );
+    expect(forwardMigration).not.toContain("UPDATE public.songs");
+    expect(forwardMigration).not.toContain("DELETE FROM public.songs");
+  });
+});

--- a/src/lib/api/__tests__/universityClassHoursMigration.database.test.ts
+++ b/src/lib/api/__tests__/universityClassHoursMigration.database.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const prematureMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251001120000_add_class_hours_to_university_courses.sql",
+  ),
+  "utf8",
+);
+const universityMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251007090213_b9318898-e8af-43af-8eb9-f208cb95542b.sql",
+  ),
+  "utf8",
+);
+const forwardMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243450_reconcile_university_class_hours.sql",
+  ),
+  "utf8",
+);
+
+describe("university class hour migration ordering", () => {
+  it("does not alter university courses before the table exists", () => {
+    expect(prematureMigration).toContain("Historical ordering marker");
+    expect(prematureMigration).not.toContain(
+      "alter table public.university_courses",
+    );
+  });
+
+  it("creates class hours with the course table", () => {
+    expect(universityMigration).toContain(
+      "CREATE TABLE IF NOT EXISTS public.university_courses",
+    );
+    expect(universityMigration).toContain(
+      "class_start_hour INTEGER NOT NULL DEFAULT 10",
+    );
+    expect(universityMigration).toContain(
+      "class_end_hour INTEGER NOT NULL DEFAULT 14",
+    );
+    expect(universityMigration).toContain(
+      "CONSTRAINT university_courses_class_hours_check CHECK",
+    );
+  });
+
+  it("guards enrollment schema and named objects for replay", () => {
+    expect(universityMigration).toContain(
+      "CREATE TYPE public.enrollment_status AS ENUM",
+    );
+    expect(universityMigration).toContain("WHEN duplicate_object THEN NULL");
+    expect(universityMigration).toContain(
+      'DROP POLICY IF EXISTS "Courses are viewable by everyone"',
+    );
+    expect(universityMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_university_courses_updated_at",
+    );
+  });
+
+  it("restores existing databases without rewriting courses", () => {
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS class_start_hour",
+    );
+    expect(forwardMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS class_end_hour",
+    );
+    expect(forwardMigration).toContain("NOT VALID");
+    expect(forwardMigration).not.toContain("UPDATE public.university_courses");
+    expect(forwardMigration).not.toContain("DELETE FROM public.university_courses");
+  });
+});

--- a/supabase/migrations/20250917104500_add_song_collaborators.sql
+++ b/supabase/migrations/20250917104500_add_song_collaborators.sql
@@ -1,36 +1,38 @@
--- Add collaborator and split columns to songs
+-- Add collaborator and split columns to songs.
 ALTER TABLE public.songs
   ADD COLUMN IF NOT EXISTS co_writers text[] NOT NULL DEFAULT '{}'::text[],
   ADD COLUMN IF NOT EXISTS split_percentages numeric[] NOT NULL DEFAULT '{}'::numeric[];
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'songs_collaborator_splits_match'
-      AND conrelid = 'public.songs'::regclass
-  ) THEN
-    ALTER TABLE public.songs
-      ADD CONSTRAINT songs_collaborator_splits_match
-      CHECK (
-        COALESCE(array_length(co_writers, 1), 0) = COALESCE(array_length(split_percentages, 1), 0)
-      );
-  END IF;
-END
+-- PostgreSQL check constraints cannot contain subqueries. Keep the array
+-- inspection inside an immutable helper and let the constraint call it.
+CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid(
+  p_co_writers text[],
+  p_split_percentages numeric[]
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    cardinality(p_co_writers) = cardinality(p_split_percentages)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(p_split_percentages) AS split(value)
+      WHERE split.value < 0 OR split.value > 100
+    )
+    AND COALESCE((
+      SELECT SUM(split.value)
+      FROM unnest(p_split_percentages) AS split(value)
+    ), 0) <= 100;
 $$;
 
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'songs_split_percentages_total'
-      AND conrelid = 'public.songs'::regclass
-  ) THEN
-    ALTER TABLE public.songs
-      ADD CONSTRAINT songs_split_percentages_total
-      CHECK (
-        COALESCE((SELECT SUM(value) FROM unnest(split_percentages) AS value), 0) <= 100
-      );
-  END IF;
-END
-$$;
+ALTER TABLE public.songs
+  DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match,
+  DROP CONSTRAINT IF EXISTS songs_split_percentages_total,
+  DROP CONSTRAINT IF EXISTS songs_collaborator_splits_valid;
+
+ALTER TABLE public.songs
+  ADD CONSTRAINT songs_collaborator_splits_valid
+  CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages));

--- a/supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql
+++ b/supabase/migrations/20250920135913_6eb1b596-a672-4450-a6b9-557068e5b641.sql
@@ -1,143 +1,140 @@
--- Create missing enums
-CREATE TYPE friendship_status AS ENUM ('pending', 'accepted', 'declined', 'blocked');
-CREATE TYPE chat_participant_status AS ENUM ('online', 'offline', 'typing', 'away');
+-- Social and progression compatibility bundle.
+-- The base schema already owns player_skills, so this migration extends it
+-- instead of relying on CREATE TABLE IF NOT EXISTS to apply missing columns.
 
--- Add missing columns to profiles table
-ALTER TABLE public.profiles 
-ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
-ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
-ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamp with time zone,
-ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
-ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+DO $$
+BEGIN
+  CREATE TYPE public.friendship_status AS ENUM (
+    'pending', 'accepted', 'declined', 'blocked'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
 
--- Create friendships table
+DO $$
+BEGIN
+  CREATE TYPE public.chat_participant_status AS ENUM (
+    'online', 'offline', 'typing', 'away'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamptz,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+
 CREATE TABLE IF NOT EXISTS public.friendships (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  friend_user_id uuid NOT NULL,
-  user_profile_id uuid,
-  friend_profile_id uuid,
-  status friendship_status NOT NULL DEFAULT 'pending',
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
-  UNIQUE(user_id, friend_user_id)
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  friend_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  friend_profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  status public.friendship_status NOT NULL DEFAULT 'pending',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(user_id, friend_user_id),
+  CHECK (user_id <> friend_user_id)
 );
 
--- Enable RLS on friendships
-ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
-
--- Create RLS policies for friendships
-CREATE POLICY "Users can view their own friendships" 
-ON public.friendships 
-FOR SELECT 
-USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
-
-CREATE POLICY "Users can create friendships" 
-ON public.friendships 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their friendships" 
-ON public.friendships 
-FOR UPDATE 
-USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
-
--- Create chat_participants table
 CREATE TABLE IF NOT EXISTS public.chat_participants (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   channel text NOT NULL DEFAULT 'general',
-  status chat_participant_status NOT NULL DEFAULT 'offline',
-  last_seen timestamp with time zone DEFAULT now(),
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
+  status public.chat_participant_status NOT NULL DEFAULT 'offline',
+  last_seen timestamptz DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
   UNIQUE(user_id, channel)
 );
 
--- Enable RLS on chat_participants
-ALTER TABLE public.chat_participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
 
--- Create RLS policies for chat_participants
-CREATE POLICY "Chat participants are viewable by everyone" 
-ON public.chat_participants 
-FOR SELECT 
-USING (true);
-
-CREATE POLICY "Users can manage their own participation" 
-ON public.chat_participants 
-FOR ALL 
-USING (auth.uid() = user_id);
-
--- Create player_skills table
-CREATE TABLE IF NOT EXISTS public.player_skills (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  vocals integer DEFAULT 1,
-  guitar integer DEFAULT 1,
-  bass integer DEFAULT 1,
-  drums integer DEFAULT 1,
-  songwriting integer DEFAULT 1,
-  performance integer DEFAULT 1,
-  creativity integer DEFAULT 1,
-  technical integer DEFAULT 1,
-  business integer DEFAULT 1,
-  marketing integer DEFAULT 1,
-  composition integer DEFAULT 1,
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now()
-);
-
--- Enable RLS on player_skills
-ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
-
--- Create RLS policies for player_skills
-CREATE POLICY "Users can view all player skills" 
-ON public.player_skills 
-FOR SELECT 
-USING (true);
-
-CREATE POLICY "Users can manage their own skills" 
-ON public.player_skills 
-FOR ALL 
-USING (auth.uid() = user_id);
-
--- Create experience_ledger table
 CREATE TABLE IF NOT EXISTS public.experience_ledger (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id uuid NOT NULL,
-  profile_id uuid,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  profile_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
   activity_type text NOT NULL,
   xp_amount integer NOT NULL DEFAULT 0,
   skill_slug text,
   metadata jsonb DEFAULT '{}'::jsonb,
-  created_at timestamp with time zone DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS on experience_ledger
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.experience_ledger ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for experience_ledger
-CREATE POLICY "Users can view their own experience" 
-ON public.experience_ledger 
-FOR SELECT 
-USING (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can view their own friendships" ON public.friendships;
+CREATE POLICY "Users can view their own friendships"
+  ON public.friendships FOR SELECT
+  USING (auth.uid() = user_id OR auth.uid() = friend_user_id);
 
-CREATE POLICY "Users can create their own experience entries" 
-ON public.experience_ledger 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
+DROP POLICY IF EXISTS "Users can create friendships" ON public.friendships;
+CREATE POLICY "Users can create friendships"
+  ON public.friendships FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
 
--- Create triggers for updated_at columns
+DROP POLICY IF EXISTS "Users can update their friendships" ON public.friendships;
+CREATE POLICY "Users can update their friendships"
+  ON public.friendships FOR UPDATE
+  USING (auth.uid() = user_id OR auth.uid() = friend_user_id)
+  WITH CHECK (auth.uid() = user_id OR auth.uid() = friend_user_id);
+
+DROP POLICY IF EXISTS "Chat participants are viewable by everyone" ON public.chat_participants;
+CREATE POLICY "Chat participants are viewable by everyone"
+  ON public.chat_participants FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Users can manage their own participation" ON public.chat_participants;
+CREATE POLICY "Users can manage their own participation"
+  ON public.chat_participants FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can view all player skills" ON public.player_skills;
+CREATE POLICY "Users can view all player skills"
+  ON public.player_skills FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Users can manage their own skills" ON public.player_skills;
+CREATE POLICY "Users can manage their own skills"
+  ON public.player_skills FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can view their own experience" ON public.experience_ledger;
+CREATE POLICY "Users can view their own experience"
+  ON public.experience_ledger FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can create their own experience entries" ON public.experience_ledger;
+CREATE POLICY "Users can create their own experience entries"
+  ON public.experience_ledger FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP TRIGGER IF EXISTS update_friendships_updated_at ON public.friendships;
 CREATE TRIGGER update_friendships_updated_at
   BEFORE UPDATE ON public.friendships
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_chat_participants_updated_at ON public.chat_participants;
 CREATE TRIGGER update_chat_participants_updated_at
   BEFORE UPDATE ON public.chat_participants
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
 CREATE TRIGGER update_player_skills_updated_at
   BEFORE UPDATE ON public.player_skills
   FOR EACH ROW

--- a/supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql
+++ b/supabase/migrations/20250926075937_ead404e2-8dc0-425d-a244-06f4099f9a4c.sql
@@ -1,101 +1,93 @@
--- Create missing player_skills table
-CREATE TABLE public.player_skills (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  user_id UUID NOT NULL,
-  vocals INTEGER NOT NULL DEFAULT 1,
-  guitar INTEGER NOT NULL DEFAULT 1,
-  bass INTEGER NOT NULL DEFAULT 1,
-  drums INTEGER NOT NULL DEFAULT 1,
-  songwriting INTEGER NOT NULL DEFAULT 1,
-  performance INTEGER NOT NULL DEFAULT 1,
-  creativity INTEGER NOT NULL DEFAULT 1,
-  technical INTEGER NOT NULL DEFAULT 1,
-  business INTEGER NOT NULL DEFAULT 1,
-  marketing INTEGER NOT NULL DEFAULT 1,
-  composition INTEGER NOT NULL DEFAULT 1,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
+-- Additive compatibility for skills, daily XP history, education resources,
+-- and profile location. The base schema already owns public.player_skills.
 
--- Enable RLS for player_skills
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
 ALTER TABLE public.player_skills ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for player_skills
-CREATE POLICY "Users can view their own skills" 
-ON public.player_skills 
-FOR SELECT 
-USING (auth.uid() = user_id);
-
-CREATE POLICY "Users can insert their own skills" 
-ON public.player_skills 
-FOR INSERT 
-WITH CHECK (auth.uid() = user_id);
-
-CREATE POLICY "Users can update their own skills" 
-ON public.player_skills 
-FOR UPDATE 
-USING (auth.uid() = user_id);
-
--- Create missing profile_daily_xp_grants table
-CREATE TABLE public.profile_daily_xp_grants (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  profile_id UUID NOT NULL,
-  grant_date DATE NOT NULL DEFAULT CURRENT_DATE,
-  xp_amount INTEGER NOT NULL DEFAULT 0,
-  source VARCHAR NOT NULL,
-  metadata JSONB DEFAULT '{}',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  grant_date date NOT NULL DEFAULT current_date,
+  xp_amount integer NOT NULL DEFAULT 0,
+  source varchar NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS for profile_daily_xp_grants
+CREATE INDEX IF NOT EXISTS profile_daily_xp_grants_profile_date_idx
+  ON public.profile_daily_xp_grants(profile_id, grant_date DESC);
+
 ALTER TABLE public.profile_daily_xp_grants ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policies for profile_daily_xp_grants
-CREATE POLICY "Users can view their own XP grants" 
-ON public.profile_daily_xp_grants 
-FOR SELECT 
-USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_daily_xp_grants.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
-CREATE POLICY "Users can insert their own XP grants" 
-ON public.profile_daily_xp_grants 
-FOR INSERT 
-WITH CHECK (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_daily_xp_grants.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
--- Create missing education_youtube_resources table
-CREATE TABLE public.education_youtube_resources (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  title VARCHAR NOT NULL,
-  description TEXT,
-  video_url VARCHAR NOT NULL,
-  category VARCHAR,
-  difficulty_level INTEGER DEFAULT 1,
-  duration_minutes INTEGER,
-  tags TEXT[],
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS public.education_youtube_resources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title varchar NOT NULL,
+  description text,
+  video_url varchar NOT NULL,
+  category varchar,
+  difficulty_level integer DEFAULT 1,
+  duration_minutes integer,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Enable RLS for education_youtube_resources
 ALTER TABLE public.education_youtube_resources ENABLE ROW LEVEL SECURITY;
 
--- Create RLS policy for education_youtube_resources (viewable by everyone)
-CREATE POLICY "YouTube resources are viewable by everyone" 
-ON public.education_youtube_resources 
-FOR SELECT 
-USING (true);
+DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources;
+CREATE POLICY "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources
+  FOR SELECT
+  USING (true);
 
--- Add missing current_city_id column to profiles table
-ALTER TABLE public.profiles 
-ADD COLUMN current_city_id UUID;
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_city_id uuid;
 
--- Create trigger for player_skills updated_at
+DROP TRIGGER IF EXISTS update_player_skills_updated_at
+  ON public.player_skills;
 CREATE TRIGGER update_player_skills_updated_at
-BEFORE UPDATE ON public.player_skills
-FOR EACH ROW
-EXECUTE FUNCTION public.update_updated_at_column();
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
 
--- Create trigger for education_youtube_resources updated_at  
+DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at
+  ON public.education_youtube_resources;
 CREATE TRIGGER update_education_youtube_resources_updated_at
-BEFORE UPDATE ON public.education_youtube_resources
-FOR EACH ROW
-EXECUTE FUNCTION public.update_updated_at_column();
+  BEFORE UPDATE ON public.education_youtube_resources
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20251001120000_add_class_hours_to_university_courses.sql
+++ b/supabase/migrations/20251001120000_add_class_hours_to_university_courses.sql
@@ -1,26 +1,5 @@
--- Adds configurable class hours for university courses
-alter table public.university_courses
-  add column if not exists class_start_hour integer not null default 10;
-
-alter table public.university_courses
-  add column if not exists class_end_hour integer not null default 14;
-
-do $$
-begin
-  if not exists (
-    select 1
-    from pg_constraint
-    where conname = 'university_courses_class_hours_check'
-      and conrelid = 'public.university_courses'::regclass
-  ) then
-    alter table public.university_courses
-      add constraint university_courses_class_hours_check
-      check (
-        class_start_hour >= 0
-        and class_start_hour < 24
-        and class_end_hour > class_start_hour
-        and class_end_hour <= 24
-      );
-  end if;
-end
-$$;
+-- Historical ordering marker.
+-- public.university_courses is created by the later 20251007090213 migration.
+-- Class-hour columns and their constraint are now owned by that table-creation
+-- migration and a forward reconciliation for existing databases.
+SELECT 1;

--- a/supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql
+++ b/supabase/migrations/20251005110929_18de365f-86e9-4c43-8e45-c58505b495ea.sql
@@ -1,91 +1,97 @@
--- Create profile_activity_statuses table
+-- Activity-status compatibility before the timer-focused follow-up migration.
 CREATE TABLE IF NOT EXISTS public.profile_activity_statuses (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  activity_type character varying NOT NULL,
-  status character varying NOT NULL DEFAULT 'active',
-  started_at timestamp with time zone NOT NULL DEFAULT now(),
-  completed_at timestamp with time zone,
+  activity_type varchar NOT NULL,
+  status varchar NOT NULL DEFAULT 'active',
+  started_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
   metadata jsonb DEFAULT '{}'::jsonb,
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
   UNIQUE(profile_id)
 );
 
--- Enable RLS
+ALTER TABLE public.profile_activity_statuses
+  ADD COLUMN IF NOT EXISTS activity_type varchar,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
 ALTER TABLE public.profile_activity_statuses ENABLE ROW LEVEL SECURITY;
 
--- Create policies
+DROP POLICY IF EXISTS "Users can view their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can view their own activity statuses"
   ON public.profile_activity_statuses
   FOR SELECT
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can insert their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can insert their own activity statuses"
   ON public.profile_activity_statuses
   FOR INSERT
-  WITH CHECK (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can update their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can update their own activity statuses"
   ON public.profile_activity_statuses
   FOR UPDATE
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
+DROP POLICY IF EXISTS "Users can delete their own activity statuses"
+  ON public.profile_activity_statuses;
 CREATE POLICY "Users can delete their own activity statuses"
   ON public.profile_activity_statuses
   FOR DELETE
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles
+      WHERE profiles.id = profile_activity_statuses.profile_id
+        AND profiles.user_id = auth.uid()
+    )
+  );
 
--- Create jam_sessions table
-CREATE TABLE IF NOT EXISTS public.jam_sessions (
-  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  host_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-  name character varying NOT NULL,
-  description text,
-  genre character varying NOT NULL,
-  tempo integer NOT NULL DEFAULT 120,
-  max_participants integer NOT NULL DEFAULT 4,
-  current_participants integer NOT NULL DEFAULT 1,
-  skill_requirement integer NOT NULL DEFAULT 1,
-  is_private boolean NOT NULL DEFAULT false,
-  access_code character varying,
-  status character varying NOT NULL DEFAULT 'active',
-  created_at timestamp with time zone DEFAULT now(),
-  updated_at timestamp with time zone DEFAULT now()
-);
-
--- Enable RLS
-ALTER TABLE public.jam_sessions ENABLE ROW LEVEL SECURITY;
-
--- Create policies
-CREATE POLICY "Jam sessions are viewable by everyone"
-  ON public.jam_sessions
-  FOR SELECT
-  USING (true);
-
-CREATE POLICY "Users can create jam sessions"
-  ON public.jam_sessions
-  FOR INSERT
-  WITH CHECK (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Hosts can update their own jam sessions"
-  ON public.jam_sessions
-  FOR UPDATE
-  USING (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Hosts can delete their own jam sessions"
-  ON public.jam_sessions
-  FOR DELETE
-  USING (host_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
--- Create updated_at trigger for profile_activity_statuses
+DROP TRIGGER IF EXISTS update_profile_activity_statuses_updated_at
+  ON public.profile_activity_statuses;
 CREATE TRIGGER update_profile_activity_statuses_updated_at
   BEFORE UPDATE ON public.profile_activity_statuses
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
 
--- Create updated_at trigger for jam_sessions
-CREATE TRIGGER update_jam_sessions_updated_at
-  BEFORE UPDATE ON public.jam_sessions
-  FOR EACH ROW
-  EXECUTE FUNCTION public.update_updated_at_column();
+-- The 20250916153000 bundle owns the jam-session table, participant arrays,
+-- ownership policies, join function, and updated-at trigger. This migration
+-- contributes only the later compatibility status field.
+ALTER TABLE public.jam_sessions
+  ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active';

--- a/supabase/migrations/20251006052802_4b82ad0e-e2a8-49b5-a82f-9cca1bc0d525.sql
+++ b/supabase/migrations/20251006052802_4b82ad0e-e2a8-49b5-a82f-9cca1bc0d525.sql
@@ -17,10 +17,29 @@ CREATE TABLE IF NOT EXISTS public.profile_activity_statuses (
     CHECK (duration_minutes IS NULL OR duration_minutes >= 0)
 );
 
+-- A preceding compatibility migration may already have created the table with a
+-- smaller shape. Add every timer-specific field explicitly before indexes,
+-- constraints and triggers reference it.
 ALTER TABLE public.profile_activity_statuses
   ADD COLUMN IF NOT EXISTS duration_minutes integer,
   ADD COLUMN IF NOT EXISTS ends_at timestamptz,
+  ADD COLUMN IF NOT EXISTS song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
   ADD COLUMN IF NOT EXISTS metadata jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profile_activity_statuses_duration_check'
+      AND conrelid = 'public.profile_activity_statuses'::regclass
+  ) THEN
+    ALTER TABLE public.profile_activity_statuses
+      ADD CONSTRAINT profile_activity_statuses_duration_check
+      CHECK (duration_minutes IS NULL OR duration_minutes >= 0);
+  END IF;
+END
+$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS profile_activity_statuses_profile_id_key
   ON public.profile_activity_statuses (profile_id);
@@ -120,7 +139,7 @@ END
 $$;
 
 -- Keep the existing jam-session compatibility column idempotent. The table is
--- created by 20250916153000_create_jam_sessions_table.sql.
+-- created by the consolidated 20250916153000 migration.
 ALTER TABLE public.jam_sessions
   ADD COLUMN IF NOT EXISTS participant_ids uuid[] DEFAULT '{}';
 

--- a/supabase/migrations/20251007090213_b9318898-e8af-43af-8eb9-f208cb95542b.sql
+++ b/supabase/migrations/20251007090213_b9318898-e8af-43af-8eb9-f208cb95542b.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS public.universities (
   UNIQUE(name, city)
 );
 
--- Create university_courses table
+-- Create university_courses table with its class schedule fields.
 CREATE TABLE IF NOT EXISTS public.university_courses (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   university_id UUID REFERENCES public.universities(id) ON DELETE CASCADE NOT NULL,
@@ -26,14 +26,28 @@ CREATE TABLE IF NOT EXISTS public.university_courses (
   xp_per_day_max INTEGER DEFAULT 3 CHECK (xp_per_day_max >= xp_per_day_min),
   max_enrollments INTEGER,
   is_active BOOLEAN DEFAULT true,
+  class_start_hour INTEGER NOT NULL DEFAULT 10,
+  class_end_hour INTEGER NOT NULL DEFAULT 14,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  CONSTRAINT university_courses_class_hours_check CHECK (
+    class_start_hour >= 0
+    AND class_start_hour < 24
+    AND class_end_hour > class_start_hour
+    AND class_end_hour <= 24
+  )
 );
 
--- Create enrollment status enum
-CREATE TYPE enrollment_status AS ENUM ('enrolled', 'in_progress', 'completed', 'dropped');
+DO $$
+BEGIN
+  CREATE TYPE public.enrollment_status AS ENUM (
+    'enrolled', 'in_progress', 'completed', 'dropped'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
 
--- Create player_university_enrollments table
 CREATE TABLE IF NOT EXISTS public.player_university_enrollments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL,
@@ -43,7 +57,7 @@ CREATE TABLE IF NOT EXISTS public.player_university_enrollments (
   enrolled_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
   scheduled_end_date TIMESTAMP WITH TIME ZONE NOT NULL,
   actual_completion_date TIMESTAMP WITH TIME ZONE,
-  status enrollment_status DEFAULT 'enrolled',
+  status public.enrollment_status DEFAULT 'enrolled',
   total_xp_earned INTEGER DEFAULT 0,
   days_attended INTEGER DEFAULT 0,
   payment_amount INTEGER NOT NULL,
@@ -51,7 +65,6 @@ CREATE TABLE IF NOT EXISTS public.player_university_enrollments (
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
 
--- Create player_university_attendance table
 CREATE TABLE IF NOT EXISTS public.player_university_attendance (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   enrollment_id UUID REFERENCES public.player_university_enrollments(id) ON DELETE CASCADE NOT NULL,
@@ -62,66 +75,81 @@ CREATE TABLE IF NOT EXISTS public.player_university_attendance (
   UNIQUE(enrollment_id, attendance_date)
 );
 
--- Enable RLS on all tables
 ALTER TABLE public.universities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.university_courses ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.player_university_enrollments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.player_university_attendance ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies for universities
+DROP POLICY IF EXISTS "Universities are viewable by everyone" ON public.universities;
 CREATE POLICY "Universities are viewable by everyone"
-  ON public.universities FOR SELECT
-  USING (true);
+  ON public.universities FOR SELECT USING (true);
 
--- RLS Policies for university_courses
+DROP POLICY IF EXISTS "Courses are viewable by everyone" ON public.university_courses;
 CREATE POLICY "Courses are viewable by everyone"
-  ON public.university_courses FOR SELECT
-  USING (true);
+  ON public.university_courses FOR SELECT USING (true);
 
--- RLS Policies for player_university_enrollments
+DROP POLICY IF EXISTS "Users can view their own enrollments" ON public.player_university_enrollments;
 CREATE POLICY "Users can view their own enrollments"
   ON public.player_university_enrollments FOR SELECT
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Users can create their own enrollments"
-  ON public.player_university_enrollments FOR INSERT
-  WITH CHECK (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
-CREATE POLICY "Users can update their own enrollments"
-  ON public.player_university_enrollments FOR UPDATE
-  USING (profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid()));
-
--- RLS Policies for player_university_attendance
-CREATE POLICY "Users can view their own attendance"
-  ON public.player_university_attendance FOR SELECT
-  USING (enrollment_id IN (
-    SELECT id FROM player_university_enrollments 
-    WHERE profile_id IN (SELECT id FROM profiles WHERE user_id = auth.uid())
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = player_university_enrollments.profile_id
+      AND profiles.user_id = auth.uid()
   ));
 
--- Create triggers for updated_at
-CREATE OR REPLACE FUNCTION public.update_updated_at_column()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+DROP POLICY IF EXISTS "Users can create their own enrollments" ON public.player_university_enrollments;
+CREATE POLICY "Users can create their own enrollments"
+  ON public.player_university_enrollments FOR INSERT
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = player_university_enrollments.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
 
+DROP POLICY IF EXISTS "Users can update their own enrollments" ON public.player_university_enrollments;
+CREATE POLICY "Users can update their own enrollments"
+  ON public.player_university_enrollments FOR UPDATE
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = player_university_enrollments.profile_id
+      AND profiles.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = player_university_enrollments.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
+
+DROP POLICY IF EXISTS "Users can view their own attendance" ON public.player_university_attendance;
+CREATE POLICY "Users can view their own attendance"
+  ON public.player_university_attendance FOR SELECT
+  USING (EXISTS (
+    SELECT 1
+    FROM public.player_university_enrollments enrollment
+    JOIN public.profiles profile ON profile.id = enrollment.profile_id
+    WHERE enrollment.id = player_university_attendance.enrollment_id
+      AND profile.user_id = auth.uid()
+  ));
+
+DROP TRIGGER IF EXISTS update_universities_updated_at ON public.universities;
 CREATE TRIGGER update_universities_updated_at
   BEFORE UPDATE ON public.universities
   FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_university_courses_updated_at ON public.university_courses;
 CREATE TRIGGER update_university_courses_updated_at
   BEFORE UPDATE ON public.university_courses
   FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_player_university_enrollments_updated_at
+  ON public.player_university_enrollments;
 CREATE TRIGGER update_player_university_enrollments_updated_at
   BEFORE UPDATE ON public.player_university_enrollments
   FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
--- Seed initial universities data
-INSERT INTO public.universities (name, city, prestige, quality_of_learning, course_cost_modifier, description)
+INSERT INTO public.universities (
+  name, city, prestige, quality_of_learning, course_cost_modifier, description
+)
 VALUES
   ('Rockmundo Conservatory', 'London', 92, 95, 1.5, 'Premier music institution with world-class faculty and state-of-the-art facilities.'),
   ('Skyline School of Sound', 'New York', 88, 90, 1.3, 'Cutting-edge music production and performance academy in the heart of NYC.'),
@@ -129,8 +157,7 @@ VALUES
   ('Sunset Boulevard Music Academy', 'Los Angeles', 84, 87, 1.2, 'Industry-connected school with direct pathways to the entertainment business.'),
   ('Pulsewave Technology College', 'Toronto', 79, 85, 0.9, 'Modern approach to music technology and digital production.')
 ON CONFLICT (name, city) DO UPDATE
-SET 
-  prestige = EXCLUDED.prestige,
-  quality_of_learning = EXCLUDED.quality_of_learning,
-  course_cost_modifier = EXCLUDED.course_cost_modifier,
-  description = EXCLUDED.description;
+SET prestige = EXCLUDED.prestige,
+    quality_of_learning = EXCLUDED.quality_of_learning,
+    course_cost_modifier = EXCLUDED.course_cost_modifier,
+    description = EXCLUDED.description;

--- a/supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql
+++ b/supabase/migrations/20291218243420_repair_song_collaborator_constraints.sql
@@ -1,0 +1,50 @@
+-- Repair deployed collaborator constraints without rewriting existing song data.
+CREATE OR REPLACE FUNCTION public.song_collaborator_splits_valid(
+  p_co_writers text[],
+  p_split_percentages numeric[]
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = pg_catalog
+AS $$
+  SELECT
+    cardinality(p_co_writers) = cardinality(p_split_percentages)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM unnest(p_split_percentages) AS split(value)
+      WHERE split.value < 0 OR split.value > 100
+    )
+    AND COALESCE((
+      SELECT SUM(split.value)
+      FROM unnest(p_split_percentages) AS split(value)
+    ), 0) <= 100;
+$$;
+
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS co_writers text[] NOT NULL DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS split_percentages numeric[] NOT NULL DEFAULT '{}'::numeric[];
+
+DO $$
+BEGIN
+  ALTER TABLE public.songs
+    DROP CONSTRAINT IF EXISTS songs_collaborator_splits_match,
+    DROP CONSTRAINT IF EXISTS songs_split_percentages_total;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.songs'::regclass
+      AND conname = 'songs_collaborator_splits_valid'
+  ) THEN
+    ALTER TABLE public.songs
+      ADD CONSTRAINT songs_collaborator_splits_valid
+      CHECK (public.song_collaborator_splits_valid(co_writers, split_percentages))
+      NOT VALID;
+  END IF;
+END
+$$;
+
+COMMENT ON CONSTRAINT songs_collaborator_splits_valid ON public.songs IS
+  'Collaborator names and shares must align; each share is 0-100 and the total is at most 100. Existing legacy rows remain unvalidated until reviewed.';

--- a/supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql
+++ b/supabase/migrations/20291218243430_reconcile_social_skill_compatibility.sql
@@ -1,0 +1,24 @@
+-- Restore fields silently skipped when the historical compatibility migration
+-- encountered an already-existing player_skills table. Later friendship and chat
+-- migrations own their deployed schemas, so this forward repair does not replay
+-- obsolete social policies or column names.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS equipment_loadout jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS experience_at_last_weekly_bonus integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_weekly_bonus_at timestamptz,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_streak integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS weekly_bonus_metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
+CREATE TRIGGER update_player_skills_updated_at
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql
+++ b/supabase/migrations/20291218243440_reconcile_player_skills_compatibility.sql
@@ -1,0 +1,68 @@
+-- Reconcile databases where the historical migration failed while recreating
+-- public.player_skills. All operations are additive and replay-safe.
+
+ALTER TABLE public.player_skills
+  ADD COLUMN IF NOT EXISTS creativity integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS technical integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS business integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS marketing integer DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS composition integer DEFAULT 1;
+
+CREATE TABLE IF NOT EXISTS public.profile_daily_xp_grants (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  grant_date date NOT NULL DEFAULT current_date,
+  xp_amount integer NOT NULL DEFAULT 0,
+  source varchar NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS profile_daily_xp_grants_profile_date_idx
+  ON public.profile_daily_xp_grants(profile_id, grant_date DESC);
+ALTER TABLE public.profile_daily_xp_grants ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users can view their own XP grants" ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can view their own XP grants"
+  ON public.profile_daily_xp_grants FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = profile_daily_xp_grants.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
+DROP POLICY IF EXISTS "Users can insert their own XP grants" ON public.profile_daily_xp_grants;
+CREATE POLICY "Users can insert their own XP grants"
+  ON public.profile_daily_xp_grants FOR INSERT
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE profiles.id = profile_daily_xp_grants.profile_id
+      AND profiles.user_id = auth.uid()
+  ));
+
+CREATE TABLE IF NOT EXISTS public.education_youtube_resources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title varchar NOT NULL,
+  description text,
+  video_url varchar NOT NULL,
+  category varchar,
+  difficulty_level integer DEFAULT 1,
+  duration_minutes integer,
+  tags text[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.education_youtube_resources ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources;
+CREATE POLICY "YouTube resources are viewable by everyone"
+  ON public.education_youtube_resources FOR SELECT USING (true);
+
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS current_city_id uuid;
+
+DROP TRIGGER IF EXISTS update_player_skills_updated_at ON public.player_skills;
+CREATE TRIGGER update_player_skills_updated_at
+  BEFORE UPDATE ON public.player_skills
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+DROP TRIGGER IF EXISTS update_education_youtube_resources_updated_at
+  ON public.education_youtube_resources;
+CREATE TRIGGER update_education_youtube_resources_updated_at
+  BEFORE UPDATE ON public.education_youtube_resources
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/migrations/20291218243450_reconcile_university_class_hours.sql
+++ b/supabase/migrations/20291218243450_reconcile_university_class_hours.sql
@@ -1,0 +1,22 @@
+-- Restore class-hour fields for databases where the premature migration was
+-- recorded or skipped before public.university_courses existed.
+
+ALTER TABLE public.university_courses
+  ADD COLUMN IF NOT EXISTS class_start_hour integer NOT NULL DEFAULT 10,
+  ADD COLUMN IF NOT EXISTS class_end_hour integer NOT NULL DEFAULT 14;
+
+ALTER TABLE public.university_courses
+  DROP CONSTRAINT IF EXISTS university_courses_class_hours_check;
+
+ALTER TABLE public.university_courses
+  ADD CONSTRAINT university_courses_class_hours_check
+  CHECK (
+    class_start_hour >= 0
+    AND class_start_hour < 24
+    AND class_end_hour > class_start_hour
+    AND class_end_hour <= 24
+  ) NOT VALID;
+
+COMMENT ON CONSTRAINT university_courses_class_hours_check
+  ON public.university_courses IS
+  'Course class hours must be a valid same-day interval. Existing rows remain unvalidated until reviewed.';

--- a/supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql
+++ b/supabase/migrations/20291218243500_reconcile_jam_activity_compatibility.sql
@@ -1,0 +1,11 @@
+-- Restore compatibility columns that may have been skipped when the historical
+-- migration collided with the authoritative jam-session trigger. Later
+-- migrations own the final activity policies and timer triggers.
+
+ALTER TABLE public.profile_activity_statuses
+  ADD COLUMN IF NOT EXISTS activity_type varchar,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS metadata jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.jam_sessions
+  ADD COLUMN IF NOT EXISTS status varchar NOT NULL DEFAULT 'active';

--- a/supabase/migrations/20291218243510_reconcile_activity_status_song_link.sql
+++ b/supabase/migrations/20291218243510_reconcile_activity_status_song_link.sql
@@ -1,0 +1,29 @@
+-- Reconcile activity-status timer fields for databases where the historical
+-- compatibility migration was already recorded before song_id was added.
+
+ALTER TABLE public.profile_activity_statuses
+  ADD COLUMN IF NOT EXISTS duration_minutes integer,
+  ADD COLUMN IF NOT EXISTS ends_at timestamptz,
+  ADD COLUMN IF NOT EXISTS song_id uuid REFERENCES public.songs(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS metadata jsonb;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profile_activity_statuses_duration_check'
+      AND conrelid = 'public.profile_activity_statuses'::regclass
+  ) THEN
+    ALTER TABLE public.profile_activity_statuses
+      ADD CONSTRAINT profile_activity_statuses_duration_check
+      CHECK (duration_minutes IS NULL OR duration_minutes >= 0)
+      NOT VALID;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS profile_activity_statuses_song_id_idx
+  ON public.profile_activity_statuses (song_id);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

This PR flattens the validated migration repairs from stacked PRs #1422–#1426 directly onto `main`, then adds the next activity-status compatibility fix exposed by Finance verification.

It includes:

- PostgreSQL-safe song collaborator split validation
- replay-safe social, friendship, chat and skill compatibility migrations
- additive player-skills, daily XP and education resource compatibility
- corrected university class-hours migration ordering
- preservation of the authoritative jam-session schema and join behaviour
- explicit activity-status `song_id` addition before its index is created
- forward reconciliation migrations for already-deployed databases
- source authority tests for every repair

## Why this PR is needed

PR #1421 merged into `main`, but PRs #1422–#1426 were stacked against feature branches and were subsequently merged into those parent branches rather than the default branch. GitHub therefore marked them merged, but their 16-file cumulative delta was still absent from `main`.

This PR applies that exact cumulative delta to `main` in one reviewable change set.

## Latest Finance verification finding

The full stacked migration sequence passed the jam compatibility repair and then stopped at:

```text
20251006052802_4b82ad0e-e2a8-49b5-a82f-9cca1bc0d525.sql
ERROR: column "song_id" does not exist
CREATE INDEX ... ON public.profile_activity_statuses (song_id)
```

A preceding compatibility migration had already created a smaller `profile_activity_statuses` table, causing `CREATE TABLE IF NOT EXISTS` to skip the definition containing `song_id`. The migration now adds `song_id` explicitly before creating the index and also restores the timer fields and duration constraint.

## Safety

No player, song, friendship, skill, university, jam-session or activity data is deleted. All forward constraints that could encounter legacy data are installed as `NOT VALID`, protecting future writes without rejecting existing rows.

## Validation

```bash
npm test -- \
  src/lib/api/__tests__/songCollaboratorConstraint.database.test.ts \
  src/lib/api/__tests__/socialCompatibilityMigration.database.test.ts \
  src/lib/api/__tests__/playerSkillsCompatibilityMigration.database.test.ts \
  src/lib/api/__tests__/universityClassHoursMigration.database.test.ts \
  src/lib/api/__tests__/jamActivityCompatibilityMigration.database.test.ts \
  src/lib/api/__tests__/activityStatusSongCompatibilityMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in 19 focused files. It remains draft until Finance verification reports the next fresh-database boundary.