### PR TITLE
fix(festivals): restore crew schema ordering and complete core settlement certification

### DIFF
--- a/docs/festivals/festival-active-callers.json
+++ b/docs/festivals/festival-active-callers.json
@@ -19975,7 +19975,8 @@
         "supabase/tests/festival_creation_phase1_harness.sql",
         "supabase/tests/festival_editions_harness.sql",
         "supabase/tests/festival_launch_ticket_sales_harness.sql",
-        "supabase/tests/festival_london_test_fixture.sql"
+        "supabase/tests/festival_london_test_fixture.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -20012,7 +20013,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": false,
       "rls": "not_applicable",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -20530,7 +20533,8 @@
         "supabase/tests/festival_company_founding_foundation_harness.sql",
         "supabase/tests/festival_creation_phase1_harness.sql",
         "supabase/tests/festival_editions_harness.sql",
-        "supabase/tests/festival_london_test_fixture.sql"
+        "supabase/tests/festival_london_test_fixture.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -23480,7 +23484,8 @@
       "rls": "inspect policies",
       "harnessCovered": [
         "supabase/tests/festival_company_financial_correctness_harness.sql",
-        "supabase/tests/festival_company_founding_foundation_harness.sql"
+        "supabase/tests/festival_company_founding_foundation_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -23494,7 +23499,8 @@
       "publiclyExecutable": false,
       "rls": "inspect policies",
       "harnessCovered": [
-        "supabase/tests/festival_company_founding_foundation_harness.sql"
+        "supabase/tests/festival_company_founding_foundation_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -24027,7 +24033,8 @@
         "supabase/tests/festival_creation_phase1_harness.sql",
         "supabase/tests/festival_editions_harness.sql",
         "supabase/tests/festival_launch_ticket_sales_harness.sql",
-        "supabase/tests/festival_london_test_fixture.sql"
+        "supabase/tests/festival_london_test_fixture.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -24088,7 +24095,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": false,
       "rls": "not_applicable",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -24128,7 +24137,8 @@
         "supabase/tests/festival_company_founding_foundation_harness.sql",
         "supabase/tests/festival_creation_phase1_harness.sql",
         "supabase/tests/festival_editions_harness.sql",
-        "supabase/tests/festival_london_test_fixture.sql"
+        "supabase/tests/festival_london_test_fixture.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -27230,7 +27240,8 @@
       "rls": "inspect policies",
       "harnessCovered": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -27347,7 +27358,8 @@
       "rls": "not_applicable",
       "harnessCovered": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -27531,7 +27543,8 @@
       "rls": "not_applicable",
       "harnessCovered": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -31400,7 +31413,8 @@
       "publiclyExecutable": false,
       "rls": "inspect policies",
       "harnessCovered": [
-        "supabase/tests/live_festival_runtime_foundation_harness.sql"
+        "supabase/tests/live_festival_runtime_foundation_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -35483,8 +35497,7 @@
       "harnessCovered": [
         "supabase/tests/festival_settlement_v4_semantic_harness.sql",
         "supabase/tests/festival_settlement_v5_native_harness.sql",
-        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql",
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -35610,8 +35623,7 @@
       "harnessCovered": [
         "supabase/tests/festival_settlement_v4_semantic_harness.sql",
         "supabase/tests/festival_settlement_v5_native_harness.sql",
-        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql",
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -35685,8 +35697,7 @@
       "harnessCovered": [
         "supabase/tests/festival_settlement_v4_semantic_harness.sql",
         "supabase/tests/festival_settlement_v5_native_harness.sql",
-        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql",
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -36386,8 +36397,7 @@
       "harnessCovered": [
         "supabase/tests/festival_settlement_v4_semantic_harness.sql",
         "supabase/tests/festival_settlement_v5_native_harness.sql",
-        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql",
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/festival_settlement_v6_lifecycle_fixture.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37019,7 +37029,8 @@
       "publiclyExecutable": false,
       "rls": "inspect policies",
       "harnessCovered": [
-        "supabase/tests/festival_edition_runtime_harness.sql"
+        "supabase/tests/festival_edition_runtime_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37106,7 +37117,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": false,
       "rls": "inspect policies",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -37196,7 +37209,8 @@
       "rls": "inspect policies",
       "harnessCovered": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37359,7 +37373,8 @@
       "rls": "not_applicable",
       "harnessCovered": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37373,7 +37388,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37427,7 +37443,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37441,7 +37458,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37455,7 +37473,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37522,7 +37541,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": false,
       "rls": "inspect policies",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -37559,7 +37580,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37573,7 +37595,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37587,7 +37610,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37685,7 +37709,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37699,7 +37724,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -37752,9 +37778,7 @@
       "acceptsWrites": false,
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
-      "harnessCovered": [
-        "supabase/tests/live_performance_progression_harness.sql"
-      ],
+      "harnessCovered": [],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -37840,7 +37864,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -37878,7 +37904,9 @@
       "acceptsWrites": false,
       "publiclyExecutable": false,
       "rls": "inspect policies",
-      "harnessCovered": [],
+      "harnessCovered": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "replacement": null,
       "retirementStatus": "investigate"
     },
@@ -38147,7 +38175,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -38173,7 +38202,8 @@
       "publiclyExecutable": "inspect grants",
       "rls": "not_applicable",
       "harnessCovered": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "replacement": null,
       "retirementStatus": "investigate"
@@ -40997,6 +41027,7 @@
     {
       "name": "apply_festival_band_chemistry_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41008,11 +41039,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41020,6 +41053,7 @@
     {
       "name": "apply_festival_band_fame_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41031,11 +41065,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41057,11 +41093,13 @@
       "workerCallers": [
         "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
-        "scripts/festivals/certify-performance-effects-harness.mjs"
+        "scripts/festivals/certify-performance-effects-harness.mjs",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
       ],
       "testCallers": [
         "supabase/tests/live_performance_progression_harness.sql",
-        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41110,10 +41148,12 @@
         "supabase/migrations/20291218244300_canonical_festival_effect_authorities.sql"
       ],
       "workerCallers": [
-        "scripts/festivals/certify-active-system.mjs"
+        "scripts/festivals/certify-active-system.mjs",
+        "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41152,6 +41192,7 @@
     {
       "name": "apply_festival_member_xp_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41163,11 +41204,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41203,6 +41246,7 @@
     {
       "name": "apply_festival_performance_result_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41214,11 +41258,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41241,6 +41287,7 @@
     {
       "name": "apply_festival_song_familiarity_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41252,11 +41299,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41264,6 +41313,7 @@
     {
       "name": "apply_festival_song_popularity_effect",
       "typescriptCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts"
       ],
       "sqlCallers": [
@@ -41275,11 +41325,13 @@
         "supabase/migrations/20291218244700_certify_live_performance_progression.sql"
       ],
       "workerCallers": [
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts",
         "supabase/functions/process-festival-settlement-effects/dispatcher.ts",
         "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "supabase/functions/process-festival-settlement-effects/dispatcher.test.ts"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41378,9 +41430,12 @@
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
       ],
-      "workerCallers": [],
+      "workerCallers": [
+        "scripts/festivals/certify-performance-effects-harness.mjs"
+      ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -41955,10 +42010,12 @@
       ],
       "workerCallers": [
         "supabase/functions/process-festival-settlement-effects/index.ts",
-        "scripts/festivals/certify-performance-effects-harness.mjs"
+        "scripts/festivals/certify-performance-effects-harness.mjs",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
       ],
       "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
+        "supabase/tests/live_performance_progression_harness.sql",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -43423,10 +43480,12 @@
         "supabase/migrations/20291218244300_canonical_festival_effect_authorities.sql"
       ],
       "workerCallers": [
-        "scripts/festivals/certify-active-system.mjs"
+        "scripts/festivals/certify-active-system.mjs",
+        "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -43440,9 +43499,12 @@
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
       ],
-      "workerCallers": [],
+      "workerCallers": [
+        "scripts/festivals/certify-performance-effects-harness.mjs"
+      ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -43489,13 +43551,9 @@
       "sqlCallers": [
         "supabase/migrations/20291218244000_festival_settlement_effect_lifecycle.sql"
       ],
-      "workerCallers": [
-        "scripts/festivals/certify-performance-effects-harness.mjs"
-      ],
-      "testCallers": [
-        "supabase/tests/live_performance_progression_harness.sql"
-      ],
-      "classification": "active_canonical",
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "no_known_runtime_callers",
       "dynamicCallerReviewRequired": true
     },
     {
@@ -43507,9 +43565,12 @@
         "supabase/migrations/20291218244200_operational_festival_effect_worker.sql"
       ],
       "workerCallers": [
-        "supabase/functions/process-festival-settlement-effects/index.ts"
+        "supabase/functions/process-festival-settlement-effects/index.ts",
+        "scripts/festivals/certify-performance-effects-harness.mjs"
       ],
-      "testCallers": [],
+      "testCallers": [
+        "supabase/tests/live_performance_progression_harness.sql"
+      ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
     },
@@ -45027,9 +45088,14 @@
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
       ],
-      "workerCallers": [],
+      "workerCallers": [
+        "scripts/festivals/certify-performance-effects-harness.mjs",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
+      ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql",
+        "scripts/festivals/certify-performance-effects-harness.test.mjs"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -45061,10 +45127,13 @@
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
       ],
-      "workerCallers": [],
+      "workerCallers": [
+        "scripts/festivals/certify-performance-effects-harness.mjs"
+      ],
       "testCallers": [
         "supabase/tests/festival_edition_settlement_harness.sql",
-        "supabase/tests/festival_settlement_harness.sql"
+        "supabase/tests/festival_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
@@ -46448,9 +46517,12 @@
         "supabase/migrations/20291218243800_authoritative_festival_edition_settlement.sql",
         "supabase/migrations/20291218243900_complete_festival_settlement_finalisation.sql"
       ],
-      "workerCallers": [],
+      "workerCallers": [
+        "scripts/festivals/certify-performance-effects-harness.mjs"
+      ],
       "testCallers": [
-        "supabase/tests/festival_edition_settlement_harness.sql"
+        "supabase/tests/festival_edition_settlement_harness.sql",
+        "supabase/tests/live_performance_progression_harness.sql"
       ],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true

--- a/scripts/supabase/crew-schema-ordering.test.mjs
+++ b/scripts/supabase/crew-schema-ordering.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const base = readFileSync(new URL("../../supabase/migrations/20251016084400_ee0afa77-eacf-408d-96ec-7e7ce39f3558.sql", import.meta.url), "utf8");
+const catalogue = readFileSync(new URL("../../supabase/migrations/20251218145220_6eb9869d-ea30-4de9-95e6-454fcbdaec26.sql", import.meta.url), "utf8");
+const expansion = readFileSync(new URL("../../supabase/migrations/20260416221940_b8a8632f-a7ba-4c7c-b83c-313bc40beed1.sql", import.meta.url), "utf8");
+
+test("crew authorities exist before their first alteration", () => {
+  assert.match(base, /CREATE TABLE IF NOT EXISTS public\.crew_catalog\s*\(/);
+  assert.match(base, /\bid TEXT PRIMARY KEY\b/);
+  assert.match(base, /CREATE TABLE IF NOT EXISTS public\.band_crew_members\s*\(/);
+});
+
+test("catalogue seeds preserve employment state", () => {
+  assert.doesNotMatch(catalogue, /DELETE FROM (?:public\.)?crew_catalog/i);
+  assert.match(catalogue, /ON CONFLICT \(id\) DO UPDATE SET/);
+  assert.doesNotMatch(catalogue.split(/ON CONFLICT \(id\) DO UPDATE SET/)[1], /hired_by_band_id\s*=/);
+  assert.match(expansion, /ON CONFLICT \(id\) DO UPDATE SET/);
+});
+
+test("catalogue NPC exclusivity is enforced at employment authority", () => {
+  assert.doesNotMatch(catalogue, /ON public\.crew_catalog\s*\(id\)\s*WHERE hired_by_band_id/i);
+  assert.match(catalogue, /UNIQUE INDEX IF NOT EXISTS band_crew_members_catalog_crew_active_uidx[\s\S]*ON public\.band_crew_members \(catalog_crew_id\)[\s\S]*WHERE catalog_crew_id IS NOT NULL/);
+  assert.match(catalogue, /catalog_crew_id TEXT REFERENCES public\.crew_catalog\(id\) ON DELETE SET NULL/);
+});

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1735,6 +1735,13 @@ export type Database = {
             referencedRelation: "bands"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "band_crew_members_catalog_crew_id_fkey"
+            columns: ["catalog_crew_id"]
+            isOneToOne: true
+            referencedRelation: "crew_catalog"
+            referencedColumns: ["id"]
+          },
         ]
       }
       band_demographic_fans: {

--- a/supabase/migrations/20251016084400_ee0afa77-eacf-408d-96ec-7e7ce39f3558.sql
+++ b/supabase/migrations/20251016084400_ee0afa77-eacf-408d-96ec-7e7ce39f3558.sql
@@ -14,8 +14,31 @@ CREATE TABLE public.band_stage_equipment (
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 
--- Create band_crew_members table
-CREATE TABLE public.band_crew_members (
+-- Canonical crew catalogue. Catalogue identifiers are deliberately text: they
+-- are stable game-data keys (for example, t1-tm-rookie), not entity UUIDs.
+CREATE TABLE IF NOT EXISTS public.crew_catalog (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  role TEXT NOT NULL,
+  headline TEXT NOT NULL,
+  background TEXT NOT NULL,
+  skill INTEGER NOT NULL CHECK (skill BETWEEN 0 AND 100),
+  salary INTEGER NOT NULL CHECK (salary >= 0),
+  experience INTEGER NOT NULL DEFAULT 0 CHECK (experience >= 0),
+  morale TEXT NOT NULL DEFAULT 'steady',
+  loyalty INTEGER NOT NULL DEFAULT 50 CHECK (loyalty BETWEEN 0 AND 100),
+  assignment TEXT NOT NULL DEFAULT 'Standby',
+  focus TEXT NOT NULL DEFAULT '',
+  specialties TEXT[] NOT NULL DEFAULT '{}',
+  traits TEXT[] NOT NULL DEFAULT '{}',
+  openings INTEGER NOT NULL DEFAULT 1 CHECK (openings >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Canonical band employment table. Later migrations add catalogue linkage and
+-- progression fields without replacing this ownership authority.
+CREATE TABLE IF NOT EXISTS public.band_crew_members (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   band_id UUID NOT NULL REFERENCES public.bands(id) ON DELETE CASCADE,
   crew_type VARCHAR NOT NULL,
@@ -215,7 +238,7 @@ CREATE POLICY "Band members can manage their merchandise"
 
 -- Create indexes for performance
 CREATE INDEX idx_band_equipment_band_id ON public.band_stage_equipment(band_id);
-CREATE INDEX idx_band_crew_band_id ON public.band_crew_members(band_id);
+CREATE INDEX IF NOT EXISTS idx_band_crew_band_id ON public.band_crew_members(band_id);
 CREATE INDEX idx_song_rehearsals_song_band ON public.song_rehearsals(song_id, band_id);
 CREATE INDEX idx_gig_performances_gig_id ON public.gig_song_performances(gig_id);
 CREATE INDEX idx_gig_outcomes_gig_id ON public.gig_outcomes(gig_id);

--- a/supabase/migrations/20251218145220_6eb9869d-ea30-4de9-95e6-454fcbdaec26.sql
+++ b/supabase/migrations/20251218145220_6eb9869d-ea30-4de9-95e6-454fcbdaec26.sql
@@ -1,25 +1,26 @@
 
 -- Add new columns to crew_catalog for star rating, fame-based unlocking, and exclusivity
-ALTER TABLE crew_catalog ADD COLUMN IF NOT EXISTS star_rating INTEGER NOT NULL DEFAULT 5 CHECK (star_rating >= 1 AND star_rating <= 10);
-ALTER TABLE crew_catalog ADD COLUMN IF NOT EXISTS min_fame_required INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE crew_catalog ADD COLUMN IF NOT EXISTS hired_by_band_id UUID REFERENCES public.bands(id) ON DELETE SET NULL;
-ALTER TABLE crew_catalog ADD COLUMN IF NOT EXISTS city TEXT;
+ALTER TABLE public.crew_catalog ADD COLUMN IF NOT EXISTS star_rating INTEGER NOT NULL DEFAULT 5 CHECK (star_rating >= 1 AND star_rating <= 10);
+ALTER TABLE public.crew_catalog ADD COLUMN IF NOT EXISTS min_fame_required INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE public.crew_catalog ADD COLUMN IF NOT EXISTS hired_by_band_id UUID REFERENCES public.bands(id) ON DELETE SET NULL;
+ALTER TABLE public.crew_catalog ADD COLUMN IF NOT EXISTS city TEXT;
 
 -- Add new columns to band_crew_members for cohesion mechanics
-ALTER TABLE band_crew_members ADD COLUMN IF NOT EXISTS star_rating INTEGER DEFAULT 5 CHECK (star_rating >= 1 AND star_rating <= 10);
-ALTER TABLE band_crew_members ADD COLUMN IF NOT EXISTS cohesion_rating NUMERIC NOT NULL DEFAULT 0 CHECK (cohesion_rating >= 0 AND cohesion_rating <= 100);
-ALTER TABLE band_crew_members ADD COLUMN IF NOT EXISTS gigs_together INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE band_crew_members ADD COLUMN IF NOT EXISTS catalog_crew_id TEXT;
+ALTER TABLE public.band_crew_members ADD COLUMN IF NOT EXISTS star_rating INTEGER DEFAULT 5 CHECK (star_rating >= 1 AND star_rating <= 10);
+ALTER TABLE public.band_crew_members ADD COLUMN IF NOT EXISTS cohesion_rating NUMERIC NOT NULL DEFAULT 0 CHECK (cohesion_rating >= 0 AND cohesion_rating <= 100);
+ALTER TABLE public.band_crew_members ADD COLUMN IF NOT EXISTS gigs_together INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE public.band_crew_members ADD COLUMN IF NOT EXISTS catalog_crew_id TEXT REFERENCES public.crew_catalog(id) ON DELETE SET NULL;
 
--- Create unique constraint so one crew member can only be hired by one band
-CREATE UNIQUE INDEX IF NOT EXISTS idx_crew_catalog_hired_by_band ON crew_catalog(id) WHERE hired_by_band_id IS NOT NULL;
-
--- Clear existing crew_catalog to seed fresh data
-DELETE FROM crew_catalog;
+-- A catalogue NPC may have at most one active band employment. The catalogue
+-- primary key already makes hired_by_band_id exclusive there; this index closes
+-- the race between inserting employment and updating catalogue availability.
+CREATE UNIQUE INDEX IF NOT EXISTS band_crew_members_catalog_crew_active_uidx
+  ON public.band_crew_members (catalog_crew_id)
+  WHERE catalog_crew_id IS NOT NULL;
 
 -- Seed 54 crew members across 5 tiers
 -- TIER 1 (1-2 stars): Entry-level, requires 0 fame - $200-500/gig
-INSERT INTO crew_catalog (id, name, role, headline, background, skill, salary, experience, morale, loyalty, assignment, focus, specialties, traits, openings, star_rating, min_fame_required) VALUES
+INSERT INTO public.crew_catalog (id, name, role, headline, background, skill, salary, experience, morale, loyalty, assignment, focus, specialties, traits, openings, star_rating, min_fame_required) VALUES
 ('t1-tm-rookie', 'Dave Murphy', 'Tour Manager', 'Fresh out of college but eager to learn the ropes.', 'Recently graduated from music business school. Organized campus concerts.', 25, 200, 1, 'steady', 50, 'Touring', 'Basic logistics', ARRAY['Schedule management', 'Basic routing'], ARRAY['Eager', 'Learning'], 1, 2, 0),
 ('t1-foh-beginner', 'Sarah Chen', 'Front of House Engineer', 'Local venue mixer taking first tour gig.', 'Spent two years mixing at a local club. Knows the basics well.', 30, 250, 2, 'steady', 55, 'Touring', 'Basic mixing', ARRAY['PA setup', 'Basic EQ'], ARRAY['Patient', 'Detail-oriented'], 1, 2, 0),
 ('t1-ld-starter', 'Mike Torres', 'Lighting Director', 'DIY venue tech branching into touring.', 'Self-taught lighting designer from the punk scene.', 28, 220, 1, 'steady', 52, 'Production', 'Basic lighting', ARRAY['Par cans', 'Basic cues'], ARRAY['Resourceful', 'Budget-conscious'], 1, 2, 0),
@@ -77,4 +78,21 @@ INSERT INTO crew_catalog (id, name, role, headline, background, skill, salary, e
 ('t5-backline-legend', 'Eddie "Golden Hands" Sanchez', 'Backline Technician', 'The tech who maintains historys most valuable instruments.', 'Trusted with guitars worth millions. Priceless expertise.', 95, 5500, 25, 'electric', 94, 'Touring', 'Priceless care', ARRAY['Museum pieces', 'Custom builds', 'Restoration'], ARRAY['Trusted', 'Irreplaceable'], 1, 9, 50000),
 ('t5-merch-mogul', 'Zara Diamond', 'Merch Director', 'Built merchandise into a billion-dollar business.', 'Transformed artist merchandise into lifestyle brands.', 94, 5200, 18, 'electric', 92, 'Standby', 'Empire building', ARRAY['Brand licensing', 'Fashion lines', 'Global retail'], ARRAY['Mogul', 'Visionary'], 1, 9, 50000),
 ('t5-security-legend', 'John "Ghost" Mitchell', 'Security Lead', 'The security chief every superstar wants.', 'Protected the biggest names for decades. Invisible and invincible.', 98, 7500, 30, 'electric', 97, 'Touring', 'Superstar protection', ARRAY['Intelligence networks', 'Global coordination', 'Zero incidents'], ARRAY['Ghost', 'Legend'], 1, 10, 50000),
-('t5-wardrobe-icon', 'Isabella DeLuca', 'Wardrobe Stylist', 'The stylist whose looks become iconic moments.', 'Created outfits that defined generations of artists.', 96, 6000, 20, 'electric', 94, 'Standby', 'Iconic fashion', ARRAY['Costume design', 'Brand creation', 'Cultural impact'], ARRAY['Icon maker', 'Legendary'], 1, 10, 50000);
+('t5-wardrobe-icon', 'Isabella DeLuca', 'Wardrobe Stylist', 'The stylist whose looks become iconic moments.', 'Created outfits that defined generations of artists.', 96, 6000, 20, 'electric', 94, 'Standby', 'Iconic fashion', ARRAY['Costume design', 'Brand creation', 'Cultural impact'], ARRAY['Icon maker', 'Legendary'], 1, 10, 50000)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  role = EXCLUDED.role,
+  headline = EXCLUDED.headline,
+  background = EXCLUDED.background,
+  skill = EXCLUDED.skill,
+  salary = EXCLUDED.salary,
+  experience = EXCLUDED.experience,
+  morale = EXCLUDED.morale,
+  loyalty = EXCLUDED.loyalty,
+  focus = EXCLUDED.focus,
+  specialties = EXCLUDED.specialties,
+  traits = EXCLUDED.traits,
+  openings = EXCLUDED.openings,
+  star_rating = EXCLUDED.star_rating,
+  min_fame_required = EXCLUDED.min_fame_required,
+  updated_at = now();

--- a/supabase/migrations/20260416221940_b8a8632f-a7ba-4c7c-b83c-313bc40beed1.sql
+++ b/supabase/migrations/20260416221940_b8a8632f-a7ba-4c7c-b83c-313bc40beed1.sql
@@ -64,4 +64,23 @@ INSERT INTO public.crew_catalog (id, name, role, headline, background, skill, sa
 ('seed-ward-02','Andre Lefevre','Wardrobe Stylist','Theater-tour stylist with capsule-collection chops.','French stylist known for dramatic theater capsules.',62,1800,5,'steady',62,'Studio','Theater wardrobe',ARRAY['Capsule collections','Quick changes','Wardrobe budgets'],ARRAY['Visionary','Detail-driven'],1,4,1400,'wardrobe-stylist'),
 ('seed-ward-03','Mei Tanaka','Wardrobe Stylist','Festival stylist who builds tour looks that photograph beautifully.','Tokyo stylist with editorial credits, now styling festival runs.',72,2500,7,'electric',68,'Studio','Festival wardrobe',ARRAY['Editorial styling','On-stage durability','Photo-ready looks'],ARRAY['Trend-spotter','Composed'],1,6,4000,'wardrobe-stylist'),
 ('seed-ward-04','Lior Ben-Ami','Wardrobe Stylist','Arena tour stylist with award-show credits.','Worked award-show red-carpet styling, now leads arena wardrobe.',83,3300,9,'electric',76,'Studio','Arena wardrobe',ARRAY['Award-show looks','Tour capsule','Atelier collabs'],ARRAY['Visionary','Network-rich'],1,8,18000,'wardrobe-stylist'),
-('seed-ward-05','Cyra Devereux','Wardrobe Stylist','Stadium-level stylist with iconic tour-defining looks.','Defined the visual identity of two record-setting tours.',94,4700,14,'electric',86,'Studio','Stadium & broadcast wardrobe',ARRAY['Tour identity','Couture collabs','Broadcast wardrobe'],ARRAY['Iconic','Visionary'],1,10,80000,'wardrobe-stylist');
+('seed-ward-05','Cyra Devereux','Wardrobe Stylist','Stadium-level stylist with iconic tour-defining looks.','Defined the visual identity of two record-setting tours.',94,4700,14,'electric',86,'Studio','Stadium & broadcast wardrobe',ARRAY['Tour identity','Couture collabs','Broadcast wardrobe'],ARRAY['Iconic','Visionary'],1,10,80000,'wardrobe-stylist')
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  role = EXCLUDED.role,
+  headline = EXCLUDED.headline,
+  background = EXCLUDED.background,
+  skill = EXCLUDED.skill,
+  salary = EXCLUDED.salary,
+  experience = EXCLUDED.experience,
+  morale = EXCLUDED.morale,
+  loyalty = EXCLUDED.loyalty,
+  assignment = EXCLUDED.assignment,
+  focus = EXCLUDED.focus,
+  specialties = EXCLUDED.specialties,
+  traits = EXCLUDED.traits,
+  openings = EXCLUDED.openings,
+  star_rating = EXCLUDED.star_rating,
+  min_fame_required = EXCLUDED.min_fame_required,
+  image_url = EXCLUDED.image_url,
+  updated_at = now();

--- a/supabase/tests/live_performance_progression_harness.sql
+++ b/supabase/tests/live_performance_progression_harness.sql
@@ -1,9 +1,27 @@
 \set ON_ERROR_STOP on
 BEGIN;
--- Explicit deterministic production fixtures (all constraints remain enabled).
-INSERT INTO public.festival_companies (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000001', '2030-01-01T00:00:00Z');
-INSERT INTO public.festivals (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000011', '2030-01-01T00:00:00Z');
-INSERT INTO public.festival_editions_v2 (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000002', '2030-01-01T00:00:00Z');
+-- Authentication and its canonical profile are always established before the
+-- player-owned Festival graph. All constraints, triggers and RLS remain active.
+INSERT INTO auth.users (id, email, created_at, updated_at)
+VALUES ('a1000000-0000-4000-8000-000000000099','festival-owner@example.test','2030-01-01T00:00:00Z','2030-01-01T00:00:00Z');
+INSERT INTO public.profiles (id, user_id, username, display_name, cash, premium_tokens, is_vip)
+VALUES ('a1000000-0000-4000-8000-000000000098','a1000000-0000-4000-8000-000000000099','festival_certifier','Festival Certifier',5000000,100,true);
+INSERT INTO public.cities (id, name, country, timezone)
+VALUES ('a1000000-0000-4000-8000-000000000097','Certification City','GB','UTC');
+INSERT INTO public.companies (id, owner_id, name, company_type, balance, headquarters_city_id)
+VALUES ('a1000000-0000-4000-8000-000000000096','a1000000-0000-4000-8000-000000000099','Certification Festivals Ltd','festival',1000000,'a1000000-0000-4000-8000-000000000097');
+INSERT INTO public.festival_companies
+  (id, company_id, owner_profile_id, public_name, slug, status, default_city_id, setup_completed, created_at)
+VALUES
+  ('a1000000-0000-4000-8000-000000000001','a1000000-0000-4000-8000-000000000096','a1000000-0000-4000-8000-000000000098','Certification Festival','certification-festival','active','a1000000-0000-4000-8000-000000000097',true,'2030-01-01T00:00:00Z');
+INSERT INTO public.festivals
+  (id, name, city_id, start_date, end_date, expected_attendance, metadata, created_at)
+VALUES
+  ('a1000000-0000-4000-8000-000000000011','Certification Festival','a1000000-0000-4000-8000-000000000097','2030-06-01','2030-06-01',1000,'{"fixture_key":"FESTIVAL-LIFECYCLE-CERTIFICATION"}','2030-01-01T00:00:00Z');
+INSERT INTO public.festival_editions_v2
+  (id, festival_company_id, edition_year, name, status, starts_on, ends_on, city_id, runtime_inputs, created_at)
+VALUES
+  ('a1000000-0000-4000-8000-000000000002','a1000000-0000-4000-8000-000000000001',2030,'Certification Festival 2030','completed','2030-06-01','2030-06-01','a1000000-0000-4000-8000-000000000097','{"capacity":1000,"ticketsSold":1000,"fixtureKey":"FESTIVAL-LIFECYCLE-CERTIFICATION"}','2030-01-01T00:00:00Z');
 INSERT INTO public.festival_edition_runtimes (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000003', '2030-01-01T00:00:00Z');
 INSERT INTO public.festival_runtime_completion_digests (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000004', '2030-01-01T00:00:00Z');
 INSERT INTO public.festival_runtime_performances (id, created_at) VALUES ('a1000000-0000-4000-8000-000000000005', '2030-01-01T00:00:00Z');
@@ -22,12 +40,14 @@ DECLARE
   claimed_effects integer;
   processed_effects integer;
   duplicate_canonical_records integer;
-  all_seven_effects_replayed boolean := true;
+  all_seven_effects_replayed integer;
 BEGIN
-  INSERT INTO auth.users (id, email, created_at, updated_at) VALUES ('a1000000-0000-4000-8000-000000000099','festival-owner@example.test','2030-01-01T00:00:00Z','2030-01-01T00:00:00Z');
   PERFORM set_config('request.jwt.claims', jsonb_build_object('sub','a1000000-0000-4000-8000-000000000099','role','authenticated')::text, true);
   ASSERT auth.uid() = 'a1000000-0000-4000-8000-000000000099'::uuid, 'authenticated fixture owner required';
-  ASSERT ARRAY['performance_result','band_fans','band_fame','member_xp','band_chemistry','song_familiarity','song_popularity']::text[] <@ ARRAY['performance_result','band_fans','band_fame','member_xp','band_chemistry','song_familiarity','song_popularity']::text[], 'all seven effects required';
+  ASSERT NOT EXISTS (
+    SELECT required.effect_type FROM unnest(ARRAY['performance_result','band_fans','band_fame','member_xp','band_chemistry','song_familiarity','song_popularity']::text[]) required(effect_type)
+    EXCEPT SELECT DISTINCT effect_type FROM public.festival_edition_settlement_effects WHERE settlement_id=lifecycle_contract.settlement_id
+  ), 'all seven effects required';
   -- The deterministic production graph is seeded below with explicit columns.
   -- From this point every authority is invoked; any missing evidence or invalid
   -- transition aborts psql because ON_ERROR_STOP is enabled.
@@ -52,16 +72,17 @@ BEGIN
   LOOP
     SELECT public.claim_next_festival_settlement_effect(settlement_id, 'festival-lifecycle-certifier', settlement_version, 1) INTO claim;
     EXIT WHEN claim IS NULL OR claim = 'null'::jsonb OR claim->>'id' IS NULL;
-    applied := CASE claim->>'effect_type'
-      WHEN 'performance_result' THEN public.apply_festival_performance_result_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'band_fans' THEN public.apply_festival_band_fans_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'band_fame' THEN public.apply_festival_band_fame_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'member_xp' THEN public.apply_festival_member_xp_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'band_chemistry' THEN public.apply_festival_band_chemistry_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'song_familiarity' THEN public.apply_festival_song_familiarity_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      WHEN 'song_popularity' THEN public.apply_festival_song_popularity_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload')
-      ELSE NULL
-    END;
+    CASE claim->>'effect_type'
+      WHEN 'performance_result' THEN SELECT public.apply_festival_performance_result_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'band_fans' THEN SELECT public.apply_festival_band_fans_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'band_fame' THEN SELECT public.apply_festival_band_fame_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'member_xp' THEN SELECT public.apply_festival_member_xp_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'band_chemistry' THEN SELECT public.apply_festival_band_chemistry_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'song_familiarity' THEN SELECT public.apply_festival_song_familiarity_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      WHEN 'song_popularity' THEN SELECT public.apply_festival_song_popularity_effect((claim->>'id')::uuid,settlement_id,(claim->>'outcome_id')::uuid,claim->>'subject_type',claim->>'subject_id',claim->>'stable_reference',claim->'requested_payload') INTO applied;
+      ELSE
+        RAISE EXCEPTION 'Unexpected settlement effect: %', claim->>'effect_type'
+    END CASE;
     ASSERT applied->>'canonicalId' IS NOT NULL, 'authority must return a canonical record';
     SELECT public.acknowledge_festival_settlement_effect((claim->>'id')::uuid,(claim->>'claim_token')::uuid,applied->>'status',applied->'result',applied->>'canonicalId') INTO replay;
   END LOOP;
@@ -76,7 +97,10 @@ BEGIN
   SELECT count(*) INTO processed_effects FROM public.festival_effect_authority_results WHERE settlement_id=lifecycle_contract.settlement_id;
   SELECT count(*) INTO duplicate_canonical_records FROM (SELECT stable_reference FROM public.festival_effect_authority_results WHERE settlement_id=lifecycle_contract.settlement_id GROUP BY stable_reference HAVING count(*)>1) duplicates;
   ASSERT claimed_effects>0 AND processed_effects>0 AND duplicate_canonical_records=0, 'executed lifecycle counts must reconcile';
-  ASSERT all_seven_effects_replayed, 'all supported effect authorities replayed idempotently';
+  SELECT count(DISTINCT effect_type) INTO all_seven_effects_replayed
+    FROM public.festival_effect_authority_results
+   WHERE settlement_id=lifecycle_contract.settlement_id;
+  ASSERT all_seven_effects_replayed = 7, 'all supported effect authorities replayed idempotently';
 END $lifecycle_contract$;
 
 -- Deterministic scenario manifest.  Domain fixtures are transaction-local and


### PR DESCRIPTION
### Motivation
- Fix clean-database startup failures caused by missing crew base tables and a destructive catalogue reseed, and complete the deterministic Festival settlement certification work left unfinished by the previous change set. 
- Ensure the crew catalogue ownership model, migration ordering, and employment exclusivity are canonical and safe for fresh databases and already-deployed data. 
- Replace the invalid SQL harness with a proper production-style fixture that seeds auth/profile then the player-owned Festival graph and exercises the full settlement/effect lifecycle.

### Description
- Create the canonical text-keyed `public.crew_catalog` before any later ALTER/seed and make `public.band_crew_members` the canonical band-employment table (added as `CREATE TABLE IF NOT EXISTS` in the historical migration). 
- Make later migrations schema-qualified and idempotent, add `catalog_crew_id REFERENCES public.crew_catalog(id)` to `band_crew_members`, convert the prior misleading uniqueness index into a single active-employment uniqueness index on `public.band_crew_members (catalog_crew_id) WHERE catalog_crew_id IS NOT NULL`, and avoid destructive `DELETE FROM crew_catalog` by using deterministic `ON CONFLICT (id) DO UPDATE` upserts that do not overwrite employment-owned fields. 
- Regenerate the Festival active-system inventory and update `docs/festivals/festival-active-callers.json` to include the real harness and effect callers. 
- Replace the invalid `supabase/tests/live_performance_progression_harness.sql` with a production fixture that first seeds `auth.users` and `public.profiles`, then creates deterministic city/company/festival/company/edition/runtime fixtures, executes the full settlement posting loop, dispatches and applies the seven canonical effects, enforces snake_case worker claim access, fails closed on unexpected effect types, and derives replay coverage from actual authority results instead of a preinitialised boolean. 
- Add a regression test `scripts/supabase/crew-schema-ordering.test.mjs` to assert crew schema ordering, non-destructive seeding, catalogue ID compatibility, and exclusivity enforcement. 
- Update generated Supabase types to reflect the `catalog_crew_id` foreign key relationship and minor index trigger/idempotency fixes.

### Testing
- Ran `npm run lint:ci` and it passed. 
- Ran `npm run typecheck` and it passed. 
- Regenerated and verified the active-system inventory with `node scripts/festivals/certify-active-system.mjs` and `node scripts/festivals/certify-active-system.mjs --check`, both completed successfully (inventory regenerated: 35 routes, 362 frontend files, 605 RPCs, 1461 database objects).
- Executed the performance-effects harness tests with `node --test scripts/festivals/certify-performance-effects-harness.test.mjs` and the suite passed (15 subtests passed). 
- Ran the added regression tests with `node --test scripts/supabase/crew-schema-ordering.test.mjs scripts/festivals/certify-performance-effects-harness.test.mjs` and they passed (combined 18 tests). 
- Ran `npm run verify:migration-timestamps` and it passed. 
- Triggered a production build with `npm run build` (Vite production build executed). 
- Note: full Supabase lifecycle verification (`supabase start --debug`, two `supabase db reset` runs and live harness execution) could not be executed in this environment because the Supabase CLI and container runtime are unavailable here; those database-lifecycle steps remain required by CI and must pass before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dd638467083258b2dea9ea6fc32c5)