### PR TITLE
Repair completed songwriting project conversion

### DIFF
--- a/src/lib/api/__tests__/completedSongwritingProjectMigration.database.test.ts
+++ b/src/lib/api/__tests__/completedSongwritingProjectMigration.database.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251019072301_289cf6ac-da27-4fa3-82a8-7480853fa2ef.sql",
+  ),
+  "utf8",
+);
+
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243540_reconcile_completed_songwriting_projects.sql",
+  ),
+  "utf8",
+);
+
+describe("completed songwriting project conversion", () => {
+  it("uses canonical song ownership and derived profile identity", () => {
+    expect(historicalMigration).toContain("artist_id");
+    expect(historicalMigration).toContain("profile_id");
+    expect(historicalMigration).toContain("sp.user_id");
+    expect(historicalMigration).toContain(
+      "LEFT JOIN public.profiles p",
+    );
+    expect(historicalMigration).toContain("p.user_id = sp.user_id");
+    expect(historicalMigration).not.toMatch(/INSERT INTO public\.songs \(\s*user_id/i);
+  });
+
+  it("owns every target field required by the insert", () => {
+    expect(historicalMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS completed_at timestamptz",
+    );
+    expect(historicalMigration).toContain("songwriting_project_id");
+    expect(historicalMigration).toContain("catalog_status");
+  });
+
+  it("does not create duplicate songs when replayed", () => {
+    expect(historicalMigration).toContain("AND NOT EXISTS");
+    expect(historicalMigration).toContain(
+      "s.songwriting_project_id = sp.id",
+    );
+  });
+
+  it("reconciles skipped projects without deleting songwriting data", () => {
+    expect(reconciliationMigration).toContain("artist_id");
+    expect(reconciliationMigration).toContain("profile_id");
+    expect(reconciliationMigration).toContain("AND NOT EXISTS");
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251019072301_289cf6ac-da27-4fa3-82a8-7480853fa2ef.sql
+++ b/supabase/migrations/20251019072301_289cf6ac-da27-4fa3-82a8-7480853fa2ef.sql
@@ -1,21 +1,46 @@
--- Create songs for completed songwriting projects that don't have songs yet
--- Use 'draft' status since 'complete' is not allowed in the songs table
-INSERT INTO songs (user_id, title, genre, lyrics, quality_score, song_rating, status, completed_at, songwriting_project_id, catalog_status, streams, revenue)
-SELECT 
+-- Convert completed songwriting projects into draft songs using the established
+-- auth-user owner stored in songs.artist_id and the derived character profile.
+
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+INSERT INTO public.songs (
+  artist_id,
+  profile_id,
+  title,
+  genre,
+  lyrics,
+  quality_score,
+  song_rating,
+  status,
+  completed_at,
+  songwriting_project_id,
+  catalog_status,
+  streams,
+  revenue
+)
+SELECT
   sp.user_id,
+  p.id,
   sp.title,
-  COALESCE(sp.genres[1], 'Rock') as genre,
-  COALESCE(sp.initial_lyrics, '') as lyrics,
-  COALESCE(sp.quality_score, 50) as quality_score,
-  COALESCE(sp.song_rating, 1) as song_rating,
-  'draft' as status,
-  NOW() as completed_at,
-  sp.id as songwriting_project_id,
-  'private' as catalog_status,
-  0 as streams,
-  0 as revenue
-FROM songwriting_projects sp
+  COALESCE(sp.genres[1], 'Rock'),
+  COALESCE(sp.initial_lyrics, ''),
+  COALESCE(sp.quality_score, 50),
+  COALESCE(sp.song_rating, 1),
+  'draft',
+  now(),
+  sp.id,
+  'private',
+  0,
+  0
+FROM public.songwriting_projects sp
+LEFT JOIN public.profiles p
+  ON p.user_id = sp.user_id
 WHERE sp.status IN ('completed', 'complete')
   AND NOT EXISTS (
-    SELECT 1 FROM songs s WHERE s.songwriting_project_id = sp.id
+    SELECT 1
+    FROM public.songs s
+    WHERE s.songwriting_project_id = sp.id
   );
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243540_reconcile_completed_songwriting_projects.sql
+++ b/supabase/migrations/20291218243540_reconcile_completed_songwriting_projects.sql
@@ -1,0 +1,46 @@
+-- Reconcile completed songwriting projects that were not converted because the
+-- historical migration targeted a nonexistent songs.user_id column.
+
+ALTER TABLE public.songs
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+INSERT INTO public.songs (
+  artist_id,
+  profile_id,
+  title,
+  genre,
+  lyrics,
+  quality_score,
+  song_rating,
+  status,
+  completed_at,
+  songwriting_project_id,
+  catalog_status,
+  streams,
+  revenue
+)
+SELECT
+  sp.user_id,
+  p.id,
+  sp.title,
+  COALESCE(sp.genres[1], 'Rock'),
+  COALESCE(sp.initial_lyrics, ''),
+  COALESCE(sp.quality_score, 50),
+  COALESCE(sp.song_rating, 1),
+  'draft',
+  now(),
+  sp.id,
+  'private',
+  0,
+  0
+FROM public.songwriting_projects sp
+LEFT JOIN public.profiles p
+  ON p.user_id = sp.user_id
+WHERE sp.status IN ('completed', 'complete')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.songs s
+    WHERE s.songwriting_project_id = sp.id
+  );
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- repairs `20251019072301_289cf6ac-da27-4fa3-82a8-7480853fa2ef.sql` to create songs with canonical `artist_id`
- derives `profile_id` by joining `songwriting_projects.user_id` to `profiles.user_id`
- adds `songs.completed_at` before the conversion insert uses it
- preserves the existing draft status, genre, lyrics, rating, catalogue visibility, streams and revenue values
- prevents duplicate songs through `songwriting_project_id`
- adds a forward reconciliation for completed projects skipped by the broken historical migration
- adds regression coverage for ownership, target columns, replay safety and data preservation

## Root cause

PR #1428 successfully advanced Finance verification beyond band invitation and song-profile compatibility. Fresh bootstrap then stopped at:

```text
20251019072301_289cf6ac-da27-4fa3-82a8-7480853fa2ef.sql
ERROR: column "user_id" of relation "songs" does not exist
INSERT INTO songs (user_id, title, ...)
```

The authoritative songs schema uses `artist_id` for the owning auth user. `songwriting_projects.user_id` already stores that same auth user identifier.

## Safety

No songwriting project or song is deleted. Existing converted projects remain untouched, and only completed projects without a matching `songwriting_project_id` create a draft song.

## Validation

```bash
npm test -- src/lib/api/__tests__/completedSongwritingProjectMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in exactly three focused files and remains draft until Finance verification reports the next fresh-database boundary.