### PR TITLE
Repair music video ownership and chart relationship compatibility

### DIFF
--- a/src/lib/api/__tests__/chartSongRelationshipMigration.database.test.ts
+++ b/src/lib/api/__tests__/chartSongRelationshipMigration.database.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251116160234_783ee2e7-9c14-427a-9bda-1e0841750618.sql",
+  ),
+  "utf8",
+);
+
+describe("chart song relationship migration", () => {
+  it("checks the constraint catalogue before adding the foreign key", () => {
+    expect(migration).toContain("FROM pg_constraint");
+    expect(migration).toContain("chart_entries_song_id_fkey");
+    expect(migration).toContain(
+      "conrelid = 'public.chart_entries'::regclass",
+    );
+    expect(migration).toContain("IF NOT EXISTS");
+  });
+
+  it("keeps the song relationship cascading and schema-qualified", () => {
+    expect(migration).toContain("ALTER TABLE public.chart_entries");
+    expect(migration).toContain("REFERENCES public.songs(id)");
+    expect(migration).toContain("ON DELETE CASCADE");
+  });
+
+  it("rebuilds both chart views without deleting chart data", () => {
+    expect(migration).toContain("CREATE VIEW public.chart_singles");
+    expect(migration).toContain("CREATE VIEW public.chart_albums");
+    expect(migration).not.toMatch(/DELETE\s+FROM/i);
+    expect(migration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/src/lib/api/__tests__/musicVideoOwnershipMigration.database.test.ts
+++ b/src/lib/api/__tests__/musicVideoOwnershipMigration.database.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251116140250_c141bd74-7214-4fc1-8044-dffaa7d7ebf7.sql",
+  ),
+  "utf8",
+);
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243630_reconcile_music_video_ownership.sql",
+  ),
+  "utf8",
+);
+
+describe("music video ownership migration", () => {
+  it("uses canonical song ownership", () => {
+    expect(historicalMigration).toContain("s.artist_id = auth.uid()");
+    expect(historicalMigration).not.toContain("songs.user_id");
+    expect(historicalMigration).not.toContain("s.user_id");
+  });
+
+  it("allows members to manage videos for band-owned songs", () => {
+    expect(historicalMigration).toContain("FROM public.band_members bm");
+    expect(historicalMigration).toContain("bm.band_id = s.band_id");
+    expect(historicalMigration).toContain("bm.user_id = auth.uid()");
+  });
+
+  it("recreates policies and the updated-at trigger safely", () => {
+    for (const policyName of [
+      "Users can view all music videos",
+      "Users can create music videos for their own songs",
+      "Users can update their own music videos",
+      "Users can delete their own music videos",
+    ]) {
+      expect(historicalMigration).toContain(
+        `DROP POLICY IF EXISTS "${policyName}"`,
+      );
+      expect(historicalMigration).toContain(
+        `CREATE POLICY "${policyName}"`,
+      );
+    }
+
+    expect(historicalMigration).toContain(
+      "DROP TRIGGER IF EXISTS update_music_videos_updated_at",
+    );
+    expect(historicalMigration).toContain(
+      "CREATE TRIGGER update_music_videos_updated_at",
+    );
+  });
+
+  it("reconciles deployed policies without deleting videos", () => {
+    expect(reconciliationMigration).toContain("s.artist_id = auth.uid()");
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251116140250_c141bd74-7214-4fc1-8044-dffaa7d7ebf7.sql
+++ b/supabase/migrations/20251116140250_c141bd74-7214-4fc1-8044-dffaa7d7ebf7.sql
@@ -16,56 +16,111 @@ CREATE TABLE IF NOT EXISTS public.music_videos (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Enable RLS
 ALTER TABLE public.music_videos ENABLE ROW LEVEL SECURITY;
 
--- Create policies
+DROP POLICY IF EXISTS "Users can view all music videos"
+  ON public.music_videos;
 CREATE POLICY "Users can view all music videos"
   ON public.music_videos
   FOR SELECT
   USING (true);
 
+DROP POLICY IF EXISTS "Users can create music videos for their own songs"
+  ON public.music_videos;
 CREATE POLICY "Users can create music videos for their own songs"
   ON public.music_videos
   FOR INSERT
   WITH CHECK (
     EXISTS (
-      SELECT 1 FROM public.songs
-      WHERE songs.id = music_videos.song_id
-      AND songs.user_id = auth.uid()
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
     )
   );
 
+DROP POLICY IF EXISTS "Users can update their own music videos"
+  ON public.music_videos;
 CREATE POLICY "Users can update their own music videos"
   ON public.music_videos
   FOR UPDATE
   USING (
     EXISTS (
-      SELECT 1 FROM public.songs
-      WHERE songs.id = music_videos.song_id
-      AND songs.user_id = auth.uid()
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
     )
   );
 
+DROP POLICY IF EXISTS "Users can delete their own music videos"
+  ON public.music_videos;
 CREATE POLICY "Users can delete their own music videos"
   ON public.music_videos
   FOR DELETE
   USING (
     EXISTS (
-      SELECT 1 FROM public.songs
-      WHERE songs.id = music_videos.song_id
-      AND songs.user_id = auth.uid()
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1
+            FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
     )
   );
 
--- Create indexes for better performance
-CREATE INDEX idx_music_videos_song_id ON public.music_videos(song_id);
-CREATE INDEX idx_music_videos_status ON public.music_videos(status);
-CREATE INDEX idx_music_videos_hype_score ON public.music_videos(hype_score DESC);
-CREATE INDEX idx_music_videos_release_date ON public.music_videos(release_date DESC);
+CREATE INDEX IF NOT EXISTS idx_music_videos_song_id
+  ON public.music_videos (song_id);
+CREATE INDEX IF NOT EXISTS idx_music_videos_status
+  ON public.music_videos (status);
+CREATE INDEX IF NOT EXISTS idx_music_videos_hype_score
+  ON public.music_videos (hype_score DESC);
+CREATE INDEX IF NOT EXISTS idx_music_videos_release_date
+  ON public.music_videos (release_date DESC);
 
--- Create updated_at trigger
+DROP TRIGGER IF EXISTS update_music_videos_updated_at
+  ON public.music_videos;
 CREATE TRIGGER update_music_videos_updated_at
   BEFORE UPDATE ON public.music_videos
   FOR EACH ROW
   EXECUTE FUNCTION public.update_updated_at_column();
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20251116160234_783ee2e7-9c14-427a-9bda-1e0841750618.sql
+++ b/supabase/migrations/20251116160234_783ee2e7-9c14-427a-9bda-1e0841750618.sql
@@ -1,37 +1,48 @@
--- Add missing foreign key relationship between chart_entries and songs
-ALTER TABLE chart_entries
-ADD CONSTRAINT chart_entries_song_id_fkey 
-FOREIGN KEY (song_id) REFERENCES songs(id) ON DELETE CASCADE;
+-- Ensure the chart entry relationship exists without recreating an established
+-- foreign key from the base chart schema.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'chart_entries_song_id_fkey'
+      AND conrelid = 'public.chart_entries'::regclass
+  ) THEN
+    ALTER TABLE public.chart_entries
+      ADD CONSTRAINT chart_entries_song_id_fkey
+      FOREIGN KEY (song_id)
+      REFERENCES public.songs(id)
+      ON DELETE CASCADE;
+  END IF;
+END
+$$;
 
--- Update chart_singles view to ensure proper song relationship
-DROP VIEW IF EXISTS chart_singles;
-
-CREATE OR REPLACE VIEW chart_singles AS
-SELECT 
-  s.id as song_id,
+DROP VIEW IF EXISTS public.chart_singles;
+CREATE VIEW public.chart_singles AS
+SELECT
+  s.id AS song_id,
   s.title,
   s.genre,
-  b.name as band_name,
+  b.name AS band_name,
   sr.country,
   sp.platform_name,
-  SUM(COALESCE(sr.total_streams, 0)) as total_streams,
-  SUM(COALESCE(sr.total_revenue, 0)) as streaming_revenue,
-  COUNT(DISTINCT sr.id) as platform_count
-FROM songs s
-LEFT JOIN bands b ON s.band_id = b.id
-LEFT JOIN song_releases sr ON s.id = sr.song_id
-LEFT JOIN streaming_platforms sp ON sr.platform_id = sp.id
-WHERE sr.release_type = 'streaming' AND sr.is_active = true
+  SUM(COALESCE(sr.total_streams, 0)) AS total_streams,
+  SUM(COALESCE(sr.total_revenue, 0)) AS streaming_revenue,
+  COUNT(DISTINCT sr.id) AS platform_count
+FROM public.songs s
+LEFT JOIN public.bands b ON s.band_id = b.id
+LEFT JOIN public.song_releases sr ON s.id = sr.song_id
+LEFT JOIN public.streaming_platforms sp ON sr.platform_id = sp.id
+WHERE sr.release_type = 'streaming'
+  AND sr.is_active = true
 GROUP BY s.id, s.title, s.genre, b.name, sr.country, sp.platform_name;
 
--- Update chart_albums view to use proper relationships
-DROP VIEW IF EXISTS chart_albums;
-
-CREATE OR REPLACE VIEW chart_albums AS
-SELECT 
-  r.id as release_id,
+DROP VIEW IF EXISTS public.chart_albums;
+CREATE VIEW public.chart_albums AS
+SELECT
+  r.id AS release_id,
   r.title,
-  b.name as band_name,
+  b.name AS band_name,
   r.country,
   r.format_type,
   r.digital_sales,
@@ -42,9 +53,13 @@ SELECT
   r.total_revenue,
   r.release_status,
   r.created_at
-FROM releases r
-LEFT JOIN bands b ON r.band_id = b.id
+FROM public.releases r
+LEFT JOIN public.bands b ON r.band_id = b.id
 WHERE r.release_status = 'released';
 
-COMMENT ON VIEW chart_singles IS 'Aggregated view of single songs across streaming platforms by country';
-COMMENT ON VIEW chart_albums IS 'Aggregated view of album/release sales by format and country';
+COMMENT ON VIEW public.chart_singles IS
+  'Aggregated view of single songs across streaming platforms by country';
+COMMENT ON VIEW public.chart_albums IS
+  'Aggregated view of album/release sales by format and country';
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243630_reconcile_music_video_ownership.sql
+++ b/supabase/migrations/20291218243630_reconcile_music_video_ownership.sql
@@ -1,0 +1,98 @@
+-- Reconcile music-video ownership policies for databases where the historical
+-- migration referenced the removed songs.user_id column.
+
+ALTER TABLE public.music_videos ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view all music videos"
+  ON public.music_videos;
+CREATE POLICY "Users can view all music videos"
+  ON public.music_videos
+  FOR SELECT
+  USING (true);
+
+DROP POLICY IF EXISTS "Users can create music videos for their own songs"
+  ON public.music_videos;
+CREATE POLICY "Users can create music videos for their own songs"
+  ON public.music_videos
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update their own music videos"
+  ON public.music_videos;
+CREATE POLICY "Users can update their own music videos"
+  ON public.music_videos
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can delete their own music videos"
+  ON public.music_videos;
+CREATE POLICY "Users can delete their own music videos"
+  ON public.music_videos
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.songs s
+      WHERE s.id = music_videos.song_id
+        AND (
+          s.artist_id = auth.uid()
+          OR EXISTS (
+            SELECT 1 FROM public.band_members bm
+            WHERE bm.band_id = s.band_id
+              AND bm.user_id = auth.uid()
+          )
+        )
+    )
+  );
+
+DROP TRIGGER IF EXISTS update_music_videos_updated_at
+  ON public.music_videos;
+CREATE TRIGGER update_music_videos_updated_at
+  BEFORE UPDATE ON public.music_videos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

### Music videos

- repairs all music-video ownership policies in `20251116140250_c141bd74-7214-4fc1-8044-dffaa7d7ebf7.sql`
- replaces removed `songs.user_id` references with canonical `songs.artist_id`
- allows band members to manage videos for songs owned by their band
- makes policies, indexes and the updated-at trigger replay-safe
- adds a forward reconciliation and authority test

### Chart relationships

- makes `chart_entries_song_id_fkey` creation idempotent in `20251116160234_783ee2e7-9c14-427a-9bda-1e0841750618.sql`
- preserves the cascading song relationship
- continues rebuilding the `chart_singles` and `chart_albums` views
- schema-qualifies chart objects
- adds regression coverage preventing duplicate-constraint failures

## Root causes

Finance verification first stopped because music-video policies queried `songs.user_id`. After that repair passed, fresh bootstrap reached:

```text
20251116160234_783ee2e7-9c14-427a-9bda-1e0841750618.sql
ERROR: constraint "chart_entries_song_id_fkey" already exists
```

The chart relationship was already created by the earlier chart schema.

## Safety

No video, song, chart entry or release data is deleted. Music-video management remains limited to the song owner or members of its band, and chart entries retain cascading cleanup when a song is removed.

## Validation

```bash
npm test -- \
  src/lib/api/__tests__/musicVideoOwnershipMigration.database.test.ts \
  src/lib/api/__tests__/chartSongRelationshipMigration.database.test.ts
supabase db start
supabase db reset
```

The PR now contains five focused files and remains draft until Finance verification reports the next fresh-database boundary.