### PR TITLE
Repair stage equipment migration policy syntax

### DIFF
--- a/src/lib/api/__tests__/stageEquipmentPolicyMigration.database.test.ts
+++ b/src/lib/api/__tests__/stageEquipmentPolicyMigration.database.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251101120000_implement_stage_equipment_system.sql",
+  ),
+  "utf8",
+);
+
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243600_reconcile_stage_equipment_policies.sql",
+  ),
+  "utf8",
+);
+
+describe("stage equipment policy migration", () => {
+  it("does not use unsupported policy or trigger syntax", () => {
+    expect(historicalMigration).not.toContain("CREATE POLICY IF NOT EXISTS");
+    expect(historicalMigration).not.toContain("CREATE TRIGGER IF NOT EXISTS");
+  });
+
+  it("recreates every policy safely", () => {
+    const policyNames = [
+      "Band members can view their vehicles",
+      "Band members can manage their vehicles",
+      "Band members can view equipment logs",
+      "Band members can manage equipment logs",
+    ];
+
+    for (const policyName of policyNames) {
+      expect(historicalMigration).toContain(
+        `DROP POLICY IF EXISTS "${policyName}"`,
+      );
+      expect(historicalMigration).toContain(
+        `CREATE POLICY "${policyName}"`,
+      );
+    }
+  });
+
+  it("uses membership existence checks for fleet and log access", () => {
+    expect(historicalMigration).toContain("FROM public.band_members bm");
+    expect(historicalMigration).toContain("bm.user_id = auth.uid()");
+    expect(historicalMigration).not.toMatch(/band_id\s+IN\s*\(/i);
+  });
+
+  it("reconciles deployed policies without modifying equipment data", () => {
+    expect(reconciliationMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_band_vehicles_updated_at",
+    );
+    expect(reconciliationMigration).toContain(
+      "CREATE TRIGGER update_band_vehicles_updated_at",
+    );
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251101120000_implement_stage_equipment_system.sql
+++ b/supabase/migrations/20251101120000_implement_stage_equipment_system.sql
@@ -1,100 +1,130 @@
 -- Stage equipment system schema updates
 
--- Vehicles available to each band for transporting stage equipment
 CREATE TABLE IF NOT EXISTS public.band_vehicles (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  band_id UUID NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
-  vehicle_type TEXT NOT NULL,
-  capacity INTEGER NOT NULL DEFAULT 0 CHECK (capacity >= 0),
-  location TEXT,
-  condition INTEGER NOT NULL DEFAULT 100 CHECK (condition BETWEEN 0 AND 100),
-  notes TEXT,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  vehicle_type text NOT NULL,
+  capacity integer NOT NULL DEFAULT 0 CHECK (capacity >= 0),
+  location text,
+  condition integer NOT NULL DEFAULT 100 CHECK (condition BETWEEN 0 AND 100),
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Extend the existing band_stage_equipment table with operational columns
 ALTER TABLE public.band_stage_equipment
-  ADD COLUMN IF NOT EXISTS condition_rating INTEGER NOT NULL DEFAULT 100 CHECK (condition_rating BETWEEN 0 AND 100),
-  ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT FALSE,
-  ADD COLUMN IF NOT EXISTS vehicle_id UUID REFERENCES public.band_vehicles(id) ON DELETE SET NULL,
-  ADD COLUMN IF NOT EXISTS maintenance_due_at TIMESTAMP WITH TIME ZONE,
-  ADD COLUMN IF NOT EXISTS maintenance_status TEXT NOT NULL DEFAULT 'good',
-  ADD COLUMN IF NOT EXISTS in_service BOOLEAN NOT NULL DEFAULT TRUE,
-  ADD COLUMN IF NOT EXISTS size_units INTEGER NOT NULL DEFAULT 1 CHECK (size_units >= 0);
+  ADD COLUMN IF NOT EXISTS condition_rating integer NOT NULL DEFAULT 100
+    CHECK (condition_rating BETWEEN 0 AND 100),
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS vehicle_id uuid REFERENCES public.band_vehicles(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS maintenance_due_at timestamptz,
+  ADD COLUMN IF NOT EXISTS maintenance_status text NOT NULL DEFAULT 'good',
+  ADD COLUMN IF NOT EXISTS in_service boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS size_units integer NOT NULL DEFAULT 1
+    CHECK (size_units >= 0);
 
 CREATE INDEX IF NOT EXISTS idx_band_equipment_vehicle_id
-  ON public.band_stage_equipment(vehicle_id);
+  ON public.band_stage_equipment (vehicle_id);
 
--- Track maintenance and repair history for stage gear
 CREATE TABLE IF NOT EXISTS public.band_equipment_maintenance_logs (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  band_equipment_id UUID NOT NULL REFERENCES public.band_stage_equipment(id) ON DELETE CASCADE,
-  band_id UUID NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
-  performed_by UUID REFERENCES public.profiles(id),
-  action TEXT NOT NULL,
-  cost INTEGER NOT NULL DEFAULT 0 CHECK (cost >= 0),
-  notes TEXT,
-  condition_before INTEGER,
-  condition_after INTEGER,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  band_equipment_id uuid NOT NULL REFERENCES public.band_stage_equipment(id) ON DELETE CASCADE,
+  band_id uuid NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
+  performed_by uuid REFERENCES public.profiles(id),
+  action text NOT NULL,
+  cost integer NOT NULL DEFAULT 0 CHECK (cost >= 0),
+  notes text,
+  condition_before integer,
+  condition_after integer,
+  created_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_equipment_logs_band_id
-  ON public.band_equipment_maintenance_logs(band_id);
-
+  ON public.band_equipment_maintenance_logs (band_id);
 CREATE INDEX IF NOT EXISTS idx_equipment_logs_equipment_id
-  ON public.band_equipment_maintenance_logs(band_equipment_id);
+  ON public.band_equipment_maintenance_logs (band_equipment_id);
 
--- Enable row level security so only band members can manage their fleet and logs
 ALTER TABLE public.band_vehicles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.band_equipment_maintenance_logs ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY IF NOT EXISTS "Band members can view their vehicles"
-  ON public.band_vehicles FOR SELECT
+DROP POLICY IF EXISTS "Band members can view their vehicles"
+  ON public.band_vehicles;
+CREATE POLICY "Band members can view their vehicles"
+  ON public.band_vehicles
+  FOR SELECT
   USING (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
     )
   );
 
-CREATE POLICY IF NOT EXISTS "Band members can manage their vehicles"
-  ON public.band_vehicles FOR ALL
+DROP POLICY IF EXISTS "Band members can manage their vehicles"
+  ON public.band_vehicles;
+CREATE POLICY "Band members can manage their vehicles"
+  ON public.band_vehicles
+  FOR ALL
   USING (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
     )
   )
   WITH CHECK (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
     )
   );
 
-CREATE POLICY IF NOT EXISTS "Band members can view equipment logs"
-  ON public.band_equipment_maintenance_logs FOR SELECT
+DROP POLICY IF EXISTS "Band members can view equipment logs"
+  ON public.band_equipment_maintenance_logs;
+CREATE POLICY "Band members can view equipment logs"
+  ON public.band_equipment_maintenance_logs
+  FOR SELECT
   USING (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
     )
   );
 
-CREATE POLICY IF NOT EXISTS "Band members can manage equipment logs"
-  ON public.band_equipment_maintenance_logs FOR ALL
+DROP POLICY IF EXISTS "Band members can manage equipment logs"
+  ON public.band_equipment_maintenance_logs;
+CREATE POLICY "Band members can manage equipment logs"
+  ON public.band_equipment_maintenance_logs
+  FOR ALL
   USING (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
     )
   )
   WITH CHECK (
-    band_id IN (
-      SELECT band_id FROM public.band_members WHERE user_id = auth.uid()
+    EXISTS (
+      SELECT 1
+      FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
     )
   );
 
--- Keep vehicle timestamps up to date
-CREATE TRIGGER IF NOT EXISTS update_band_vehicles_updated_at
+DROP TRIGGER IF EXISTS update_band_vehicles_updated_at
+  ON public.band_vehicles;
+CREATE TRIGGER update_band_vehicles_updated_at
   BEFORE UPDATE ON public.band_vehicles
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243600_reconcile_stage_equipment_policies.sql
+++ b/supabase/migrations/20291218243600_reconcile_stage_equipment_policies.sql
@@ -1,0 +1,80 @@
+-- Reconcile stage-equipment policies and vehicle timestamp trigger for databases
+-- where the historical migration used unsupported IF NOT EXISTS syntax.
+
+ALTER TABLE public.band_vehicles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.band_equipment_maintenance_logs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Band members can view their vehicles"
+  ON public.band_vehicles;
+CREATE POLICY "Band members can view their vehicles"
+  ON public.band_vehicles
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band members can manage their vehicles"
+  ON public.band_vehicles;
+CREATE POLICY "Band members can manage their vehicles"
+  ON public.band_vehicles
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_vehicles.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band members can view equipment logs"
+  ON public.band_equipment_maintenance_logs;
+CREATE POLICY "Band members can view equipment logs"
+  ON public.band_equipment_maintenance_logs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "Band members can manage equipment logs"
+  ON public.band_equipment_maintenance_logs;
+CREATE POLICY "Band members can manage equipment logs"
+  ON public.band_equipment_maintenance_logs
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.band_members bm
+      WHERE bm.band_id = band_equipment_maintenance_logs.band_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+DROP TRIGGER IF EXISTS update_band_vehicles_updated_at
+  ON public.band_vehicles;
+CREATE TRIGGER update_band_vehicles_updated_at
+  BEFORE UPDATE ON public.band_vehicles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- replaces four unsupported `CREATE POLICY IF NOT EXISTS` statements in `20251101120000_implement_stage_equipment_system.sql`
- replaces the unsupported `CREATE TRIGGER IF NOT EXISTS` statement
- recreates stage vehicle and maintenance-log policies through replay-safe drop/create operations
- uses explicit band-membership `EXISTS` checks for fleet and log access
- preserves all vehicle, equipment and maintenance data
- adds a forward reconciliation for deployed databases
- adds regression coverage for PostgreSQL syntax, policy ownership, membership checks and data preservation

## Root cause

PR #1430 advanced fresh Finance verification into November 2025, where database startup stopped at:

```text
20251101120000_implement_stage_equipment_system.sql
ERROR: syntax error at or near "NOT"
CREATE POLICY IF NOT EXISTS "Band members can view their vehicles"
```

The repository's PostgreSQL version does not support `IF NOT EXISTS` on `CREATE POLICY` or `CREATE TRIGGER`.

## Behaviour

Band members retain access to their band's vehicles and equipment maintenance history. Existing stage equipment assignments and logs are unchanged.

## Validation

```bash
npm test -- src/lib/api/__tests__/stageEquipmentPolicyMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in exactly three focused files and remains draft until Finance verification reports the next fresh-database boundary.