### PR TITLE
Repair setlist performance item migration order

### DIFF
--- a/src/lib/api/__tests__/setlistPerformanceItemMigration.database.test.ts
+++ b/src/lib/api/__tests__/setlistPerformanceItemMigration.database.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const prerequisiteMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251108074321_prepare_setlist_performance_items.sql",
+  ),
+  "utf8",
+);
+const catalogueMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251108074322_9771195b-45f9-4da8-af67-22dc72cc6b0a.sql",
+  ),
+  "utf8",
+);
+const finaliserMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251108074323_finalize_setlist_performance_items.sql",
+  ),
+  "utf8",
+);
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243620_reconcile_setlist_performance_items.sql",
+  ),
+  "utf8",
+);
+
+describe("setlist performance item migration ordering", () => {
+  it("adds every compatibility field before the catalogue constraint uses it", () => {
+    for (const column of [
+      "item_type",
+      "performance_item_id",
+      "section",
+      "is_encore",
+    ]) {
+      expect(prerequisiteMigration).toContain(`ADD COLUMN IF NOT EXISTS ${column}`);
+    }
+
+    expect(prerequisiteMigration).toContain("ALTER COLUMN song_id DROP NOT NULL");
+    expect(catalogueMigration).toContain("item_type = 'performance_item'");
+  });
+
+  it("finalises a strict either-song-or-performance-item rule", () => {
+    expect(finaliserMigration).toContain(
+      "setlist_songs_performance_item_id_fkey",
+    );
+    expect(finaliserMigration).toContain(
+      "item_type = 'song' AND song_id IS NOT NULL AND performance_item_id IS NULL",
+    );
+    expect(finaliserMigration).toContain(
+      "item_type = 'performance_item' AND song_id IS NULL AND performance_item_id IS NOT NULL",
+    );
+  });
+
+  it("supports the sectioned setlist fields used by the UI", () => {
+    expect(prerequisiteMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS section text NOT NULL DEFAULT 'main'",
+    );
+    expect(prerequisiteMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS is_encore boolean NOT NULL DEFAULT false",
+    );
+    expect(finaliserMigration).toContain(
+      "idx_setlist_songs_section_position",
+    );
+  });
+
+  it("reconciles deployed setlists without deleting setlist items", () => {
+    expect(reconciliationMigration).toContain(
+      "ADD COLUMN IF NOT EXISTS performance_item_id uuid",
+    );
+    expect(reconciliationMigration).toContain("NOT VALID");
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251108074321_prepare_setlist_performance_items.sql
+++ b/supabase/migrations/20251108074321_prepare_setlist_performance_items.sql
@@ -1,0 +1,37 @@
+-- Prepare the established setlist_songs table for the performance-item catalogue
+-- created by the immediately following migration.
+
+ALTER TABLE public.setlist_songs
+  ADD COLUMN IF NOT EXISTS item_type text NOT NULL DEFAULT 'song',
+  ADD COLUMN IF NOT EXISTS performance_item_id uuid,
+  ADD COLUMN IF NOT EXISTS section text NOT NULL DEFAULT 'main',
+  ADD COLUMN IF NOT EXISTS is_encore boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.setlist_songs
+  ALTER COLUMN song_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'setlist_songs_item_type_check'
+      AND conrelid = 'public.setlist_songs'::regclass
+  ) THEN
+    ALTER TABLE public.setlist_songs
+      ADD CONSTRAINT setlist_songs_item_type_check
+      CHECK (item_type IN ('song', 'performance_item'));
+  END IF;
+END
+$$;
+
+-- The original song-only uniqueness constraint prevents multiple rows where
+-- song_id is NULL. The following catalogue migration replaces it with the
+-- appropriate song/performance-item rules.
+ALTER TABLE public.setlist_songs
+  DROP CONSTRAINT IF EXISTS setlist_songs_setlist_id_song_id_key;
+
+CREATE INDEX IF NOT EXISTS idx_setlist_songs_section_position
+  ON public.setlist_songs (setlist_id, section, position);
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20251108074323_finalize_setlist_performance_items.sql
+++ b/supabase/migrations/20251108074323_finalize_setlist_performance_items.sql
@@ -1,0 +1,38 @@
+-- Finalise setlist performance-item integrity after the catalogue exists.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'setlist_songs_performance_item_id_fkey'
+      AND conrelid = 'public.setlist_songs'::regclass
+  ) THEN
+    ALTER TABLE public.setlist_songs
+      ADD CONSTRAINT setlist_songs_performance_item_id_fkey
+      FOREIGN KEY (performance_item_id)
+      REFERENCES public.performance_items_catalog(id)
+      ON DELETE SET NULL;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.setlist_songs
+  DROP CONSTRAINT IF EXISTS setlist_songs_unique_song;
+
+ALTER TABLE public.setlist_songs
+  ADD CONSTRAINT setlist_songs_unique_song
+  CHECK (
+    (item_type = 'song' AND song_id IS NOT NULL AND performance_item_id IS NULL)
+    OR
+    (item_type = 'performance_item' AND song_id IS NULL AND performance_item_id IS NOT NULL)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_setlist_songs_performance_item
+  ON public.setlist_songs (performance_item_id)
+  WHERE item_type = 'performance_item';
+
+CREATE INDEX IF NOT EXISTS idx_setlist_songs_section_position
+  ON public.setlist_songs (setlist_id, section, position);
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243620_reconcile_setlist_performance_items.sql
+++ b/supabase/migrations/20291218243620_reconcile_setlist_performance_items.sql
@@ -1,0 +1,67 @@
+-- Reconcile setlist performance-item compatibility for databases where the
+-- historical catalogue migration ran against a smaller song-only setlist table.
+
+ALTER TABLE public.setlist_songs
+  ADD COLUMN IF NOT EXISTS item_type text NOT NULL DEFAULT 'song',
+  ADD COLUMN IF NOT EXISTS performance_item_id uuid,
+  ADD COLUMN IF NOT EXISTS section text NOT NULL DEFAULT 'main',
+  ADD COLUMN IF NOT EXISTS is_encore boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.setlist_songs
+  ALTER COLUMN song_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'setlist_songs_item_type_check'
+      AND conrelid = 'public.setlist_songs'::regclass
+  ) THEN
+    ALTER TABLE public.setlist_songs
+      ADD CONSTRAINT setlist_songs_item_type_check
+      CHECK (item_type IN ('song', 'performance_item'))
+      NOT VALID;
+  END IF;
+
+  IF to_regclass('public.performance_items_catalog') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM pg_constraint
+       WHERE conname = 'setlist_songs_performance_item_id_fkey'
+         AND conrelid = 'public.setlist_songs'::regclass
+     ) THEN
+    ALTER TABLE public.setlist_songs
+      ADD CONSTRAINT setlist_songs_performance_item_id_fkey
+      FOREIGN KEY (performance_item_id)
+      REFERENCES public.performance_items_catalog(id)
+      ON DELETE SET NULL
+      NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'setlist_songs_unique_song'
+      AND conrelid = 'public.setlist_songs'::regclass
+  ) THEN
+    ALTER TABLE public.setlist_songs
+      ADD CONSTRAINT setlist_songs_unique_song
+      CHECK (
+        (item_type = 'song' AND song_id IS NOT NULL AND performance_item_id IS NULL)
+        OR
+        (item_type = 'performance_item' AND song_id IS NULL AND performance_item_id IS NOT NULL)
+      )
+      NOT VALID;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_setlist_songs_performance_item
+  ON public.setlist_songs (performance_item_id)
+  WHERE item_type = 'performance_item';
+
+CREATE INDEX IF NOT EXISTS idx_setlist_songs_section_position
+  ON public.setlist_songs (setlist_id, section, position);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- adds a prerequisite migration immediately before the performance-item catalogue migration
- adds `item_type`, `performance_item_id`, `section` and `is_encore` before the existing constraint and index use them
- makes `setlist_songs.song_id` nullable so performance-only rows are valid
- preserves the full 200-item performance catalogue seed unchanged
- adds a post-catalogue finaliser with the foreign key and a strict either-song-or-performance-item rule
- adds section/position and performance-item indexes
- adds a forward reconciliation for deployed databases
- adds regression coverage for migration ordering, UI fields, integrity and data preservation

## Root cause

PR #1432 advanced fresh Finance verification to:

```text
20251108074322_9771195b-45f9-4da8-af67-22dc72cc6b0a.sql
ERROR: column "item_type" does not exist
ALTER TABLE setlist_songs ADD CONSTRAINT ...
```

The original `setlist_songs` table was song-only. The performance catalogue migration referenced its new compatibility columns without adding them first.

## Behaviour

Setlists can contain normal songs and performance actions such as stage dives, crowd interactions and special effects. Each row must represent exactly one type, and existing song-only setlists remain valid.

## Validation

```bash
npm test -- src/lib/api/__tests__/setlistPerformanceItemMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in exactly four focused files and remains draft until Finance verification reports the next fresh-database boundary.