### PR TITLE
Repair band invitation and song profile compatibility

### DIFF
--- a/src/lib/api/__tests__/bandInvitationCompatibilityMigration.database.test.ts
+++ b/src/lib/api/__tests__/bandInvitationCompatibilityMigration.database.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251007130559_cab5223d-b43a-423b-9fb7-e102b362f61c.sql",
+  ),
+  "utf8",
+);
+
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243520_reconcile_band_invitation_schema.sql",
+  ),
+  "utf8",
+);
+
+describe("band invitation compatibility migration", () => {
+  it("extends the authoritative table instead of recreating it", () => {
+    expect(historicalMigration).not.toMatch(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?public\.band_invitations/i,
+    );
+    expect(historicalMigration).toContain(
+      "ALTER TABLE public.band_invitations",
+    );
+  });
+
+  it("adds and backfills every field used by the current invitation RPC", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS inviter_user_id",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS invited_user_id",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS instrument_role",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS vocal_role",
+    );
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS message",
+    );
+    expect(historicalMigration).toContain(
+      "inviter_user_id = COALESCE(inviter_user_id, inviter_id)",
+    );
+    expect(historicalMigration).toContain(
+      "invited_user_id = COALESCE(invited_user_id, invitee_id)",
+    );
+    expect(historicalMigration).toContain(
+      "NULLIF(btrim(role), '')",
+    );
+  });
+
+  it("protects pending invitations and removes the public read policy", () => {
+    expect(historicalMigration).toContain(
+      "band_invitations_one_pending_per_user_band_idx",
+    );
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Band invitations are viewable by everyone"',
+    );
+    expect(historicalMigration).not.toContain(
+      'CREATE POLICY "Band invitations are viewable by everyone"',
+    );
+    expect(historicalMigration).toContain(
+      'CREATE POLICY "Band members can view their band invitations"',
+    );
+  });
+
+  it("reconciles deployed databases without deleting invitation data", () => {
+    expect(reconciliationMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS invited_user_id",
+    );
+    expect(reconciliationMigration).toContain(
+      "UPDATE public.band_invitations",
+    );
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/src/lib/api/__tests__/songProfileOwnershipMigration.database.test.ts
+++ b/src/lib/api/__tests__/songProfileOwnershipMigration.database.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251016124606_f8655f2e-9c9a-48f2-8593-827a076acc13.sql",
+  ),
+  "utf8",
+);
+
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243530_reconcile_song_profile_ownership.sql",
+  ),
+  "utf8",
+);
+
+describe("song profile ownership migration", () => {
+  it("maps canonical song ownership through artist_id", () => {
+    expect(historicalMigration).toContain(
+      "WHERE s.artist_id = p.user_id",
+    );
+    expect(historicalMigration).not.toContain("s.user_id");
+    expect(historicalMigration).not.toContain("songs.user_id");
+  });
+
+  it("adds the profile reference without replacing artist ownership", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES public.profiles(id)",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_songs_profile_id",
+    );
+    expect(historicalMigration).not.toMatch(/DROP\s+COLUMN\s+artist_id/i);
+  });
+
+  it("keeps band-song visibility tied to actual membership", () => {
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Band members can view band songs"',
+    );
+    expect(historicalMigration).toContain(
+      "bm.band_id = songs.band_id",
+    );
+    expect(historicalMigration).toContain(
+      "bm.user_id = auth.uid()",
+    );
+  });
+
+  it("reconciles deployed rows without deleting songs", () => {
+    expect(reconciliationMigration).toContain(
+      "WHERE s.artist_id = p.user_id",
+    );
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251007130559_cab5223d-b43a-423b-9fb7-e102b362f61c.sql
+++ b/supabase/migrations/20251007130559_cab5223d-b43a-423b-9fb7-e102b362f61c.sql
@@ -1,60 +1,152 @@
--- Create band invitations table
-CREATE TABLE public.band_invitations (
-  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
-  band_id UUID NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
-  inviter_user_id UUID NOT NULL,
-  invited_user_id UUID NOT NULL,
-  instrument_role VARCHAR NOT NULL DEFAULT 'Guitar',
-  vocal_role VARCHAR,
-  message TEXT,
-  status VARCHAR NOT NULL DEFAULT 'pending',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  responded_at TIMESTAMP WITH TIME ZONE,
-  CONSTRAINT unique_active_invitation UNIQUE (band_id, invited_user_id, status)
-);
+-- Bridge the original band invitation table to the canonical invitation model.
+-- The table is created by 20250916160000_create_band_invitations_table.sql;
+-- this migration adds the richer role/message fields used by the current RPCs.
 
--- Enable RLS
+ALTER TABLE public.band_invitations
+  ADD COLUMN IF NOT EXISTS inviter_user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS invited_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS instrument_role varchar,
+  ADD COLUMN IF NOT EXISTS vocal_role varchar,
+  ADD COLUMN IF NOT EXISTS message text;
+
+UPDATE public.band_invitations
+SET
+  inviter_user_id = COALESCE(inviter_user_id, inviter_id),
+  invited_user_id = COALESCE(invited_user_id, invitee_id),
+  instrument_role = COALESCE(NULLIF(btrim(instrument_role), ''), NULLIF(btrim(role), ''), 'Guitar')
+WHERE inviter_user_id IS NULL
+   OR invited_user_id IS NULL
+   OR instrument_role IS NULL
+   OR btrim(instrument_role) = '';
+
+ALTER TABLE public.band_invitations
+  ALTER COLUMN instrument_role SET DEFAULT 'Guitar',
+  ALTER COLUMN instrument_role SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.band_invitations WHERE inviter_user_id IS NULL
+  ) THEN
+    ALTER TABLE public.band_invitations
+      ALTER COLUMN inviter_user_id SET NOT NULL;
+  END IF;
+
+  -- Legacy open invitations could have no explicit invitee. Preserve those rows,
+  -- but make the canonical column required once no such rows remain.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.band_invitations WHERE invited_user_id IS NULL
+  ) THEN
+    ALTER TABLE public.band_invitations
+      ALTER COLUMN invited_user_id SET NOT NULL;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS band_invitations_invited_user_idx
+  ON public.band_invitations (invited_user_id);
+
+CREATE INDEX IF NOT EXISTS band_invitations_inviter_created_idx
+  ON public.band_invitations (inviter_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS band_invitations_band_status_idx
+  ON public.band_invitations (band_id, status);
+
+CREATE UNIQUE INDEX IF NOT EXISTS band_invitations_one_pending_per_user_band_idx
+  ON public.band_invitations (band_id, invited_user_id)
+  WHERE status = 'pending' AND invited_user_id IS NOT NULL;
+
 ALTER TABLE public.band_invitations ENABLE ROW LEVEL SECURITY;
 
--- Policy: Band members can view invitations for their band
+-- Retire the original public-read and legacy-column policies.
+DROP POLICY IF EXISTS "Band invitations are viewable by everyone"
+  ON public.band_invitations;
+DROP POLICY IF EXISTS "Band leaders can create invitations"
+  ON public.band_invitations;
+DROP POLICY IF EXISTS "Band leaders can update invitations"
+  ON public.band_invitations;
+DROP POLICY IF EXISTS "Band leaders can delete invitations"
+  ON public.band_invitations;
+DROP POLICY IF EXISTS "Invitees can accept invitations"
+  ON public.band_invitations;
+
+DROP POLICY IF EXISTS "Band members can view their band invitations"
+  ON public.band_invitations;
 CREATE POLICY "Band members can view their band invitations"
-ON public.band_invitations
-FOR SELECT
-USING (
-  band_id IN (
-    SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
-  )
-  OR invited_user_id = auth.uid()
-);
+  ON public.band_invitations
+  FOR SELECT
+  USING (
+    invited_user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_invitations.band_id
+        AND bm.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
 
--- Policy: Band leaders can create invitations
 CREATE POLICY "Band leaders can create invitations"
-ON public.band_invitations
-FOR INSERT
-WITH CHECK (
-  band_id IN (
-    SELECT id FROM public.bands WHERE leader_id = auth.uid()
-  )
-  AND inviter_user_id = auth.uid()
-);
+  ON public.band_invitations
+  FOR INSERT
+  WITH CHECK (
+    inviter_user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
 
--- Policy: Invited users can update their own invitations (accept/reject)
+DROP POLICY IF EXISTS "Invited users can respond to invitations"
+  ON public.band_invitations;
 CREATE POLICY "Invited users can respond to invitations"
-ON public.band_invitations
-FOR UPDATE
-USING (invited_user_id = auth.uid());
+  ON public.band_invitations
+  FOR UPDATE
+  USING (invited_user_id = auth.uid())
+  WITH CHECK (invited_user_id = auth.uid());
 
--- Policy: Band leaders can cancel pending invitations
-CREATE POLICY "Band leaders can cancel invitations"
-ON public.band_invitations
-FOR DELETE
-USING (
-  band_id IN (
-    SELECT id FROM public.bands WHERE leader_id = auth.uid()
+DROP POLICY IF EXISTS "Band leaders can update invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band leaders can update invitations"
+  ON public.band_invitations
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
   )
-  AND status = 'pending'
-);
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
 
--- Add index for performance
-CREATE INDEX idx_band_invitations_invited_user ON public.band_invitations(invited_user_id);
-CREATE INDEX idx_band_invitations_band_status ON public.band_invitations(band_id, status);
+DROP POLICY IF EXISTS "Band leaders can cancel invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band leaders can cancel invitations"
+  ON public.band_invitations
+  FOR DELETE
+  USING (
+    status = 'pending'
+    AND EXISTS (
+      SELECT 1
+      FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20251016124606_f8655f2e-9c9a-48f2-8593-827a076acc13.sql
+++ b/supabase/migrations/20251016124606_f8655f2e-9c9a-48f2-8593-827a076acc13.sql
@@ -1,48 +1,54 @@
--- Add missing columns to songs table
-ALTER TABLE songs 
-ADD COLUMN IF NOT EXISTS rating_revealed_at timestamp with time zone,
-ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES profiles(id);
+-- Add profile-oriented compatibility fields to songs without changing the
+-- authoritative auth-user ownership stored in songs.artist_id.
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS rating_revealed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES public.profiles(id);
 
--- Add missing column to profiles table  
-ALTER TABLE profiles
-ADD COLUMN IF NOT EXISTS current_activity text;
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_activity text;
 
--- Create index on songs profile_id for better query performance
-CREATE INDEX IF NOT EXISTS idx_songs_profile_id ON songs(profile_id);
+CREATE INDEX IF NOT EXISTS idx_songs_profile_id
+  ON public.songs (profile_id);
 
--- Update existing songs to link to profiles via user_id
-UPDATE songs s
+-- artist_id is the established auth.users owner. Resolve the corresponding
+-- character profile through profiles.user_id; songs.user_id never existed in
+-- the authoritative schema.
+UPDATE public.songs s
 SET profile_id = p.id
-FROM profiles p
-WHERE s.user_id = p.user_id
-AND s.profile_id IS NULL;
+FROM public.profiles p
+WHERE s.artist_id = p.user_id
+  AND s.profile_id IS NULL;
 
--- Drop policy if exists and recreate
-DROP POLICY IF EXISTS "Band members can view band songs" ON songs;
-
+DROP POLICY IF EXISTS "Band members can view band songs"
+  ON public.songs;
 CREATE POLICY "Band members can view band songs"
-ON songs FOR SELECT
-USING (
-  band_id IN (
-    SELECT band_id FROM band_members WHERE user_id = auth.uid()
-  )
-);
+  ON public.songs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = songs.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
 
--- Create a view for bands to see their gifted songs
-CREATE OR REPLACE VIEW band_gift_notifications AS
-SELECT 
+CREATE OR REPLACE VIEW public.band_gift_notifications AS
+SELECT
   asg.id,
   asg.created_at,
   asg.gift_message,
   asg.gifted_to_band_id,
-  b.name as band_name,
-  s.id as song_id,
-  s.title as song_title,
+  b.name AS band_name,
+  s.id AS song_id,
+  s.title AS song_title,
   s.genre,
   s.song_rating,
   s.quality_score,
-  FALSE as viewed
-FROM admin_song_gifts asg
-JOIN songs s ON s.id = asg.song_id
-JOIN bands b ON b.id = asg.gifted_to_band_id
+  FALSE AS viewed
+FROM public.admin_song_gifts asg
+JOIN public.songs s ON s.id = asg.song_id
+JOIN public.bands b ON b.id = asg.gifted_to_band_id
 WHERE asg.gifted_to_band_id IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243520_reconcile_band_invitation_schema.sql
+++ b/supabase/migrations/20291218243520_reconcile_band_invitation_schema.sql
@@ -1,0 +1,132 @@
+-- Reconcile the canonical band invitation columns for databases where the
+-- historical October compatibility migration was already recorded.
+
+ALTER TABLE public.band_invitations
+  ADD COLUMN IF NOT EXISTS inviter_user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS invited_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS instrument_role varchar,
+  ADD COLUMN IF NOT EXISTS vocal_role varchar,
+  ADD COLUMN IF NOT EXISTS message text;
+
+UPDATE public.band_invitations
+SET
+  inviter_user_id = COALESCE(inviter_user_id, inviter_id),
+  invited_user_id = COALESCE(invited_user_id, invitee_id),
+  instrument_role = COALESCE(NULLIF(btrim(instrument_role), ''), NULLIF(btrim(role), ''), 'Guitar')
+WHERE inviter_user_id IS NULL
+   OR invited_user_id IS NULL
+   OR instrument_role IS NULL
+   OR btrim(instrument_role) = '';
+
+ALTER TABLE public.band_invitations
+  ALTER COLUMN instrument_role SET DEFAULT 'Guitar',
+  ALTER COLUMN instrument_role SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.band_invitations WHERE inviter_user_id IS NULL
+  ) THEN
+    ALTER TABLE public.band_invitations
+      ALTER COLUMN inviter_user_id SET NOT NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.band_invitations WHERE invited_user_id IS NULL
+  ) THEN
+    ALTER TABLE public.band_invitations
+      ALTER COLUMN invited_user_id SET NOT NULL;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS band_invitations_invited_user_idx
+  ON public.band_invitations (invited_user_id);
+CREATE INDEX IF NOT EXISTS band_invitations_inviter_created_idx
+  ON public.band_invitations (inviter_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS band_invitations_band_status_idx
+  ON public.band_invitations (band_id, status);
+CREATE UNIQUE INDEX IF NOT EXISTS band_invitations_one_pending_per_user_band_idx
+  ON public.band_invitations (band_id, invited_user_id)
+  WHERE status = 'pending' AND invited_user_id IS NOT NULL;
+
+ALTER TABLE public.band_invitations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Band invitations are viewable by everyone"
+  ON public.band_invitations;
+DROP POLICY IF EXISTS "Band members can view their band invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band members can view their band invitations"
+  ON public.band_invitations
+  FOR SELECT
+  USING (
+    invited_user_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_invitations.band_id
+        AND bm.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band leaders can create invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band leaders can create invitations"
+  ON public.band_invitations
+  FOR INSERT
+  WITH CHECK (
+    inviter_user_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Invited users can respond to invitations"
+  ON public.band_invitations;
+CREATE POLICY "Invited users can respond to invitations"
+  ON public.band_invitations
+  FOR UPDATE
+  USING (invited_user_id = auth.uid())
+  WITH CHECK (invited_user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Band leaders can update invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band leaders can update invitations"
+  ON public.band_invitations
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band leaders can cancel invitations"
+  ON public.band_invitations;
+CREATE POLICY "Band leaders can cancel invitations"
+  ON public.band_invitations
+  FOR DELETE
+  USING (
+    status = 'pending'
+    AND EXISTS (
+      SELECT 1 FROM public.bands b
+      WHERE b.id = band_invitations.band_id
+        AND b.leader_id = auth.uid()
+    )
+  );
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243530_reconcile_song_profile_ownership.sql
+++ b/supabase/migrations/20291218243530_reconcile_song_profile_ownership.sql
@@ -1,0 +1,20 @@
+-- Reconcile the profile-facing song owner reference from the authoritative
+-- auth-user owner stored in songs.artist_id.
+
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS rating_revealed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS profile_id uuid REFERENCES public.profiles(id);
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS current_activity text;
+
+UPDATE public.songs s
+SET profile_id = p.id
+FROM public.profiles p
+WHERE s.artist_id = p.user_id
+  AND s.profile_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_songs_profile_id
+  ON public.songs (profile_id);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

### Band invitations

- converts `20251007130559_cab5223d-b43a-423b-9fb7-e102b362f61c.sql` from a duplicate `band_invitations` table creator into additive compatibility work
- preserves original invitation rows and legacy columns
- adds and backfills `inviter_user_id`, `invited_user_id`, `instrument_role`, `vocal_role` and `message`
- removes the original public-read invitation policy
- restricts invitation visibility to invitees, band members and band leaders
- adds replay-safe indexes and the pending-invitation uniqueness rule
- adds a forward reconciliation and authority test

### Song/profile ownership

- repairs `20251016124606_f8655f2e-9c9a-48f2-8593-827a076acc13.sql` to backfill `songs.profile_id` through canonical `songs.artist_id = profiles.user_id`
- removes the invalid dependency on nonexistent `songs.user_id`
- keeps `artist_id` as the authoritative auth-user owner
- retains band-song visibility through actual `band_members` membership
- adds a forward reconciliation and authority test

## Root causes

Finance verification first stopped at the October band invitation migration because the table had already been created by the September migration. After the invitation bridge was added, fresh bootstrap advanced to:

```text
20251016124606_f8655f2e-9c9a-48f2-8593-827a076acc13.sql
ERROR: column s.user_id does not exist
UPDATE songs s ... WHERE s.user_id = p.user_id
```

The authoritative song schema has always used `artist_id` for auth-user ownership.

## Safety

No invitation or song is deleted. Legacy invitation columns remain available, canonical invitation fields are backfilled, and song ownership remains with `artist_id`. The new `profile_id` is a derived character-profile reference only.

## Validation

```bash
npm test -- \
  src/lib/api/__tests__/bandInvitationCompatibilityMigration.database.test.ts \
  src/lib/api/__tests__/songProfileOwnershipMigration.database.test.ts
supabase db start
supabase db reset
```

The PR now contains six focused files and remains draft until Finance verification reports the next fresh-database boundary.