### PR TITLE
Repair setlist performance catalogue policies

### DIFF
--- a/src/lib/api/__tests__/setlistPerformancePolicyMigration.database.test.ts
+++ b/src/lib/api/__tests__/setlistPerformancePolicyMigration.database.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const historicalMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20251116161634_a15e5fed-31f9-49bf-8005-e67b3fa2a8bf.sql",
+  ),
+  "utf8",
+);
+const reconciliationMigration = fs.readFileSync(
+  path.resolve(
+    "supabase/migrations/20291218243640_reconcile_setlist_performance_policies.sql",
+  ),
+  "utf8",
+);
+
+describe("setlist performance policy migration", () => {
+  it("targets the real public performance catalogue", () => {
+    expect(historicalMigration).toContain(
+      "ON public.performance_items_catalog",
+    );
+    expect(historicalMigration).not.toMatch(
+      /ON\s+(?:public\.)?performance_items(?:\s|;)/i,
+    );
+    expect(historicalMigration).toContain(
+      'DROP POLICY IF EXISTS "Everyone can view performance items catalog"',
+    );
+    expect(historicalMigration).toContain(
+      'CREATE POLICY "Everyone can view performance items catalog"',
+    );
+  });
+
+  it("limits setlist item management to members of the owning band", () => {
+    expect(historicalMigration).toContain("FROM public.setlists s");
+    expect(historicalMigration).toContain(
+      "JOIN public.band_members bm ON bm.band_id = s.band_id",
+    );
+    expect(historicalMigration).toContain("bm.user_id = auth.uid()");
+  });
+
+  it("recreates all setlist policies safely", () => {
+    const policyNames = [
+      "Band members can view their setlist songs",
+      "Band members can insert setlist songs",
+      "Band members can update setlist songs",
+      "Band members can delete setlist songs",
+    ];
+
+    for (const policyName of policyNames) {
+      expect(historicalMigration).toContain(
+        `DROP POLICY IF EXISTS "${policyName}"`,
+      );
+      expect(historicalMigration).toContain(
+        `CREATE POLICY "${policyName}"`,
+      );
+    }
+
+    expect(historicalMigration).toMatch(
+      /CREATE POLICY "Band members can update setlist songs"[\s\S]*?WITH CHECK \(/,
+    );
+  });
+
+  it("reconciles deployed policies without deleting setlists or catalogue items", () => {
+    expect(reconciliationMigration).toContain(
+      "ON public.performance_items_catalog",
+    );
+    expect(reconciliationMigration).toContain(
+      "JOIN public.band_members bm ON bm.band_id = s.band_id",
+    );
+    expect(reconciliationMigration).not.toMatch(/DELETE\s+FROM/i);
+    expect(reconciliationMigration).not.toMatch(/DROP\s+TABLE/i);
+  });
+});

--- a/supabase/migrations/20251116161634_a15e5fed-31f9-49bf-8005-e67b3fa2a8bf.sql
+++ b/supabase/migrations/20251116161634_a15e5fed-31f9-49bf-8005-e67b3fa2a8bf.sql
@@ -1,60 +1,93 @@
--- Fix setlist_songs and performance_items RLS policies to allow all band members
+-- Allow members of a band to manage entries in that band's setlists while
+-- keeping the reusable performance-item catalogue publicly readable.
 
--- Drop existing restrictive policies on setlist_songs if they exist
-DROP POLICY IF EXISTS "Band members can view setlist songs" ON setlist_songs;
-DROP POLICY IF EXISTS "Band leaders can manage setlist songs" ON setlist_songs;
-DROP POLICY IF EXISTS "Band members can add songs to setlists" ON setlist_songs;
-DROP POLICY IF EXISTS "Band members can update setlist songs" ON setlist_songs;
-DROP POLICY IF EXISTS "Band members can delete setlist songs" ON setlist_songs;
+ALTER TABLE public.setlist_songs ENABLE ROW LEVEL SECURITY;
 
--- Create permissive policies for all band members
+DROP POLICY IF EXISTS "Band members can view setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band leaders can manage setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can add songs to setlists"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can view their setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can insert setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can update setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can delete setlist songs"
+  ON public.setlist_songs;
+
 CREATE POLICY "Band members can view their setlist songs"
-  ON setlist_songs FOR SELECT
+  ON public.setlist_songs
+  FOR SELECT
   USING (
     EXISTS (
-      SELECT 1 FROM setlists s
-      JOIN band_members bm ON bm.band_id = s.band_id
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
       WHERE s.id = setlist_songs.setlist_id
-      AND bm.user_id = auth.uid()
+        AND bm.user_id = auth.uid()
     )
   );
 
 CREATE POLICY "Band members can insert setlist songs"
-  ON setlist_songs FOR INSERT
+  ON public.setlist_songs
+  FOR INSERT
   WITH CHECK (
     EXISTS (
-      SELECT 1 FROM setlists s
-      JOIN band_members bm ON bm.band_id = s.band_id
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
       WHERE s.id = setlist_songs.setlist_id
-      AND bm.user_id = auth.uid()
+        AND bm.user_id = auth.uid()
     )
   );
 
 CREATE POLICY "Band members can update setlist songs"
-  ON setlist_songs FOR UPDATE
+  ON public.setlist_songs
+  FOR UPDATE
   USING (
     EXISTS (
-      SELECT 1 FROM setlists s
-      JOIN band_members bm ON bm.band_id = s.band_id
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
       WHERE s.id = setlist_songs.setlist_id
-      AND bm.user_id = auth.uid()
+        AND bm.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
     )
   );
 
 CREATE POLICY "Band members can delete setlist songs"
-  ON setlist_songs FOR DELETE
+  ON public.setlist_songs
+  FOR DELETE
   USING (
     EXISTS (
-      SELECT 1 FROM setlists s
-      JOIN band_members bm ON bm.band_id = s.band_id
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
       WHERE s.id = setlist_songs.setlist_id
-      AND bm.user_id = auth.uid()
+        AND bm.user_id = auth.uid()
     )
   );
 
--- Also ensure performance_items table allows viewing by all users
-DROP POLICY IF EXISTS "Performance items are viewable by everyone" ON performance_items;
+ALTER TABLE public.performance_items_catalog ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Performance items are viewable by everyone"
-  ON performance_items FOR SELECT
+DROP POLICY IF EXISTS "Performance items are viewable by everyone"
+  ON public.performance_items_catalog;
+DROP POLICY IF EXISTS "Everyone can view performance items catalog"
+  ON public.performance_items_catalog;
+CREATE POLICY "Everyone can view performance items catalog"
+  ON public.performance_items_catalog
+  FOR SELECT
   USING (true);
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20291218243640_reconcile_setlist_performance_policies.sql
+++ b/supabase/migrations/20291218243640_reconcile_setlist_performance_policies.sql
@@ -1,0 +1,92 @@
+-- Reconcile setlist and performance-catalogue policies for databases where the
+-- historical migration targeted a nonexistent public.performance_items table.
+
+ALTER TABLE public.setlist_songs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Band members can view setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band leaders can manage setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can add songs to setlists"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can view their setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can insert setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can update setlist songs"
+  ON public.setlist_songs;
+DROP POLICY IF EXISTS "Band members can delete setlist songs"
+  ON public.setlist_songs;
+
+CREATE POLICY "Band members can view their setlist songs"
+  ON public.setlist_songs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Band members can insert setlist songs"
+  ON public.setlist_songs
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Band members can update setlist songs"
+  ON public.setlist_songs
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Band members can delete setlist songs"
+  ON public.setlist_songs
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.setlists s
+      JOIN public.band_members bm ON bm.band_id = s.band_id
+      WHERE s.id = setlist_songs.setlist_id
+        AND bm.user_id = auth.uid()
+    )
+  );
+
+ALTER TABLE public.performance_items_catalog ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Performance items are viewable by everyone"
+  ON public.performance_items_catalog;
+DROP POLICY IF EXISTS "Everyone can view performance items catalog"
+  ON public.performance_items_catalog;
+CREATE POLICY "Everyone can view performance items catalog"
+  ON public.performance_items_catalog
+  FOR SELECT
+  USING (true);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- repairs `20251116161634_a15e5fed-31f9-49bf-8005-e67b3fa2a8bf.sql` to target the real `performance_items_catalog` table
- removes references to the nonexistent `performance_items` relation
- recreates setlist select, insert, update and delete policies safely
- limits setlist management to members of the owning band
- adds `WITH CHECK` to updates so rows cannot be moved into another band's setlist
- keeps the reusable performance-item catalogue publicly readable
- leaves per-setlist performance records membership-protected
- adds a forward reconciliation for deployed databases
- adds regression coverage for policy targets, membership checks, replay safety and data preservation

## Root cause

PR #1435 advanced fresh Finance verification to:

```text
20251116161634_a15e5fed-31f9-49bf-8005-e67b3fa2a8bf.sql
ERROR: relation "performance_items" does not exist
DROP POLICY ... ON performance_items
```

The reusable public table is `performance_items_catalog`. `setlist_performance_items` is a separate per-setlist table and must remain private to the owning band.

## Behaviour

Band members can manage songs and performance actions in their own setlists. All players can browse the reusable action catalogue when building a show, but another band's setlist remains private.

## Validation

```bash
npm test -- src/lib/api/__tests__/setlistPerformancePolicyMigration.database.test.ts
supabase db start
supabase db reset
```

The branch differs from current `main` in exactly three focused files and remains draft until Finance verification reports the next fresh-database boundary.