### PR TITLE
Pack gig crowds from the stage outward

### DIFF
--- a/src/features/gig-experience/viewer/engine/CrowdLifecycle.ts
+++ b/src/features/gig-experience/viewer/engine/CrowdLifecycle.ts
@@ -1,24 +1,102 @@
 import type { GigViewerReplay } from "../../events/types";
 import type { Point, Rect, Size } from "./Viewport";
 import { pointInRect } from "./Viewport";
-import type { ScaledVenuePreset } from "./VenueLayout";
 import { selectVenuePreset, scaleVenuePreset } from "./VenueLayout";
 
 export type CrowdEntityState = "queued" | "entering" | "moving_to_zone" | "settling" | "waiting";
-export interface CrowdEntity { id: string; seedIndex: number; weight: number; entranceId: string; targetZoneId: string; x: number; y: number; start: Point; waypoint: Point; target: Point; spawnOffsetMs: number; travelMs: number; speed: number; state: CrowdEntityState; radius: number; idlePhase: number; visible: boolean }
-export interface CrowdMilestone { key: string; label: string; progress: number; reached: boolean }
-export interface CrowdState { entities: CrowdEntity[]; attendance: number; capacity: number; cap: number; fillProgress: number; phaseLabel: string; occupiedZones: string[]; milestones: CrowdMilestone[]; diagnostics: { entityCount: number; movingCount: number; settledCount: number } }
-export interface CrowdLayoutPlan { baseEntities: CrowdEntity[]; attendance: number; capacity: number; cap: number; entryStartMs: number; entryEndMs: number; milestones: CrowdMilestone[] }
+
+export interface CrowdEntity {
+  id: string;
+  seedIndex: number;
+  weight: number;
+  entranceId: string;
+  targetZoneId: string;
+  x: number;
+  y: number;
+  start: Point;
+  waypoint: Point;
+  target: Point;
+  spawnOffsetMs: number;
+  travelMs: number;
+  speed: number;
+  state: CrowdEntityState;
+  radius: number;
+  idlePhase: number;
+  visible: boolean;
+}
+
+export interface CrowdMilestone {
+  key: string;
+  label: string;
+  progress: number;
+  reached: boolean;
+}
+
+export interface CrowdState {
+  entities: CrowdEntity[];
+  attendance: number;
+  capacity: number;
+  cap: number;
+  fillProgress: number;
+  phaseLabel: string;
+  occupiedZones: string[];
+  milestones: CrowdMilestone[];
+  diagnostics: { entityCount: number; movingCount: number; settledCount: number };
+}
+
+export interface CrowdLayoutPlan {
+  baseEntities: CrowdEntity[];
+  attendance: number;
+  capacity: number;
+  cap: number;
+  entryStartMs: number;
+  entryEndMs: number;
+  milestones: CrowdMilestone[];
+}
+
+export interface CrowdPackingCell {
+  id: string;
+  rect: Rect;
+  stageDistance: number;
+  lateralDistance: number;
+  area: number;
+}
 
 export const CROWD_DENSITY_MULTIPLIER = 2;
-export const CROWD_ENTITY_CAPS = { reducedMotion: 300, mobileLow: 1800, mobileDefault: 2800, tablet: 3800, desktopDefault: 5800, desktopHigh: 9200 } as const;
+export const CROWD_ENTITY_CAPS = {
+  reducedMotion: 300,
+  mobileLow: 1800,
+  mobileDefault: 2800,
+  tablet: 3800,
+  desktopDefault: 5800,
+  desktopHigh: 9200,
+} as const;
 
-export function selectCrowdEntityCap({ reducedMotion, width, devicePixelRatio = 1, attendanceRatio = 0, highPerformance = false }: { reducedMotion: boolean; width: number; devicePixelRatio?: number; attendanceRatio?: number; highPerformance?: boolean }) {
+const PACKING_DEPTH_BANDS = 8;
+const PACKING_LATERAL_BANDS = 5;
+const LATERAL_COLUMN_ORDER = [2, 1, 3, 0, 4] as const;
+const LATERAL_LABELS = ["outer-left", "inner-left", "centre", "inner-right", "outer-right"] as const;
+
+export function selectCrowdEntityCap({
+  reducedMotion,
+  width,
+  devicePixelRatio = 1,
+  attendanceRatio = 0,
+  highPerformance = false,
+}: {
+  reducedMotion: boolean;
+  width: number;
+  devicePixelRatio?: number;
+  attendanceRatio?: number;
+  highPerformance?: boolean;
+}) {
   if (reducedMotion) return CROWD_ENTITY_CAPS.reducedMotion;
   if (width < 420 || devicePixelRatio > 2.75) return CROWD_ENTITY_CAPS.mobileLow;
   if (width < 760) return CROWD_ENTITY_CAPS.mobileDefault;
   if (width < 1024) return CROWD_ENTITY_CAPS.tablet;
-  return highPerformance && attendanceRatio > .85 ? CROWD_ENTITY_CAPS.desktopHigh : CROWD_ENTITY_CAPS.desktopDefault;
+  return highPerformance && attendanceRatio > 0.85
+    ? CROWD_ENTITY_CAPS.desktopHigh
+    : CROWD_ENTITY_CAPS.desktopDefault;
 }
 
 export function representedWeights(attendance: number, cap: number, densityMultiplier = 1): number[] {
@@ -26,68 +104,396 @@ export function representedWeights(attendance: number, cap: number, densityMulti
   const safeMultiplier = Math.max(1, Number.isFinite(densityMultiplier) ? densityMultiplier : 1);
   const count = Math.min(Math.max(0, Math.floor(cap)), Math.ceil(total * safeMultiplier));
   if (count === 0) return [];
+
   if (count > total) {
     const weight = total / count;
     const weights = Array.from({ length: count }, () => weight);
     weights[count - 1] += total - weights.reduce((sum, value) => sum + value, 0);
     return weights;
   }
-  const base = Math.floor(total / count); const remainder = total - base * count;
+
+  const base = Math.floor(total / count);
+  const remainder = total - base * count;
   return Array.from({ length: count }, (_, i) => base + (i >= count - remainder ? 1 : 0));
 }
 
-export function buildCrowdPlan({ replay, attendance, capacity, size, reducedMotion = false, devicePixelRatio = 1 }: { replay: GigViewerReplay; attendance: number; capacity: number; size: Size; reducedMotion?: boolean; devicePixelRatio?: number }): CrowdLayoutPlan {
+export function buildCrowdPackingCells(zones: Rect[], stage: Rect): CrowdPackingCell[] {
+  const source = zones.length ? zones : [{ x: stage.x, y: stage.y + stage.height, width: stage.width, height: 1 }];
+  const axes = packingAxes(source, stage);
+  const orderedZones = [...source]
+    .map((rect, originalIndex) => ({ rect, originalIndex, distance: projectedDepth(rectCentre(rect), axes) }))
+    .sort((a, b) => a.distance - b.distance || a.originalIndex - b.originalIndex);
+
+  return orderedZones
+    .flatMap(({ rect }, orderedIndex) => {
+      const zoneLabel = orderedIndex === 0 ? "front" : orderedIndex === orderedZones.length - 1 && orderedZones.length > 2 ? "rear" : "middle";
+      const cellWidth = rect.width / PACKING_LATERAL_BANDS;
+      const cellHeight = rect.height / PACKING_DEPTH_BANDS;
+
+      return Array.from({ length: PACKING_DEPTH_BANDS }, (_, depthIndex) =>
+        LATERAL_COLUMN_ORDER.map((columnIndex) => {
+          const cellRect = {
+            x: rect.x + columnIndex * cellWidth,
+            y: rect.y + depthIndex * cellHeight,
+            width: cellWidth,
+            height: cellHeight,
+          };
+          const centre = rectCentre(cellRect);
+          return {
+            id: `${zoneLabel}-${depthIndex}-${LATERAL_LABELS[columnIndex]}`,
+            rect: cellRect,
+            stageDistance: projectedDepth(centre, axes),
+            lateralDistance: projectedLateralDistance(centre, axes),
+            area: Math.max(1, cellRect.width * cellRect.height),
+          };
+        }),
+      ).flat();
+    })
+    .sort(
+      (a, b) =>
+        a.stageDistance - b.stageDistance ||
+        a.lateralDistance - b.lateralDistance ||
+        a.rect.y - b.rect.y ||
+        a.rect.x - b.rect.x,
+    );
+}
+
+export function selectActivePackingCells(cells: CrowdPackingCell[], attendanceRatio: number, entityCount: number): CrowdPackingCell[] {
+  if (!cells.length || entityCount <= 0) return [];
+  const ratio = Math.max(0, Math.min(1, Number.isFinite(attendanceRatio) ? attendanceRatio : 0));
+  const activeCount = Math.min(cells.length, entityCount, Math.max(1, Math.ceil(cells.length * ratio)));
+  return cells.slice(0, activeCount);
+}
+
+export function buildCrowdPlan({
+  replay,
+  attendance,
+  capacity,
+  size,
+  reducedMotion = false,
+  devicePixelRatio = 1,
+}: {
+  replay: GigViewerReplay;
+  attendance: number;
+  capacity: number;
+  size: Size;
+  reducedMotion?: boolean;
+  devicePixelRatio?: number;
+}): CrowdLayoutPlan {
   const safeAttendance = Math.max(0, Math.floor(Number.isFinite(attendance) ? attendance : 0));
   const safeCapacity = Math.max(0, Math.floor(Number.isFinite(capacity) ? capacity : 0));
   const ratio = safeCapacity > 0 ? Math.min(1, safeAttendance / safeCapacity) : 0;
-  const cap = selectCrowdEntityCap({ reducedMotion, width: size.width, devicePixelRatio, attendanceRatio: ratio, highPerformance: ratio > .85 });
+  const cap = selectCrowdEntityCap({
+    reducedMotion,
+    width: size.width,
+    devicePixelRatio,
+    attendanceRatio: ratio,
+    highPerformance: ratio > 0.85,
+  });
   const preset = scaleVenuePreset(selectVenuePreset({ capacity: safeCapacity }), size);
   const weights = representedWeights(safeAttendance, cap, CROWD_DENSITY_MULTIPLIER);
+  const packingCells = selectActivePackingCells(
+    buildCrowdPackingCells(preset.crowdZones.length ? preset.crowdZones : [preset.audience], preset.stage),
+    ratio,
+    weights.length,
+  );
+  const packingSlots = allocatePackingSlots(packingCells, weights.length);
+
   const entryStartMs = findEventOffset(replay, "venue_open", 0);
-  const crowdFill = replay.events.filter((e) => e.visualPayload.type === "crowd_fill");
-  const firstSong = replay.events.find((e) => e.visualPayload.type === "song_start")?.scheduledOffsetMs;
-  const lastFillEnd = crowdFill.reduce((m, e) => Math.max(m, e.scheduledOffsetMs + Math.max(1000, e.durationMs || 0)), entryStartMs + 9000);
-  const entryEndMs = Math.max(entryStartMs + 4000, Math.min(firstSong ?? lastFillEnd, Math.max(lastFillEnd, entryStartMs + 9000)));
-  const rand = deterministicRandom(`${replay.simulationSeed}:crowd-entry:${preset.name}:${Math.round(size.width)}x${Math.round(size.height)}`);
-  const zones = splitZones(preset.crowdZones, ratio);
+  const crowdFill = replay.events.filter((event) => event.visualPayload.type === "crowd_fill");
+  const firstSong = replay.events.find((event) => event.visualPayload.type === "song_start")?.scheduledOffsetMs;
+  const lastFillEnd = crowdFill.reduce(
+    (maximum, event) => Math.max(maximum, event.scheduledOffsetMs + Math.max(1000, event.durationMs || 0)),
+    entryStartMs + 9000,
+  );
+  const entryEndMs = Math.max(
+    entryStartMs + 4000,
+    Math.min(firstSong ?? lastFillEnd, Math.max(lastFillEnd, entryStartMs + 9000)),
+  );
+  const rand = deterministicRandom(
+    `${replay.simulationSeed}:crowd-entry:${preset.name}:${Math.round(size.width)}x${Math.round(size.height)}`,
+  );
+
   const baseEntities = weights.map((weight, i) => {
     const entranceIndex = weightedIndex(i, preset.entrances.length || 1, replay.simulationSeed);
     const entrance = preset.entrances[entranceIndex] ?? fallbackEntrance(preset.audience);
     const start = boundedEntrancePoint(entrance, preset.audience, rand, i);
-    const frontBias = Math.pow(i / Math.max(1, weights.length), 2.7);
-    const zone = zones[Math.min(zones.length - 1, Math.floor(frontBias * zones.length))] ?? { id: "front-centre", rect: preset.audience };
-    const target = deterministicPointIn(zone.rect, rand, i);
-    const waypoint = { x: start.x + (target.x - start.x) * .45, y: Math.max(preset.audience.y + 8, start.y + (target.y - start.y) * .35) };
+    const slot = packingSlots[i] ?? {
+      cell: {
+        id: "front-0-centre",
+        rect: preset.audience,
+        stageDistance: 0,
+        lateralDistance: 0,
+        area: preset.audience.width * preset.audience.height,
+      },
+      localIndex: i,
+      localCount: weights.length,
+    };
+    const target = deterministicPackedPoint(slot.cell.rect, rand, slot.localIndex, slot.localCount);
+    const waypoint = {
+      x: start.x + (target.x - start.x) * 0.45,
+      y: Math.max(preset.audience.y + 8, start.y + (target.y - start.y) * 0.35),
+    };
     const stagger = weights.length <= 1 ? 0 : i / (weights.length - 1);
-    const spawnOffsetMs = entryStartMs + stagger * Math.max(1, entryEndMs - entryStartMs) * .72;
+    const spawnOffsetMs = entryStartMs + stagger * Math.max(1, entryEndMs - entryStartMs) * 0.72;
     const travelMs = reducedMotion ? 0 : 2400 + rand() * 2200;
-    return { id: `crowd-${i}`, seedIndex: i, weight, entranceId: `entrance-${entranceIndex}`, targetZoneId: zone.id, x: start.x, y: start.y, start, waypoint, target, spawnOffsetMs, travelMs, speed: travelMs ? distance(start, target) / travelMs : 0, state: "queued" as CrowdEntityState, radius: Math.max(1, Math.min(2.4, 1 + Math.sqrt(weight) * .08)), idlePhase: rand() * Math.PI * 2, visible: false };
+
+    return {
+      id: `crowd-${i}`,
+      seedIndex: i,
+      weight,
+      entranceId: `entrance-${entranceIndex}`,
+      targetZoneId: slot.cell.id,
+      x: start.x,
+      y: start.y,
+      start,
+      waypoint,
+      target,
+      spawnOffsetMs,
+      travelMs,
+      speed: travelMs ? distance(start, target) / travelMs : 0,
+      state: "queued" as CrowdEntityState,
+      radius: Math.max(1, Math.min(2.4, 1 + Math.sqrt(weight) * 0.08)),
+      idlePhase: rand() * Math.PI * 2,
+      visible: false,
+    };
   });
-  return { baseEntities, attendance: safeAttendance, capacity: safeCapacity, cap, entryStartMs, entryEndMs, milestones: milestoneTemplates() };
+
+  return {
+    baseEntities,
+    attendance: safeAttendance,
+    capacity: safeCapacity,
+    cap,
+    entryStartMs,
+    entryEndMs,
+    milestones: milestoneTemplates(),
+  };
 }
 
 export function reconstructCrowdState(plan: CrowdLayoutPlan, positionMs: number, reducedMotion = false): CrowdState {
-  const pos = Math.max(0, positionMs); const entrySpan = Math.max(1, plan.entryEndMs - plan.entryStartMs);
-  const fillProgress = plan.baseEntities.length ? Math.min(1, Math.max(0, (pos - plan.entryStartMs) / entrySpan)) : 0;
-  const entities = plan.baseEntities.map((e) => projectEntity(e, pos, reducedMotion));
-  const visible = entities.filter((e) => e.visible); const settled = visible.filter((e) => e.state === "waiting").length;
-  const moving = visible.filter((e) => e.state !== "waiting").length;
-  const zoneSet = new Set(visible.filter((e) => e.state === "waiting" || e.state === "settling").map((e) => e.targetZoneId));
-  const phaseLabel = plan.attendance <= 0 ? "No audience attendance recorded." : fillProgress <= 0 ? "Doors are open." : fillProgress < .25 ? "The first fans are entering." : fillProgress < .75 ? "The venue is filling." : settled < plan.baseEntities.length ? "The audience is settling." : "The audience has settled before the band enters.";
-  return { entities, attendance: plan.attendance, capacity: plan.capacity, cap: plan.cap, fillProgress, phaseLabel, occupiedZones: [...zoneSet], milestones: plan.milestones.map((m) => ({ ...m, reached: fillProgress >= m.progress })), diagnostics: { entityCount: entities.length, movingCount: moving, settledCount: settled } };
+  const pos = Math.max(0, positionMs);
+  const entrySpan = Math.max(1, plan.entryEndMs - plan.entryStartMs);
+  const fillProgress = plan.baseEntities.length
+    ? Math.min(1, Math.max(0, (pos - plan.entryStartMs) / entrySpan))
+    : 0;
+  const entities = plan.baseEntities.map((entity) => projectEntity(entity, pos, reducedMotion));
+  const visible = entities.filter((entity) => entity.visible);
+  const settled = visible.filter((entity) => entity.state === "waiting").length;
+  const moving = visible.filter((entity) => entity.state !== "waiting").length;
+  const zoneSet = new Set(
+    visible
+      .filter((entity) => entity.state === "waiting" || entity.state === "settling")
+      .map((entity) => entity.targetZoneId),
+  );
+  const phaseLabel =
+    plan.attendance <= 0
+      ? "No audience attendance recorded."
+      : fillProgress <= 0
+        ? "Doors are open."
+        : fillProgress < 0.25
+          ? "The first fans are entering."
+          : fillProgress < 0.75
+            ? "The venue is filling."
+            : settled < plan.baseEntities.length
+              ? "The audience is settling."
+              : "The audience has settled before the band enters.";
+
+  return {
+    entities,
+    attendance: plan.attendance,
+    capacity: plan.capacity,
+    cap: plan.cap,
+    fillProgress,
+    phaseLabel,
+    occupiedZones: [...zoneSet],
+    milestones: plan.milestones.map((milestone) => ({ ...milestone, reached: fillProgress >= milestone.progress })),
+    diagnostics: { entityCount: entities.length, movingCount: moving, settledCount: settled },
+  };
 }
 
-function hashSeed(seed: string) { let h = 2166136261; for (let i = 0; i < seed.length; i++) { h ^= seed.charCodeAt(i); h = Math.imul(h, 16777619); } return h >>> 0; }
-function deterministicRandom(seed: string) { let s = hashSeed(seed); return () => { let t = s += 0x6D2B79F5; t = Math.imul(t ^ t >>> 15, t | 1); t ^= t + Math.imul(t ^ t >>> 7, t | 61); return ((t ^ t >>> 14) >>> 0) / 4294967296; }; }
-function projectEntity(e: CrowdEntity, pos: number, reducedMotion: boolean): CrowdEntity { if (reducedMotion) { const visible = pos >= e.spawnOffsetMs; return { ...e, x: e.target.x, y: e.target.y, state: visible ? "waiting" : "queued", visible }; } if (pos < e.spawnOffsetMs) return { ...e, x: e.start.x, y: e.start.y, state: "queued", visible: false }; const t = Math.min(1, (pos - e.spawnOffsetMs) / Math.max(1, e.travelMs)); const p = t < .35 ? lerp(e.start, e.waypoint, ease(t / .35)) : lerp(e.waypoint, e.target, ease((t - .35) / .65)); const state = t < .18 ? "entering" : t < .92 ? "moving_to_zone" : t < 1 ? "settling" : "waiting"; const idle = state === "waiting" ? Math.sin(pos / 950 + e.idlePhase) * 1.2 : 0; return { ...e, x: p.x + idle, y: p.y, state, visible: true }; }
-function splitZones(zones: Rect[], ratio: number) { const source = zones.length ? zones : [{ x: 0, y: 0, width: 1, height: 1 }]; const parts = source.flatMap((z, zi) => ["centre", "left", "right"].map((part, pi) => ({ id: `${zi === 0 ? "front" : zi === 1 ? "middle" : "rear"}-${part}`, rect: thirdRect(z, pi) }))); const count = ratio < .25 ? Math.min(3, parts.length) : ratio < .65 ? Math.min(5, parts.length) : parts.length; return parts.slice(0, Math.max(1, count)); }
-function thirdRect(r: Rect, part: number): Rect { if (part === 0) return { x: r.x + r.width * .25, y: r.y, width: r.width * .5, height: r.height }; if (part === 1) return { x: r.x, y: r.y, width: r.width * .28, height: r.height }; return { x: r.x + r.width * .72, y: r.y, width: r.width * .28, height: r.height }; }
-function deterministicPointIn(rect: Rect, rand: () => number, i: number): Point { const cols = Math.max(3, Math.ceil(Math.sqrt(i + 7))); const rows = cols; const col = i % cols; const row = Math.floor(i / cols) % rows; const rowFrac = (row + .35 + rand() * .3) / rows; return { x: rect.x + ((col + .35 + rand() * .3) / cols) * rect.width, y: rect.y + Math.pow(rowFrac, 2.1) * rect.height }; }
-function boundedEntrancePoint(entrance: Point, audience: Rect, rand: () => number, i: number): Point { const spread = 18; const p = { x: entrance.x + (rand() - .5) * spread + ((i % 5) - 2) * 2, y: entrance.y + (rand() - .5) * 10 }; return pointInRect(p, audience) ? p : { x: Math.min(audience.x + audience.width - 8, Math.max(audience.x + 8, p.x)), y: Math.min(audience.y + audience.height - 8, Math.max(audience.y + 8, p.y)) }; }
-function fallbackEntrance(audience: Rect): Point { return { x: audience.x + audience.width / 2, y: audience.y + audience.height - 8 }; }
-function weightedIndex(i: number, count: number, seed: string) { return Math.abs((i * 1103515245 + seed.length * 97) % Math.max(1, count)); }
-function findEventOffset(replay: GigViewerReplay, type: string, fallback: number) { return replay.events.find((e) => e.visualPayload.type === type)?.scheduledOffsetMs ?? fallback; }
-function milestoneTemplates(): CrowdMilestone[] { return [{ key: "doors", label: "Doors are open.", progress: 0, reached: false }, { key: "first", label: "The first fans are entering.", progress: .05, reached: false }, { key: "quarter", label: "The venue is one quarter full.", progress: .25, reached: false }, { key: "half", label: "The venue is half full.", progress: .5, reached: false }, { key: "three-quarter", label: "The venue is three quarters full.", progress: .75, reached: false }, { key: "full", label: "Target attendance has arrived.", progress: 1, reached: false }]; }
-function lerp(a: Point, b: Point, t: number): Point { return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }; }
-function ease(t: number) { return t * t * (3 - 2 * t); }
-function distance(a: Point, b: Point) { return Math.hypot(a.x - b.x, a.y - b.y); }
+function allocatePackingSlots(cells: CrowdPackingCell[], entityCount: number) {
+  if (!cells.length || entityCount <= 0) return [];
+  const allocations = Array.from({ length: cells.length }, () => 1);
+  let remaining = Math.max(0, entityCount - cells.length);
+  const totalArea = cells.reduce((sum, cell) => sum + cell.area, 0);
+  const fractions = cells.map((cell, index) => {
+    const exact = totalArea > 0 ? (remaining * cell.area) / totalArea : remaining / cells.length;
+    const whole = Math.floor(exact);
+    allocations[index] += whole;
+    return { index, fraction: exact - whole };
+  });
+  remaining -= allocations.reduce((sum, count) => sum + count, 0) - cells.length;
+  fractions
+    .sort((a, b) => b.fraction - a.fraction || a.index - b.index)
+    .slice(0, remaining)
+    .forEach(({ index }) => {
+      allocations[index] += 1;
+    });
+
+  return cells.flatMap((cell, cellIndex) =>
+    Array.from({ length: allocations[cellIndex] }, (_, localIndex) => ({
+      cell,
+      localIndex,
+      localCount: allocations[cellIndex],
+    })),
+  );
+}
+
+function deterministicPackedPoint(rect: Rect, rand: () => number, localIndex: number, localCount: number): Point {
+  const aspect = Math.max(0.2, rect.width / Math.max(1, rect.height));
+  const columns = Math.max(1, Math.ceil(Math.sqrt(localCount * aspect)));
+  const rows = Math.max(1, Math.ceil(localCount / columns));
+  const column = localIndex % columns;
+  const row = Math.floor(localIndex / columns);
+  const jitterX = (rand() - 0.5) * 0.28;
+  const jitterY = (rand() - 0.5) * 0.28;
+  return {
+    x: rect.x + ((column + 0.5 + jitterX) / columns) * rect.width,
+    y: rect.y + ((row + 0.5 + jitterY) / rows) * rect.height,
+  };
+}
+
+function hashSeed(seed: string) {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function deterministicRandom(seed: string) {
+  let state = hashSeed(seed);
+  return () => {
+    let value = (state += 0x6d2b79f5);
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function projectEntity(entity: CrowdEntity, pos: number, reducedMotion: boolean): CrowdEntity {
+  if (reducedMotion) {
+    const visible = pos >= entity.spawnOffsetMs;
+    return {
+      ...entity,
+      x: entity.target.x,
+      y: entity.target.y,
+      state: visible ? "waiting" : "queued",
+      visible,
+    };
+  }
+  if (pos < entity.spawnOffsetMs) {
+    return { ...entity, x: entity.start.x, y: entity.start.y, state: "queued", visible: false };
+  }
+
+  const progress = Math.min(1, (pos - entity.spawnOffsetMs) / Math.max(1, entity.travelMs));
+  const point =
+    progress < 0.35
+      ? lerp(entity.start, entity.waypoint, ease(progress / 0.35))
+      : lerp(entity.waypoint, entity.target, ease((progress - 0.35) / 0.65));
+  const state =
+    progress < 0.18
+      ? "entering"
+      : progress < 0.92
+        ? "moving_to_zone"
+        : progress < 1
+          ? "settling"
+          : "waiting";
+  const idle = state === "waiting" ? Math.sin(pos / 950 + entity.idlePhase) * 1.2 : 0;
+  return { ...entity, x: point.x + idle, y: point.y, state, visible: true };
+}
+
+function rectCentre(rect: Rect): Point {
+  return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+}
+
+function packingAxes(zones: Rect[], stage: Rect) {
+  const stageCentre = rectCentre(stage);
+  const audienceBounds = zones.reduce(
+    (bounds, zone) => ({
+      x: Math.min(bounds.x, zone.x),
+      y: Math.min(bounds.y, zone.y),
+      right: Math.max(bounds.right, zone.x + zone.width),
+      bottom: Math.max(bounds.bottom, zone.y + zone.height),
+    }),
+    { x: Number.POSITIVE_INFINITY, y: Number.POSITIVE_INFINITY, right: Number.NEGATIVE_INFINITY, bottom: Number.NEGATIVE_INFINITY },
+  );
+  const audienceCentre = {
+    x: (audienceBounds.x + audienceBounds.right) / 2,
+    y: (audienceBounds.y + audienceBounds.bottom) / 2,
+  };
+  const rawDepth = { x: audienceCentre.x - stageCentre.x, y: audienceCentre.y - stageCentre.y };
+  const length = Math.hypot(rawDepth.x, rawDepth.y) || 1;
+  const depth = { x: rawDepth.x / length, y: rawDepth.y / length };
+  const lateral = { x: -depth.y, y: depth.x };
+  const stageCorners = [
+    { x: stage.x, y: stage.y },
+    { x: stage.x + stage.width, y: stage.y },
+    { x: stage.x, y: stage.y + stage.height },
+    { x: stage.x + stage.width, y: stage.y + stage.height },
+  ];
+  const stageFrontProjection = Math.max(...stageCorners.map((point) => dot(point, depth)));
+  return { stageCentre, depth, lateral, stageFrontProjection };
+}
+
+function projectedDepth(point: Point, axes: ReturnType<typeof packingAxes>) {
+  return Math.max(0, dot(point, axes.depth) - axes.stageFrontProjection);
+}
+
+function projectedLateralDistance(point: Point, axes: ReturnType<typeof packingAxes>) {
+  return Math.abs(dot({ x: point.x - axes.stageCentre.x, y: point.y - axes.stageCentre.y }, axes.lateral));
+}
+
+function dot(a: Point, b: Point) {
+  return a.x * b.x + a.y * b.y;
+}
+
+function boundedEntrancePoint(entrance: Point, audience: Rect, rand: () => number, i: number): Point {
+  const spread = 18;
+  const point = {
+    x: entrance.x + (rand() - 0.5) * spread + ((i % 5) - 2) * 2,
+    y: entrance.y + (rand() - 0.5) * 10,
+  };
+  return pointInRect(point, audience)
+    ? point
+    : {
+        x: Math.min(audience.x + audience.width - 8, Math.max(audience.x + 8, point.x)),
+        y: Math.min(audience.y + audience.height - 8, Math.max(audience.y + 8, point.y)),
+      };
+}
+
+function fallbackEntrance(audience: Rect): Point {
+  return { x: audience.x + audience.width / 2, y: audience.y + audience.height - 8 };
+}
+
+function weightedIndex(i: number, count: number, seed: string) {
+  return Math.abs((i * 1103515245 + seed.length * 97) % Math.max(1, count));
+}
+
+function findEventOffset(replay: GigViewerReplay, type: string, fallback: number) {
+  return replay.events.find((event) => event.visualPayload.type === type)?.scheduledOffsetMs ?? fallback;
+}
+
+function milestoneTemplates(): CrowdMilestone[] {
+  return [
+    { key: "doors", label: "Doors are open.", progress: 0, reached: false },
+    { key: "first", label: "The first fans are entering.", progress: 0.05, reached: false },
+    { key: "quarter", label: "The venue is one quarter full.", progress: 0.25, reached: false },
+    { key: "half", label: "The venue is half full.", progress: 0.5, reached: false },
+    { key: "three-quarter", label: "The venue is three quarters full.", progress: 0.75, reached: false },
+    { key: "full", label: "Target attendance has arrived.", progress: 1, reached: false },
+  ];
+}
+
+function lerp(a: Point, b: Point, t: number): Point {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}
+
+function ease(t: number) {
+  return t * t * (3 - 2 * t);
+}
+
+function distance(a: Point, b: Point) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}

--- a/src/features/gig-experience/viewer/tests/engine.test.ts
+++ b/src/features/gig-experience/viewer/tests/engine.test.ts
@@ -4,8 +4,42 @@ import { buildEntityLayout } from "../engine/EntityLayout";
 import { derivePlaybackState, ReplayClock } from "../engine/PlaybackController";
 import type { GigViewerReplay } from "../../events/types";
 
-const event = (sequence: number, offset: number, payload: any = { type: "venue_open", entranceIds: ["main"], lightLevel: .4 }) => ({ id: `e${sequence}`, gigId: "g1", sequence, scheduledOffsetMs: offset, durationMs: 1000, phase: sequence === 2 ? "completed" : "venue_opening", eventType: sequence === 2 ? "replay_completed" : "venue_opened", importance: "normal", messageKey: "gig.viewer.venue_opened", messageParams: {}, visualPayload: payload }) as any;
-const replay: GigViewerReplay = { id: "r1", gigId: "g1", gigOutcomeId: "o1", viewerVersion: 1, eventSchemaVersion: 1, simulationSeed: "seed", durationMs: 3000, generatedAt: "now", checksum: null, status: "ready", events: [event(0, 0), event(1, 1000, { type: "song_start", songId: "s1", title: "Song", position: 1, montage: false }), event(2, 3000)] };
+const event = (
+  sequence: number,
+  offset: number,
+  payload: any = { type: "venue_open", entranceIds: ["main"], lightLevel: 0.4 },
+) =>
+  ({
+    id: `e${sequence}`,
+    gigId: "g1",
+    sequence,
+    scheduledOffsetMs: offset,
+    durationMs: 1000,
+    phase: sequence === 2 ? "completed" : "venue_opening",
+    eventType: sequence === 2 ? "replay_completed" : "venue_opened",
+    importance: "normal",
+    messageKey: "gig.viewer.venue_opened",
+    messageParams: {},
+    visualPayload: payload,
+  }) as any;
+
+const replay: GigViewerReplay = {
+  id: "r1",
+  gigId: "g1",
+  gigOutcomeId: "o1",
+  viewerVersion: 1,
+  eventSchemaVersion: 1,
+  simulationSeed: "seed",
+  durationMs: 3000,
+  generatedAt: "now",
+  checksum: null,
+  status: "ready",
+  events: [
+    event(0, 0),
+    event(1, 1000, { type: "song_start", songId: "s1", title: "Song", position: 1, montage: false }),
+    event(2, 3000),
+  ],
+};
 
 describe("venue layout", () => {
   it("selects small, medium, and large presets with safe geometry", () => {
@@ -25,10 +59,27 @@ describe("deterministic entity layout", () => {
     const b = buildEntityLayout({ replay, size: { width: 800, height: 450 } });
     expect(a.crowd).toEqual(b.crowd);
     expect(a.performers).toEqual(b.performers);
-    a.crowd.forEach((c) => { expect(c.x).toBeGreaterThanOrEqual(0); expect(c.x).toBeLessThanOrEqual(800); expect(c.y).toBeGreaterThanOrEqual(0); expect(c.y).toBeLessThanOrEqual(450); });
+    a.crowd.forEach((crowdMember) => {
+      expect(crowdMember.x).toBeGreaterThanOrEqual(0);
+      expect(crowdMember.x).toBeLessThanOrEqual(800);
+      expect(crowdMember.y).toBeGreaterThanOrEqual(0);
+      expect(crowdMember.y).toBeLessThanOrEqual(450);
+    });
   });
+
   it("supports unknown and large performer groups", () => {
-    const many = { ...replay, events: Array.from({ length: 12 }, (_, i) => event(i, i * 100, { type: "performer_enter", performerId: `p${i}`, displayName: `Member ${i + 1}`, roleOrInstrument: i % 2 ? "unknown" : "drums", startPosition: { x: .5, y: .5, zone: "front_center" } })) };
+    const many = {
+      ...replay,
+      events: Array.from({ length: 12 }, (_, i) =>
+        event(i, i * 100, {
+          type: "performer_enter",
+          performerId: `p${i}`,
+          displayName: `Member ${i + 1}`,
+          roleOrInstrument: i % 2 ? "unknown" : "drums",
+          startPosition: { x: 0.5, y: 0.5, zone: "front_center" },
+        }),
+      ),
+    };
     expect(buildEntityLayout({ replay: many, size: { width: 900, height: 500 } }).performers).toHaveLength(12);
   });
 });
@@ -41,19 +92,45 @@ describe("playback", () => {
     expect(state.completedEventIds.has("e0")).toBe(true);
     expect(state.nextEvent?.id).toBe("e2");
   });
+
   it("handles play, pause, speed, restart, and clock jumps", () => {
-    let now = 0; const clock = new ReplayClock(3000, () => now);
-    clock.play(); now = 100; expect(clock.position()).toBe(100);
-    clock.setSpeed(2); now = 200; expect(clock.position()).toBe(300);
-    clock.pause(); now = 10000; expect(clock.position()).toBe(300);
-    clock.restart(); expect(clock.position()).toBe(0);
+    let now = 0;
+    const clock = new ReplayClock(3000, () => now);
+    clock.play();
+    now = 100;
+    expect(clock.position()).toBe(100);
+    clock.setSpeed(2);
+    now = 200;
+    expect(clock.position()).toBe(300);
+    clock.pause();
+    now = 10000;
+    expect(clock.position()).toBe(300);
+    clock.restart();
+    expect(clock.position()).toBe(0);
   });
 });
-import { buildCrowdPlan, reconstructCrowdState, representedWeights, selectCrowdEntityCap } from "../engine/CrowdLifecycle";
+
+import {
+  buildCrowdPackingCells,
+  buildCrowdPlan,
+  reconstructCrowdState,
+  representedWeights,
+  selectCrowdEntityCap,
+} from "../engine/CrowdLifecycle";
 import { pointInRect } from "../engine/Viewport";
 
 describe("animated crowd lifecycle", () => {
-  const crowdReplay: GigViewerReplay = { ...replay, durationMs: 20000, events: [event(0, 0, { type: "venue_open", entranceIds: ["main"], lightLevel: .4 }), event(1, 1000, { type: "crowd_fill", targetDensity: .5, zoneIds: ["front"], enteringCount: 50 }), event(2, 9000, { type: "song_start", songId: "s1", title: "Song", position: 1, montage: false }), event(3, 20000)] };
+  const crowdReplay: GigViewerReplay = {
+    ...replay,
+    durationMs: 20000,
+    events: [
+      event(0, 0, { type: "venue_open", entranceIds: ["main"], lightLevel: 0.4 }),
+      event(1, 1000, { type: "crowd_fill", targetDensity: 0.5, zoneIds: ["front"], enteringCount: 50 }),
+      event(2, 9000, { type: "song_start", songId: "s1", title: "Song", position: 1, montage: false }),
+      event(3, 20000),
+    ],
+  };
+
   it("builds exact represented weights without overstatement", () => {
     expect(representedWeights(0, 100)).toEqual([]);
     expect(representedWeights(7, 100).reduce((a, b) => a + b, 0)).toBe(7);
@@ -66,33 +143,105 @@ describe("animated crowd lifecycle", () => {
     expect(doubled).toHaveLength(1006);
     expect(doubled.reduce((a, b) => a + b, 0)).toBeCloseTo(503, 8);
   });
+
   it("centralizes doubled caps by device mode", () => {
     expect(selectCrowdEntityCap({ reducedMotion: true, width: 1400 })).toBeLessThanOrEqual(300);
     expect(selectCrowdEntityCap({ reducedMotion: false, width: 390 })).toBe(1800);
     expect(selectCrowdEntityCap({ reducedMotion: false, width: 800 })).toBe(3800);
     expect(selectCrowdEntityCap({ reducedMotion: false, width: 1300 })).toBe(5800);
   });
+
   it("assigns entrances and denser target positions deterministically inside audience bounds", () => {
-    const plan = buildCrowdPlan({ replay: crowdReplay, attendance: 503, capacity: 1500, size: { width: 900, height: 500 } });
-    const again = buildCrowdPlan({ replay: crowdReplay, attendance: 503, capacity: 1500, size: { width: 900, height: 500 } });
+    const plan = buildCrowdPlan({
+      replay: crowdReplay,
+      attendance: 503,
+      capacity: 1500,
+      size: { width: 900, height: 500 },
+    });
+    const again = buildCrowdPlan({
+      replay: crowdReplay,
+      attendance: 503,
+      capacity: 1500,
+      size: { width: 900, height: 500 },
+    });
     expect(plan.baseEntities).toEqual(again.baseEntities);
     expect(plan.baseEntities).toHaveLength(1006);
-    expect(new Set(plan.baseEntities.map((e) => e.entranceId)).size).toBeGreaterThan(1);
+    expect(new Set(plan.baseEntities.map((entity) => entity.entranceId)).size).toBeGreaterThan(1);
     const preset = scaleVenuePreset(selectVenuePreset({ capacity: 1500 }), { width: 900, height: 500 });
-    plan.baseEntities.forEach((e) => { expect(pointInRect(e.target, preset.audience)).toBe(true); expect(pointInRect(e.target, preset.stage)).toBe(false); });
+    plan.baseEntities.forEach((entity) => {
+      expect(pointInRect(entity.target, preset.audience)).toBe(true);
+      expect(pointInRect(entity.target, preset.stage)).toBe(false);
+    });
   });
-  it("clusters low attendance toward the stage before sold-out plans use more zones", () => {
-    const low = buildCrowdPlan({ replay: crowdReplay, attendance: 50, capacity: 1500, size: { width: 900, height: 500 } });
-    const full = buildCrowdPlan({ replay: crowdReplay, attendance: 1500, capacity: 1500, size: { width: 900, height: 500 } });
-    expect(new Set(low.baseEntities.map((e) => e.targetZoneId)).size).toBeLessThan(new Set(full.baseEntities.map((e) => e.targetZoneId)).size);
-    expect(low.baseEntities.every((e) => e.targetZoneId.startsWith("front"))).toBe(true);
-    const preset = scaleVenuePreset(selectVenuePreset({ capacity: 1500 }), { width: 900, height: 500 });
-    const frontZone = preset.crowdZones[0];
-    const averageTargetY = low.baseEntities.reduce((sum, entity) => sum + entity.target.y, 0) / low.baseEntities.length;
-    expect(averageTargetY).toBeLessThan(frontZone.y + frontZone.height * .55);
+
+  it("orders packing cells from the stage edge outward and centre-first", () => {
+    for (const capacity of [250, 700, 2000]) {
+      const preset = scaleVenuePreset(selectVenuePreset({ capacity }), { width: 900, height: 500 });
+      const cells = buildCrowdPackingCells(preset.crowdZones, preset.stage);
+      expect(cells.length).toBeGreaterThan(0);
+      for (let i = 1; i < cells.length; i += 1) {
+        expect(cells[i].stageDistance).toBeGreaterThanOrEqual(cells[i - 1].stageDistance);
+      }
+      const nearestDepth = cells[0].stageDistance;
+      const nearestBand = cells.filter((cell) => Math.abs(cell.stageDistance - nearestDepth) < 0.001);
+      expect(nearestBand[0].lateralDistance).toBeLessThanOrEqual(nearestBand.at(-1)?.lateralDistance ?? 0);
+      expect(cells[0].id).toContain("centre");
+    }
   });
+
+  it("fills front-centre areas before back and side areas in every venue size", () => {
+    for (const capacity of [250, 700, 2000]) {
+      const attendance = Math.max(1, Math.round(capacity * 0.1));
+      const plan = buildCrowdPlan({
+        replay: crowdReplay,
+        attendance,
+        capacity,
+        size: { width: 900, height: 500 },
+      });
+      const preset = scaleVenuePreset(selectVenuePreset({ capacity }), { width: 900, height: 500 });
+      const firstQuarter = plan.baseEntities.slice(0, Math.max(1, Math.floor(plan.baseEntities.length / 4)));
+      const lastQuarter = plan.baseEntities.slice(-Math.max(1, Math.floor(plan.baseEntities.length / 4)));
+      const stageEdgeY = preset.stage.y + preset.stage.height;
+      const stageCentreX = preset.stage.x + preset.stage.width / 2;
+      const averageDepth = (entities: typeof plan.baseEntities) =>
+        entities.reduce((sum, entity) => sum + Math.max(0, entity.target.y - stageEdgeY), 0) / entities.length;
+      const averageSideDistance = (entities: typeof plan.baseEntities) =>
+        entities.reduce((sum, entity) => sum + Math.abs(entity.target.x - stageCentreX), 0) / entities.length;
+
+      expect(plan.baseEntities.every((entity) => entity.targetZoneId.startsWith("front"))).toBe(true);
+      expect(averageDepth(firstQuarter)).toBeLessThan(averageDepth(lastQuarter));
+      expect(averageSideDistance(firstQuarter)).toBeLessThan(averageSideDistance(lastQuarter));
+      const deepestTarget = Math.max(...plan.baseEntities.map((entity) => entity.target.y));
+      expect(deepestTarget).toBeLessThan(preset.audience.y + preset.audience.height * 0.45);
+    }
+  });
+
+  it("uses rear zones only after front zones are populated", () => {
+    for (const capacity of [700, 2000]) {
+      const partial = buildCrowdPlan({
+        replay: crowdReplay,
+        attendance: Math.round(capacity * 0.35),
+        capacity,
+        size: { width: 900, height: 500 },
+      });
+      const full = buildCrowdPlan({
+        replay: crowdReplay,
+        attendance: capacity,
+        capacity,
+        size: { width: 900, height: 500 },
+      });
+      expect(partial.baseEntities.every((entity) => entity.targetZoneId.startsWith("front"))).toBe(true);
+      expect(full.baseEntities.some((entity) => !entity.targetZoneId.startsWith("front"))).toBe(true);
+    }
+  });
+
   it("reconstructs spawn, movement, settling, seeking, and reduced motion deterministically", () => {
-    const plan = buildCrowdPlan({ replay: crowdReplay, attendance: 120, capacity: 250, size: { width: 640, height: 360 } });
+    const plan = buildCrowdPlan({
+      replay: crowdReplay,
+      attendance: 120,
+      capacity: 250,
+      size: { width: 640, height: 360 },
+    });
     const start = reconstructCrowdState(plan, 0);
     const mid = reconstructCrowdState(plan, 4500);
     const late = reconstructCrowdState(plan, 15000);
@@ -102,7 +251,7 @@ describe("animated crowd lifecycle", () => {
     expect(reconstructCrowdState(plan, 4500)).toEqual(mid);
     expect(reconstructCrowdState(plan, 1000).diagnostics.entityCount).toBe(plan.baseEntities.length);
     const reduced = reconstructCrowdState(plan, 4500, true);
-    expect(reduced.entities.some((e) => e.visible && e.x !== e.target.x)).toBe(false);
-    expect(reduced.milestones.some((m) => m.label.includes("half"))).toBe(true);
+    expect(reduced.entities.some((entity) => entity.visible && entity.x !== entity.target.x)).toBe(false);
+    expect(reduced.milestones.some((milestone) => milestone.label.includes("half"))).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed
- replaced crowd zone biasing with deterministic packing cells ordered from the stage edge toward the rear
- fills each depth band centre-first before using its side cells
- scales the number of active packing cells with actual attendance, keeping low-attendance crowds compact
- prevents middle/rear crowd zones from receiving fans until the front zone has been populated
- keeps target positions deterministic and evenly packed within each active cell
- applies through the shared crowd lifecycle used by both the live and demo gig viewers

## Tests
- added coverage for small, medium, and large venue layouts
- verifies packing cells remain ordered stage-outward and centre-first
- verifies low attendance remains in front zones and close to the stage
- verifies later arrivals spread deeper and farther to the sides
- verifies rear zones are only used after front-zone population
- ran an isolated TypeScript compile and focused deterministic packing harness against representative venue geometries

## Known repository validation issue
The repository-wide GitHub workflows may still stop at `npm ci` because `package.json` and `package-lock.json` are currently out of sync, as observed on the preceding crowd-density PR.