### PR TITLE
Retire duplicate leaderboard prototype migration

### DIFF
--- a/src/lib/api/__tests__/duplicateLeaderboardPrototypeMigration.database.test.ts
+++ b/src/lib/api/__tests__/duplicateLeaderboardPrototypeMigration.database.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const canonicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20250917090000_create_label_system.sql",
+  ),
+  "utf8",
+);
+const duplicateMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251116074100_00b9b268-8bc7-4675-ad1e-03fe1ee58e0f.sql",
+  ),
+  "utf8",
+);
+
+describe("duplicate leaderboard prototype migration", () => {
+  it("leaves leaderboard schema ownership with the consolidated migration", () => {
+    expect(canonicalMigration).toContain(
+      "create table if not exists public.leaderboard_seasons",
+    );
+    expect(canonicalMigration).toContain(
+      "create table if not exists public.leaderboard_season_snapshots",
+    );
+    expect(canonicalMigration).toContain(
+      "create table if not exists public.leaderboard_badges",
+    );
+    expect(canonicalMigration).toContain(
+      "create table if not exists public.leaderboard_badge_awards",
+    );
+  });
+
+  it("does not recreate tables, policies, indexes or triggers", () => {
+    expect(duplicateMigration).not.toMatch(/CREATE\s+TABLE/i);
+    expect(duplicateMigration).not.toMatch(/CREATE\s+POLICY/i);
+    expect(duplicateMigration).not.toMatch(/CREATE\s+INDEX/i);
+    expect(duplicateMigration).not.toMatch(/CREATE\s+TRIGGER/i);
+  });
+
+  it("does not introduce the incompatible is_active leaderboard contract", () => {
+    expect(duplicateMigration).not.toMatch(/ADD\s+COLUMN[^;]*is_active/i);
+    expect(duplicateMigration).not.toMatch(/INDEX[^;]*is_active/i);
+    expect(duplicateMigration).toContain(
+      "Skipping duplicate leaderboard prototype",
+    );
+  });
+});

--- a/supabase/migrations/20251116074100_00b9b268-8bc7-4675-ad1e-03fe1ee58e0f.sql
+++ b/supabase/migrations/20251116074100_00b9b268-8bc7-4675-ad1e-03fe1ee58e0f.sql
@@ -1,122 +1,16 @@
--- Phase 2: Leaderboard & Competitive Features Tables
+-- Historical duplicate leaderboard prototype.
+--
+-- The authoritative leaderboard season, snapshot, badge and badge-award schema
+-- is created by the consolidated 20250917090000 migration. That schema also
+-- owns the public read policies, indexes and updated-at triggers.
+--
+-- This later prototype used an incompatible `is_active` model and attempted to
+-- recreate the same tables. It is intentionally retained as a no-op migration
+-- marker so deployed migration history is preserved without creating a second
+-- leaderboard contract.
 
--- Create leaderboard_seasons table
-CREATE TABLE IF NOT EXISTS public.leaderboard_seasons (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  name TEXT NOT NULL,
-  description TEXT,
-  start_date TIMESTAMP WITH TIME ZONE NOT NULL,
-  end_date TIMESTAMP WITH TIME ZONE NOT NULL,
-  is_active BOOLEAN NOT NULL DEFAULT false,
-  season_number INTEGER,
-  reward_pool JSONB DEFAULT '{}',
-  metadata JSONB DEFAULT '{}',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Create leaderboard_badges table
-CREATE TABLE IF NOT EXISTS public.leaderboard_badges (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  code TEXT NOT NULL UNIQUE,
-  name TEXT NOT NULL,
-  description TEXT,
-  icon TEXT NOT NULL DEFAULT 'trophy',
-  rarity TEXT NOT NULL DEFAULT 'rare',
-  tier TEXT,
-  season_id UUID REFERENCES public.leaderboard_seasons(id) ON DELETE CASCADE,
-  criteria JSONB DEFAULT '{}',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Create leaderboard_badge_awards table
-CREATE TABLE IF NOT EXISTS public.leaderboard_badge_awards (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  badge_id UUID NOT NULL REFERENCES public.leaderboard_badges(id) ON DELETE CASCADE,
-  user_id UUID NOT NULL,
-  season_id UUID REFERENCES public.leaderboard_seasons(id) ON DELETE CASCADE,
-  profile_id UUID,
-  awarded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  rank INTEGER,
-  metadata JSONB DEFAULT '{}',
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Create leaderboard_season_snapshots table
-CREATE TABLE IF NOT EXISTS public.leaderboard_season_snapshots (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  season_id UUID NOT NULL REFERENCES public.leaderboard_seasons(id) ON DELETE CASCADE,
-  profile_id UUID,
-  user_id UUID,
-  division TEXT NOT NULL,
-  region TEXT NOT NULL,
-  instrument TEXT NOT NULL,
-  tier TEXT,
-  final_rank INTEGER,
-  final_score NUMERIC,
-  total_revenue NUMERIC,
-  total_gigs INTEGER,
-  total_achievements INTEGER,
-  fame NUMERIC,
-  experience NUMERIC,
-  breakdown JSONB DEFAULT '{}',
-  awarded_badges TEXT[] DEFAULT '{}',
-  recorded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
-);
-
--- Create indexes for better query performance
-CREATE INDEX IF NOT EXISTS idx_leaderboard_seasons_active ON public.leaderboard_seasons(is_active);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_seasons_dates ON public.leaderboard_seasons(start_date, end_date);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_badges_season ON public.leaderboard_badges(season_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_badges_code ON public.leaderboard_badges(code);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_badge_awards_badge ON public.leaderboard_badge_awards(badge_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_badge_awards_user ON public.leaderboard_badge_awards(user_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_badge_awards_season ON public.leaderboard_badge_awards(season_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_snapshots_season ON public.leaderboard_season_snapshots(season_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_snapshots_profile ON public.leaderboard_season_snapshots(profile_id);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_snapshots_rank ON public.leaderboard_season_snapshots(season_id, final_rank);
-CREATE INDEX IF NOT EXISTS idx_leaderboard_snapshots_division ON public.leaderboard_season_snapshots(division, region, instrument);
-
--- Enable RLS on all tables
-ALTER TABLE public.leaderboard_seasons ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.leaderboard_badges ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.leaderboard_badge_awards ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.leaderboard_season_snapshots ENABLE ROW LEVEL SECURITY;
-
--- RLS Policies for leaderboard_seasons (public read)
-CREATE POLICY "Anyone can view leaderboard seasons"
-  ON public.leaderboard_seasons
-  FOR SELECT
-  USING (true);
-
--- RLS Policies for leaderboard_badges (public read)
-CREATE POLICY "Anyone can view leaderboard badges"
-  ON public.leaderboard_badges
-  FOR SELECT
-  USING (true);
-
--- RLS Policies for leaderboard_badge_awards (public read, user can see their own)
-CREATE POLICY "Anyone can view badge awards"
-  ON public.leaderboard_badge_awards
-  FOR SELECT
-  USING (true);
-
--- RLS Policies for leaderboard_season_snapshots (public read)
-CREATE POLICY "Anyone can view season snapshots"
-  ON public.leaderboard_season_snapshots
-  FOR SELECT
-  USING (true);
-
--- Add update trigger for leaderboard_seasons
-CREATE TRIGGER update_leaderboard_seasons_updated_at
-  BEFORE UPDATE ON public.leaderboard_seasons
-  FOR EACH ROW
-  EXECUTE FUNCTION public.update_updated_at_column();
-
--- Add update trigger for leaderboard_badges
-CREATE TRIGGER update_leaderboard_badges_updated_at
-  BEFORE UPDATE ON public.leaderboard_badges
-  FOR EACH ROW
-  EXECUTE FUNCTION public.update_updated_at_column();
+DO $$
+BEGIN
+  RAISE NOTICE 'Skipping duplicate leaderboard prototype; canonical schema already exists';
+END
+$$;


### PR DESCRIPTION
## What changed

- converts `20251116074100_00b9b268-8bc7-4675-ad1e-03fe1ee58e0f.sql` into an explicit no-op migration marker
- preserves leaderboard schema ownership in the consolidated `20250917090000` migration
- prevents a second incompatible `is_active` leaderboard contract
- prevents duplicate leaderboard tables, policies, indexes and updated-at triggers
- preserves deployed migration history and all leaderboard data
- adds regression coverage for canonical ownership and duplicate retirement

## Root cause

PR #1433 advanced fresh Finance verification to:

```text
20251116074100_00b9b268-8bc7-4675-ad1e-03fe1ee58e0f.sql
ERROR: column "is_active" does not exist
CREATE INDEX ... leaderboard_seasons(is_active)
```

The leaderboard tables already exist from the consolidated September migration, which uses the canonical `status`, `slug` and `reward_summary` model. The November prototype attempted to recreate those same tables with incompatible fields.

## Safety

No season, snapshot, badge or award data is changed. The historical timestamp remains in place as a no-op so migration history is preserved.

## Validation

```bash
npm test -- src/lib/api/__tests__/duplicateLeaderboardPrototypeMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in exactly two focused files and remains draft until Finance verification reports the next fresh-database boundary.