### PR TITLE
Save gig crowd tuning as global defaults

### DIFF
--- a/src/features/gig-experience/events/types.ts
+++ b/src/features/gig-experience/events/types.ts
@@ -7,6 +7,16 @@ export type GigEventImportance = "ambient" | "normal" | "important" | "critical"
 
 export interface StagePosition { x: number; y: number; zone: "front_left" | "front_center" | "front_right" | "mid_left" | "mid_center" | "mid_right" | "back_left" | "back_center" | "back_right" }
 
+export interface GigReplayCrowdTuning {
+  densityMultiplier: number;
+  depthSpread: number;
+  lateralSpread: number;
+  stagePull: number;
+  randomness: number;
+  fanScale: number;
+  arrivalSpeed: number;
+}
+
 export type GigVisualPayload =
   | { type: "venue_open"; entranceIds: string[]; lightLevel: number }
   | { type: "crowd_fill"; targetDensity: number; zoneIds: string[]; enteringCount: number }
@@ -50,6 +60,8 @@ export interface GigViewerReplay {
   events: GigViewerEvent[];
   checksum: string | null;
   status: GigReplayStatus;
+  crowdTuning?: GigReplayCrowdTuning | null;
+  crowdTuningRevision?: number | null;
 }
 
 export type GigViewerReplayLoadState = "loading" | "ready" | "unavailable" | "generating" | "failed" | "unsupported_version";

--- a/src/features/gig-experience/services/GigViewerReplayService.ts
+++ b/src/features/gig-experience/services/GigViewerReplayService.ts
@@ -2,8 +2,14 @@ import { supabase } from "@/integrations/supabase/client";
 import { GIG_EVENT_SCHEMA_VERSION, GIG_VIEWER_VERSION } from "../events/constants";
 import { isSupportedReplayVersion, validateGigViewerReplay } from "../events/schema";
 import type { GigReplayStatus, GigViewerReplay, GigViewerReplayLoadState } from "../events/types";
+import { normalizeCrowdTuning } from "../viewer/engine/CrowdTuning";
 
-type ReplayRow = { id: string; gig_id: string; gig_outcome_id: string; viewer_version: number; event_schema_version: number; simulation_seed: string; duration_ms: number; event_payload: { events?: unknown[] } | unknown[]; generated_at: string; generation_status: GigReplayStatus; checksum: string | null };
+type ReplayPayload = {
+  events?: unknown[];
+  crowdTuning?: unknown;
+  crowdTuningRevision?: unknown;
+};
+type ReplayRow = { id: string; gig_id: string; gig_outcome_id: string; viewer_version: number; event_schema_version: number; simulation_seed: string; duration_ms: number; event_payload: ReplayPayload | unknown[]; generated_at: string; generation_status: GigReplayStatus; checksum: string | null };
 export interface GigViewerReplayResult { state: GigViewerReplayLoadState; replay: GigViewerReplay | null; reason?: string }
 
 export async function getGigViewerReplay(gigId: string): Promise<GigViewerReplayResult> {
@@ -21,11 +27,28 @@ export async function getGigViewerReplay(gigId: string): Promise<GigViewerReplay
   if (row.generation_status === "failed") return { state: "failed", replay: null };
   if (row.generation_status === "legacy_unavailable") return { state: "unavailable", replay: null, reason: "legacy_unavailable" };
   if (!isSupportedReplayVersion(row.viewer_version, row.event_schema_version)) return { state: "unsupported_version", replay: null };
-  const events = Array.isArray(row.event_payload) ? row.event_payload : (row.event_payload as { events?: unknown[] })?.events;
-  const replay: GigViewerReplay = { id: row.id, gigId: row.gig_id, gigOutcomeId: row.gig_outcome_id, viewerVersion: row.viewer_version, eventSchemaVersion: row.event_schema_version, simulationSeed: row.simulation_seed, durationMs: row.duration_ms, generatedAt: row.generated_at, events: (events ?? []) as GigViewerReplay["events"], checksum: row.checksum, status: row.generation_status };
+
+  const payload = Array.isArray(row.event_payload) ? null : row.event_payload as ReplayPayload;
+  const events = Array.isArray(row.event_payload) ? row.event_payload : payload?.events;
+  const revision = Number(payload?.crowdTuningRevision);
+  const replay: GigViewerReplay = {
+    id: row.id,
+    gigId: row.gig_id,
+    gigOutcomeId: row.gig_outcome_id,
+    viewerVersion: row.viewer_version,
+    eventSchemaVersion: row.event_schema_version,
+    simulationSeed: row.simulation_seed,
+    durationMs: row.duration_ms,
+    generatedAt: row.generated_at,
+    events: (events ?? []) as GigViewerReplay["events"],
+    checksum: row.checksum,
+    status: row.generation_status,
+    crowdTuning: payload?.crowdTuning ? normalizeCrowdTuning(payload.crowdTuning as any) : null,
+    crowdTuningRevision: Number.isFinite(revision) && revision > 0 ? revision : null,
+  };
   if (replay.eventSchemaVersion !== GIG_EVENT_SCHEMA_VERSION) return { state: "unsupported_version", replay: null };
   const validation = validateGigViewerReplay(replay);
   if (!validation.valid) return { state: "failed", replay: null, reason: "malformed_replay" };
-  console.info("[gig-viewer-replay] loaded", { gigId, replayId: row.id, eventCount: replay.events.length, durationMs: replay.durationMs });
+  console.info("[gig-viewer-replay] loaded", { gigId, replayId: row.id, eventCount: replay.events.length, durationMs: replay.durationMs, crowdTuningRevision: replay.crowdTuningRevision });
   return { state: "ready", replay };
 }

--- a/src/features/gig-experience/viewer/GigCanvas.tsx
+++ b/src/features/gig-experience/viewer/GigCanvas.tsx
@@ -7,6 +7,7 @@ import type { DerivedPlaybackState } from "./engine/PlaybackController";
 import { CanvasRenderer } from "./engine/CanvasRenderer";
 import type { CrowdTuningOptions } from "./engine/CrowdTuning";
 import { crowdTuningSignature } from "./engine/CrowdTuning";
+import { resolveCrowdTuning } from "./engine/CrowdTuningResolution";
 import { useCanvasSize } from "./hooks/useCanvasSize";
 import { useGlobalCrowdTuning } from "./hooks/useGlobalCrowdTuning";
 
@@ -39,13 +40,14 @@ export function GigCanvas({
   const replayTuning = replay.crowdTuning ?? null;
   const shouldLoadGlobal = !crowdTuning && !demoTuning.demoMode && !replayTuning;
   const globalTuning = useGlobalCrowdTuning(shouldLoadGlobal);
-  const resolvedCrowdTuning =
-    crowdTuning ??
-    (demoTuning.demoMode ? demoTuning.value : null) ??
-    replayTuning ??
-    globalTuning.data?.settings ??
-    null;
-  const tuningKey = crowdTuningSignature(resolvedCrowdTuning);
+  const resolved = resolveCrowdTuning({
+    explicit: crowdTuning,
+    demoMode: demoTuning.demoMode,
+    demo: demoTuning.value,
+    replay: replayTuning,
+    global: globalTuning.data?.settings,
+  });
+  const tuningKey = crowdTuningSignature(resolved.tuning);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -53,7 +55,7 @@ export function GigCanvas({
     const renderer = new CanvasRenderer(canvas, replay, experience, reducedMotion, {
       pyrotechnics,
       pyroIntensity,
-      crowdTuning: resolvedCrowdTuning,
+      crowdTuning: resolved.tuning,
     });
     rendererRef.current = renderer;
     renderer.resize(size);
@@ -67,7 +69,7 @@ export function GigCanvas({
   const capacity = experience?.gig?.venue?.capacity ?? 0;
 
   return (
-    <div className={className ?? (fill ? "h-full w-full" : "w-full")}>
+    <div className={className ?? (fill ? "h-full w-full" : "w-full")} data-crowd-tuning-source={resolved.source}>
       {demoTuning.demoMode && !fill ? (
         <>
           <GlobalCrowdDefaultsControls value={demoTuning.value} onLoad={demoTuning.setValue} />

--- a/src/features/gig-experience/viewer/GigCanvas.tsx
+++ b/src/features/gig-experience/viewer/GigCanvas.tsx
@@ -2,11 +2,13 @@ import { useEffect, useRef } from "react";
 import type { GigViewerReplay } from "../events/types";
 import type { GigExperienceDTO } from "../types";
 import { CrowdTuningPanel, useDemoCrowdTuning } from "./CrowdTuningPanel";
+import { GlobalCrowdDefaultsControls } from "./GlobalCrowdDefaultsControls";
 import type { DerivedPlaybackState } from "./engine/PlaybackController";
 import { CanvasRenderer } from "./engine/CanvasRenderer";
 import type { CrowdTuningOptions } from "./engine/CrowdTuning";
 import { crowdTuningSignature } from "./engine/CrowdTuning";
 import { useCanvasSize } from "./hooks/useCanvasSize";
+import { useGlobalCrowdTuning } from "./hooks/useGlobalCrowdTuning";
 
 export function GigCanvas({
   replay,
@@ -34,7 +36,15 @@ export function GigCanvas({
   const rendererRef = useRef<CanvasRenderer | null>(null);
   const size = useCanvasSize(wrapRef, { fill });
   const demoTuning = useDemoCrowdTuning();
-  const resolvedCrowdTuning = crowdTuning ?? (demoTuning.demoMode ? demoTuning.value : null);
+  const replayTuning = replay.crowdTuning ?? null;
+  const shouldLoadGlobal = !crowdTuning && !demoTuning.demoMode && !replayTuning;
+  const globalTuning = useGlobalCrowdTuning(shouldLoadGlobal);
+  const resolvedCrowdTuning =
+    crowdTuning ??
+    (demoTuning.demoMode ? demoTuning.value : null) ??
+    replayTuning ??
+    globalTuning.data?.settings ??
+    null;
   const tuningKey = crowdTuningSignature(resolvedCrowdTuning);
 
   useEffect(() => {
@@ -59,12 +69,15 @@ export function GigCanvas({
   return (
     <div className={className ?? (fill ? "h-full w-full" : "w-full")}>
       {demoTuning.demoMode && !fill ? (
-        <CrowdTuningPanel
-          value={demoTuning.value}
-          onChange={demoTuning.setValue}
-          attendance={attendance}
-          capacity={capacity}
-        />
+        <>
+          <GlobalCrowdDefaultsControls value={demoTuning.value} onLoad={demoTuning.setValue} />
+          <CrowdTuningPanel
+            value={demoTuning.value}
+            onChange={demoTuning.setValue}
+            attendance={attendance}
+            capacity={capacity}
+          />
+        </>
       ) : null}
       <div ref={wrapRef} className={fill ? "h-full w-full" : "w-full"}>
         <canvas

--- a/src/features/gig-experience/viewer/GlobalCrowdDefaultsControls.tsx
+++ b/src/features/gig-experience/viewer/GlobalCrowdDefaultsControls.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  DEFAULT_CROWD_TUNING,
+  crowdTuningSignature,
+  type CrowdTuningOptions,
+} from "./engine/CrowdTuning";
+import {
+  useGlobalCrowdTuning,
+  useRestoreGlobalCrowdTuning,
+  useSaveGlobalCrowdTuning,
+} from "./hooks/useGlobalCrowdTuning";
+
+export function GlobalCrowdDefaultsControls({
+  value,
+  onLoad,
+}: {
+  value: CrowdTuningOptions;
+  onLoad: (value: CrowdTuningOptions) => void;
+}) {
+  const globalQuery = useGlobalCrowdTuning(true);
+  const saveMutation = useSaveGlobalCrowdTuning();
+  const restoreMutation = useRestoreGlobalCrowdTuning();
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [restoreOpen, setRestoreOpen] = useState(false);
+  const [saveReason, setSaveReason] = useState("");
+  const [restoreReason, setRestoreReason] = useState("");
+
+  const global = globalQuery.data;
+  const matchesGlobal = useMemo(
+    () => !!global && crowdTuningSignature(global.settings) === crowdTuningSignature(value),
+    [global, value],
+  );
+  const isBusy = saveMutation.isPending || restoreMutation.isPending;
+
+  const save = async () => {
+    if (saveReason.trim().length < 8) return;
+    await saveMutation.mutateAsync({ settings: value, reason: saveReason.trim() });
+    setSaveOpen(false);
+    setSaveReason("");
+  };
+
+  const restore = async () => {
+    if (restoreReason.trim().length < 8) return;
+    const result = await restoreMutation.mutateAsync({ reason: restoreReason.trim() });
+    onLoad(result.settings);
+    setRestoreOpen(false);
+    setRestoreReason("");
+  };
+
+  return (
+    <section className="mb-3 space-y-3 rounded-xl border border-primary/30 bg-primary/5 p-4" aria-label="Global crowd defaults">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold">Global gig crowd defaults</h3>
+          <p className="text-sm text-muted-foreground">
+            Save the current demo settings for normal gigs. New replays snapshot the active revision so later edits do not change them.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {global ? <Badge variant="outline">Revision {global.revision}</Badge> : null}
+          <Badge variant={matchesGlobal ? "secondary" : "outline"}>
+            {matchesGlobal ? "Demo matches global" : "Unsaved demo changes"}
+          </Badge>
+        </div>
+      </div>
+
+      {globalQuery.isError ? (
+        <p className="text-sm text-destructive">
+          Global settings could not be loaded. Apply the database migration before using the production save controls.
+        </p>
+      ) : null}
+
+      {global ? (
+        <p className="text-xs text-muted-foreground">
+          Last change: {global.reason ?? "No reason recorded"}
+          {global.updatedAt ? ` · ${new Date(global.updatedAt).toLocaleString()}` : ""}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={!global || isBusy}
+          onClick={() => global && onLoad(global.settings)}
+        >
+          Load global into demo
+        </Button>
+
+        <AlertDialog open={saveOpen} onOpenChange={setSaveOpen}>
+          <AlertDialogTrigger asChild>
+            <Button type="button" disabled={isBusy || globalQuery.isError || matchesGlobal}>
+              Save as global default
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Replace the global gig crowd defaults?</AlertDialogTitle>
+              <AlertDialogDescription>
+                These settings will be used for every newly generated gig replay. Existing replays with a saved crowd revision remain unchanged; older unsnapshotted replays receive this revision once.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="crowd-default-save-reason">Reason for this change</Label>
+              <Textarea
+                id="crowd-default-save-reason"
+                value={saveReason}
+                onChange={(event) => setSaveReason(event.target.value)}
+                placeholder="Describe why these crowd defaults are changing"
+                maxLength={240}
+              />
+              <p className="text-xs text-muted-foreground">Minimum 8 characters. This is stored in the admin audit log.</p>
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={saveMutation.isPending}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={saveReason.trim().length < 8 || saveMutation.isPending}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void save();
+                }}
+              >
+                {saveMutation.isPending ? "Saving…" : "Save global defaults"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        <AlertDialog open={restoreOpen} onOpenChange={setRestoreOpen}>
+          <AlertDialogTrigger asChild>
+            <Button type="button" variant="destructive" disabled={isBusy || globalQuery.isError}>
+              Restore system defaults
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Restore the original production crowd defaults?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This creates a new global revision using the built-in production values. It does not rewrite replays that already have a crowd tuning snapshot.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="crowd-default-restore-reason">Reason for restoring</Label>
+              <Textarea
+                id="crowd-default-restore-reason"
+                value={restoreReason}
+                onChange={(event) => setRestoreReason(event.target.value)}
+                placeholder="Describe why the system defaults are being restored"
+                maxLength={240}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={restoreMutation.isPending}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={restoreReason.trim().length < 8 || restoreMutation.isPending}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void restore();
+                }}
+              >
+                {restoreMutation.isPending ? "Restoring…" : "Restore defaults"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Built-in fallback: density {DEFAULT_CROWD_TUNING.densityMultiplier}×, depth {DEFAULT_CROWD_TUNING.depthSpread}×, lateral {DEFAULT_CROWD_TUNING.lateralSpread}×.
+      </p>
+    </section>
+  );
+}

--- a/src/features/gig-experience/viewer/GlobalCrowdDefaultsControls.tsx
+++ b/src/features/gig-experience/viewer/GlobalCrowdDefaultsControls.tsx
@@ -49,17 +49,25 @@ export function GlobalCrowdDefaultsControls({
 
   const save = async () => {
     if (saveReason.trim().length < 8) return;
-    await saveMutation.mutateAsync({ settings: value, reason: saveReason.trim() });
-    setSaveOpen(false);
-    setSaveReason("");
+    try {
+      await saveMutation.mutateAsync({ settings: value, reason: saveReason.trim() });
+      setSaveOpen(false);
+      setSaveReason("");
+    } catch {
+      // Mutation feedback is shown by the hook; keep the dialog open for retry.
+    }
   };
 
   const restore = async () => {
     if (restoreReason.trim().length < 8) return;
-    const result = await restoreMutation.mutateAsync({ reason: restoreReason.trim() });
-    onLoad(result.settings);
-    setRestoreOpen(false);
-    setRestoreReason("");
+    try {
+      const result = await restoreMutation.mutateAsync({ reason: restoreReason.trim() });
+      onLoad(result.settings);
+      setRestoreOpen(false);
+      setRestoreReason("");
+    } catch {
+      // Mutation feedback is shown by the hook; keep the dialog open for retry.
+    }
   };
 
   return (

--- a/src/features/gig-experience/viewer/engine/CrowdTuningResolution.ts
+++ b/src/features/gig-experience/viewer/engine/CrowdTuningResolution.ts
@@ -1,0 +1,23 @@
+import type { CrowdTuningOptions } from "./CrowdTuning";
+
+export type CrowdTuningSource = "explicit" | "demo" | "replay" | "global" | "built_in";
+
+export function resolveCrowdTuning({
+  explicit,
+  demoMode,
+  demo,
+  replay,
+  global,
+}: {
+  explicit?: Partial<CrowdTuningOptions> | null;
+  demoMode: boolean;
+  demo?: CrowdTuningOptions | null;
+  replay?: Partial<CrowdTuningOptions> | null;
+  global?: CrowdTuningOptions | null;
+}): { tuning: Partial<CrowdTuningOptions> | null; source: CrowdTuningSource } {
+  if (explicit) return { tuning: explicit, source: "explicit" };
+  if (demoMode && demo) return { tuning: demo, source: "demo" };
+  if (replay) return { tuning: replay, source: "replay" };
+  if (global) return { tuning: global, source: "global" };
+  return { tuning: null, source: "built_in" };
+}

--- a/src/features/gig-experience/viewer/hooks/useGlobalCrowdTuning.ts
+++ b/src/features/gig-experience/viewer/hooks/useGlobalCrowdTuning.ts
@@ -1,0 +1,108 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import {
+  DEFAULT_CROWD_TUNING,
+  normalizeCrowdTuning,
+  type CrowdTuningOptions,
+} from "../engine/CrowdTuning";
+
+export interface GlobalCrowdTuningSettings {
+  revision: number;
+  settings: CrowdTuningOptions;
+  updatedAt: string | null;
+  updatedBy: string | null;
+  reason: string | null;
+}
+
+const QUERY_KEY = ["gig-viewer", "global-crowd-tuning"] as const;
+
+export function useGlobalCrowdTuning(enabled = true) {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+    queryFn: fetchGlobalCrowdTuning,
+  });
+}
+
+export function useSaveGlobalCrowdTuning() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ settings, reason }: { settings: CrowdTuningOptions; reason: string }) => {
+      const { data, error } = await (supabase as any).rpc("admin_set_gig_viewer_crowd_settings", {
+        p_settings: normalizeCrowdTuning(settings),
+        p_reason: reason,
+      });
+      if (error) throw error;
+      return mapRpcResult(data);
+    },
+    onSuccess: (settings) => {
+      queryClient.setQueryData(QUERY_KEY, settings);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      toast.success(`Crowd defaults saved as revision ${settings.revision}`);
+    },
+    onError: (error: Error) => {
+      toast.error(`Unable to save crowd defaults: ${error.message}`);
+    },
+  });
+}
+
+export function useRestoreGlobalCrowdTuning() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ reason }: { reason: string }) => {
+      const { data, error } = await (supabase as any).rpc("admin_restore_gig_viewer_crowd_settings", {
+        p_reason: reason,
+      });
+      if (error) throw error;
+      return mapRpcResult(data);
+    },
+    onSuccess: (settings) => {
+      queryClient.setQueryData(QUERY_KEY, settings);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      toast.success(`System crowd defaults restored as revision ${settings.revision}`);
+    },
+    onError: (error: Error) => {
+      toast.error(`Unable to restore crowd defaults: ${error.message}`);
+    },
+  });
+}
+
+async function fetchGlobalCrowdTuning(): Promise<GlobalCrowdTuningSettings> {
+  const { data, error } = await (supabase as any)
+    .from("gig_viewer_crowd_settings")
+    .select("revision,settings,updated_at,updated_by,reason")
+    .eq("id", true)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) {
+    return {
+      revision: 1,
+      settings: { ...DEFAULT_CROWD_TUNING },
+      updatedAt: null,
+      updatedBy: null,
+      reason: "Production fallback",
+    };
+  }
+
+  return {
+    revision: Math.max(1, Number(data.revision) || 1),
+    settings: normalizeCrowdTuning(data.settings),
+    updatedAt: typeof data.updated_at === "string" ? data.updated_at : null,
+    updatedBy: typeof data.updated_by === "string" ? data.updated_by : null,
+    reason: typeof data.reason === "string" ? data.reason : null,
+  };
+}
+
+function mapRpcResult(data: any): GlobalCrowdTuningSettings {
+  return {
+    revision: Math.max(1, Number(data?.revision) || 1),
+    settings: normalizeCrowdTuning(data?.settings),
+    updatedAt: typeof data?.updatedAt === "string" ? data.updatedAt : null,
+    updatedBy: typeof data?.updatedBy === "string" ? data.updatedBy : null,
+    reason: typeof data?.reason === "string" ? data.reason : null,
+  };
+}

--- a/src/features/gig-experience/viewer/tests/CrowdTuningResolution.test.ts
+++ b/src/features/gig-experience/viewer/tests/CrowdTuningResolution.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CROWD_TUNING } from "../engine/CrowdTuning";
+import { resolveCrowdTuning } from "../engine/CrowdTuningResolution";
+
+const tuning = (densityMultiplier: number) => ({
+  ...DEFAULT_CROWD_TUNING,
+  densityMultiplier,
+});
+
+describe("crowd tuning resolution", () => {
+  it("keeps explicit overrides above every other source", () => {
+    const result = resolveCrowdTuning({
+      explicit: tuning(4),
+      demoMode: true,
+      demo: tuning(3),
+      replay: tuning(2.5),
+      global: tuning(1.5),
+    });
+    expect(result.source).toBe("explicit");
+    expect(result.tuning?.densityMultiplier).toBe(4);
+  });
+
+  it("uses demo settings only on the admin demo route", () => {
+    expect(resolveCrowdTuning({ demoMode: true, demo: tuning(3), replay: tuning(2.5), global: tuning(1.5) }).source).toBe("demo");
+    expect(resolveCrowdTuning({ demoMode: false, demo: tuning(3), replay: tuning(2.5), global: tuning(1.5) }).source).toBe("replay");
+  });
+
+  it("prefers a replay snapshot over a later global revision", () => {
+    const result = resolveCrowdTuning({
+      demoMode: false,
+      replay: tuning(2.25),
+      global: tuning(4),
+    });
+    expect(result.source).toBe("replay");
+    expect(result.tuning?.densityMultiplier).toBe(2.25);
+  });
+
+  it("uses the active global setting for unsnapshotted replays", () => {
+    const result = resolveCrowdTuning({ demoMode: false, global: tuning(3.5) });
+    expect(result.source).toBe("global");
+    expect(result.tuning?.densityMultiplier).toBe(3.5);
+  });
+
+  it("falls back to the built-in production plan when settings are unavailable", () => {
+    expect(resolveCrowdTuning({ demoMode: false })).toEqual({ tuning: null, source: "built_in" });
+  });
+});

--- a/src/features/gig-experience/viewer/tests/GlobalCrowdDefaultsControls.test.tsx
+++ b/src/features/gig-experience/viewer/tests/GlobalCrowdDefaultsControls.test.tsx
@@ -3,16 +3,23 @@ import { describe, expect, it, vi } from "vitest";
 import { GlobalCrowdDefaultsControls } from "../GlobalCrowdDefaultsControls";
 import { DEFAULT_CROWD_TUNING } from "../engine/CrowdTuning";
 
-const globalSettings = {
-  ...DEFAULT_CROWD_TUNING,
-  densityMultiplier: 2,
-};
+const mockState = vi.hoisted(() => ({
+  globalSettings: {
+    densityMultiplier: 2,
+    depthSpread: 1,
+    lateralSpread: 1,
+    stagePull: 0,
+    randomness: 0,
+    fanScale: 1,
+    arrivalSpeed: 1,
+  },
+}));
 
 vi.mock("../hooks/useGlobalCrowdTuning", () => ({
   useGlobalCrowdTuning: () => ({
     data: {
       revision: 4,
-      settings: globalSettings,
+      settings: mockState.globalSettings,
       updatedAt: "2026-08-04T12:00:00Z",
       updatedBy: "admin-user",
       reason: "Previous crowd balance",
@@ -49,6 +56,6 @@ describe("global crowd defaults controls", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Load global into demo" }));
-    expect(onLoad).toHaveBeenCalledWith(globalSettings);
+    expect(onLoad).toHaveBeenCalledWith(mockState.globalSettings);
   });
 });

--- a/src/features/gig-experience/viewer/tests/GlobalCrowdDefaultsControls.test.tsx
+++ b/src/features/gig-experience/viewer/tests/GlobalCrowdDefaultsControls.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GlobalCrowdDefaultsControls } from "../GlobalCrowdDefaultsControls";
+import { DEFAULT_CROWD_TUNING } from "../engine/CrowdTuning";
+
+const globalSettings = {
+  ...DEFAULT_CROWD_TUNING,
+  densityMultiplier: 2,
+};
+
+vi.mock("../hooks/useGlobalCrowdTuning", () => ({
+  useGlobalCrowdTuning: () => ({
+    data: {
+      revision: 4,
+      settings: globalSettings,
+      updatedAt: "2026-08-04T12:00:00Z",
+      updatedBy: "admin-user",
+      reason: "Previous crowd balance",
+    },
+    isError: false,
+  }),
+  useSaveGlobalCrowdTuning: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useRestoreGlobalCrowdTuning: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+describe("global crowd defaults controls", () => {
+  it("shows the active revision and exposes guarded production actions", () => {
+    render(
+      <GlobalCrowdDefaultsControls
+        value={{ ...DEFAULT_CROWD_TUNING, densityMultiplier: 3 }}
+        onLoad={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Global gig crowd defaults")).toBeInTheDocument();
+    expect(screen.getByText("Revision 4")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved demo changes")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save as global default" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Restore system defaults" })).toBeEnabled();
+  });
+
+  it("loads the saved global values back into the demo", () => {
+    const onLoad = vi.fn();
+    render(
+      <GlobalCrowdDefaultsControls
+        value={{ ...DEFAULT_CROWD_TUNING, densityMultiplier: 3 }}
+        onLoad={onLoad}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load global into demo" }));
+    expect(onLoad).toHaveBeenCalledWith(globalSettings);
+  });
+});

--- a/supabase/functions/_shared/gig-viewer-replay/types.ts
+++ b/supabase/functions/_shared/gig-viewer-replay/types.ts
@@ -7,6 +7,16 @@ export type GigEventImportance = "ambient" | "normal" | "important" | "critical"
 
 export interface StagePosition { x: number; y: number; zone: "front_left" | "front_center" | "front_right" | "mid_left" | "mid_center" | "mid_right" | "back_left" | "back_center" | "back_right" }
 
+export interface GigReplayCrowdTuning {
+  densityMultiplier: number;
+  depthSpread: number;
+  lateralSpread: number;
+  stagePull: number;
+  randomness: number;
+  fanScale: number;
+  arrivalSpeed: number;
+}
+
 export type GigVisualPayload =
   | { type: "venue_open"; entranceIds: string[]; lightLevel: number }
   | { type: "crowd_fill"; targetDensity: number; zoneIds: string[]; enteringCount: number }
@@ -50,6 +60,8 @@ export interface GigViewerReplay {
   events: GigViewerEvent[];
   checksum: string | null;
   status: GigReplayStatus;
+  crowdTuning?: GigReplayCrowdTuning | null;
+  crowdTuningRevision?: number | null;
 }
 
 export type GigViewerReplayLoadState = "loading" | "ready" | "unavailable" | "generating" | "failed" | "unsupported_version";

--- a/supabase/functions/generate-gig-viewer-replay/index.ts
+++ b/supabase/functions/generate-gig-viewer-replay/index.ts
@@ -2,9 +2,19 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { buildGigViewerReplay } from "../_shared/gig-viewer-replay/generator.ts";
 import { GIG_VIEWER_VERSION } from "../_shared/gig-viewer-replay/constants.ts";
+import type { GigReplayCrowdTuning } from "../_shared/gig-viewer-replay/types.ts";
 
 const corsHeaders = { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type" };
 const response = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+const fallbackCrowdTuning: GigReplayCrowdTuning = {
+  densityMultiplier: 2,
+  depthSpread: 1,
+  lateralSpread: 1,
+  stagePull: 0,
+  randomness: 0,
+  fanScale: 1,
+  arrivalSpeed: 1,
+};
 
 serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
@@ -14,39 +24,148 @@ serve(async (req) => {
   try {
     ({ gigId } = await req.json());
     if (!gigId) return response({ error: "missing_gig_id" }, 400);
-    const { data: existing, error: existingError } = await supabase.from("gig_viewer_replays").select("id,generation_status,event_count,duration_ms,checksum").eq("gig_id", gigId).eq("viewer_version", GIG_VIEWER_VERSION).eq("generation_status", "ready").maybeSingle();
-    if (existingError) throw existingError;
-    if (existing) { console.log("[gig-viewer-replay] returned existing", { gigId, replayId: existing.id }); return response({ success: true, existing: true, replay: existing }); }
 
-    const { data: gig, error: gigError } = await supabase.from("gigs").select("id,status,completed_at,result_ready_at,venue_id,venues!gigs_venue_id_fkey(capacity)").eq("id", gigId).single();
+    const { data: existing, error: existingError } = await supabase
+      .from("gig_viewer_replays")
+      .select("id,generation_status,event_count,duration_ms,checksum")
+      .eq("gig_id", gigId)
+      .eq("viewer_version", GIG_VIEWER_VERSION)
+      .eq("generation_status", "ready")
+      .maybeSingle();
+    if (existingError) throw existingError;
+    if (existing) {
+      console.log("[gig-viewer-replay] returned existing", { gigId, replayId: existing.id });
+      return response({ success: true, existing: true, replay: existing });
+    }
+
+    const { data: gig, error: gigError } = await supabase
+      .from("gigs")
+      .select("id,status,completed_at,result_ready_at,venue_id,venues!gigs_venue_id_fkey(capacity)")
+      .eq("id", gigId)
+      .single();
     if (gigError || !gig) return response({ error: "gig_not_found" }, 404);
     if (gig.status !== "completed" || !gig.result_ready_at) return response({ error: "gig_not_completed" }, 409);
-    const { data: outcome, error: outcomeError } = await supabase.from("gig_outcomes").select("id,completed_at,actual_attendance,overall_rating,net_profit").eq("gig_id", gigId).single();
+
+    const { data: outcome, error: outcomeError } = await supabase
+      .from("gig_outcomes")
+      .select("id,completed_at,actual_attendance,overall_rating,net_profit")
+      .eq("gig_id", gigId)
+      .single();
     if (outcomeError || !outcome) return response({ error: "outcome_not_found" }, 409);
 
-    const { data: claim, error: claimError } = await supabase.rpc("claim_gig_viewer_replay_generation", { p_gig_id: gigId, p_gig_outcome_id: outcome.id, p_viewer_version: GIG_VIEWER_VERSION });
+    const { data: claim, error: claimError } = await supabase.rpc("claim_gig_viewer_replay_generation", {
+      p_gig_id: gigId,
+      p_gig_outcome_id: outcome.id,
+      p_viewer_version: GIG_VIEWER_VERSION,
+    });
     if (claimError) throw claimError;
-    if (claim?.alreadyReady || claim?.alreadyGenerating) return response({ success: true, existing: Boolean(claim.alreadyReady), generating: Boolean(claim.alreadyGenerating), replayId: claim.replayId });
+    if (claim?.alreadyReady || claim?.alreadyGenerating) {
+      return response({
+        success: true,
+        existing: Boolean(claim.alreadyReady),
+        generating: Boolean(claim.alreadyGenerating),
+        replayId: claim.replayId,
+      });
+    }
     replayId = claim.replayId;
     console.log("[gig-viewer-replay] generation started", { gigId, outcomeId: outcome.id, replayId });
 
-    const [songsRes, performersRes] = await Promise.all([
+    const [songsRes, performersRes, crowdSettingsRes] = await Promise.all([
       supabase.from("gig_song_performances").select("id,song_id,position,performance_score,crowd_response,song_title,performance_item_name").eq("gig_outcome_id", outcome.id).order("position"),
       supabase.from("gig_performers").select("profile_id,role_or_instrument,lineup_status,profiles:profiles!gig_performers_profile_id_fkey(display_name,username)").eq("gig_id", gigId).order("created_at", { ascending: true }),
+      supabase.from("gig_viewer_crowd_settings").select("revision,settings").eq("id", true).maybeSingle(),
     ]);
     if (songsRes.error) throw songsRes.error;
     if (performersRes.error) throw performersRes.error;
     if (!songsRes.data?.length) throw new Error("MISSING_SONGS");
 
-    const replay = await buildGigViewerReplay({ replayId, gig: { id: gig.id, completedAt: outcome.completed_at ?? gig.completed_at, resultReadyAt: gig.result_ready_at, venueCapacity: gig.venues?.capacity ?? null, actualAttendance: outcome.actual_attendance, overallRating: outcome.overall_rating, netProfit: outcome.net_profit }, outcomeId: outcome.id, generatedAt: new Date().toISOString(), songs: songsRes.data.map((s: any) => ({ id: s.id, songId: s.song_id, position: s.position, title: s.song_title ?? s.performance_item_name ?? "Unknown Song", performanceScore: s.performance_score, crowdResponse: s.crowd_response })), performers: (performersRes.data ?? []).map((p: any) => ({ profileId: p.profile_id, displayName: p.profiles?.display_name ?? p.profiles?.username ?? "Unknown Performer", roleOrInstrument: p.role_or_instrument, lineupStatus: p.lineup_status })) });
-    const { error: updateError } = await supabase.from("gig_viewer_replays").update({ event_payload: { events: replay.events }, event_count: replay.events.length, duration_ms: replay.durationMs, simulation_seed: replay.simulationSeed, event_schema_version: replay.eventSchemaVersion, generation_status: "ready", generation_error_code: null, checksum: replay.checksum, generated_at: replay.generatedAt }).eq("id", replayId);
+    if (crowdSettingsRes.error) {
+      console.warn("[gig-viewer-replay] crowd settings unavailable; using fallback", {
+        code: crowdSettingsRes.error.code,
+        message: crowdSettingsRes.error.message,
+      });
+    }
+    const crowdTuning = (crowdSettingsRes.data?.settings ?? fallbackCrowdTuning) as GigReplayCrowdTuning;
+    const crowdTuningRevision = Math.max(1, Number(crowdSettingsRes.data?.revision) || 1);
+
+    const replay = await buildGigViewerReplay({
+      replayId,
+      gig: {
+        id: gig.id,
+        completedAt: outcome.completed_at ?? gig.completed_at,
+        resultReadyAt: gig.result_ready_at,
+        venueCapacity: gig.venues?.capacity ?? null,
+        actualAttendance: outcome.actual_attendance,
+        overallRating: outcome.overall_rating,
+        netProfit: outcome.net_profit,
+      },
+      outcomeId: outcome.id,
+      generatedAt: new Date().toISOString(),
+      songs: songsRes.data.map((song: any) => ({
+        id: song.id,
+        songId: song.song_id,
+        position: song.position,
+        title: song.song_title ?? song.performance_item_name ?? "Unknown Song",
+        performanceScore: song.performance_score,
+        crowdResponse: song.crowd_response,
+      })),
+      performers: (performersRes.data ?? []).map((performer: any) => ({
+        profileId: performer.profile_id,
+        displayName: performer.profiles?.display_name ?? performer.profiles?.username ?? "Unknown Performer",
+        roleOrInstrument: performer.role_or_instrument,
+        lineupStatus: performer.lineup_status,
+      })),
+    });
+    replay.crowdTuning = crowdTuning;
+    replay.crowdTuningRevision = crowdTuningRevision;
+
+    const { error: updateError } = await supabase
+      .from("gig_viewer_replays")
+      .update({
+        event_payload: {
+          events: replay.events,
+          crowdTuning: replay.crowdTuning,
+          crowdTuningRevision: replay.crowdTuningRevision,
+        },
+        event_count: replay.events.length,
+        duration_ms: replay.durationMs,
+        simulation_seed: replay.simulationSeed,
+        event_schema_version: replay.eventSchemaVersion,
+        generation_status: "ready",
+        generation_error_code: null,
+        checksum: replay.checksum,
+        generated_at: replay.generatedAt,
+      })
+      .eq("id", replayId);
     if (updateError) throw updateError;
-    console.log("[gig-viewer-replay] generation succeeded", { gigId, outcomeId: outcome.id, replayId, eventCount: replay.events.length, durationMs: replay.durationMs });
-    return response({ success: true, existing: false, replayId, eventCount: replay.events.length, durationMs: replay.durationMs, checksum: replay.checksum });
+
+    console.log("[gig-viewer-replay] generation succeeded", {
+      gigId,
+      outcomeId: outcome.id,
+      replayId,
+      eventCount: replay.events.length,
+      durationMs: replay.durationMs,
+      crowdTuningRevision,
+    });
+    return response({
+      success: true,
+      existing: false,
+      replayId,
+      eventCount: replay.events.length,
+      durationMs: replay.durationMs,
+      checksum: replay.checksum,
+      crowdTuningRevision,
+    });
   } catch (error) {
-    const code = error instanceof Error && error.message.startsWith("INVALID_REPLAY") ? "validation_failed" : error instanceof Error ? error.message.slice(0, 64) : "unknown_error";
+    const code = error instanceof Error && error.message.startsWith("INVALID_REPLAY")
+      ? "validation_failed"
+      : error instanceof Error
+        ? error.message.slice(0, 64)
+        : "unknown_error";
     console.error("[gig-viewer-replay] generation failed", { gigId, replayId, code });
-    if (replayId) await supabase.from("gig_viewer_replays").update({ generation_status: "failed", generation_error_code: code }).eq("id", replayId);
+    if (replayId) {
+      await supabase.from("gig_viewer_replays").update({ generation_status: "failed", generation_error_code: code }).eq("id", replayId);
+    }
     return response({ error: "replay_generation_failed", code }, 500);
   }
 });

--- a/supabase/migrations/20260804130000_gig_viewer_crowd_defaults.sql
+++ b/supabase/migrations/20260804130000_gig_viewer_crowd_defaults.sql
@@ -1,0 +1,210 @@
+-- Global, versioned crowd tuning defaults for the gig viewer.
+-- Admins can promote settings from the demo; viewers can read the active singleton.
+
+CREATE OR REPLACE FUNCTION public.normalize_gig_viewer_crowd_settings(p_settings jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public
+AS $$
+DECLARE
+  v_settings jsonb := COALESCE(p_settings, '{}'::jsonb);
+  v_density numeric;
+  v_depth numeric;
+  v_lateral numeric;
+  v_stage_pull numeric;
+  v_randomness numeric;
+  v_fan_scale numeric;
+  v_arrival_speed numeric;
+BEGIN
+  IF jsonb_typeof(v_settings) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'Crowd settings must be a JSON object' USING ERRCODE = '22023';
+  END IF;
+
+  BEGIN
+    v_density := COALESCE((v_settings ->> 'densityMultiplier')::numeric, 2);
+    v_depth := COALESCE((v_settings ->> 'depthSpread')::numeric, 1);
+    v_lateral := COALESCE((v_settings ->> 'lateralSpread')::numeric, 1);
+    v_stage_pull := COALESCE((v_settings ->> 'stagePull')::numeric, 0);
+    v_randomness := COALESCE((v_settings ->> 'randomness')::numeric, 0);
+    v_fan_scale := COALESCE((v_settings ->> 'fanScale')::numeric, 1);
+    v_arrival_speed := COALESCE((v_settings ->> 'arrivalSpeed')::numeric, 1);
+  EXCEPTION WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'Crowd settings contain an invalid number' USING ERRCODE = '22023';
+  END;
+
+  IF v_density < 0.5 OR v_density > 4 THEN
+    RAISE EXCEPTION 'densityMultiplier must be between 0.5 and 4';
+  END IF;
+  IF v_depth < 0.45 OR v_depth > 1.5 THEN
+    RAISE EXCEPTION 'depthSpread must be between 0.45 and 1.5';
+  END IF;
+  IF v_lateral < 0.45 OR v_lateral > 1.5 THEN
+    RAISE EXCEPTION 'lateralSpread must be between 0.45 and 1.5';
+  END IF;
+  IF v_stage_pull < 0 OR v_stage_pull > 1 THEN
+    RAISE EXCEPTION 'stagePull must be between 0 and 1';
+  END IF;
+  IF v_randomness < 0 OR v_randomness > 0.8 THEN
+    RAISE EXCEPTION 'randomness must be between 0 and 0.8';
+  END IF;
+  IF v_fan_scale < 0.6 OR v_fan_scale > 1.6 THEN
+    RAISE EXCEPTION 'fanScale must be between 0.6 and 1.6';
+  END IF;
+  IF v_arrival_speed < 0.5 OR v_arrival_speed > 2 THEN
+    RAISE EXCEPTION 'arrivalSpeed must be between 0.5 and 2';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'densityMultiplier', v_density,
+    'depthSpread', v_depth,
+    'lateralSpread', v_lateral,
+    'stagePull', v_stage_pull,
+    'randomness', v_randomness,
+    'fanScale', v_fan_scale,
+    'arrivalSpeed', v_arrival_speed
+  );
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.gig_viewer_crowd_settings (
+  id boolean PRIMARY KEY DEFAULT true,
+  revision integer NOT NULL DEFAULT 1 CHECK (revision > 0),
+  settings jsonb NOT NULL,
+  updated_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  reason text,
+  CONSTRAINT gig_viewer_crowd_settings_singleton CHECK (id = true),
+  CONSTRAINT gig_viewer_crowd_settings_valid CHECK (
+    settings = public.normalize_gig_viewer_crowd_settings(settings)
+  )
+);
+
+INSERT INTO public.gig_viewer_crowd_settings (id, revision, settings, reason)
+VALUES (
+  true,
+  1,
+  public.normalize_gig_viewer_crowd_settings('{}'::jsonb),
+  'Initial production defaults'
+)
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE public.gig_viewer_crowd_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Authenticated users can read gig viewer crowd settings" ON public.gig_viewer_crowd_settings;
+CREATE POLICY "Authenticated users can read gig viewer crowd settings"
+  ON public.gig_viewer_crowd_settings
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+REVOKE INSERT, UPDATE, DELETE ON public.gig_viewer_crowd_settings FROM anon, authenticated;
+GRANT SELECT ON public.gig_viewer_crowd_settings TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.admin_set_gig_viewer_crowd_settings(
+  p_settings jsonb,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_settings jsonb;
+  v_reason text := trim(COALESCE(p_reason, ''));
+  v_previous jsonb;
+  v_revision integer;
+  v_updated_at timestamptz := timezone('utc', now());
+  v_snapshotted integer := 0;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'admin'::public.app_role) THEN
+    RAISE EXCEPTION 'Admin access required';
+  END IF;
+  IF length(v_reason) < 8 THEN
+    RAISE EXCEPTION 'A reason of at least 8 characters is required';
+  END IF;
+
+  v_settings := public.normalize_gig_viewer_crowd_settings(p_settings);
+
+  SELECT settings, revision
+  INTO v_previous, v_revision
+  FROM public.gig_viewer_crowd_settings
+  WHERE id = true
+  FOR UPDATE;
+
+  v_revision := COALESCE(v_revision, 0) + 1;
+
+  INSERT INTO public.gig_viewer_crowd_settings AS current_settings (
+    id, revision, settings, updated_by, updated_at, reason
+  )
+  VALUES (
+    true, v_revision, v_settings, auth.uid(), v_updated_at, v_reason
+  )
+  ON CONFLICT (id) DO UPDATE
+  SET revision = EXCLUDED.revision,
+      settings = EXCLUDED.settings,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = EXCLUDED.updated_at,
+      reason = EXCLUDED.reason;
+
+  -- Give legacy ready replays a one-time snapshot. Replays that already carry
+  -- a crowd tuning revision remain immutable and reproducible.
+  UPDATE public.gig_viewer_replays
+  SET event_payload = jsonb_set(
+    jsonb_set(COALESCE(event_payload, '{}'::jsonb), '{crowdTuning}', v_settings, true),
+    '{crowdTuningRevision}',
+    to_jsonb(v_revision),
+    true
+  )
+  WHERE generation_status = 'ready'
+    AND jsonb_typeof(event_payload) = 'object'
+    AND NOT (event_payload ? 'crowdTuningRevision');
+  GET DIAGNOSTICS v_snapshotted = ROW_COUNT;
+
+  INSERT INTO public.admin_action_audit (
+    actor_user_id, action, target_table, target_id, metadata
+  )
+  VALUES (
+    auth.uid(),
+    'admin_set_gig_viewer_crowd_settings',
+    'gig_viewer_crowd_settings',
+    'global',
+    jsonb_build_object(
+      'reason', v_reason,
+      'revision', v_revision,
+      'previous_settings', v_previous,
+      'new_settings', v_settings,
+      'legacy_replays_snapshotted', v_snapshotted
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'revision', v_revision,
+    'settings', v_settings,
+    'updatedAt', v_updated_at,
+    'updatedBy', auth.uid(),
+    'reason', v_reason,
+    'legacyReplaysSnapshotted', v_snapshotted
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_restore_gig_viewer_crowd_settings(p_reason text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN public.admin_set_gig_viewer_crowd_settings(
+    public.normalize_gig_viewer_crowd_settings('{}'::jsonb),
+    p_reason
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_set_gig_viewer_crowd_settings(jsonb, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_restore_gig_viewer_crowd_settings(text) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/tests/gig_viewer_crowd_defaults_harness.sql
+++ b/supabase/tests/gig_viewer_crowd_defaults_harness.sql
@@ -1,0 +1,62 @@
+-- Run after migrations in a disposable Supabase database.
+BEGIN;
+
+DO $$
+DECLARE
+  v_settings jsonb;
+BEGIN
+  IF to_regclass('public.gig_viewer_crowd_settings') IS NULL THEN
+    RAISE EXCEPTION 'gig_viewer_crowd_settings table is missing';
+  END IF;
+
+  IF to_regprocedure('public.normalize_gig_viewer_crowd_settings(jsonb)') IS NULL THEN
+    RAISE EXCEPTION 'crowd settings normalizer is missing';
+  END IF;
+
+  IF to_regprocedure('public.admin_set_gig_viewer_crowd_settings(jsonb,text)') IS NULL THEN
+    RAISE EXCEPTION 'admin crowd settings save RPC is missing';
+  END IF;
+
+  IF to_regprocedure('public.admin_restore_gig_viewer_crowd_settings(text)') IS NULL THEN
+    RAISE EXCEPTION 'admin crowd settings restore RPC is missing';
+  END IF;
+
+  SELECT settings INTO v_settings
+  FROM public.gig_viewer_crowd_settings
+  WHERE id = true;
+
+  IF v_settings IS NULL THEN
+    RAISE EXCEPTION 'crowd settings singleton was not seeded';
+  END IF;
+
+  IF (v_settings ->> 'densityMultiplier')::numeric <> 2 THEN
+    RAISE EXCEPTION 'unexpected seeded density multiplier';
+  END IF;
+
+  BEGIN
+    PERFORM public.normalize_gig_viewer_crowd_settings('{"densityMultiplier":9}'::jsonb);
+    RAISE EXCEPTION 'out-of-range density was accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM = 'out-of-range density was accepted' THEN
+      RAISE;
+    END IF;
+  END;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'gig_viewer_crowd_settings'
+      AND c.relrowsecurity
+  ) THEN
+    RAISE EXCEPTION 'RLS is not enabled for gig_viewer_crowd_settings';
+  END IF;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## What changed
- adds **Save as global default**, **Load global into demo**, and **Restore system defaults** controls to the Gig Viewer Demo crowd lab
- requires an admin confirmation and audit reason before production defaults can change
- stores the active crowd tuning in a validated, versioned singleton configuration table
- protects writes with the existing server-side admin role check and records changes in `admin_action_audit`
- applies the saved defaults to normal gig viewers
- snapshots the active settings revision into every newly generated replay so later changes do not alter historical gigs
- gives older ready replays without a snapshot the first saved revision once, while leaving already-versioned replays immutable
- falls back to the built-in production crowd plan if the settings table is temporarily unavailable

## Production behaviour
Resolution order is:
1. explicit viewer override
2. admin demo override
3. replay crowd-tuning snapshot
4. active global setting for an unsnapshotted replay
5. built-in production defaults

## Database
- migration: `20260804130000_gig_viewer_crowd_defaults.sql`
- singleton table with RLS read access and no direct authenticated writes
- admin save/restore RPCs with range validation, revision increments and audit logging
- SQL harness verifies schema, seed, validation, RPC presence and RLS

## Tests
- crowd tuning resolution precedence
- replay snapshots taking precedence over later global revisions
- global fallback for unsnapshotted replays
- built-in fallback when settings are unavailable
- global controls, revision display and loading saved values back into the demo

## Deployment note
Apply the Supabase migration and deploy the updated `generate-gig-viewer-replay` function before using **Save as global default**.