### PR TITLE
fix(festivals): implement real settlement lifecycle database certification

### DIFF
--- a/.github/workflows/festival-runtime-gate.yml
+++ b/.github/workflows/festival-runtime-gate.yml
@@ -113,15 +113,26 @@ jobs:
         run: |
           set -o pipefail
           npm run test:festivals:performance-effects:db 2>&1 | tee festival-runtime-diagnostics/performance-effects-replay-run.log
+      - name: Compare clean-database certification summaries
+        run: |
+          first="$(grep '^FESTIVAL_LIFECYCLE_SUMMARY ' festival-runtime-diagnostics/performance-effects-first-run.log)"
+          second="$(grep '^FESTIVAL_LIFECYCLE_SUMMARY ' festival-runtime-diagnostics/performance-effects-replay-run.log)"
+          test -n "$first"
+          test "$first" = "$second"
 
       - name: Capture runtime diagnostics
         if: always()
         run: |
           mkdir -p festival-runtime-diagnostics
-          supabase status > festival-runtime-diagnostics/supabase-status.txt 2>&1 || true
-          supabase logs db > festival-runtime-diagnostics/db.log 2>&1 || true
-          psql "$SUPABASE_DB_URL" -X -v ON_ERROR_STOP=0 -f scripts/festivals/runtime-diagnostics.sql \
-            > festival-runtime-diagnostics/database-summary.txt 2>&1 || true
+          if [ "$SUPABASE_STARTED" = true ]; then
+            supabase status > festival-runtime-diagnostics/supabase-status.txt 2>&1 || true
+            supabase logs db > festival-runtime-diagnostics/db.log 2>&1 || true
+            psql "$SUPABASE_DB_URL" -X -v ON_ERROR_STOP=0 -f scripts/festivals/runtime-diagnostics.sql \
+              > festival-runtime-diagnostics/database-summary.txt 2>&1 || true
+          else
+            printf '%s\n' 'Supabase was not started; database diagnostics skipped.' \
+              > festival-runtime-diagnostics/supabase-status.txt
+          fi
           sed -i -E 's#postgres(ql)?://[^[:space:]]+#postgresql://[redacted]#g; s#(password=)[^[:space:]]+#\1[redacted]#g' festival-runtime-diagnostics/* || true
       - name: Upload runtime diagnostics
         if: always()

--- a/scripts/festivals/certify-performance-effects-harness.mjs
+++ b/scripts/festivals/certify-performance-effects-harness.mjs
@@ -78,6 +78,13 @@ export function certifyPerformanceEffectsHarness(sql) {
   }
   if (/\bupdate\s+(?:public\.)?festival_edition_settlement_effects\b[\s\S]{0,500}?\bset\s+[\s\S]{0,200}?\b(?:status|applied_at)\s*=/i.test(executable))
     failures.push("effect lifecycle bypass");
+  if (/\binsert\s+into\s+(?:public\.)?(?:live_performance_outcomes|band_fan_progression_events|band_fame_progression_events|member_xp_transactions|song_performance_progression_events|festival_effect_authority_results)\b/i.test(executable))
+    failures.push("fabricated canonical record");
+  if (/\binsert\s+into\s+(?:public\.)?festival_edition_settlement_effects\s*\([^)]*\b(?:status|applied_at)\b/i.test(executable))
+    failures.push("pre-resolved seeded effect");
+  if (!/\bprepare_festival_(?:edition_)?settlement\s*\(/i.test(executable))
+    failures.push("production settlement preparation");
+  if (!/\bFESTIVAL_LIFECYCLE_SUMMARY\b/.test(sql)) failures.push("deterministic lifecycle summary");
   if (!/\b(?:raise\s+exception|assert)\b/i.test(executable) || !/\b(?:replay|duplicate|idempotent)[A-Za-z_0-9]*\b/i.test(executable)) failures.push("executable replay assertion");
   if (failures.length) throw new Error(`progression harness missing required coverage: ${failures.join(", ")}`);
   return { lifecycleCalls: lifecycleFunctions.length, persistedFixtureKinds: fixtureTables.length };

--- a/scripts/festivals/certify-performance-effects-harness.test.mjs
+++ b/scripts/festivals/certify-performance-effects-harness.test.mjs
@@ -4,8 +4,9 @@ import { certifyPerformanceEffectsHarness, lifecycleFunctions } from "./certify-
 
 const tables = ["festival_companies", "festivals", "festival_editions", "festival_runtime_performances", "festival_edition_settlements", "festival_edition_settlement_outcomes", "festival_edition_settlement_effects"];
 const valid = `\\set ON_ERROR_STOP on\nBEGIN;\n${tables.map(t => `INSERT INTO public.${t} DEFAULT VALUES;`).join("\n")}
+SELECT public.prepare_festival_edition_settlement(NULL, NULL, NULL);
 ${lifecycleFunctions.map(f => `SELECT public.${f}(NULL);`).join("\n")}
-DO $$ DECLARE replay_count integer := 0; BEGIN ASSERT replay_count = 0; END $$;\nROLLBACK;`;
+DO $$ DECLARE replay_count integer := 0; BEGIN ASSERT replay_count = 0; RAISE NOTICE 'FESTIVAL_LIFECYCLE_SUMMARY scenarios=1 settlements=1 effects=1'; END $$;\nROLLBACK;`;
 
 describe("performance effect SQL certification", () => {
   it("accepts executable lifecycle SQL", () => assert.doesNotThrow(() => certifyPerformanceEffectsHarness(valid)));
@@ -13,6 +14,9 @@ describe("performance effect SQL certification", () => {
   it("rejects scenario names and RPCs in quoted documentation", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("SELECT public.apply_festival_band_fans_effect(NULL);", "SELECT 'NPC scenario apply_festival_band_fans_effect(NULL)';")), /band_fans/));
   it("rejects calculator-only SQL", () => assert.throws(() => certifyPerformanceEffectsHarness("\\set ON_ERROR_STOP on\nBEGIN; SELECT calculate_live_performance_fans('{}'); ROLLBACK;"), /claim_next/));
   it("rejects a direct effect status update", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("ROLLBACK;", "UPDATE festival_edition_settlement_effects SET status='applied'; ROLLBACK;")), /bypass/));
-  it("rejects missing replay assertions", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("DO $$ DECLARE replay_count integer := 0; BEGIN ASSERT replay_count = 0; END $$;", "")), /replay/));
+  it("rejects missing replay assertions", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace(/DO \$\$ DECLARE replay_count[\s\S]*?END \$\$;/, "RAISE NOTICE 'FESTIVAL_LIFECYCLE_SUMMARY scenarios=1';")), /replay/));
   it("rejects missing rollback", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("ROLLBACK;", "COMMIT;")), /ROLLBACK/));
+  it("rejects fabricated canonical rows", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("ROLLBACK;", "INSERT INTO live_performance_outcomes DEFAULT VALUES; ROLLBACK;")), /fabricated/));
+  it("rejects manually pre-resolved effects", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("ROLLBACK;", "INSERT INTO festival_edition_settlement_effects(status) VALUES ('applied'); ROLLBACK;")), /pre-resolved/));
+  it("rejects missing production preparation", () => assert.throws(() => certifyPerformanceEffectsHarness(valid.replace("SELECT public.prepare_festival_edition_settlement(NULL, NULL, NULL);", "")), /preparation/));
 });


### PR DESCRIPTION
### Motivation

- Finish the Festival certification work by replacing fragile validator shortcuts with a stricter, production-oriented certification gate and prepare the CI workflow for a real disposable Supabase-driven harness run.
- Prevent accidental bypasses where test SQL could fabricate canonical records, pre-resolve effects, or omit the production settlement preparation call which would mask real failures.

### Description

- Hardened the SQL harness validator (`scripts/festivals/certify-performance-effects-harness.mjs`) to reject fabricated canonical rows, pre-resolved seeded effects, missing `prepare_festival_edition_settlement` calls, and missing deterministic lifecycle summary output, and to require replay assertions and transactional rollback. 
- Added focused unit tests (`scripts/festivals/certify-performance-effects-harness.test.mjs`) that assert the validator rejects calculator-only SQL, commented/quoted RPC names, missing replay assertions, missing rollback, fabricated canonical rows, pre-resolved effects, and missing production preparation, and added a deterministic lifecycle summary notice in the test fixture.
- Made the Festival runtime gate workflow (`.github/workflows/festival-runtime-gate.yml`) compare deterministic lifecycle summaries from two clean-database runs for bitwise equality and made diagnostic DB capture conditional on whether `supabase start` actually succeeded (uses `SUPABASE_STARTED` env flag), preserving strict `supabase stop --no-backup` when the stack was started.
- Kept explicit dispatcher behaviour by replacing implicit slice-based effect lists with explicit arrays in `supabase/functions/process-festival-settlement-effects/dispatcher.ts` (seven supported effect types and nine explicit fail-closed effect types).

### Testing

- Branch: `codex/fix-festivals-real-settlement-certification`, Commit: `c9fcd84`.
- `npm run test:festivals:performance-effects` — passed (validator tests + progression/dispatcher tests: 10 validator checks and 30 festival progression/dispatcher tests ran and passed in this environment).
- `npm run typecheck` — passed.
- `npm run verify:migration-timestamps` — passed.
- `npm run lint:ci` — used the new baseline file `.eslint-error-baseline.json` (baseline errors: 2717) and produced no new baseline regression in this workspace run.
- Database-driven lifecycle certification (`npm run test:festivals:performance-effects:db` and full Supabase stack runs) were not executed here because Docker and Supabase CLI were unavailable in this execution environment, so no hosted disposable-DB evidence is claimed; the workflow changes prepare CI to run and strictly compare two clean runs and fail on mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d899b01848325855d83d5ab93624e)