### PR TITLE
Draft: fix(festivals): complete clean database rebuild and execute a real settlement

### DIFF
--- a/src/hooks/useAwardInvites.ts
+++ b/src/hooks/useAwardInvites.ts
@@ -17,7 +17,7 @@ export const useNominatableBands = (search: string) => {
   return useQuery({
     queryKey: ["nominatable-bands", term],
     queryFn: async (): Promise<NominatableBand[]> => {
-      let query = (supabase as any)
+      let query = supabase
         .from("bands")
         .select("id, name, genre, fame, popularity")
         .eq("status", "active")
@@ -56,7 +56,7 @@ export const useAwardShowInvites = (showId?: string) =>
   useQuery({
     queryKey: ["award-show-invites", showId ?? "all"],
     queryFn: async (): Promise<AwardShowInviteRow[]> => {
-      let query = (supabase as any)
+      let query = supabase
         .from("award_show_invites")
         .select("*, bands:invitee_band_id(name)")
         .order("created_at", { ascending: false });
@@ -83,7 +83,7 @@ export const useInviteBandToPerform = () => {
       category_name?: string;
       message?: string;
     }) => {
-      const { data, error } = await (supabase as any).rpc("award_show_invite_band", {
+      const { data, error } = await supabase.rpc("award_show_invite_band", {
         p_award_show_id: input.award_show_id,
         p_band_id: input.band_id,
         p_invite_type: input.invite_type ?? "performer",
@@ -101,7 +101,7 @@ export const useInviteBandToPerform = () => {
       queryClient.invalidateQueries({ queryKey: ["award-invites"] });
       toast.success("Performance invitation sent");
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       toast.error("Failed to send invitation", { description: error.message });
     },
   });

--- a/src/hooks/useAwards.ts
+++ b/src/hooks/useAwards.ts
@@ -412,7 +412,7 @@ export const useAwards = (userId?: string, bandId?: string) => {
       invite_id: string;
       response_status: "accepted" | "declined";
     }) => {
-      const { data, error } = await (supabase as any).rpc("award_show_respond_invite", {
+      const { data, error } = await supabase.rpc("award_show_respond_invite", {
         p_invite_id: params.invite_id,
         p_response: params.response_status,
       });
@@ -429,7 +429,7 @@ export const useAwards = (userId?: string, bandId?: string) => {
           : "Invitation declined"
       );
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       toast.error("Failed to respond to invitation", { description: error.message });
     },
   });

--- a/supabase/migrations/20251218143953_884bd0f4-d2c9-4df5-afc3-50ea23053cf4.sql
+++ b/supabase/migrations/20251218143953_884bd0f4-d2c9-4df5-afc3-50ea23053cf4.sql
@@ -1,6 +1,51 @@
--- Seed record labels across major music cities worldwide
-INSERT INTO labels (name, description, headquarters_city, roster_slot_capacity, marketing_budget, genre_focus, reputation_score, market_share)
-VALUES
+-- Seed record labels across major music cities worldwide. Migrations do not run
+-- with an authenticated request, so auth.uid() cannot satisfy labels.created_by.
+-- Keep a real, deterministic auth principal for system-owned catalogue records.
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+VALUES (
+  '00000000-0000-0000-0000-000000000000'::uuid,
+  '00000000-0000-0000-0000-00000000a11e'::uuid,
+  'authenticated',
+  'authenticated',
+  'system-label-catalogue@rockmundo.invalid',
+  '',
+  '2000-01-01 00:00:00+00'::timestamptz,
+  '{"provider":"email","providers":["email"],"system_owned":true}'::jsonb,
+  '{"display_name":"Rockmundo label catalogue"}'::jsonb,
+  '2000-01-01 00:00:00+00'::timestamptz,
+  '2000-01-01 00:00:00+00'::timestamptz
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO labels (
+  id,
+  name,
+  description,
+  headquarters_city,
+  roster_slot_capacity,
+  marketing_budget,
+  genre_focus,
+  reputation_score,
+  market_share,
+  created_by
+)
+SELECT
+  md5('rockmundo:system-label:' || seed.name)::uuid,
+  seed.*,
+  '00000000-0000-0000-0000-00000000a11e'::uuid
+FROM (VALUES
   -- USA Labels
   ('Sonic Empire Records', 'Major label dominating the American rock and pop scene with worldwide distribution.', 'Los Angeles', 25, 5000000, ARRAY['Pop', 'Rock', 'R&B'], 85, 12.5),
   ('Brooklyn Underground', 'Indie label championing emerging artists from the NYC underground scene.', 'New York', 12, 500000, ARRAY['Indie Rock', 'Hip Hop', 'Electronic'], 45, 2.1),
@@ -62,4 +107,14 @@ VALUES
   ('Moscow Red Square Music', 'Russian label with diverse roster from classical to pop.', 'Moscow', 15, 2000000, ARRAY['Pop', 'Classical', 'Rock'], 60, 2.8),
   ('Warsaw Rising Records', 'Polish label championing Central European alternative music.', 'Warsaw', 10, 700000, ARRAY['Alternative', 'Electronic', 'Hip Hop'], 45, 1.0),
   ('Prague Bohemian Sounds', 'Czech label blending classical traditions with modern rock.', 'Prague', 8, 600000, ARRAY['Rock', 'Classical', 'Indie'], 42, 0.8)
+) AS seed (
+  name,
+  description,
+  headquarters_city,
+  roster_slot_capacity,
+  marketing_budget,
+  genre_focus,
+  reputation_score,
+  market_share
+)
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
### Motivation

- The label catalogue seed failed during clean migrations because `labels.created_by` defaults to `auth.uid()` which is NULL during migration runs, so the migration must deterministically create or reference a system auth user and supply `created_by` explicitly.
- A recent change introduced a small lint regression (4 new errors above baseline) that must be fixed so `lint:ci` reports no new errors.
- This change is a narrow, safe repair to enable a future full festival lifecycle certification and to unblock the database migration chain from an empty database.

### Description

- Repair the label seed migration by creating a deterministic system-owned `auth.users` principal and inserting labels with deterministic UUIDs and an explicit `created_by`, preserving the non-null foreign key and making reapplication conflict-safe (`supabase/migrations/20251218143953_884bd0f4-d2c9-4df5-afc3-50ea23053cf4.sql`).
- Replace ad-hoc `any` usages in awards hooks with the typed Supabase client and stricter error types to resolve the lint regressions (`src/hooks/useAwardInvites.ts` and `src/hooks/useAwards.ts`).
- Fix the four lint regressions that increased the ESLint count and ensure the `lint:ci` script still reports baseline/current/new counts unchanged from the baseline policy.
- Opened this work as a draft branch `codex/festival-clean-rebuild-real-settlement` so further database lifecycle work and harness replacement can be executed and validated in an environment with Supabase CLI and Docker available.

### Testing

- Ran `npm run lint:ci` which printed `ESLint baseline errors: 2717`, `ESLint current errors: 2715`, and `ESLint new errors: 0` (regressions resolved).
- Ran `npm run typecheck` which completed without errors.
- Ran `npm run verify:migration-timestamps` which completed successfully and validated migration filenames.
- Executed `node --test scripts/festivals/certify-performance-effects-harness.test.mjs` and the static certification suite passed (`15/15` tests passed).
- Could not execute Supabase lifecycle commands (`supabase start`, `supabase db reset`, and DB-backed festival lifecycle tests) in this environment because the Supabase CLI and a container runtime are not available and `npx supabase` fetch was blocked by registry policy, so clean database startup, two resets, and the live DB harness runs were not performed here.

Repaired migration(s)

- `supabase/migrations/20251218143953_884bd0f4-d2c9-4df5-afc3-50ea23053cf4.sql` (deterministic auth principal + deterministic label IDs and explicit `created_by`).

Lint / CI summary

- `ESLint baseline errors`: 2717
- `ESLint current errors`: 2715
- `ESLint new errors`: 0

Note: This PR is intentionally opened as a draft because the full acceptance gate (clean Supabase startup, two independent DB resets, full festival lifecycle execution and hosted workflow run IDs) could not be executed from this environment and must be validated in CI or a developer environment with Supabase CLI and Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dae156b2c83258c314a3c0a7385d7)