### PR TITLE
fix(festivals): operationalise canonical settlement effect processing

### DIFF
--- a/docs/festivals/festival-active-callers.json
+++ b/docs/festivals/festival-active-callers.json
@@ -37730,6 +37730,114 @@
       "harnessCovered": [],
       "replacement": null,
       "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "_festival_outcome_application_guard",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "trigger",
+      "name": "festival_outcome_application_guard",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "claim_next_festival_settlement_effect",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "resume_festival_settlement_effects",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "_festival_effect_completion_guard",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "trigger",
+      "name": "festival_effect_completion_guard",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "finalise_ready_festival_settlement_effects",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "get_festival_settlement_effect_progress",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "acknowledge_festival_settlement_effect",
+      "migration": "supabase/migrations/20291218244200_operational_festival_effect_worker.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
     }
   ],
   "rpcs": [
@@ -38232,7 +38340,8 @@
       "sqlCallers": [
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql",
-        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
       ],
       "workerCallers": [],
       "testCallers": [
@@ -38247,13 +38356,25 @@
       "sqlCallers": [
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql",
-        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
       ],
       "workerCallers": [],
       "testCallers": [
         "supabase/tests/festival_edition_settlement_harness.sql"
       ],
       "classification": "test_only",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "_festival_effect_completion_guard",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -38546,6 +38667,17 @@
       "typescriptCallers": [],
       "sqlCallers": [
         "supabase/migrations/20291217161000_complete_festival_staffing_supplier_workflows.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "_festival_outcome_application_guard",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
       ],
       "workerCallers": [],
       "testCallers": [],
@@ -39616,13 +39748,18 @@
     },
     {
       "name": "acknowledge_festival_settlement_effect",
-      "typescriptCallers": [],
-      "sqlCallers": [
-        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+      "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
       ],
-      "workerCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
+      ],
       "testCallers": [],
-      "classification": "no_known_runtime_callers",
+      "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -40677,13 +40814,18 @@
     },
     {
       "name": "claim_next_festival_settlement_effect",
-      "typescriptCallers": [],
-      "sqlCallers": [
-        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
+      "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
       ],
-      "workerCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql",
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
+      ],
       "testCallers": [],
-      "classification": "no_known_runtime_callers",
+      "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -42215,6 +42357,21 @@
       "dynamicCallerReviewRequired": true
     },
     {
+      "name": "finalise_ready_festival_settlement_effects",
+      "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
+      ],
+      "sqlCallers": [
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/index.ts"
+      ],
+      "testCallers": [],
+      "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
       "name": "found_festival_company",
       "typescriptCallers": [
         "src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts",
@@ -42752,6 +42909,17 @@
       "workerCallers": [],
       "testCallers": [],
       "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "get_festival_settlement_effect_progress",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -44620,6 +44788,17 @@
       "workerCallers": [],
       "testCallers": [],
       "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "resume_festival_settlement_effects",
+      "typescriptCallers": [],
+      "sqlCallers": [
+        "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test:festivals:runtime:db": "bash scripts/festivals/run-edition-runtime-db-gate.sh",
     "test:festivals:runtime": "vitest run --config vitest.runtime.config.ts src/features/festivals/runtime/model.test.ts",
     "test:festivals:settlement:db": "bash scripts/festivals/run-settlement-db-gate.sh",
-    "test:festivals:settlement": "vitest run --config vitest.settlement.config.ts src/features/festivals/settlement/model.test.ts src/features/festivals/settlement/outcomeLifecycle.test.ts"
+    "test:festivals:settlement": "vitest run --config vitest.settlement.config.ts src/features/festivals/settlement/model.test.ts src/features/festivals/settlement/outcomeLifecycle.test.ts",
+    "test:festivals:effects": "vitest run --config vitest.settlement.config.ts supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/supabase/functions/process-festival-settlement-effects/dispatcher.test.ts
+++ b/supabase/functions/process-festival-settlement-effects/dispatcher.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { EFFECT_TYPES, authorityFor, dispatchFestivalEffect, FestivalEffectError, type Effect } from "./dispatcher";
+
+const effect = (overrides: Partial<Effect> = {}): Effect => ({ id:"e",settlement_id:"s",outcome_id:"o",effect_type:"band_fans",subject_type:"band",subject_id:"b",stable_reference:"festival-performance:p:band_fans:b",requested_payload:{delta:2},claim_token:"c",...overrides });
+describe("Festival effect dispatcher", () => {
+  it("maps every supported effect to an explicit authority", () => expect(EFFECT_TYPES.every(type => authorityFor(type))).toBe(true));
+  it("fails closed for unknown required effects", async () => { await expect(dispatchFestivalEffect({rpc:async()=>({data:null,error:null})},effect({effect_type:"mystery"}))).rejects.toMatchObject({code:"FESTIVAL_EFFECT_CANONICAL_AUTHORITY_MISSING"}); });
+  it("requires a canonical id for applied results", async () => { await expect(dispatchFestivalEffect({rpc:async()=>({data:{status:"applied",result:{}},error:null})},effect())).rejects.toMatchObject({code:"FESTIVAL_EFFECT_CANONICAL_ID_MISSING"}); });
+  it("preserves canonical not-applicable exclusions", async () => expect(dispatchFestivalEffect({rpc:async()=>({data:{status:"not_applicable",reason:"npc_act"},error:null})},effect())).resolves.toEqual({status:"not_applicable",reason:"npc_act"}));
+  it("passes the deterministic stable reference to canonical handlers", async () => { let args:Record<string,unknown>={}; const got=await dispatchFestivalEffect({rpc:async(_n,a)=>(args=a,{data:{status:"applied",canonicalId:"tx-1",result:{existing:true}},error:null})},effect()); expect(args.p_stable_reference).toBe("festival-performance:p:band_fans:b"); expect(got).toMatchObject({canonicalId:"tx-1"}); });
+  it("rejects invalid subject identities before authority invocation", async () => { const error=dispatchFestivalEffect({rpc:async()=>{throw Error("unreachable")}},effect({subject_id:""})); await expect(error).rejects.toBeInstanceOf(FestivalEffectError); });
+});

--- a/supabase/functions/process-festival-settlement-effects/dispatcher.ts
+++ b/supabase/functions/process-festival-settlement-effects/dispatcher.ts
@@ -1,0 +1,68 @@
+export const EFFECT_TYPES = [
+  "performance_result", "band_fans", "band_fame", "member_xp", "band_chemistry",
+  "song_familiarity", "song_popularity", "festival_company_reputation",
+  "festival_company_fame", "artist_relationship", "sponsor_relationship",
+  "achievement_award", "licence_progress", "world_event", "notification", "tax_projection",
+] as const;
+
+export type FestivalEffectType = typeof EFFECT_TYPES[number];
+export type Effect = {
+  id: string; settlement_id: string; outcome_id: string; effect_type: string;
+  subject_type: string; subject_id: string; stable_reference: string;
+  requested_payload: Record<string, unknown>; claim_token: string; required?: boolean;
+};
+export type Applied = { status: "applied"; canonicalId: string; result: Record<string, unknown> };
+export type NotApplicable = { status: "not_applicable"; reason: string };
+export type DispatchResult = Applied | NotApplicable;
+export type RpcClient = { rpc(name: string, args: Record<string, unknown>): Promise<{ data: unknown; error: { message: string; code?: string } | null }> };
+
+export class FestivalEffectError extends Error {
+  constructor(public code: string, message: string, public recoverable = false) { super(message); }
+}
+
+const authorities: Record<FestivalEffectType, string> = {
+  performance_result: "apply_festival_performance_result_effect",
+  band_fans: "apply_festival_band_fans_effect",
+  band_fame: "apply_festival_band_fame_effect",
+  member_xp: "apply_festival_member_xp_effect",
+  band_chemistry: "apply_festival_band_chemistry_effect",
+  song_familiarity: "apply_festival_song_familiarity_effect",
+  song_popularity: "apply_festival_song_popularity_effect",
+  festival_company_reputation: "apply_festival_company_reputation_effect",
+  festival_company_fame: "apply_festival_company_fame_effect",
+  artist_relationship: "apply_festival_artist_relationship_effect",
+  sponsor_relationship: "apply_festival_sponsor_relationship_effect",
+  achievement_award: "apply_festival_achievement_effect",
+  licence_progress: "apply_festival_licence_progress_effect",
+  world_event: "apply_festival_world_event_effect",
+  notification: "apply_festival_notification_effect",
+  tax_projection: "apply_festival_tax_projection_effect",
+};
+
+export function validateEffect(value: Effect): void {
+  if (!value.id || !value.settlement_id || !value.outcome_id || !value.subject_id || !value.claim_token)
+    throw new FestivalEffectError("FESTIVAL_EFFECT_INVALID_SUBJECT", "Effect identity is incomplete");
+  if (!value.stable_reference || !value.stable_reference.startsWith("festival-"))
+    throw new FestivalEffectError("FESTIVAL_EFFECT_INVALID_REFERENCE", "Stable reference is invalid");
+  if (!value.requested_payload || Array.isArray(value.requested_payload))
+    throw new FestivalEffectError("FESTIVAL_EFFECT_INVALID_PAYLOAD", "Requested payload must be an object");
+}
+
+export async function dispatchFestivalEffect(client: RpcClient, effect: Effect): Promise<DispatchResult> {
+  validateEffect(effect);
+  const authority = authorities[effect.effect_type as FestivalEffectType];
+  if (!authority) throw new FestivalEffectError("FESTIVAL_EFFECT_CANONICAL_AUTHORITY_MISSING", `No canonical authority for ${effect.effect_type}`);
+  const { data, error } = await client.rpc(authority, {
+    p_effect_id: effect.id, p_settlement_id: effect.settlement_id, p_outcome_id: effect.outcome_id,
+    p_subject_type: effect.subject_type, p_subject_id: effect.subject_id,
+    p_stable_reference: effect.stable_reference, p_requested_payload: effect.requested_payload,
+  });
+  if (error) throw new FestivalEffectError(error.code ?? "FESTIVAL_EFFECT_AUTHORITY_FAILED", error.message, true);
+  const result = data as Partial<Applied & NotApplicable> | null;
+  if (result?.status === "not_applicable" && typeof result.reason === "string") return { status: "not_applicable", reason: result.reason };
+  if (result?.status !== "applied" || typeof result.canonicalId !== "string" || !result.canonicalId)
+    throw new FestivalEffectError("FESTIVAL_EFFECT_CANONICAL_ID_MISSING", `${authority} did not return a canonical ID`, true);
+  return { status: "applied", canonicalId: result.canonicalId, result: (result.result ?? {}) as Record<string, unknown> };
+}
+
+export function authorityFor(type: FestivalEffectType): string { return authorities[type]; }

--- a/supabase/functions/process-festival-settlement-effects/index.ts
+++ b/supabase/functions/process-festival-settlement-effects/index.ts
@@ -1,0 +1,43 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { dispatchFestivalEffect, FestivalEffectError, type Effect } from "./dispatcher.ts";
+
+const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+serve(async (request) => {
+  if (request.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+  const supplied = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  if (!serviceKey || supplied !== serviceKey) return json({ error: "service_role_required" }, 401);
+  const client = createClient(Deno.env.get("SUPABASE_URL") ?? "", serviceKey, { auth: { persistSession: false } });
+  const input = await request.json().catch(() => ({})) as { batchSize?: number };
+  const limit = Math.min(Math.max(input.batchSize ?? 25, 1), 100);
+  let processed = 0, failed = 0;
+  for (let i = 0; i < limit; i++) {
+    const { data: effect, error: claimError } = await client.rpc("claim_next_festival_settlement_effect", {
+      p_settlement_id: null, p_worker_identity: "process-festival-settlement-effects", p_expected_settlement_version: null, p_lease_seconds: 90,
+    });
+    if (claimError) return json({ error: claimError.message, processed, failed }, 500);
+    if (!effect) break;
+    const claimed = effect as Effect;
+    try {
+      const result = await dispatchFestivalEffect(client, claimed);
+      await client.rpc("acknowledge_festival_settlement_effect", {
+        p_effect_id: claimed.id, p_claim_token: claimed.claim_token, p_status: result.status,
+        p_applied_result: result.status === "applied" ? result.result : { reason: result.reason },
+        p_canonical_id: result.status === "applied" ? result.canonicalId : null,
+      });
+      processed++;
+    } catch (cause) {
+      const error = cause instanceof FestivalEffectError ? cause : new FestivalEffectError("FESTIVAL_EFFECT_WORKER_FAILED", String(cause), true);
+      await client.rpc("acknowledge_festival_settlement_effect", {
+        p_effect_id: claimed.id, p_claim_token: claimed.claim_token,
+        p_status: error.recoverable ? "recovery_required" : "failed", p_applied_result: null,
+        p_canonical_id: null, p_failure_code: error.code, p_failure_details: { message: error.message },
+      });
+      failed++;
+    }
+  }
+  await client.rpc("finalise_ready_festival_settlement_effects", { p_limit: limit });
+  return json({ processed, failed, boundedBy: limit });
+});

--- a/supabase/migrations/20291218244100_festival_effect_settlement_states.sql
+++ b/supabase/migrations/20291218244100_festival_effect_settlement_states.sql
@@ -1,0 +1,4 @@
+ALTER TYPE public.festival_edition_settlement_state ADD VALUE IF NOT EXISTS 'calculating_outcomes';
+ALTER TYPE public.festival_edition_settlement_state ADD VALUE IF NOT EXISTS 'outcomes_calculated';
+ALTER TYPE public.festival_edition_settlement_state ADD VALUE IF NOT EXISTS 'applying_outcomes';
+ALTER TYPE public.festival_edition_settlement_state ADD VALUE IF NOT EXISTS 'effects_complete';

--- a/supabase/migrations/20291218244200_operational_festival_effect_worker.sql
+++ b/supabase/migrations/20291218244200_operational_festival_effect_worker.sql
@@ -1,0 +1,131 @@
+-- Complete the durable Festival outcome chain. The browser can prepare/recover
+-- its own settlement, but claiming, authority dispatch and acknowledgement stay
+-- service-role operations performed by process-festival-settlement-effects.
+ALTER TABLE public.festival_edition_settlement_effects
+  ADD COLUMN IF NOT EXISTS first_failed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS latest_failed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS canonical_handler text,
+  ADD COLUMN IF NOT EXISTS repair_recommendation text,
+  ADD COLUMN IF NOT EXISTS admin_decision jsonb,
+  ADD COLUMN IF NOT EXISTS resolved_at timestamptz;
+ALTER TABLE public.festival_edition_settlement_effects DROP CONSTRAINT IF EXISTS festival_effect_status_check;
+ALTER TABLE public.festival_edition_settlement_effects ADD CONSTRAINT festival_effect_status_check
+  CHECK(status IN('pending','applying','applied','not_applicable','failed','recovery_required','dead_letter'));
+
+-- Proven links only: the subject and outcome type must agree. Ambiguous legacy
+-- requests are retained as dead letters rather than attached to arbitrary rows.
+UPDATE public.festival_edition_settlement_effects e SET outcome_id=o.id
+FROM public.festival_edition_settlement_outcomes o
+WHERE e.outcome_id IS NULL AND o.settlement_id=e.settlement_id
+  AND o.subject_type=e.subject_type AND o.subject_id=e.subject_id
+  AND (o.outcome_type=e.effect_type OR
+       (o.outcome_type='artist' AND e.effect_type IN('performance_result','band_fans','band_fame','member_xp','band_chemistry','song_familiarity','song_popularity','artist_relationship')) OR
+       (o.outcome_type='sponsor' AND e.effect_type='sponsor_relationship'));
+UPDATE public.festival_edition_settlement_effects SET status='dead_letter',failure_code='FESTIVAL_EFFECT_OUTCOME_LINK_AMBIGUOUS',
+ failure_details=jsonb_build_object('migration','20291218244100','provenance','legacy result request'),latest_failed_at=now(),repair_recommendation='Platform admin must select the evidence-matching outcome'
+WHERE outcome_id IS NULL;
+
+CREATE OR REPLACE FUNCTION public._festival_outcome_application_guard() RETURNS trigger LANGUAGE plpgsql SET search_path='' AS $$
+BEGIN
+ IF NEW.applied_at IS NOT NULL AND EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.outcome_id=NEW.id AND e.status NOT IN('applied','not_applicable')) THEN
+  PERFORM public._festival_edition_settlement_error('FESTIVAL_OUTCOME_NOT_READY');
+ END IF; RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS festival_outcome_application_guard ON public.festival_edition_settlement_outcomes;
+CREATE TRIGGER festival_outcome_application_guard BEFORE UPDATE OF applied_at ON public.festival_edition_settlement_outcomes FOR EACH ROW EXECUTE FUNCTION public._festival_outcome_application_guard();
+
+-- A worker may request the next settlement globally. Version and ownership are
+-- checked when explicitly supplied; the function itself remains service-only.
+CREATE OR REPLACE FUNCTION public.claim_next_festival_settlement_effect(p_settlement_id uuid DEFAULT NULL,p_worker_identity text DEFAULT 'festival-effect-worker',p_expected_settlement_version integer DEFAULT NULL,p_lease_seconds integer DEFAULT 60)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE e public.festival_edition_settlement_effects%ROWTYPE; token uuid:=gen_random_uuid(); sid uuid;
+BEGIN
+ UPDATE public.festival_edition_settlement_effects SET status='pending',claim_token=NULL,worker_identity=NULL,lease_expires_at=NULL
+ WHERE status='applying' AND lease_expires_at<now();
+ SELECT x.id INTO sid FROM public.festival_edition_settlements x WHERE (p_settlement_id IS NULL OR x.id=p_settlement_id)
+  AND x.state IN('outcomes_calculated','applying_outcomes') AND EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects q WHERE q.settlement_id=x.id AND q.status='pending')
+  ORDER BY x.updated_at,x.id LIMIT 1 FOR UPDATE SKIP LOCKED;
+ IF sid IS NULL THEN RETURN NULL; END IF;
+ IF p_expected_settlement_version IS NOT NULL AND NOT EXISTS(SELECT 1 FROM public.festival_edition_settlements WHERE id=sid AND settlement_version=p_expected_settlement_version) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_VERSION_CONFLICT'); END IF;
+ UPDATE public.festival_edition_settlements SET state='applying_outcomes',updated_at=now() WHERE id=sid AND state='outcomes_calculated';
+ SELECT * INTO e FROM public.festival_edition_settlement_effects WHERE settlement_id=sid AND status='pending' ORDER BY created_at,id LIMIT 1 FOR UPDATE SKIP LOCKED;
+ UPDATE public.festival_edition_settlement_effects SET status='applying',claim_token=token,worker_identity=nullif(btrim(p_worker_identity),''),lease_expires_at=now()+make_interval(secs=>least(greatest(p_lease_seconds,15),300)),attempt_count=attempt_count+1,expected_settlement_version=(SELECT settlement_version FROM public.festival_edition_settlements WHERE id=sid),canonical_handler=effect_type WHERE id=e.id RETURNING * INTO e;
+ RETURN to_jsonb(e);
+END $$;
+
+CREATE OR REPLACE FUNCTION public.resume_festival_settlement_effects(p_settlement_id uuid,p_effect_ids uuid[] DEFAULT NULL,p_reason text DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE s public.festival_edition_settlements%ROWTYPE; retried integer;
+BEGIN
+ SELECT * INTO s FROM public.festival_edition_settlements WHERE id=p_settlement_id FOR UPDATE;
+ IF NOT FOUND OR NOT public._festival_edition_settlement_authorised(s.festival_company_id) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_ACCESS_DENIED'); END IF;
+ IF s.state<>'recovery_required' THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_INVALID_TRANSITION'); END IF;
+ IF EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects WHERE settlement_id=s.id AND status='applying' AND lease_expires_at>now()) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_ACTIVE_LEASE'); END IF;
+ UPDATE public.festival_edition_settlement_effects SET status='pending',claim_token=NULL,worker_identity=NULL,lease_expires_at=NULL
+ WHERE settlement_id=s.id AND status IN('failed','recovery_required') AND (p_effect_ids IS NULL OR id=ANY(p_effect_ids)) AND attempt_count<5;
+ GET DIAGNOSTICS retried=ROW_COUNT;
+ IF retried=0 THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_NO_RECOVERABLE_WORK'); END IF;
+ UPDATE public.festival_edition_settlements SET state='applying_outcomes',updated_at=now(),audit_metadata=jsonb_set(coalesce(audit_metadata,'{}'),'{lastEffectResume}',jsonb_build_object('at',now(),'reason',p_reason,'retried',retried)) WHERE id=s.id;
+ RETURN jsonb_build_object('settlementId',s.id,'retried',retried,'state','applying_outcomes');
+END $$;
+
+CREATE OR REPLACE FUNCTION public._festival_effect_completion_guard() RETURNS trigger LANGUAGE plpgsql SET search_path='' AS $$
+BEGIN
+ IF NEW.state='completed' AND (OLD.state<>'effects_complete'
+   OR NOT EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.settlement_id=NEW.id)
+   OR EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.settlement_id=NEW.id AND e.status NOT IN('applied','not_applicable'))
+   OR EXISTS(SELECT 1 FROM public.festival_edition_settlement_outcomes o WHERE o.settlement_id=NEW.id AND o.applied_at IS NULL)
+   OR (SELECT coalesce(sum(t.amount_minor),0) FROM public.festival_edition_tax_lines t WHERE t.settlement_id=NEW.id)<>NEW.tax_minor) THEN
+  PERFORM public._festival_edition_settlement_error('FESTIVAL_OUTCOME_NOT_READY');
+ END IF; RETURN NEW;
+END $$;
+DROP TRIGGER IF EXISTS festival_effect_completion_guard ON public.festival_edition_settlements;
+CREATE TRIGGER festival_effect_completion_guard BEFORE UPDATE OF state ON public.festival_edition_settlements FOR EACH ROW EXECUTE FUNCTION public._festival_effect_completion_guard();
+
+CREATE OR REPLACE FUNCTION public.finalise_ready_festival_settlement_effects(p_limit integer DEFAULT 25) RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE changed integer;
+BEGIN
+ UPDATE public.festival_edition_settlements s SET state='effects_complete',updated_at=now()
+ WHERE s.id IN (SELECT x.id FROM public.festival_edition_settlements x WHERE x.state='applying_outcomes'
+   AND EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.settlement_id=x.id)
+   AND NOT EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects e WHERE e.settlement_id=x.id AND e.status NOT IN('applied','not_applicable')) LIMIT least(greatest(p_limit,1),100));
+ GET DIAGNOSTICS changed=ROW_COUNT; RETURN changed;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.get_festival_settlement_effect_progress(p_settlement_id uuid) RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path='' AS $$
+DECLARE s public.festival_edition_settlements%ROWTYPE;
+BEGIN SELECT * INTO s FROM public.festival_edition_settlements WHERE id=p_settlement_id;
+ IF NOT FOUND OR NOT public._festival_edition_settlement_authorised(s.festival_company_id) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_SETTLEMENT_ACCESS_DENIED'); END IF;
+ RETURN jsonb_build_object('settlementId',s.id,'state',s.state,'outcomesCalculated',EXISTS(SELECT 1 FROM public.festival_edition_settlement_outcomes WHERE settlement_id=s.id),
+  'total',(SELECT count(*) FROM public.festival_edition_settlement_effects WHERE settlement_id=s.id),
+  'statuses',(SELECT coalesce(jsonb_object_agg(status,n),'{}') FROM (SELECT status,count(*) n FROM public.festival_edition_settlement_effects WHERE settlement_id=s.id GROUP BY status) q),
+  'lastFailure',(SELECT jsonb_build_object('code',failure_code,'at',latest_failed_at) FROM public.festival_edition_settlement_effects WHERE settlement_id=s.id AND failure_code IS NOT NULL ORDER BY latest_failed_at DESC NULLS LAST LIMIT 1));
+END $$;
+
+-- Failure metadata is append-only in spirit: acknowledgement records both first
+-- and latest failure, and moves exhausted work to manual repair.
+CREATE OR REPLACE FUNCTION public.acknowledge_festival_settlement_effect(p_effect_id uuid,p_claim_token uuid,p_status text,p_applied_result jsonb,p_canonical_id text,p_failure_code text DEFAULT NULL,p_failure_details jsonb DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE e public.festival_edition_settlement_effects%ROWTYPE; terminal text;
+BEGIN SELECT * INTO e FROM public.festival_edition_settlement_effects WHERE id=p_effect_id FOR UPDATE;
+ IF NOT FOUND OR e.status<>'applying' OR e.claim_token IS DISTINCT FROM p_claim_token OR e.lease_expires_at<now() THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_RECOVERY_REQUIRED'); END IF;
+ IF p_status='applied' AND (p_applied_result IS NULL OR nullif(p_canonical_id,'') IS NULL) THEN PERFORM public._festival_edition_settlement_error('FESTIVAL_EFFECT_CANONICAL_ID_MISSING'); END IF;
+ terminal:=CASE WHEN p_status IN('failed','recovery_required') AND e.attempt_count>=5 THEN 'dead_letter' ELSE p_status END;
+ UPDATE public.festival_edition_settlement_effects SET status=terminal,applied_result=CASE WHEN terminal IN('applied','not_applicable') THEN p_applied_result END,canonical_transaction_or_event_id=CASE WHEN terminal='applied' THEN p_canonical_id END,
+  applied_at=CASE WHEN terminal IN('applied','not_applicable') THEN now() END,failure_code=CASE WHEN terminal IN('failed','recovery_required','dead_letter') THEN coalesce(p_failure_code,'FESTIVAL_EFFECT_APPLICATION_FAILED') END,
+  failure_details=CASE WHEN terminal IN('failed','recovery_required','dead_letter') THEN p_failure_details END,first_failed_at=CASE WHEN terminal IN('failed','recovery_required','dead_letter') THEN coalesce(first_failed_at,now()) ELSE first_failed_at END,
+  latest_failed_at=CASE WHEN terminal IN('failed','recovery_required','dead_letter') THEN now() ELSE latest_failed_at END,repair_recommendation=CASE WHEN terminal='dead_letter' THEN 'Inspect immutable evidence and retry through admin repair' ELSE repair_recommendation END,
+  claim_token=NULL,worker_identity=NULL,lease_expires_at=NULL WHERE id=e.id RETURNING * INTO e;
+ IF terminal IN('failed','recovery_required','dead_letter') THEN UPDATE public.festival_edition_settlements SET state='recovery_required',updated_at=now() WHERE id=e.settlement_id; END IF;
+ UPDATE public.festival_edition_settlement_outcomes o SET applied_at=now() WHERE o.id=e.outcome_id AND NOT EXISTS(SELECT 1 FROM public.festival_edition_settlement_effects x WHERE x.outcome_id=o.id AND x.status NOT IN('applied','not_applicable'));
+ RETURN to_jsonb(e);
+END $$;
+
+REVOKE ALL ON FUNCTION public.claim_next_festival_settlement_effect(uuid,text,integer,integer),public.acknowledge_festival_settlement_effect(uuid,uuid,text,jsonb,text,text,jsonb),public.finalise_ready_festival_settlement_effects(integer) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_next_festival_settlement_effect(uuid,text,integer,integer),public.acknowledge_festival_settlement_effect(uuid,uuid,text,jsonb,text,text,jsonb),public.finalise_ready_festival_settlement_effects(integer) TO service_role;
+REVOKE ALL ON FUNCTION public.resume_festival_settlement_effects(uuid,uuid[],text),public.get_festival_settlement_effect_progress(uuid) FROM PUBLIC,anon;
+GRANT EXECUTE ON FUNCTION public.resume_festival_settlement_effects(uuid,uuid[],text),public.get_festival_settlement_effect_progress(uuid) TO authenticated,service_role;
+
+INSERT INTO public.cron_job_config(job_name,edge_function_name,display_name,description,schedule,is_active,allow_manual_trigger)
+VALUES('process-festival-settlement-effects','process-festival-settlement-effects','Process Festival settlement effects','Applies prepared Festival effects through canonical authorities','*/2 * * * *',true,true)
+ON CONFLICT(job_name) DO UPDATE SET edge_function_name=excluded.edge_function_name,schedule=excluded.schedule,is_active=true;


### PR DESCRIPTION
### Motivation
- Replace the legacy in-SQL outcome application that treated prepared requests as applied and instead ensure every Festival settlement effect is applied through canonical progression authorities using a trusted worker. 
- Provide a durable, auditable lifecycle for outcome calculation, pending effects, claims, canonical application, failure recovery and final settlement completion. 
- Prevent premature `applied_at` markers and settlement finalisation before canonical authorities, tax reconciliation and required world/achievement side-effects are persisted.

### Description
- Add a typed dispatcher with explicit `effect_type -> canonical RPC` mappings and payload validation in `supabase/functions/process-festival-settlement-effects/dispatcher.ts`. 
- Add a service-role Edge Function worker `supabase/functions/process-festival-settlement-effects/index.ts` that claims effects via `claim_next_festival_settlement_effect`, calls canonical handlers, and acknowledges results with `acknowledge_festival_settlement_effect`. 
- Add operational migrations `supabase/migrations/20291218244100_festival_effect_settlement_states.sql` and `supabase/migrations/20291218244200_operational_festival_effect_worker.sql` that introduce durable states (`calculating_outcomes`, `outcomes_calculated`, `applying_outcomes`, `effects_complete`), per-effect lease/attempt/failure/dead-letter metadata, safe legacy backfill logic linking only provable `outcome_id`s, and triggers preventing outcomes or settlements completing while effects or tax lines remain incomplete. 
- Implement recovery and admin-retry primitives (`resume_festival_settlement_effects`, `finalise_ready_festival_settlement_effects`) and add a `get_festival_settlement_effect_progress` projection for safe owner reads. 
- Wire the worker into the existing scheduler via `cron_job_config` and add a focused test harness and script entry `test:festivals:effects` with `supabase/functions/process-festival-settlement-effects/dispatcher.test.ts`. 

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully. 
- Ran effect unit tests with `npm run test:festivals:effects` and all dispatcher tests passed. 
- Ran settlement unit tests with `npm run test:festivals:settlement` and all settlement lifecycle tests passed. 
- Ran migration verification with `npm run verify:migration-timestamps` and it passed. 
- Ran the active-caller certification `npm run test:festivals:active-callers` and the inventory was refreshed successfully. 
- Built the project with `npm run build` and the production build completed successfully. 
- Note: the full disposable Festival DB gates were not executed because an explicit disposable `SUPABASE_DB_URL` was not provided in this environment, so no claim of database certification or end-to-end worker application against a disposable DB is made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c61dbfd308325820b7245a178a94a)