### PR TITLE
Add character recovery to main admin navigation

### DIFF
--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -28,6 +28,7 @@ export const adminCategories: AdminCategory[] = [
     icon: Users,
     items: [
       { path: "/admin/players", label: "Player Management", description: "Manage user accounts" },
+      { path: "/admin/character-recovery", label: "Character Recovery", description: "Revive dead or deleted characters" },
       { path: "/admin/user-roles", label: "User Roles", description: "Manage admin/moderator roles" },
       { path: "/admin/vip", label: "VIP Management", description: "Grant and manage VIP subscriptions" },
       { path: "/admin/achievements", label: "Achievements", description: "Configure achievement system" },


### PR DESCRIPTION
## What changed

- Added a **Character Recovery** entry to the **Players & Community** section of the main admin navigation.
- Linked the entry to the existing `/admin/character-recovery` route.

## Why

The recovery page and route already existed, but the page was not discoverable from the main admin navigation.

## Impact

Admins can now open the character recovery tool directly from the main admin screen. Recovery behaviour and permissions are unchanged.

## Validation

- Confirmed `/admin/character-recovery` is registered in `src/App.tsx`.
- Verified the branch is one commit ahead of `main` with a one-line navigation-only diff.