### PR TITLE
Fix Financial Command Center profile loading

### DIFF
--- a/src/hooks/__tests__/useFinances.authority.test.ts
+++ b/src/hooks/__tests__/useFinances.authority.test.ts
@@ -40,6 +40,11 @@ describe("canonical Financial Command Center UI", () => {
     expect(hookSource).not.toContain("band_balance");
   });
 
+  it("does not hide active-profile loading failures behind an empty dashboard", () => {
+    expect(hookSource).toContain("isProfileLoading");
+    expect(hookSource).toContain("profileError ?? query.error");
+  });
+
   it("keeps transfers visible without classifying them as spending", () => {
     expect(hookSource).toContain('"transfer"');
     expect(hookSource).toContain("externalCashFlow");

--- a/src/hooks/useActiveProfile.ts
+++ b/src/hooks/useActiveProfile.ts
@@ -10,7 +10,7 @@ import { useAuth } from "@/hooks/use-auth-context";
 export function useActiveProfile() {
   const { user } = useAuth();
 
-  const { data: profile, isLoading } = useQuery({
+  const { data: profile, isLoading, error } = useQuery({
     queryKey: ["active-profile", user?.id],
     queryFn: async () => {
       if (!user?.id) return null;
@@ -27,5 +27,6 @@ export function useActiveProfile() {
     /** The auth-level user ID — use for tables where user_id stores auth.users.id */
     userId: user?.id ?? null,
     isLoading,
+    error,
   };
 }

--- a/src/hooks/useFinances.ts
+++ b/src/hooks/useFinances.ts
@@ -230,7 +230,11 @@ const mapCommandCenter = (data: FinanceCommandCenter) => {
 };
 
 export const useFinances = () => {
-  const { profileId } = useActiveProfile();
+  const {
+    profileId,
+    isLoading: isProfileLoading,
+    error: profileError,
+  } = useActiveProfile();
   const query = useQuery({
     queryKey: ["finance-command-center", profileId],
     queryFn: () => fetchFinanceCommandCenter(250),
@@ -253,8 +257,8 @@ export const useFinances = () => {
     investmentOptions: INVESTMENT_OPTIONS,
     banking: query.data?.banking ?? null,
     otherCurrencyBalances: query.data?.otherCurrencyBalances ?? [],
-    isLoading: !!profileId && query.isLoading,
-    error: query.error,
+    isLoading: isProfileLoading || (!!profileId && query.isLoading),
+    error: profileError ?? query.error,
     refetch: query.refetch,
   };
 };

--- a/src/services/__tests__/profileService.activeProfile.test.ts
+++ b/src/services/__tests__/profileService.activeProfile.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.resolve("src/services/profileService.ts"), "utf8");
+
+describe("active profile selection", () => {
+  it("deterministically selects one active profile when legacy data contains duplicates", () => {
+    const activeProfileQuery = source.slice(
+      source.indexOf("export async function getActiveProfile"),
+      source.indexOf("export async function getFirstLivingProfile"),
+    );
+
+    expect(activeProfileQuery).toContain('.order("updated_at"');
+    expect(activeProfileQuery).toContain('.order("created_at"');
+    expect(activeProfileQuery).toContain('.order("id"');
+    expect(activeProfileQuery).toContain(".limit(1)");
+    expect(activeProfileQuery.indexOf(".limit(1)")).toBeLessThan(
+      activeProfileQuery.indexOf(".maybeSingle()"),
+    );
+  });
+});

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -16,6 +16,13 @@ export async function getActiveProfile(userId: string): Promise<ProfileRow | nul
     .eq("user_id", userId)
     .eq("is_active", true)
     .is("died_at", null)
+    // Match current_active_player_profile_id(). Older accounts can contain more
+    // than one active row; maybeSingle() would otherwise reject the response and
+    // leave every active-character query (including Finances) disabled.
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false, nullsFirst: false })
+    .order("id", { ascending: true })
+    .limit(1)
     .maybeSingle();
 
   if (error) {


### PR DESCRIPTION
### Motivation

- The Financial Command Center could render an empty or failing UI when legacy accounts contain duplicate active-character rows and when active-profile load errors were swallowed.
- Make active-profile selection deterministic and surface profile loading/query errors to the finance hook so the dashboard shows loading/error states correctly.

### Description

- Change `getActiveProfile` in `src/services/profileService.ts` to order and `limit(1)` before `maybeSingle()` so a single active profile is deterministically selected for legacy data with duplicates.\n- Expose the query `error` from `useActiveProfile` in `src/hooks/useActiveProfile.ts`.\n- Update `useFinances` in `src/hooks/useFinances.ts` to include active-profile loading in its `isLoading` and to surface `profileError` via the hook `error` so the Finances page shows the proper error UI instead of an empty dashboard.\n- Add a regression test `src/services/__tests__/profileService.activeProfile.test.ts` and extend `src/hooks/__tests__/useFinances.authority.test.ts` to cover deterministic active-profile selection and finance error propagation.\n- Commit message: `Fix Financial Command Center profile loading` (changes across `profileService.ts`, `useActiveProfile.ts`, `useFinances.ts`, and tests).

### Testing

- Ran `npm run build` and the production build completed successfully; only existing mixed-import and chunk-size warnings were reported.\n- Ran `npm run typecheck` and it completed successfully.\n- Ran `git diff --check` which passed.\n- Targeted `vitest` runs (`src/hooks/__tests__/useFinances.authority.test.ts`, `src/lib/api/__tests__/financeCommandCenter.database.test.ts`, and the new `profileService` test) could not initialize due to missing test-tree dependencies (`rrweb-cssom` and `redent`), causing the test runner to fail to start.\n- Attempt to `npm install --no-save rrweb-cssom@0.7.1` was blocked by the registry with HTTP 403, preventing repair of the local test environment.\n- ESLint surfaced a pre-existing `@typescript-eslint/no-explicit-any` warning in `src/services/profileService.ts` unrelated to the loading logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a837455fc8325934db60d819c4c49)