### PR TITLE
Festivals Realignment 1: Restore annual editions and original setup contract

### DIFF
--- a/docs/festivals/FESTIVAL_REPLACEMENT_ARCHITECTURE.md
+++ b/docs/festivals/FESTIVAL_REPLACEMENT_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Festival Replacement Architecture
 
-Status: **Phase 10B — implementation complete through configuration, planning, runtime, settlement, progression, history and analytics; certification is the merge boundary.**
+Status: **Realignment in progress. The original 12-PR sequence remains the normative product contract. Realignment 1 restores the annual-edition and setup boundary without changing later balancing.**
 
 The original replacement sequence and architectural decisions are retained below as implementation history. They no longer describe work that is merely starting: Phases 1–8 and 9A are implemented, and the Phase 9B progression, immutable history, analytics/export and admin-observability surfaces are present with executable coverage.
 
@@ -87,6 +87,20 @@ The festival **company** persists year-round: balance, upgrades, staff
 relationships, reputation. The annual **edition** owns per-year mutable
 state: dates, site, lineup, tickets, settlement. Completed editions
 become read-only snapshot rows.
+
+### Implementation alignment register
+
+| Original planned phase | Current implementation | Alignment status | Known deviation | Required realignment PR |
+|---|---|---|---|---|
+| 2. Festival company | `festival_companies`, company ledger and permissions | Aligned | None in this boundary | — |
+| 3. Configuration + annual editions | `festival_configurations` and canonical `festival_editions_v2` | **Resolved here** | Planning was company-unique; completion did not create an edition; original setup fields were missing | Realignment 1 |
+| 4. Upgrades | Five upgrade levels | Deviated | Original contract requires levels 1–50 and a rolling purchase limit | Later upgrades realignment |
+| 5. Stages + timetable | Flexible timetable | Deviated | Original slot durations and 13:00–22:00 rules are not enforced | Later timetable realignment |
+| 6–8. Applications, contracts, fallback | Mature planning workflows | Partially aligned | Root planning records were company-scoped; new roots are now edition-addressable | Realignment 1 plus caller conversion |
+| 9–11. Runtime, settlement, history | Edition runtime, settlement and immutable snapshots | Aligned boundary | Rewards and formulas are deliberately unchanged | Later balancing only if approved |
+| 12. Legacy retirement | Legacy routes and tables remain enabled | Deviated by design | Replacement is not global and legacy is not deleted | Dedicated retirement PR |
+
+Cancelled editions do not consume the company/year uniqueness slot; a replacement draft may be created for that canonical game year. Cancelled rows remain retained and auditable.
 
 ## 8. Authority boundaries
 

--- a/docs/festivals/festival-active-callers.json
+++ b/docs/festivals/festival-active-callers.json
@@ -5859,6 +5859,7 @@
         "src/features/festival-company/ui/FestivalTicketPlanner.tsx",
         "src/features/festival-company/ui/FestivalTimetablePlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/features/festival-company/ui/PublicFestivalDirectory.tsx",
         "src/features/festival-company/ui/PublicFestivalPage.tsx",
         "src/features/festival-company/upgrades/FestivalUpgradeWorkspace.tsx",
@@ -5997,6 +5998,7 @@
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/lib/api/labels.ts",
         "src/lib/api/sponsorships.ts",
         "src/lib/workflows/contracts.ts",
@@ -9796,6 +9798,7 @@
         "src/features/festival-company/ui/FestivalTicketPlanner.tsx",
         "src/features/festival-company/ui/FestivalTimetablePlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/features/festival-company/ui/PublicFestivalDirectory.tsx",
         "src/features/festival-company/ui/PublicFestivalPage.tsx",
         "src/features/festival-company/upgrades/FestivalUpgradeWorkspace.tsx",
@@ -10852,6 +10855,7 @@
         "src/features/festivals/booking/components/FestivalSetlistEditor.tsx",
         "src/features/festivals/settlement/components/SettlementProgress.tsx",
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
+        "src/features/festival-company/ui/FestivalConfigurationWizard.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
@@ -16391,6 +16395,7 @@
         "src/features/festivals/booking/components/FestivalSetlistEditor.tsx",
         "src/features/festivals/settlement/components/SettlementProgress.tsx",
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
+        "src/features/festival-company/ui/FestivalConfigurationWizard.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
@@ -16628,6 +16633,7 @@
         "src/features/festivals/booking/components/FestivalSetlistEditor.tsx",
         "src/features/festivals/settlement/components/SettlementProgress.tsx",
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
+        "src/features/festival-company/ui/FestivalConfigurationWizard.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
@@ -17066,7 +17072,8 @@
         "src/features/festival-company/application/useFestivalTicketPlan.ts",
         "src/features/festival-company/application/useFestivalTimetable.ts",
         "src/features/festival-company/application/useFoundFestivalCompany.ts",
-        "src/features/festival-company/ui/FestivalCompanyCard.tsx"
+        "src/features/festival-company/ui/FestivalCompanyCard.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx"
       ],
       "status": "canonical_active",
       "directDatabaseWriter": false,
@@ -17098,6 +17105,14 @@
         },
         {
           "target": "save_festival_configuration",
+          "operation": "rpc"
+        },
+        {
+          "target": "complete_festival_setup_with_edition",
+          "operation": "rpc"
+        },
+        {
+          "target": "plan_next_festival_edition",
           "operation": "rpc"
         },
         {
@@ -17263,6 +17278,7 @@
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalTicketPlanner.tsx",
         "src/features/festival-company/ui/FestivalTimetablePlanner.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/features/festival-company/ui/PublicFestivalPage.tsx",
         "src/features/festival-company/upgrades/FestivalUpgradeWorkspace.tsx",
         "src/features/festival-company/upgrades/repository.ts",
@@ -17773,6 +17789,17 @@
         "src/features/festival-company/__tests__/appRouteBoundary.test.ts",
         "src/features/festival-company/__tests__/festivalCompanyFoundation.test.ts",
         "src/features/festival-company/__tests__/legacyFestivalGate.test.tsx"
+      ],
+      "status": "canonical_active",
+      "directDatabaseWriter": false,
+      "browserAuthoritativeCalculation": false,
+      "writes": []
+    },
+    {
+      "file": "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
+      "kind": "module",
+      "importers": [
+        "src/features/festival-company/ui/FestivalCompanySetupPage.tsx"
       ],
       "status": "canonical_active",
       "directDatabaseWriter": false,
@@ -19367,6 +19394,18 @@
     {
       "file": "src/features/festival-company/data/festivalCompanyRepository.ts",
       "target": "save_festival_configuration",
+      "operation": "rpc",
+      "classification": "canonical_rpc"
+    },
+    {
+      "file": "src/features/festival-company/data/festivalCompanyRepository.ts",
+      "target": "complete_festival_setup_with_edition",
+      "operation": "rpc",
+      "classification": "canonical_rpc"
+    },
+    {
+      "file": "src/features/festival-company/data/festivalCompanyRepository.ts",
+      "target": "plan_next_festival_edition",
       "operation": "rpc",
       "classification": "canonical_rpc"
     },
@@ -38573,6 +38612,140 @@
       "harnessCovered": [],
       "replacement": null,
       "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_vibe_catalogue",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_site_type_catalogue",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_environmental_policy_catalogue",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_edition_creation_requests",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [
+        "supabase/tests/festival_editions_harness.sql"
+      ],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_edition_audit",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "table",
+      "name": "festival_edition_migration_review",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "inspect policies",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "policy",
+      "name": "festival_edition_audit_owner_read",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "policy",
+      "name": "festival_edition_migration_admin_read",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "complete_festival_setup_with_edition",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "legacy_or_compatibility",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "function",
+      "name": "plan_next_festival_edition",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": "inspect grants",
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
+    },
+    {
+      "type": "view",
+      "name": "festival_edition_migration_summary",
+      "migration": "supabase/migrations/20291218244900_festival_annual_edition_realign.sql",
+      "ownerDomain": "festival-company",
+      "acceptsWrites": false,
+      "publiclyExecutable": false,
+      "rls": "not_applicable",
+      "harnessCovered": [],
+      "replacement": null,
+      "retirementStatus": "investigate"
     }
   ],
   "rpcs": [
@@ -42161,6 +42334,19 @@
       "dynamicCallerReviewRequired": true
     },
     {
+      "name": "complete_festival_setup_with_edition",
+      "typescriptCallers": [
+        "src/features/festival-company/data/festivalCompanyRepository.ts"
+      ],
+      "sqlCallers": [
+        "supabase/migrations/20291218244900_festival_annual_edition_realign.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
+      "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
       "name": "complete_festival_site_clearance",
       "typescriptCallers": [
         "src/features/festival-company/data/festivalRuntimeRepository.ts"
@@ -45047,6 +45233,19 @@
       "testCallers": [
         "supabase/tests/live_festival_runtime_foundation_harness.sql"
       ],
+      "classification": "active_canonical",
+      "dynamicCallerReviewRequired": true
+    },
+    {
+      "name": "plan_next_festival_edition",
+      "typescriptCallers": [
+        "src/features/festival-company/data/festivalCompanyRepository.ts"
+      ],
+      "sqlCallers": [
+        "supabase/migrations/20291218244900_festival_annual_edition_realign.sql"
+      ],
+      "workerCallers": [],
+      "testCallers": [],
       "classification": "active_canonical",
       "dynamicCallerReviewRequired": true
     },
@@ -52343,6 +52542,7 @@
         "src/features/festival-company/ui/FestivalTicketPlanner.tsx",
         "src/features/festival-company/ui/FestivalTimetablePlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/features/festival-company/ui/PublicFestivalDirectory.tsx",
         "src/features/festival-company/ui/PublicFestivalPage.tsx",
         "src/features/festival-company/upgrades/FestivalUpgradeWorkspace.tsx",
@@ -52483,6 +52683,7 @@
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/lib/api/labels.ts",
         "src/lib/api/sponsorships.ts",
         "src/lib/workflows/contracts.ts",
@@ -56269,6 +56470,7 @@
         "src/features/festival-company/ui/FestivalTicketPlanner.tsx",
         "src/features/festival-company/ui/FestivalTimetablePlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
+        "src/features/festival-company/ui/PlanNextAnnualEdition.tsx",
         "src/features/festival-company/ui/PublicFestivalDirectory.tsx",
         "src/features/festival-company/ui/PublicFestivalPage.tsx",
         "src/features/festival-company/upgrades/FestivalUpgradeWorkspace.tsx",
@@ -57329,6 +57531,7 @@
         "src/features/festivals/booking/components/FestivalSetlistEditor.tsx",
         "src/features/festivals/settlement/components/SettlementProgress.tsx",
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
+        "src/features/festival-company/ui/FestivalConfigurationWizard.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",
@@ -63020,6 +63223,7 @@
         "src/features/festivals/booking/components/FestivalSetlistEditor.tsx",
         "src/features/festivals/settlement/components/SettlementProgress.tsx",
         "src/features/festival-company/ui/FestivalArtistOpportunitiesPage.tsx",
+        "src/features/festival-company/ui/FestivalConfigurationWizard.tsx",
         "src/features/festival-company/ui/FestivalOperationsPlanner.tsx",
         "src/features/festival-company/ui/FestivalSponsorshipPlanner.tsx",
         "src/features/festival-company/ui/FestivalWizardProgress.tsx",

--- a/src/features/festival-company/README.md
+++ b/src/features/festival-company/README.md
@@ -1,4 +1,26 @@
-# festival-company (PR1 skeleton)
+# Festival Company replacement module
+
+## Canonical aggregate boundary
+
+`festival_companies` is permanent identity: company relationship, balance,
+permissions, reputation, upgrades, staff relationships and annual defaults.
+`festival_editions_v2` is the canonical occurrence aggregate: game year, dates,
+location, site, scale, programme, operations, sponsorship, timetable, runtime,
+settlement and immutable history. Company-only planning keys are transitional
+compatibility fields, not the final architecture.
+
+### Current-table mapping (Realignment 1 audit)
+
+| Classification | Tables |
+|---|---|
+| Permanent Festival Company data | `festival_companies`, `companies`, `festival_company_upgrades`, company ledger and permission relationships |
+| Annual Festival Edition data | `festival_editions_v2`; configuration, site, ticket, artist, operations, sponsorship and timetable roots linked by `festival_edition_id`; edition runtime and settlement tables |
+| Immutable historical data | `festival_edition_history_snapshots`, settlement evidence/digests, readiness snapshots and completed runtime evidence |
+| Legacy compatibility data | `festivals`, `festival_editions`, public legacy bridges/mappings, route resolvers and retained company IDs on planning rows |
+
+The additive migration links a planning root only when exactly one edition is a
+candidate. Ambiguous and unmapped rows are recorded in
+`festival_edition_migration_review`; no completed history is inferred or deleted.
 
 Replacement bounded context for the legacy festival system. PR1 introduces
 only the module boundary, feature flags and a legacy gate. No gameplay,

--- a/src/features/festival-company/application/useFestivalConfiguration.ts
+++ b/src/features/festival-company/application/useFestivalConfiguration.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getFestivalConfiguration, saveFestivalConfiguration } from "../data/festivalCompanyRepository";
+import { completeFestivalSetup, getFestivalConfiguration, saveFestivalConfiguration } from "../data/festivalCompanyRepository";
 import type { FestivalConfigurationDraft } from "../domain/festivalConfiguration";
 
 export const festivalConfigurationQueryKey = (id?: string) => ["festival-configuration", id] as const;
@@ -7,7 +7,11 @@ export const useFestivalConfiguration = (id?: string, enabled = true) => useQuer
 export const useSaveFestivalConfiguration = () => {
   const client = useQueryClient();
   return useMutation({
-    mutationFn: (input: { festivalCompanyId: string; expectedVersion: number; configuration: FestivalConfigurationDraft; idempotencyKey: string }) => saveFestivalConfiguration(input),
+    mutationFn: async (input: { festivalCompanyId: string; expectedVersion: number; configuration: FestivalConfigurationDraft; idempotencyKey: string }) => {
+      if (!input.configuration.complete) return saveFestivalConfiguration(input);
+      await completeFestivalSetup(input);
+      return getFestivalConfiguration(input.festivalCompanyId);
+    },
     onSuccess: (data) => {
       client.setQueryData(festivalConfigurationQueryKey(data.festivalCompanyId), data);
       void Promise.all(["festival-company-setup", "owned-festival-companies", "companies", "festival-company-capabilities"].map((key) => client.invalidateQueries({ queryKey: [key] })));

--- a/src/features/festival-company/data/festivalCompanyRepository.ts
+++ b/src/features/festival-company/data/festivalCompanyRepository.ts
@@ -183,6 +183,28 @@ export const saveFestivalConfiguration = async (input: { festivalCompanyId: stri
   return parseFestivalConfiguration(data);
 };
 
+export interface FestivalEditionCreationResult {
+  festivalCompanyId: string;
+  festivalEditionId: string;
+  editionYear: number;
+  status: "draft";
+  idempotent: boolean;
+}
+
+export const completeFestivalSetup = async (input: { festivalCompanyId: string; expectedVersion: number; configuration: FestivalConfigurationDraft; idempotencyKey: string }): Promise<FestivalEditionCreationResult> => {
+  const { data, error } = await (supabase as any).rpc("complete_festival_setup_with_edition", { p_festival_company_id: input.festivalCompanyId, p_expected_version: input.expectedVersion, p_configuration: toJson(input.configuration), p_idempotency_key: input.idempotencyKey });
+  if (error) throw normalizeFestivalConfigurationError(error);
+  if (!data || !isUuid(data.festivalCompanyId) || !isUuid(data.festivalEditionId) || !Number.isInteger(data.editionYear) || data.status !== "draft" || typeof data.idempotent !== "boolean") throw new Error("malformed_festival_edition_result");
+  return data;
+};
+
+export const planNextFestivalEdition = async (festivalCompanyId: string, idempotencyKey: string): Promise<FestivalEditionCreationResult> => {
+  const { data, error } = await (supabase as any).rpc("plan_next_festival_edition", { p_festival_company_id: festivalCompanyId, p_idempotency_key: idempotencyKey });
+  if (error) throw error;
+  if (!data || !isUuid(data.festivalCompanyId) || !isUuid(data.festivalEditionId) || !Number.isInteger(data.editionYear) || data.status !== "draft" || typeof data.idempotent !== "boolean") throw new Error("malformed_festival_edition_result");
+  return data;
+};
+
 
 const siteErrors: Record<string, string> = { festival_site_plan_forbidden: "festival_site_plan_forbidden", festival_configuration_incomplete: "festival_configuration_incomplete", festival_site_invalid: "festival_site_invalid", festival_venue_invalid: "festival_venue_invalid", festival_city_mismatch: "festival_city_mismatch", festival_capacity_invalid: "festival_capacity_invalid", festival_stage_invalid: "festival_stage_invalid", festival_stage_limit_exceeded: "festival_stage_limit_exceeded", festival_site_plan_stale: "festival_site_plan_stale", festival_site_plan_idempotency_conflict: "festival_site_plan_idempotency_conflict" };
 const normalizeSiteError = (error: { message?: string }) => new Error(Object.entries(siteErrors).find(([key]) => error.message?.includes(key))?.[1] ?? "festival_site_plan_unavailable");

--- a/src/features/festival-company/domain/festivalConfiguration.ts
+++ b/src/features/festival-company/domain/festivalConfiguration.ts
@@ -16,6 +16,12 @@ export const festivalConfigurationStatuses = [
 export type FestivalScale = (typeof festivalScales)[number];
 export type FestivalConfigurationStatus =
   (typeof festivalConfigurationStatuses)[number];
+export const festivalVibes = ["community", "alternative", "mainstream", "premium"] as const;
+export const festivalSiteTypes = ["indoor", "outdoor", "mixed"] as const;
+export const festivalEnvironmentalPolicies = ["standard", "responsible", "regenerative"] as const;
+export type FestivalVibe = (typeof festivalVibes)[number];
+export type FestivalSiteType = (typeof festivalSiteTypes)[number];
+export type FestivalEnvironmentalPolicy = (typeof festivalEnvironmentalPolicies)[number];
 
 export interface FestivalScaleOption {
   key: FestivalScale;
@@ -41,6 +47,13 @@ export interface FestivalConfiguration {
   description: string;
   homeCity: FestivalCity | null;
   festivalScale: FestivalScale | null;
+  annualMonth: number | null;
+  countryCode: string;
+  vibe: FestivalVibe | null;
+  siteType: FestivalSiteType | null;
+  environmentalPolicy: FestivalEnvironmentalPolicy | null;
+  festivalEditionId: string | null;
+  editionYear: number | null;
   plannedStartDate: string | null;
   plannedEndDate: string | null;
   durationDays: number | null;
@@ -59,6 +72,10 @@ export interface FestivalConfigurationDraft {
   description: string;
   homeCityId: string | null;
   festivalScale: FestivalScale | null;
+  annualMonth: number | null;
+  vibe: FestivalVibe | null;
+  siteType: FestivalSiteType | null;
+  environmentalPolicy: FestivalEnvironmentalPolicy | null;
   plannedStartDate: string | null;
   plannedEndDate: string | null;
   currentStep: number;
@@ -242,6 +259,13 @@ export function parseFestivalConfiguration(
     canWrite: value.canWrite,
     scales: scales as FestivalScaleOption[],
     cities: cities as FestivalCity[],
+    annualMonth: Number.isInteger(value.annualMonth) ? value.annualMonth as number : null,
+    countryCode: typeof value.countryCode === "string" ? value.countryCode : (homeCity?.country ?? ""),
+    vibe: festivalVibes.includes(value.vibe as FestivalVibe) ? value.vibe as FestivalVibe : null,
+    siteType: festivalSiteTypes.includes(value.siteType as FestivalSiteType) ? value.siteType as FestivalSiteType : null,
+    environmentalPolicy: festivalEnvironmentalPolicies.includes(value.environmentalPolicy as FestivalEnvironmentalPolicy) ? value.environmentalPolicy as FestivalEnvironmentalPolicy : null,
+    festivalEditionId: typeof value.festivalEditionId === "string" && uuid.test(value.festivalEditionId) ? value.festivalEditionId : null,
+    editionYear: Number.isInteger(value.editionYear) ? value.editionYear as number : null,
   };
 }
 
@@ -254,6 +278,10 @@ export const configurationToDraft = (
   description: configuration.description,
   homeCityId: configuration.homeCity?.id ?? null,
   festivalScale: configuration.festivalScale,
+  annualMonth: configuration.annualMonth,
+  vibe: configuration.vibe,
+  siteType: configuration.siteType,
+  environmentalPolicy: configuration.environmentalPolicy,
   plannedStartDate: configuration.plannedStartDate,
   plannedEndDate: configuration.plannedEndDate,
   currentStep: configuration.currentStep,

--- a/src/features/festival-company/domain/festivalConfigurationValidation.ts
+++ b/src/features/festival-company/domain/festivalConfigurationValidation.ts
@@ -18,6 +18,10 @@ export interface FestivalDraftValidation {
     | "description"
     | "homeCityId"
     | "festivalScale"
+    | "annualMonth"
+    | "vibe"
+    | "siteType"
+    | "environmentalPolicy"
     | "plannedStartDate"
     | "plannedEndDate",
     FieldValidation
@@ -93,6 +97,10 @@ export function validateFestivalDraft(
           "The selected scale is no longer available. Choose another scale.",
         )
       : ok();
+  const annualMonth = !Number.isInteger(draft.annualMonth) || draft.annualMonth! < 1 || draft.annualMonth! > 12 ? error("festival_annual_month_required", "Choose the recurring annual month.") : ok();
+  const vibe = !draft.vibe ? error("festival_vibe_required", "Choose a festival vibe.") : ok();
+  const siteType = !draft.siteType ? error("festival_site_type_required", "Choose a site approach.") : ok();
+  const environmentalPolicy = !draft.environmentalPolicy ? error("festival_environmental_policy_required", "Choose an environmental policy.") : ok();
   const plannedStartDate = !draft.plannedStartDate
     ? error("festival_start_required", "Choose a start date.")
     : !dateValid(draft.plannedStartDate)
@@ -130,12 +138,16 @@ export function validateFestivalDraft(
     description,
     homeCityId,
     festivalScale,
+    annualMonth,
+    vibe,
+    siteType,
+    environmentalPolicy,
     plannedStartDate,
     plannedEndDate,
   };
   const identityValid =
     publicName.valid && shortName.valid && tagline.valid && description.valid;
-  const locationValid = homeCityId.valid && festivalScale.valid;
+  const locationValid = homeCityId.valid && festivalScale.valid && annualMonth.valid && vibe.valid && siteType.valid && environmentalPolicy.valid;
   const datesValid =
     plannedStartDate.valid && plannedEndDate.valid && durationDays !== null;
   return {

--- a/src/features/festival-company/ui/FestivalCompanySetupPage.tsx
+++ b/src/features/festival-company/ui/FestivalCompanySetupPage.tsx
@@ -8,6 +8,7 @@ import { useFestivalCompanySetup } from "../application/useFestivalCompanySetup"
 import { FestivalSetupSummary } from "./FestivalSetupSummary";
 import { FestivalSetupState } from "./FestivalSetupState";
 import { FestivalConfigurationWizard } from "./FestivalConfigurationWizard";
+import { PlanNextAnnualEdition } from "./PlanNextAnnualEdition";
 import { FestivalSitePlanner } from "./FestivalSitePlanner";
 import { FestivalTicketPlanner } from "./FestivalTicketPlanner";
 import { FestivalArtistPlanner } from "./FestivalArtistPlanner";
@@ -47,7 +48,7 @@ const FestivalCompanySetupPage = () => {
     return <FMPageScaffold title={setup.publicName} subtitle="Festival configuration is paused." icon={Tent} backTo="/my-companies"><FestivalSetupSummary setup={setup} /><FestivalSetupState title="Configuration unavailable" message="The setup shell is readable, but configuration submission is disabled by server rollout settings." /></FMPageScaffold>;
   }
 
-  return <FMPageScaffold title={setup.publicName} subtitle="Festival planning and commercial partnerships" icon={Tent} backTo="/my-companies"><FestivalSetupSummary setup={setup} /><FestivalConfigurationWizard festivalCompanyId={festivalCompanyId} /><FestivalSitePlanner festivalCompanyId={festivalCompanyId} /><FestivalTicketPlanner festivalCompanyId={festivalCompanyId} /><FestivalArtistPlanner festivalCompanyId={festivalCompanyId} /><FestivalOperationsPlanner festivalCompanyId={festivalCompanyId} /><FestivalSponsorshipPlanner festivalCompanyId={festivalCompanyId} /><FestivalTimetablePlanner festivalCompanyId={festivalCompanyId} /><FestivalLaunchManager festivalCompanyId={festivalCompanyId} /></FMPageScaffold>;
+  return <FMPageScaffold title={setup.publicName} subtitle="Festival planning and commercial partnerships" icon={Tent} backTo="/my-companies"><FestivalSetupSummary setup={setup} /><PlanNextAnnualEdition festivalCompanyId={festivalCompanyId} active={setup.setupCompleted && setup.companyStatus === "active"} /><FestivalConfigurationWizard festivalCompanyId={festivalCompanyId} /><FestivalSitePlanner festivalCompanyId={festivalCompanyId} /><FestivalTicketPlanner festivalCompanyId={festivalCompanyId} /><FestivalArtistPlanner festivalCompanyId={festivalCompanyId} /><FestivalOperationsPlanner festivalCompanyId={festivalCompanyId} /><FestivalSponsorshipPlanner festivalCompanyId={festivalCompanyId} /><FestivalTimetablePlanner festivalCompanyId={festivalCompanyId} /><FestivalLaunchManager festivalCompanyId={festivalCompanyId} /></FMPageScaffold>;
 };
 
 export default FestivalCompanySetupPage;

--- a/src/features/festival-company/ui/FestivalConfigurationWizard.tsx
+++ b/src/features/festival-company/ui/FestivalConfigurationWizard.tsx
@@ -511,8 +511,17 @@ function LocationStep({
         state={validation.festivalScale}
         show={attempted}
       />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div><Label htmlFor="annual-month">Recurring annual month</Label><select id="annual-month" disabled={disabled} className="min-h-11 w-full rounded border bg-background p-2" value={draft.annualMonth ?? ""} onChange={(event) => patch({ annualMonth: event.target.value ? Number(event.target.value) : null })}><option value="">Choose a month</option>{Array.from({ length: 12 }, (_, index) => <option key={index + 1} value={index + 1}>{new Intl.DateTimeFormat("en", { month: "long", timeZone: "UTC" }).format(new Date(Date.UTC(2026, index, 1)))}</option>)}</select><ErrorText id="annual-month-error" state={validation.annualMonth} show={attempted} /></div>
+        <CatalogueSelect id="vibe" label="Festival vibe" value={draft.vibe} disabled={disabled} options={["community", "alternative", "mainstream", "premium"]} validation={validation.vibe} attempted={attempted} onChange={(vibe) => patch({ vibe })} />
+        <CatalogueSelect id="site-type" label="Site approach" value={draft.siteType} disabled={disabled} options={["indoor", "outdoor", "mixed"]} validation={validation.siteType} attempted={attempted} onChange={(siteType) => patch({ siteType })} />
+        <CatalogueSelect id="environmental-policy" label="Environmental policy" value={draft.environmentalPolicy} disabled={disabled} options={["standard", "responsible", "regenerative"]} validation={validation.environmentalPolicy} attempted={attempted} onChange={(environmentalPolicy) => patch({ environmentalPolicy })} />
+      </div>
     </div>
   );
+}
+function CatalogueSelect({ id, label, value, disabled, options, validation, attempted, onChange }: any) {
+  return <div><Label htmlFor={id}>{label}</Label><select id={id} disabled={disabled} className="min-h-11 w-full rounded border bg-background p-2" value={value ?? ""} onChange={(event) => onChange(event.target.value || null)}><option value="">Choose an option</option>{options.map((option: string) => <option key={option} value={option}>{option.replaceAll("_", " ")}</option>)}</select><ErrorText id={`${id}-error`} state={validation} show={attempted} /></div>;
 }
 function ScheduleStep({
   draft,
@@ -584,6 +593,8 @@ function ReviewStep({ draft, legalName, city, scale, duration, status }: any) {
         <dd>{city ?? "Incomplete"}</dd>
         <dt>Scale</dt>
         <dd>{scale ?? "Incomplete"}</dd>
+        <dt>Annual pattern</dt><dd>Month {draft.annualMonth ?? "Incomplete"} · {draft.vibe ?? "Incomplete"} · {draft.siteType ?? "Incomplete"}</dd>
+        <dt>Environmental policy</dt><dd>{draft.environmentalPolicy ?? "Incomplete"}</dd>
         <dt>Dates</dt>
         <dd>
           {draft.plannedStartDate ?? "Incomplete"} –{" "}
@@ -595,8 +606,8 @@ function ReviewStep({ draft, legalName, city, scale, duration, status }: any) {
         <dd>{status.replaceAll("_", " ")}</dd>
       </dl>
       <p>
-        Completion only enables later planning. It does not announce the
-        festival or create editions, stages, tickets or bookings.
+        Completion creates a private draft annual edition. It does not announce
+        the festival or create stages, tickets, sales or bookings.
       </p>
     </div>
   );

--- a/src/features/festival-company/ui/PlanNextAnnualEdition.tsx
+++ b/src/features/festival-company/ui/PlanNextAnnualEdition.tsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { planNextFestivalEdition, type FestivalEditionCreationResult } from "../data/festivalCompanyRepository";
+
+export function PlanNextAnnualEdition({ festivalCompanyId, active }: { festivalCompanyId: string; active: boolean }) {
+  const [created, setCreated] = useState<FestivalEditionCreationResult | null>(null);
+  const mutation = useMutation({ mutationFn: () => planNextFestivalEdition(festivalCompanyId, crypto.randomUUID()), onSuccess: setCreated });
+  return <section className="space-y-3 rounded border p-4" aria-labelledby="next-edition-title">
+    <h2 id="next-edition-title" className="text-xl font-semibold">Annual editions</h2>
+    <p>Create the next permitted game-year draft from permanent company defaults. Runtime, ticket sales, artist contracts and settlement state are never copied.</p>
+    {created && <Alert><AlertDescription>Edition {created.editionYear} is ready for private planning.</AlertDescription></Alert>}
+    {mutation.isError && <Alert variant="destructive"><AlertDescription>The next annual edition could not be planned. An edition may already exist for that year.</AlertDescription></Alert>}
+    <Button type="button" disabled={!active || mutation.isPending || Boolean(created)} onClick={() => mutation.mutate()}>{mutation.isPending ? "Planning…" : "Plan next annual edition"}</Button>
+  </section>;
+}

--- a/supabase/migrations/20291218244900_festival_annual_edition_realign.sql
+++ b/supabase/migrations/20291218244900_festival_annual_edition_realign.sql
@@ -1,0 +1,121 @@
+-- Realign replacement Festival planning around the existing canonical festival_editions_v2.
+-- Additive only: legacy, runtime, settlement and history tables are intentionally untouched.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE OR REPLACE FUNCTION public.rockmundo_game_year(p_at timestamptz DEFAULT now())
+RETURNS integer LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path=public AS $$
+DECLARE v_days integer; v_epoch date := date '2026-01-01';
+BEGIN
+ SELECT real_world_days_per_game_year INTO v_days FROM public.game_calendar_config WHERE is_active ORDER BY updated_at DESC,id LIMIT 1;
+ IF v_days IS NULL OR v_days < 1 THEN RAISE EXCEPTION 'game_calendar_unavailable' USING ERRCODE='P0001'; END IF;
+ RETURN greatest(1, floor((p_at::date-v_epoch)::numeric/v_days)::integer+1);
+END $$;
+REVOKE ALL ON FUNCTION public.rockmundo_game_year(timestamptz) FROM PUBLIC,anon;
+GRANT EXECUTE ON FUNCTION public.rockmundo_game_year(timestamptz) TO authenticated,service_role;
+COMMENT ON FUNCTION public.rockmundo_game_year(timestamptz) IS 'Canonical server game-year authority: 2026-01-01 is year 1 and cadence comes from active game_calendar_config.';
+
+ALTER TABLE public.festival_editions_v2
+ ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 1,
+ ADD COLUMN IF NOT EXISTS locked_at timestamptz,
+ ADD COLUMN IF NOT EXISTS expected_capacity integer,
+ ADD COLUMN IF NOT EXISTS festival_scale text REFERENCES public.festival_scale_catalogue(key),
+ ADD COLUMN IF NOT EXISTS creation_source text NOT NULL DEFAULT 'legacy' CHECK (creation_source IN ('setup','next_annual','migration','legacy'));
+ALTER TABLE public.festival_editions_v2 DROP CONSTRAINT IF EXISTS festival_editions_v2_duration_matches_dates;
+ALTER TABLE public.festival_editions_v2 ADD CONSTRAINT festival_editions_v2_duration_matches_dates CHECK
+ ((starts_on IS NULL AND ends_on IS NULL) OR (starts_on IS NOT NULL AND ends_on IS NOT NULL AND ends_on>=starts_on AND duration_days=(ends_on-starts_on)+1));
+ALTER TABLE public.festival_editions_v2 DROP CONSTRAINT IF EXISTS festival_editions_v2_festival_company_id_edition_year_key;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_editions_v2_one_live_year
+ ON public.festival_editions_v2(festival_company_id,edition_year) WHERE status <> 'cancelled';
+
+CREATE TABLE public.festival_vibe_catalogue(key text PRIMARY KEY,display_name text NOT NULL,description text NOT NULL,sort_order smallint UNIQUE NOT NULL,active boolean NOT NULL DEFAULT true);
+CREATE TABLE public.festival_site_type_catalogue(key text PRIMARY KEY,display_name text NOT NULL,description text NOT NULL,sort_order smallint UNIQUE NOT NULL,active boolean NOT NULL DEFAULT true);
+CREATE TABLE public.festival_environmental_policy_catalogue(key text PRIMARY KEY,display_name text NOT NULL,description text NOT NULL,sort_order smallint UNIQUE NOT NULL,active boolean NOT NULL DEFAULT true);
+INSERT INTO public.festival_vibe_catalogue VALUES ('community','Community','Welcoming and locally rooted.',1,true),('alternative','Alternative','Independent and discovery-led.',2,true),('mainstream','Mainstream','Broad, high-energy appeal.',3,true),('premium','Premium','Curated hospitality-led experience.',4,true);
+INSERT INTO public.festival_site_type_catalogue VALUES ('indoor','Indoor','Weather-protected venue approach.',1,true),('outdoor','Outdoor','Open-air festival site.',2,true),('mixed','Mixed','Combined indoor and outdoor site.',3,true);
+INSERT INTO public.festival_environmental_policy_catalogue VALUES ('standard','Standard','Meet baseline environmental requirements.',1,true),('responsible','Responsible','Reduce waste and travel impact.',2,true),('regenerative','Regenerative','Invest in measurable positive impact.',3,true);
+ALTER TABLE public.festival_vibe_catalogue ENABLE ROW LEVEL SECURITY; ALTER TABLE public.festival_site_type_catalogue ENABLE ROW LEVEL SECURITY; ALTER TABLE public.festival_environmental_policy_catalogue ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.festival_vibe_catalogue,public.festival_site_type_catalogue,public.festival_environmental_policy_catalogue FROM PUBLIC,anon,authenticated;
+
+ALTER TABLE public.festival_configurations
+ ADD COLUMN IF NOT EXISTS annual_month smallint CHECK(annual_month BETWEEN 1 AND 12),
+ ADD COLUMN IF NOT EXISTS country_code text,
+ ADD COLUMN IF NOT EXISTS vibe text REFERENCES public.festival_vibe_catalogue(key),
+ ADD COLUMN IF NOT EXISTS site_type text REFERENCES public.festival_site_type_catalogue(key),
+ ADD COLUMN IF NOT EXISTS environmental_policy text REFERENCES public.festival_environmental_policy_catalogue(key),
+ ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_configurations DROP CONSTRAINT IF EXISTS festival_configuration_step;
+ALTER TABLE public.festival_configurations ADD CONSTRAINT festival_configuration_step CHECK(current_step BETWEEN 1 AND 6);
+
+-- Root occurrence aggregates become edition-addressable. Existing unique company keys remain
+-- temporarily as compatibility guards; all new canonical writes use edition identity.
+ALTER TABLE public.festival_site_plans ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_ticket_plans ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_artist_programmes ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_operations_plans ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_sponsorship_plans ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+ALTER TABLE public.festival_timetable_plans ADD COLUMN IF NOT EXISTS festival_edition_id uuid REFERENCES public.festival_editions_v2(id);
+CREATE UNIQUE INDEX IF NOT EXISTS festival_site_plans_edition_unique ON public.festival_site_plans(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_ticket_plans_edition_unique ON public.festival_ticket_plans(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_artist_programmes_edition_unique ON public.festival_artist_programmes(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_operations_plans_edition_unique ON public.festival_operations_plans(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_sponsorship_plans_edition_unique ON public.festival_sponsorship_plans(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS festival_timetable_plans_edition_unique ON public.festival_timetable_plans(festival_edition_id) WHERE festival_edition_id IS NOT NULL;
+
+CREATE TABLE public.festival_edition_creation_requests(
+ id uuid PRIMARY KEY DEFAULT gen_random_uuid(),festival_company_id uuid NOT NULL REFERENCES public.festival_companies(id),actor_profile_id uuid NOT NULL REFERENCES public.profiles(id),action text NOT NULL CHECK(action IN('complete_setup','plan_next')),
+ idempotency_key uuid NOT NULL,payload_hash text NOT NULL,status text NOT NULL DEFAULT 'processing' CHECK(status IN('processing','succeeded')),festival_edition_id uuid REFERENCES public.festival_editions_v2(id),result jsonb,created_at timestamptz NOT NULL DEFAULT now(),completed_at timestamptz,
+ UNIQUE(festival_company_id,actor_profile_id,action,idempotency_key));
+CREATE TABLE public.festival_edition_audit(id uuid PRIMARY KEY DEFAULT gen_random_uuid(),festival_company_id uuid NOT NULL REFERENCES public.festival_companies(id),festival_edition_id uuid NOT NULL REFERENCES public.festival_editions_v2(id),actor_profile_id uuid REFERENCES public.profiles(id),event_type text NOT NULL,previous_version integer,new_version integer NOT NULL,metadata jsonb NOT NULL DEFAULT '{}',created_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE public.festival_edition_migration_review(id uuid PRIMARY KEY DEFAULT gen_random_uuid(),festival_company_id uuid REFERENCES public.festival_companies(id),source_table text NOT NULL,source_id uuid,classification text NOT NULL CHECK(classification IN('linked','created_migration_edition','ambiguous','unmapped','company_year_conflict')),festival_edition_id uuid REFERENCES public.festival_editions_v2(id),evidence jsonb NOT NULL DEFAULT '{}',created_at timestamptz NOT NULL DEFAULT now(),UNIQUE(source_table,source_id));
+ALTER TABLE public.festival_edition_creation_requests ENABLE ROW LEVEL SECURITY; ALTER TABLE public.festival_edition_audit ENABLE ROW LEVEL SECURITY; ALTER TABLE public.festival_edition_migration_review ENABLE ROW LEVEL SECURITY;
+CREATE POLICY festival_edition_audit_owner_read ON public.festival_edition_audit FOR SELECT USING(EXISTS(SELECT 1 FROM public.festival_companies fc WHERE fc.id=festival_company_id AND (fc.owner_profile_id=public._caller_profile_id() OR coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false))));
+CREATE POLICY festival_edition_migration_admin_read ON public.festival_edition_migration_review FOR SELECT USING(coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false));
+REVOKE ALL ON public.festival_edition_creation_requests,public.festival_edition_audit,public.festival_edition_migration_review FROM PUBLIC,anon,authenticated;
+
+-- Deterministic compatibility migration: only a company with exactly one plausible edition is linked.
+DO $$ DECLARE t text; BEGIN
+ FOREACH t IN ARRAY ARRAY['festival_configurations','festival_site_plans','festival_ticket_plans','festival_artist_programmes','festival_operations_plans','festival_sponsorship_plans','festival_timetable_plans'] LOOP
+  EXECUTE format('UPDATE public.%I p SET festival_edition_id=e.id FROM public.festival_editions_v2 e WHERE p.festival_company_id=e.festival_company_id AND p.festival_edition_id IS NULL AND 1=(SELECT count(*) FROM public.festival_editions_v2 x WHERE x.festival_company_id=p.festival_company_id)',t);
+  EXECUTE format('INSERT INTO public.festival_edition_migration_review(festival_company_id,source_table,source_id,classification,festival_edition_id,evidence) SELECT p.festival_company_id,%L,p.id,CASE WHEN p.festival_edition_id IS NOT NULL THEN %L WHEN (SELECT count(*) FROM public.festival_editions_v2 x WHERE x.festival_company_id=p.festival_company_id)>1 THEN %L ELSE %L END,p.festival_edition_id,jsonb_build_object(%L,(SELECT count(*) FROM public.festival_editions_v2 x WHERE x.festival_company_id=p.festival_company_id)) FROM public.%I p ON CONFLICT(source_table,source_id) DO NOTHING',t,'linked','ambiguous','unmapped','candidateEditions',t);
+ END LOOP;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.complete_festival_setup_with_edition(p_festival_company_id uuid,p_expected_version integer,p_configuration jsonb,p_idempotency_key uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE actor uuid:=public._caller_profile_id(); fc public.festival_companies%ROWTYPE; cfg public.festival_configurations%ROWTYPE; req public.festival_edition_creation_requests%ROWTYPE; ed public.festival_editions_v2%ROWTYPE; h text; s date; e date; d int; gy int; city uuid; scale text; vibe text; site text; env text; month int;
+BEGIN
+ IF auth.uid() IS NULL OR actor IS NULL THEN RAISE EXCEPTION 'festival_configuration_forbidden' USING ERRCODE='P0001'; END IF;
+ PERFORM pg_advisory_xact_lock(hashtextextended(p_festival_company_id::text||p_idempotency_key::text,0));
+ SELECT * INTO fc FROM public.festival_companies WHERE id=p_festival_company_id FOR UPDATE;
+ IF NOT FOUND OR (fc.owner_profile_id<>actor AND NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false)) THEN RAISE EXCEPTION 'festival_configuration_forbidden' USING ERRCODE='P0001'; END IF;
+ h:=encode(digest(p_configuration::text,'sha256'),'hex'); SELECT * INTO req FROM public.festival_edition_creation_requests WHERE festival_company_id=fc.id AND actor_profile_id=actor AND action='complete_setup' AND idempotency_key=p_idempotency_key FOR UPDATE;
+ IF FOUND THEN IF req.payload_hash<>h THEN RAISE EXCEPTION 'festival_configuration_idempotency_conflict' USING ERRCODE='P0001'; END IF; IF req.status='succeeded' THEN RETURN req.result||jsonb_build_object('idempotent',true); END IF; ELSE INSERT INTO public.festival_edition_creation_requests(festival_company_id,actor_profile_id,action,idempotency_key,payload_hash) VALUES(fc.id,actor,'complete_setup',p_idempotency_key,h) RETURNING * INTO req; END IF;
+ SELECT * INTO cfg FROM public.festival_configurations WHERE festival_company_id=fc.id FOR UPDATE; IF NOT FOUND OR cfg.configuration_version<>p_expected_version THEN RAISE EXCEPTION 'festival_configuration_stale' USING ERRCODE='P0001'; END IF;
+ s:=(p_configuration->>'plannedStartDate')::date; e:=(p_configuration->>'plannedEndDate')::date; d:=(e-s)+1; city:=(p_configuration->>'homeCityId')::uuid; scale:=p_configuration->>'festivalScale'; vibe:=p_configuration->>'vibe'; site:=p_configuration->>'siteType'; env:=p_configuration->>'environmentalPolicy'; month:=(p_configuration->>'annualMonth')::int; gy:=public.rockmundo_game_year(s::timestamptz);
+ IF s IS NULL OR e<s OR d NOT BETWEEN 1 AND 7 OR month NOT BETWEEN 1 AND 12 OR city IS NULL OR NOT EXISTS(SELECT 1 FROM public.cities WHERE id=city) OR NOT EXISTS(SELECT 1 FROM public.festival_scale_catalogue WHERE key=scale AND active) OR NOT EXISTS(SELECT 1 FROM public.festival_vibe_catalogue WHERE key=vibe AND active) OR NOT EXISTS(SELECT 1 FROM public.festival_site_type_catalogue WHERE key=site AND active) OR NOT EXISTS(SELECT 1 FROM public.festival_environmental_policy_catalogue WHERE key=env AND active) THEN RAISE EXCEPTION 'festival_configuration_invalid' USING ERRCODE='P0001'; END IF;
+ INSERT INTO public.festival_editions_v2(festival_company_id,edition_year,name,status,starts_on,ends_on,country_code,city_id,vibe,site_type,duration_days,environmental_policy,festival_scale,creation_source)
+ VALUES(fc.id,gy,btrim(p_configuration->>'publicName'),'draft',s,e,(SELECT country FROM public.cities WHERE id=city),city,vibe,site,d,env,scale,'setup') RETURNING * INTO ed;
+ UPDATE public.festival_companies SET public_name=btrim(p_configuration->>'publicName'),tagline=nullif(btrim(p_configuration->>'tagline'),''),description=nullif(btrim(p_configuration->>'description'),''),annual_month=month,country_code=ed.country_code,default_city_id=city,default_vibe=vibe,default_site_type=site,default_duration_days=d,environmental_policy=env,setup_completed=true,status='active',updated_at=now() WHERE id=fc.id;
+ UPDATE public.festival_configurations SET short_name=nullif(btrim(p_configuration->>'shortName'),''),annual_month=month,country_code=ed.country_code,vibe=vibe,site_type=site,environmental_policy=env,festival_edition_id=ed.id,setup_status='ready_for_planning',current_step=6,configuration_version=configuration_version+1,completed_at=now(),updated_at=now() WHERE id=cfg.id;
+ INSERT INTO public.festival_edition_audit(festival_company_id,festival_edition_id,actor_profile_id,event_type,new_version,metadata) VALUES(fc.id,ed.id,actor,'first_annual_edition_created',ed.version,jsonb_build_object('editionYear',gy,'source','setup'));
+ req.result:=jsonb_build_object('festivalCompanyId',fc.id,'festivalEditionId',ed.id,'editionYear',gy,'status',ed.status,'idempotent',false); UPDATE public.festival_edition_creation_requests SET status='succeeded',festival_edition_id=ed.id,result=req.result,completed_at=now() WHERE id=req.id; RETURN req.result;
+EXCEPTION WHEN unique_violation THEN RAISE EXCEPTION 'festival_edition_year_exists' USING ERRCODE='P0001'; END $$;
+
+CREATE OR REPLACE FUNCTION public.plan_next_festival_edition(p_festival_company_id uuid,p_idempotency_key uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path=public AS $$
+DECLARE actor uuid:=public._caller_profile_id(); fc public.festival_companies%ROWTYPE; req public.festival_edition_creation_requests%ROWTYPE; ed public.festival_editions_v2%ROWTYPE; y int; h text;
+BEGIN
+ IF actor IS NULL THEN RAISE EXCEPTION 'festival_edition_forbidden' USING ERRCODE='P0001'; END IF; PERFORM pg_advisory_xact_lock(hashtextextended(p_festival_company_id::text||p_idempotency_key::text,0));
+ SELECT * INTO fc FROM public.festival_companies WHERE id=p_festival_company_id FOR UPDATE; IF NOT FOUND OR fc.status<>'active' OR (fc.owner_profile_id<>actor AND NOT coalesce(public.has_role(auth.uid(),'admin'::public.app_role),false)) THEN RAISE EXCEPTION 'festival_edition_forbidden' USING ERRCODE='P0001'; END IF;
+ y:=greatest(public.rockmundo_game_year(),coalesce((SELECT max(edition_year)+1 FROM public.festival_editions_v2 WHERE festival_company_id=fc.id AND status<>'cancelled'),public.rockmundo_game_year())); h:=encode(digest(fc.id::text||'|'||y::text,'sha256'),'hex');
+ SELECT * INTO req FROM public.festival_edition_creation_requests WHERE festival_company_id=fc.id AND actor_profile_id=actor AND action='plan_next' AND idempotency_key=p_idempotency_key FOR UPDATE;
+ IF FOUND THEN IF req.payload_hash<>h THEN RAISE EXCEPTION 'festival_edition_idempotency_conflict' USING ERRCODE='P0001'; END IF; IF req.status='succeeded' THEN RETURN req.result||jsonb_build_object('idempotent',true); END IF; ELSE INSERT INTO public.festival_edition_creation_requests(festival_company_id,actor_profile_id,action,idempotency_key,payload_hash) VALUES(fc.id,actor,'plan_next',p_idempotency_key,h) RETURNING * INTO req; END IF;
+ INSERT INTO public.festival_editions_v2(festival_company_id,edition_year,name,status,country_code,city_id,vibe,site_type,duration_days,environmental_policy,creation_source) VALUES(fc.id,y,fc.public_name,'draft',fc.country_code,fc.default_city_id,fc.default_vibe,fc.default_site_type,fc.default_duration_days,fc.environmental_policy,'next_annual') RETURNING * INTO ed;
+ INSERT INTO public.festival_edition_audit(festival_company_id,festival_edition_id,actor_profile_id,event_type,new_version,metadata) VALUES(fc.id,ed.id,actor,'next_annual_edition_planned',1,jsonb_build_object('editionYear',y)); req.result:=jsonb_build_object('festivalCompanyId',fc.id,'festivalEditionId',ed.id,'editionYear',y,'status','draft','idempotent',false); UPDATE public.festival_edition_creation_requests SET status='succeeded',festival_edition_id=ed.id,result=req.result,completed_at=now() WHERE id=req.id; RETURN req.result;
+END $$;
+REVOKE ALL ON FUNCTION public.complete_festival_setup_with_edition(uuid,integer,jsonb,uuid),public.plan_next_festival_edition(uuid,uuid) FROM PUBLIC,anon;
+GRANT EXECUTE ON FUNCTION public.complete_festival_setup_with_edition(uuid,integer,jsonb,uuid),public.plan_next_festival_edition(uuid,uuid) TO authenticated;
+
+CREATE OR REPLACE VIEW public.festival_edition_migration_summary WITH (security_invoker=true) AS SELECT classification,count(*) record_count,count(DISTINCT festival_company_id) company_count FROM public.festival_edition_migration_review GROUP BY classification;
+GRANT SELECT ON public.festival_edition_migration_summary TO authenticated;
+NOTIFY pgrst,'reload schema';

--- a/supabase/tests/festival_annual_editions_harness.sql
+++ b/supabase/tests/festival_annual_editions_harness.sql
@@ -1,0 +1,13 @@
+\set ON_ERROR_STOP on
+BEGIN;
+DO $$
+BEGIN
+ IF to_regprocedure('public.complete_festival_setup_with_edition(uuid,integer,jsonb,uuid)') IS NULL THEN RAISE EXCEPTION 'missing atomic setup RPC'; END IF;
+ IF to_regprocedure('public.plan_next_festival_edition(uuid,uuid)') IS NULL THEN RAISE EXCEPTION 'missing next-edition RPC'; END IF;
+ IF to_regprocedure('public.rockmundo_game_year(timestamp with time zone)') IS NULL THEN RAISE EXCEPTION 'missing game-year authority'; END IF;
+ IF NOT EXISTS(SELECT 1 FROM pg_indexes WHERE schemaname='public' AND tablename='festival_editions_v2' AND indexname='festival_editions_v2_one_live_year' AND indexdef LIKE '%WHERE (status <> ''cancelled''%') THEN RAISE EXCEPTION 'missing non-cancelled year uniqueness'; END IF;
+ IF EXISTS(SELECT 1 FROM information_schema.role_table_grants WHERE table_schema='public' AND table_name='festival_editions_v2' AND grantee='authenticated' AND privilege_type IN('INSERT','UPDATE','DELETE')) THEN RAISE EXCEPTION 'browser has direct edition writes'; END IF;
+ IF (SELECT count(*) FROM (VALUES('festival_site_plans'),('festival_ticket_plans'),('festival_artist_programmes'),('festival_operations_plans'),('festival_sponsorship_plans'),('festival_timetable_plans')) t(n) WHERE NOT EXISTS(SELECT 1 FROM information_schema.columns c WHERE c.table_schema='public' AND c.table_name=t.n AND c.column_name='festival_edition_id'))>0 THEN RAISE EXCEPTION 'planning root missing edition scope'; END IF;
+ IF to_regclass('public.festival_edition_migration_review') IS NULL OR to_regclass('public.festival_edition_migration_summary') IS NULL THEN RAISE EXCEPTION 'missing migration evidence'; END IF;
+END $$;
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Restore the original Festival Replacement Architecture boundary by making `festival_editions_v2` the canonical per-year occurrence aggregate while keeping `festival_companies` as the permanent organisation owner of balance, reputation and defaults. 
- Ensure the initial setup wizard creates the first annual edition atomically and add an owner action to plan the next annual edition so planning aggregates are edition-scoped rather than company-unique. 
- Preserve all existing Festival data and runtime/settlement behaviour while adding deterministic, additive migration and admin-visible evidence rather than guessing or deleting historical rows.

### Description

- Database: added `supabase/migrations/20291218244900_festival_annual_edition_realign.sql` which introduces `rockmundo_game_year(...)` server-year authority, extends `festival_editions_v2` (version, locked_at, expected_capacity, festival_scale, creation_source), enforces one non-cancelled edition per company/year via a partial index, and creates catalogues `festival_vibe_catalogue`, `festival_site_type_catalogue` and `festival_environmental_policy_catalogue` and RLS/grants. 
- Edition scoping & migration: added nullable `festival_edition_id` columns and edition-unique indexes to planning roots (`festival_site_plans`, `festival_ticket_plans`, `festival_artist_programmes`, `festival_operations_plans`, `festival_sponsorship_plans`, `festival_timetable_plans`) and a deterministic compatibility migration that only links records when a single candidate edition exists and records ambiguous/unmapped rows in `festival_edition_migration_review`; an admin summary view `festival_edition_migration_summary` was added. 
- RPCs & idempotency: added atomic server RPCs `complete_festival_setup_with_edition(...)` and `plan_next_festival_edition(...)` with transaction-scoped advisory locking, idempotent request receipts (`festival_edition_creation_requests`), optimistic version checks, audit entries (`festival_edition_audit`) and safe failure semantics. 
- Frontend & domain: restored setup contract fields and validation in `src/features/festival-company/domain/*` and `src/features/festival-company/ui/FestivalConfigurationWizard.tsx` (annual month, vibe, site type, environmental policy, exact dates and server-authoritative validation); added `PlanNextAnnualEdition.tsx` owner UI and repository methods `completeFestivalSetup` and `planNextFestivalEdition` and wired `useFestivalConfiguration` to call the atomic setup RPC on completion. 
- Docs & safety: updated `docs/festivals/FESTIVAL_REPLACEMENT_ARCHITECTURE.md` and `src/features/festival-company/README.md` to record the canonical company vs edition boundary, the alignment register and migration policy; added a disposable DB harness `supabase/tests/festival_annual_editions_harness.sql` to verify RPC availability, game-year authority, uniqueness guard and edition-scoping columns in CI. 
- Preservation: this PR is additive only and explicitly does not delete legacy tables, alter settlement formulas, upgrade progression limits, timetable balancing rules, or enable global replacement; those remain out-of-scope and unchanged.

### Testing

- Typecheck and unit/feature suites: `npm run typecheck` and `npm run test:festivals` (includes festival-company and festival feature tests) passed locally. 
- Route, app-routes and runtime/settlement certification: `npm run verify:migration-timestamps`, `npm run test:festivals:routes`, `npm run test:festivals:app-routes`, `node scripts/festivals/certify-active-system.mjs` and the `test:festivals:active-callers`, `test:festivals:runtime` and `test:festivals:settlement` gates executed and passed in this environment. 
- Lint and build: `npm run lint:ci` completed; `npm run build` started successfully (Vite transformation began), but the capture window ended during Vite transformation so a completed production-build result is not represented here. 
- Database harness (environment-blocked): running `psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/festival_annual_editions_harness.sql` is included in the PR but was blocked locally because `SUPABASE_DB_URL` was not set; CI should run this harness against a disposable Supabase instance. 

If anything in CI fails, roll back by disabling callers of the new RPCs, then reverse only the nullable edition links and catalogue/table additions; no legacy festival tables are removed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f4fedef6083259319924e06afc22a)