### PR TITLE
fix(festivals): apply settlement outcomes through canonical progression authorities

### DIFF
--- a/docs/festivals/festival-active-callers.json
+++ b/docs/festivals/festival-active-callers.json
@@ -2365,6 +2365,7 @@
         "src/features/festivals/admin/mappers.ts",
         "src/features/festivals/admin/service.ts",
         "src/features/festivals/admin/types.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
         "src/features/festivals/admin/__tests__/operationsSummarySchema.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
         "src/features/festivals/admin/components/AdminFestivalCatalogue.tsx",
@@ -5800,6 +5801,8 @@
         "src/features/festivals/runtime/FestivalLiveControlRoom.tsx",
         "src/features/festivals/settlement/EditionSettlementWorkspace.tsx",
         "src/features/festivals/settlement/model.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.ts",
         "src/features/festivals/ui/CanonicalFestivalRoutes.tsx",
         "src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
@@ -9732,6 +9735,8 @@
         "src/features/festivals/runtime/FestivalLiveControlRoom.tsx",
         "src/features/festivals/settlement/EditionSettlementWorkspace.tsx",
         "src/features/festivals/settlement/model.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.ts",
         "src/features/festivals/ui/CanonicalFestivalRoutes.tsx",
         "src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
@@ -14883,6 +14888,26 @@
       "status": "legacy_active_or_cross_domain",
       "directDatabaseWriter": false,
       "browserAuthoritativeCalculation": false,
+      "writes": []
+    },
+    {
+      "file": "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+      "kind": "test",
+      "importers": [],
+      "status": "unused_or_dynamic",
+      "directDatabaseWriter": false,
+      "browserAuthoritativeCalculation": true,
+      "writes": []
+    },
+    {
+      "file": "src/features/festivals/settlement/outcomeLifecycle.ts",
+      "kind": "module",
+      "importers": [
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts"
+      ],
+      "status": "test_only",
+      "directDatabaseWriter": false,
+      "browserAuthoritativeCalculation": true,
       "writes": []
     },
     {
@@ -37657,6 +37682,54 @@
       ],
       "replacement": null,
       "retirementStatus": "investigate"
+    },
+    {
+      "type": "index",
+      "name": "festival_settlement_effect_claim_idx",
+      "migration": "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "claim_next_festival_settlement_effect",
+      "migration": "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "acknowledge_festival_settlement_effect",
+      "migration": "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "finalise_festival_settlement_effects",
+      "migration": "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
     }
   ],
   "rpcs": [
@@ -38158,7 +38231,8 @@
       "typescriptCallers": [],
       "sqlCallers": [
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
-        "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
+        "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql",
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
       ],
       "workerCallers": [],
       "testCallers": [
@@ -38172,7 +38246,8 @@
       "typescriptCallers": [],
       "sqlCallers": [
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
-        "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
+        "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql",
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
       ],
       "workerCallers": [],
       "testCallers": [
@@ -39540,6 +39615,17 @@
       "dynamicCallerReviewRequired": true
     },
     {
+      "name": "acknowledge_festival_settlement_effect",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
+      "dynamicCallerReviewRequired": true
+    },
+    {
       "name": "activate_completed_festival_upgrades",
       "typescriptCallers": [],
       "sqlCallers": [
@@ -40587,6 +40673,17 @@
         "supabase/tests/festival_crowds_incidents_operations_harness.sql"
       ],
       "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "claim_next_festival_settlement_effect",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -42104,6 +42201,17 @@
         "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql"
       ],
       "classification": "test_only",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "finalise_festival_settlement_effects",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -47324,6 +47432,7 @@
         "src/features/festivals/admin/mappers.ts",
         "src/features/festivals/admin/service.ts",
         "src/features/festivals/admin/types.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
         "src/features/festivals/admin/__tests__/operationsSummarySchema.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
         "src/features/festivals/admin/components/AdminFestivalCatalogue.tsx",
@@ -50767,6 +50876,8 @@
         "src/features/festivals/runtime/FestivalLiveControlRoom.tsx",
         "src/features/festivals/settlement/EditionSettlementWorkspace.tsx",
         "src/features/festivals/settlement/model.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.ts",
         "src/features/festivals/ui/CanonicalFestivalRoutes.tsx",
         "src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
@@ -54688,6 +54799,8 @@
         "src/features/festivals/runtime/FestivalLiveControlRoom.tsx",
         "src/features/festivals/settlement/EditionSettlementWorkspace.tsx",
         "src/features/festivals/settlement/model.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+        "src/features/festivals/settlement/outcomeLifecycle.ts",
         "src/features/festivals/ui/CanonicalFestivalRoutes.tsx",
         "src/features/festivals/admin/__tests__/adminFestivalManagement.test.ts",
         "src/features/festivals/admin/__tests__/ownerOperationsDashboard.test.ts",
@@ -59889,6 +60002,17 @@
       "risk": "medium",
       "verification": "npm run test:festivals:active-callers",
       "category": "remove_after_route_migration"
+    },
+    {
+      "candidate": "src/features/festivals/settlement/outcomeLifecycle.test.ts",
+      "currentCallers": [],
+      "replacement": null,
+      "dataMigrationRequirement": "none for source file; preserve data tables",
+      "safeRemovalPrerequisite": "route/import/dynamic-reference smoke proof",
+      "recommendedRetirementPr": "festival-route-migration",
+      "risk": "medium",
+      "verification": "npm run test:festivals:active-callers",
+      "category": "investigate"
     },
     {
       "candidate": "src/features/festivals/settlement/permissions.ts",

--- a/docs/festivals/settlement-progression-authorities.md
+++ b/docs/festivals/settlement-progression-authorities.md
@@ -1,0 +1,23 @@
+# Festival settlement progression authority audit
+
+Festival settlement is an orchestrator. It owns deterministic evidence, effect state, and stable references; it does **not** own progression balances.
+
+| Effect | Canonical authority / evidence | Festival policy |
+|---|---|---|
+| Performance score, fans, fame, member XP, fatigue, injury and song effects | `gig_outcomes` and the `auto-complete-gigs` / gig post-processing pipeline | Consume the immutable gig result. Never recompute or write its progression tables. Only attending members and performed setlist items may appear. |
+| Band chemistry | band contribution events followed by `recalculate_band_chemistry(uuid)` | Reuse the gig-completed contribution reference; do not add chemistry directly. |
+| Achievements | stable `achievements` definitions and canonical `player_achievements` award rows (whose trigger awards unlock XP) | Resolve an existing definition and recipient; store the returned award id. Evidence alone is not an award. |
+| Festival company reputation / fame | company reputation service (no safe Festival adapter currently exists) | Required effect fails with `FESTIVAL_EFFECT_CANONICAL_AUTHORITY_MISSING` until an adapter is deployed; never update a reputation column here. |
+| Artist and sponsor relationships | canonical relationship/sponsorship contract services | Verify `festival_contracts.band_id` or the accepted sponsor contract before applying a bounded delta. |
+| Licence | canonical Festival licence/application projection | Store the canonical projection id and result, rather than an isolated evidence document. |
+| World Pulse/news | `world_events` writer | Public, evidence-only payload and stable event reference; settlement financial details are excluded. |
+| Notifications | `create_notification` / typed `notifications` authority | Use a typed route and stable reference; recipients are resolved server-side. |
+| Finance and tax | finance RPCs and `financial_transactions` | Tax lines reconcile to `tax_minor`; payment transaction identifiers are canonical finance identifiers. |
+
+## Shared gig decision
+
+A Festival performance session must be adapted into the existing gig completion pipeline, or consume an already-completed immutable `gig_outcomes` projection. Settlement must use `festival-performance:{sessionId}:{effectType}:{subjectId}` as the authority idempotency key. If the projection already records that key, settlement classifies the effect as applied using that canonical result; it never awards it again. NPC sessions provide public performance evidence but player XP, player achievements, and player finance effects are `not_applicable`.
+
+## Lifecycle
+
+Calculation reads the locked runtime/settlement snapshots, records every component's source/raw/normalised/weight/contribution/missing handling/rules version, and creates `pending` effects. A bounded worker claims one row with a lease. Only a canonical authority response can acknowledge `applied`; failures preserve earlier results. Outcome `applied_at` is derived only after all its effects are `applied` or `not_applicable`. Final history must project `applied_result` and canonical identifiers, never requested payloads.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:festivals:runtime:db": "bash scripts/festivals/run-edition-runtime-db-gate.sh",
     "test:festivals:runtime": "vitest run --config vitest.runtime.config.ts src/features/festivals/runtime/model.test.ts",
     "test:festivals:settlement:db": "bash scripts/festivals/run-settlement-db-gate.sh",
-    "test:festivals:settlement": "vitest run --config vitest.settlement.config.ts src/features/festivals/settlement/model.test.ts"
+    "test:festivals:settlement": "vitest run --config vitest.settlement.config.ts src/features/festivals/settlement/model.test.ts src/features/festivals/settlement/outcomeLifecycle.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/festivals/certify-active-system.mjs
+++ b/scripts/festivals/certify-active-system.mjs
@@ -22,6 +22,14 @@ const allFiles = [...tsFiles, ...sqlFiles, ...walk("supabase/functions"), ...wal
 const contents = new Map(allFiles.map(file => [file, read(file)]));
 const festivalFiles = tsFiles.filter(file => /festival/i.test(file) || /festival/i.test(contents.get(file)));
 const finalSettlementMigration = read("supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql");
+const effectLifecycleMigration = read("supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql");
+if (!/ALTER COLUMN applied_at DROP DEFAULT/i.test(effectLifecycleMigration) || !/status NOT IN\('applied','not_applicable'\)/i.test(effectLifecycleMigration)) {
+  throw new Error("Festival effects may be recorded as applied before canonical completion.");
+}
+if (/SET requested_payload=result,status='applied'/i.test(effectLifecycleMigration)) throw new Error("Requested Festival effects are treated as applied results.");
+if (!/FESTIVAL_EFFECT_RECOVERY_REQUIRED/.test(effectLifecycleMigration) || !/lease_expires_at/.test(effectLifecycleMigration)) throw new Error("Festival effect recovery lifecycle is incomplete.");
+const browserProgressionWrite = festivalFiles.filter(file => file.includes("/settlement/")).some(file => /\.from\(["'`](?:bands|profiles|player_achievements|band_chemistry_snapshots|companies)["'`]\)\s*\.\s*(?:update|insert|upsert)/i.test(contents.get(file)));
+if (browserProgressionWrite) throw new Error("Browser Festival code writes canonical progression directly.");
 if (!/DROP\s+FUNCTION\s+IF\s+EXISTS\s+public\.post_festival_edition_settlement\(uuid,integer,uuid\)/i.test(finalSettlementMigration.replaceAll(/\s+/g, " ").replaceAll(/,\s+/g, ","))) {
   throw new Error("The retired monolithic Festival posting RPC is not permanently dropped.");
 }

--- a/src/features/festivals/settlement/outcomeLifecycle.test.ts
+++ b/src/features/festivals/settlement/outcomeLifecycle.test.ts
@@ -1,0 +1,12 @@
+import {describe,expect,it} from "vitest";
+import {appliedHistory,calculateEvidenceOutcome,licenceProgress,mapAchievement,outcomeAppliedAt,performanceEffectReference,resolveArtistIdentity,transitionEffect} from "./outcomeLifecycle";
+describe("Festival outcome lifecycle",()=>{
+ it("weights only runtime evidence and exposes missing evidence",()=>{const r=calculateEvidenceOutcome({performance:{source:"performance_sessions.score",raw:90,weight:3},queues:{source:"runtime.queue_minutes",raw:null,weight:1}});expect(r.score).toBe(90);expect(r.components.queues).toMatchObject({available:false,effectiveWeight:0,missing:"redistribute"});expect(r.components.performance.weightedContribution).toBe(90)});
+ it("never invents a neutral score without evidence",()=>expect(calculateEvidenceOutcome({sound:{source:"upgrade",raw:null,weight:1}}).score).toBeNull());
+ it("resolves the canonical performer instead of a contract id",()=>expect(resolveArtistIdentity({performer_type:"band",performer_id:"band-1"},{band_id:"other"})).toEqual({subjectType:"band",subjectId:"band-1"}));
+ it("rejects unresolved artists",()=>expect(resolveArtistIdentity({performer_id:"contract-1"})).toBeNull());
+ it("enforces transitions and completion",()=>{expect(transitionEffect("pending","applying")).toBe("applying");expect(()=>transitionEffect("pending","applied")).toThrow();expect(outcomeAppliedAt(["applied","not_applicable"],"now")).toBe("now");expect(outcomeAppliedAt(["applied","pending"],"now")).toBeNull()});
+ it("builds stable performance idempotency references",()=>expect(performanceEffectReference("session","band_fans","band")).toBe("festival-performance:session:band_fans:band"));
+ it("maps existing achievement keys and licence requirements",()=>{expect(mapAchievement("festival.sell_out")).toBe("festival.sell_out");expect(mapAchievement("made.up")).toBeNull();expect(licenceProgress({attendance:true,safety:false})).toEqual({requirementsMet:["attendance"],requirementsMissing:["safety"],percentageProgress:50,applicationEligible:false})});
+ it("history uses applied results only",()=>expect(appliedHistory([{stableReference:"a",status:"pending",appliedResult:{delta:5}},{stableReference:"b",status:"applied",appliedResult:{delta:3},canonicalId:"tx"}])).toEqual([{stableReference:"b",status:"applied",appliedResult:{delta:3},canonicalId:"tx"}]))
+});

--- a/src/features/festivals/settlement/outcomeLifecycle.ts
+++ b/src/features/festivals/settlement/outcomeLifecycle.ts
@@ -1,0 +1,38 @@
+export const FESTIVAL_OUTCOME_RULES_VERSION = "festival-outcomes-v2";
+
+export type EvidenceValue = { source: string; raw: number | null; normalised?: number; weight: number; missing?: "redistribute" | "not_applicable" };
+export type WeightedEvidence = EvidenceValue & { available: boolean; normalised: number | null; effectiveWeight: number; weightedContribution: number };
+export type WeightedOutcome = { score: number | null; components: Record<string, WeightedEvidence>; rulesVersion: string; missingEvidenceHandling: "redistribute_available_weights" };
+const clamp = (value:number) => Math.max(0, Math.min(100, value));
+
+/** Missing evidence is explicit and its weight is redistributed; no hidden neutral score is introduced. */
+export function calculateEvidenceOutcome(input: Record<string, EvidenceValue>): WeightedOutcome {
+  const availableWeight = Object.values(input).reduce((sum, item) => sum + (Number.isFinite(item.raw) && item.weight > 0 ? item.weight : 0), 0);
+  const components: Record<string, WeightedEvidence> = {};
+  let score = 0;
+  for (const [key, item] of Object.entries(input)) {
+    const available = Number.isFinite(item.raw) && item.weight > 0;
+    const normalised = available ? clamp(item.normalised ?? item.raw!) : null;
+    const effectiveWeight = availableWeight ? (available ? item.weight / availableWeight : 0) : 0;
+    const weightedContribution = normalised === null ? 0 : normalised * effectiveWeight;
+    score += weightedContribution;
+    components[key] = {...item, available, normalised, effectiveWeight, weightedContribution, missing: available ? item.missing : "redistribute"};
+  }
+  return {score: availableWeight ? Math.round(score * 100) / 100 : null, components, rulesVersion:FESTIVAL_OUTCOME_RULES_VERSION, missingEvidenceHandling:"redistribute_available_weights"};
+}
+
+export type EffectStatus = "pending"|"applying"|"applied"|"not_applicable"|"failed"|"recovery_required";
+const transitions:Record<EffectStatus,readonly EffectStatus[]>={pending:["applying","not_applicable"],applying:["applied","failed","recovery_required"],failed:["pending","recovery_required"],recovery_required:["pending"],applied:[],not_applicable:[]};
+export function transitionEffect(current:EffectStatus,next:EffectStatus){if(!transitions[current].includes(next))throw new Error(`Invalid Festival effect transition: ${current} -> ${next}`);return next;}
+export function outcomeAppliedAt(statuses:EffectStatus[],now:string):string|null{return statuses.length>0&&statuses.every(s=>s==="applied"||s==="not_applicable")?now:null;}
+
+export function performanceEffectReference(sessionId:string,effectType:string,subjectId:string){if(!sessionId||!effectType||!subjectId)throw new Error("Festival effect identity is incomplete");return `festival-performance:${sessionId}:${effectType}:${subjectId}`;}
+export function resolveArtistIdentity(contract:{performer_type?:unknown;performer_id?:unknown},session?:{band_id?:unknown;artist_id?:unknown}){
+ const type=contract.performer_type==="band"?"band":contract.performer_type==="solo_artist"?"solo_artist":null;
+ const id=typeof contract.performer_id==="string"?contract.performer_id:type==="band"&&typeof session?.band_id==="string"?session.band_id:type==="solo_artist"&&typeof session?.artist_id==="string"?session.artist_id:null;
+ if(!type||!id)return null; return {subjectType:type,subjectId:id};
+}
+export const FESTIVAL_ACHIEVEMENTS = new Set(["festival.found_company","festival.run_first","festival.profitable","festival.sell_out","festival.safe_event","festival.multi_day","festival.major","festival.max_upgrades","festival.five_editions","festival.ten_editions"]);
+export function mapAchievement(key:string){return FESTIVAL_ACHIEVEMENTS.has(key)?key:null;}
+export function licenceProgress(requirements:Record<string,boolean>){const entries=Object.entries(requirements),met=entries.filter(([,v])=>v).map(([k])=>k),missing=entries.filter(([,v])=>!v).map(([k])=>k);return {requirementsMet:met,requirementsMissing:missing,percentageProgress:entries.length?Math.round(met.length/entries.length*100):0,applicationEligible:entries.length>0&&missing.length===0};}
+export function appliedHistory(effects:Array<{stableReference:string;status:EffectStatus;appliedResult?:unknown;canonicalId?:string}>){return effects.filter(e=>e.status==="applied"||e.status==="not_applicable").map(({stableReference,status,appliedResult,canonicalId})=>({stableReference,status,appliedResult:status==="applied"?appliedResult:undefined,canonicalId}));}

--- a/supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql
+++ b/supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql
@@ -1,0 +1,71 @@
+-- Festival settlement effects are durable work, not evidence that work happened.
+-- Canonical authority inventory: docs/festivals/settlement-progression-authorities.md.
+ALTER TABLE public.festival_edition_settlement_effects
+  ADD COLUMN outcome_id uuid REFERENCES public.festival_edition_settlement_outcomes(id),
+  ADD COLUMN requested_payload jsonb NOT NULL DEFAULT '{}',
+  ADD COLUMN status text NOT NULL DEFAULT 'pending',
+  ADD COLUMN applied_result jsonb,
+  ADD COLUMN canonical_transaction_or_event_id text,
+  ADD COLUMN attempt_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN failure_code text,
+  ADD COLUMN failure_details jsonb,
+  ADD COLUMN claim_token uuid,
+  ADD COLUMN worker_identity text,
+  ADD COLUMN lease_expires_at timestamptz,
+  ADD COLUMN expected_settlement_version integer;
+ALTER TABLE public.festival_edition_settlement_effects ALTER COLUMN applied_at DROP NOT NULL;
+ALTER TABLE public.festival_edition_settlement_effects ALTER COLUMN applied_at DROP DEFAULT;
+ALTER TABLE public.festival_edition_settlement_effects ADD CONSTRAINT festival_effect_status_check CHECK(status IN('pending','applying','applied','not_applicable','failed','recovery_required'));
+CREATE INDEX festival_settlement_effect_claim_idx ON public.festival_edition_settlement_effects(settlement_id,status,created_at);
+
+-- Correct rows created by the previous placeholder migration. They have no
+-- canonical result identifier and therefore were never applied.
+UPDATE public.festival_edition_settlement_effects SET requested_payload=result,status='pending',result='{}',applied_at=NULL
+WHERE canonical_transaction_or_event_id IS NULL;
+UPDATE public.festival_edition_settlement_outcomes SET applied_at=NULL
+WHERE EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.settlement_id=festival_edition_settlement_outcomes.settlement_id AND e.canonical_transaction_or_event_id IS NULL);
+
+CREATE OR REPLACE FUNCTION public.claim_next_festival_settlement_effect(p_settlement_id uuid,p_worker_identity text,p_expected_settlement_version integer,p_lease_seconds integer DEFAULT 60)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE e public.festival_edition_settlement_effects%ROWTYPE; token uuid:=gen_random_uuid();
+BEGIN
+ IF NOT public._festival_edition_settlement_authorised((SELECT festival_company_id FROM public.festival_edition_settlements WHERE id=p_settlement_id)) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_ACCESS_DENIED'); END IF;
+ IF NOT EXISTS(SELECT 1 FROM public.festival_edition_settlements WHERE id=p_settlement_id AND settlement_version=p_expected_settlement_version AND state='applying_outcomes') THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_OUTCOME_NOT_READY'); END IF;
+ UPDATE public.festival_edition_settlement_effects SET status='pending',claim_token=NULL,worker_identity=NULL,lease_expires_at=NULL
+ WHERE settlement_id=p_settlement_id AND status='applying' AND lease_expires_at<now();
+ SELECT * INTO e FROM public.festival_edition_settlement_effects WHERE settlement_id=p_settlement_id AND status IN('pending','failed') ORDER BY created_at,id LIMIT 1 FOR UPDATE SKIP LOCKED;
+ IF NOT FOUND THEN RETURN NULL; END IF;
+ UPDATE public.festival_edition_settlement_effects SET status='applying',claim_token=token,worker_identity=nullif(btrim(p_worker_identity),''),lease_expires_at=now()+make_interval(secs=>least(greatest(p_lease_seconds,15),300)),attempt_count=attempt_count+1,expected_settlement_version=p_expected_settlement_version,failure_code=NULL,failure_details=NULL WHERE id=e.id RETURNING * INTO e;
+ RETURN to_jsonb(e);
+END $$;
+
+-- Called by the trusted effect worker only after the canonical authority returns.
+-- The stable reference is supplied to that authority, so its own uniqueness is
+-- the final defence against a worker crash between authority and acknowledgement.
+CREATE OR REPLACE FUNCTION public.acknowledge_festival_settlement_effect(p_effect_id uuid,p_claim_token uuid,p_status text,p_applied_result jsonb,p_canonical_id text,p_failure_code text DEFAULT NULL,p_failure_details jsonb DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE e public.festival_edition_settlement_effects%ROWTYPE;
+BEGIN
+ SELECT * INTO e FROM public.festival_edition_settlement_effects WHERE id=p_effect_id FOR UPDATE;
+ IF NOT FOUND THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_NOT_FOUND'); END IF;
+ IF e.status IN('applied','not_applicable') THEN RETURN to_jsonb(e); END IF;
+ IF e.status<>'applying' OR e.claim_token IS DISTINCT FROM p_claim_token OR e.lease_expires_at<now() THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_RECOVERY_REQUIRED'); END IF;
+ IF p_status NOT IN('applied','not_applicable','failed','recovery_required') THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_APPLICATION_FAILED'); END IF;
+ IF p_status='applied' AND (p_applied_result IS NULL OR nullif(p_canonical_id,'') IS NULL) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_APPLICATION_FAILED'); END IF;
+ UPDATE public.festival_edition_settlement_effects SET status=p_status,applied_result=CASE WHEN p_status='applied' THEN p_applied_result END,canonical_transaction_or_event_id=CASE WHEN p_status='applied' THEN p_canonical_id END,failure_code=CASE WHEN p_status IN('failed','recovery_required') THEN coalesce(p_failure_code,'FESTIVAL_EFFECT_APPLICATION_FAILED') END,failure_details=CASE WHEN p_status IN('failed','recovery_required') THEN p_failure_details END,applied_at=CASE WHEN p_status IN('applied','not_applicable') THEN now() END,claim_token=NULL,worker_identity=NULL,lease_expires_at=NULL WHERE id=e.id RETURNING * INTO e;
+ IF p_status IN('failed','recovery_required') THEN UPDATE public.festival_edition_settlements SET state='recovery_required',updated_at=now() WHERE id=e.settlement_id; END IF;
+ UPDATE public.festival_edition_settlement_outcomes o SET applied_at=now() WHERE o.id=e.outcome_id AND o.applied_at IS NULL AND NOT EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects x WHERE x.outcome_id=o.id AND x.status NOT IN('applied','not_applicable'));
+ RETURN to_jsonb(e);
+END $$;
+
+CREATE OR REPLACE FUNCTION public.finalise_festival_settlement_effects(p_settlement_id uuid) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE pending integer; failed integer;
+BEGIN
+ IF NOT public._festival_edition_settlement_authorised((SELECT festival_company_id FROM public.festival_edition_settlements WHERE id=p_settlement_id)) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_ACCESS_DENIED'); END IF;
+ SELECT count(*) FILTER(WHERE status NOT IN('applied','not_applicable')),count(*) FILTER(WHERE status IN('failed','recovery_required')) INTO pending,failed FROM public.festival_edition_settlement_effects WHERE settlement_id=p_settlement_id;
+ IF failed>0 THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_RECOVERY_REQUIRED'); END IF;
+ IF pending>0 OR NOT EXISTS(SELECT 1 FROM public.festival_edition_settlement_outcomes WHERE settlement_id=p_settlement_id) OR EXISTS(SELECT 1 FROM public.festival_edition_settlement_outcomes WHERE settlement_id=p_settlement_id AND applied_at IS NULL) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_OUTCOME_NOT_READY'); END IF;
+ RETURN jsonb_build_object('settlementId',p_settlement_id,'state','effects_complete','appliedEffects',(SELECT count(*) FROM public.festival_edition_settlement_effects WHERE settlement_id=p_settlement_id AND status='applied'),'notApplicableEffects',(SELECT count(*) FROM public.festival_edition_settlement_effects WHERE settlement_id=p_settlement_id AND status='not_applicable'));
+END $$;
+REVOKE ALL ON FUNCTION public.claim_next_festival_settlement_effect(uuid,text,integer,integer),public.acknowledge_festival_settlement_effect(uuid,uuid,text,jsonb,text,text,jsonb),public.finalise_festival_settlement_effects(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_next_festival_settlement_effect(uuid,text,integer,integer),public.acknowledge_festival_settlement_effect(uuid,uuid,text,jsonb,text,text,jsonb),public.finalise_festival_settlement_effects(uuid) TO service_role;


### PR DESCRIPTION
### Motivation
- Replace placeholder "applied" outcome recording with a replay-safe lifecycle that uses existing canonical progression authorities rather than Festival-only progression tables.
- Ensure every festival outcome is evidence-derived, idempotent, and only marked applied after a canonical authority returns a stable result identifier.
- Provide an explicit leased worker/claim lifecycle so effect application is retryable, recoverable, and prevents duplicate progression changes.

### Description
- Add a migration `20291218244000_festival_settlement_effect_lifecycle.sql` that extends `festival_edition_settlement_effects`, introduces `status`/`claim_token`/`lease_expires_at`/`attempt_count`/`failure_*` fields, resets placeholder rows, and creates the index `festival_settlement_effect_claim_idx`.
- Add three database RPCs: `claim_next_festival_settlement_effect`, `acknowledge_festival_settlement_effect`, and `finalise_festival_settlement_effects` which implement leased claims, canonical-id-required acknowledgements, per-effect failure handling, and outcome `applied_at` derivation only after terminal effect states.
- Add Node utilities and deterministic helpers in `src/features/festivals/settlement/outcomeLifecycle.ts` for evidence weighting, effect transitions, stable performance idempotency references, artist identity resolution, achievement mapping and history projection, plus tests in `outcomeLifecycle.test.ts` and include them in the settlement test target (`package.json`).
- Document the audited canonical authorities and shared gig integration rules in `docs/festivals/settlement-progression-authorities.md` and harden the active-system certification checks in `scripts/festivals/certify-active-system.mjs` to detect premature application, missing leases, requested-result confusion and browser writes to canonical progression tables.

### Testing
- `npm run build` succeeded.
- `npm run verify:migration-timestamps` succeeded and the route/static certification checks ran (`test:festivals:routes`, `test:festivals:app-routes`, `test:festivals:active-callers`) all succeeded.
- `npm run test:festivals:settlement` (including the new `outcomeLifecycle` tests) passed.
- `npm run typecheck` did not complete within the available validation window and produced no diagnostic (stopped during validation).
- `npm run test:festivals:certification` reached the safety guard but failed in the local environment due to a missing `rrweb-cssom` module required by `jsdom`.
- Database lifecycle gates were not executed because the CI environment lacked `SUPABASE_DB_URL` or explicit local DB confirmation (`FESTIVAL_TEST_DATABASE_CONFIRMED=true`), so disposable-DB integration gates were intentionally refused.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b21e2833c83258de7a47569c5b45b)