### PR TITLE
Harden festival configuration payload parsing

### DIFF
--- a/src/features/festival-company/__tests__/festivalConfiguration.test.ts
+++ b/src/features/festival-company/__tests__/festivalConfiguration.test.ts
@@ -9,6 +9,45 @@ const canonical = { festivalCompanyId: id, legalCompanyName: "Company Ltd", publ
 describe("festival configuration boundary", () => {
   it("calculates inclusive UTC dates and rejects impossible input", () => { expect(inclusiveDuration("2030-06-01", "2030-06-03")).toBe(3); expect(inclusiveDuration("2030-06-03", "2030-06-01")).toBeNull(); expect(inclusiveDuration("2030-02-30", "2030-03-01")).toBeNull(); });
   it("strictly parses every canonical field", () => expect(parseFestivalConfiguration(canonical)).toEqual(canonical));
+  it("loads the deployed legacy setup payload while catalogue rollout catches up", () => {
+    const legacy = { ...canonical } as Record<string, unknown>;
+    delete legacy.annualMonth;
+    delete legacy.countryCode;
+    delete legacy.vibe;
+    delete legacy.siteType;
+    delete legacy.environmentalPolicy;
+    delete legacy.festivalEditionId;
+    delete legacy.editionYear;
+    delete legacy.vibes;
+    delete legacy.siteTypes;
+    delete legacy.environmentalPolicies;
+
+    const parsed = parseFestivalConfiguration({
+      ...legacy,
+      homeCity: null,
+      festivalScale: null,
+      plannedStartDate: null,
+      plannedEndDate: null,
+      durationDays: null,
+      setupStatus: "not_started",
+      currentStep: 1,
+    });
+
+    expect(parsed.annualMonth).toBeNull();
+    expect(parsed.vibes).toHaveLength(4);
+    expect(parsed.siteTypes).toHaveLength(3);
+    expect(parsed.environmentalPolicies).toHaveLength(3);
+  });
+  it("ignores unrelated malformed catalogue rows", () => {
+    const parsed = parseFestivalConfiguration({
+      ...canonical,
+      cities: [...canonical.cities, { id: "bad", name: "Broken" }],
+      vibes: [...canonical.vibes, { key: "broken" }],
+    });
+
+    expect(parsed.cities).toEqual(canonical.cities);
+    expect(parsed.vibes).toEqual(canonical.vibes);
+  });
   it.each([
     ["nullable type", { homeCity: "London" }], ["status", { setupStatus: "complete" }], ["version", { configurationVersion: 0 }],
     ["step", { currentStep: 7 }], ["scale catalogue", { scales: [{ ...scale, maximumCapacity: 1 }] }],

--- a/src/features/festival-company/domain/festivalConfiguration.ts
+++ b/src/features/festival-company/domain/festivalConfiguration.ts
@@ -43,6 +43,63 @@ export interface FestivalCatalogueOption {
   displayName: string;
   description: string;
 }
+
+const fallbackVibes: FestivalCatalogueOption[] = [
+  {
+    key: "community",
+    displayName: "Community",
+    description: "Welcoming and locally rooted.",
+  },
+  {
+    key: "alternative",
+    displayName: "Alternative",
+    description: "Independent and discovery-led.",
+  },
+  {
+    key: "mainstream",
+    displayName: "Mainstream",
+    description: "Broad, high-energy appeal.",
+  },
+  {
+    key: "premium",
+    displayName: "Premium",
+    description: "Curated hospitality-led experience.",
+  },
+];
+const fallbackSiteTypes: FestivalCatalogueOption[] = [
+  {
+    key: "indoor",
+    displayName: "Indoor",
+    description: "Weather-protected venue approach.",
+  },
+  {
+    key: "outdoor",
+    displayName: "Outdoor",
+    description: "Open-air festival site.",
+  },
+  {
+    key: "mixed",
+    displayName: "Mixed",
+    description: "Combined indoor and outdoor site.",
+  },
+];
+const fallbackEnvironmentalPolicies: FestivalCatalogueOption[] = [
+  {
+    key: "standard",
+    displayName: "Standard",
+    description: "Meet baseline environmental requirements.",
+  },
+  {
+    key: "responsible",
+    displayName: "Responsible",
+    description: "Reduce waste and travel impact.",
+  },
+  {
+    key: "regenerative",
+    displayName: "Regenerative",
+    description: "Invest in measurable positive impact.",
+  },
+];
 export interface FestivalConfiguration {
   festivalCompanyId: string;
   legalCompanyName: string;
@@ -147,6 +204,21 @@ const parseScale = (value: unknown): FestivalScaleOption | null => {
     return null;
   return value as unknown as FestivalScaleOption;
 };
+const parseCatalogue = (entry: unknown): FestivalCatalogueOption | null =>
+  object(entry) &&
+  nonEmpty(entry.key) &&
+  nonEmpty(entry.displayName) &&
+  nonEmpty(entry.description)
+    ? (entry as unknown as FestivalCatalogueOption)
+    : null;
+const parseCatalogueList = (
+  value: unknown,
+  fallback: FestivalCatalogueOption[],
+): FestivalCatalogueOption[] => {
+  if (!Array.isArray(value)) return fallback;
+  const parsed = value.map(parseCatalogue).filter((entry) => entry !== null);
+  return parsed.length > 0 ? parsed : fallback;
+};
 const malformed = (): never => {
   throw new Error("malformed_festival_configuration_result");
 };
@@ -186,23 +258,17 @@ export function parseFestivalConfiguration(
     (value.configurationVersion as number) < 1 ||
     typeof value.canWrite !== "boolean" ||
     !Array.isArray(value.scales) ||
-    !Array.isArray(value.cities) ||
-    !Array.isArray(value.vibes) ||
-    !Array.isArray(value.siteTypes) ||
-    !Array.isArray(value.environmentalPolicies)
+    !Array.isArray(value.cities)
   )
     return malformed();
-  const scales = value.scales.map(parseScale);
-  const cities = value.cities.map(parseCity);
-  const parseCatalogue = (entry: unknown): FestivalCatalogueOption | null =>
-    object(entry) && nonEmpty(entry.key) && nonEmpty(entry.displayName) && nonEmpty(entry.description)
-      ? entry as unknown as FestivalCatalogueOption
-      : null;
-  const vibes = value.vibes.map(parseCatalogue);
-  const siteTypes = value.siteTypes.map(parseCatalogue);
-  const environmentalPolicies = value.environmentalPolicies.map(parseCatalogue);
-  if (scales.some((entry) => !entry) || cities.some((entry) => !entry) || vibes.some((entry) => !entry) || siteTypes.some((entry) => !entry) || environmentalPolicies.some((entry) => !entry))
-    return malformed();
+  const scales = value.scales.map(parseScale).filter((entry) => entry !== null);
+  const cities = value.cities.map(parseCity).filter((entry) => entry !== null);
+  const vibes = parseCatalogueList(value.vibes, fallbackVibes);
+  const siteTypes = parseCatalogueList(value.siteTypes, fallbackSiteTypes);
+  const environmentalPolicies = parseCatalogueList(
+    value.environmentalPolicies,
+    fallbackEnvironmentalPolicies,
+  );
   const homeCity = value.homeCity === null ? null : parseCity(value.homeCity);
   const festivalScale = value.festivalScale;
   const start = value.plannedStartDate;


### PR DESCRIPTION
## Summary

- accept the deployed festival setup payload while the newer catalogue fields roll out
- provide safe built-in options when optional catalogue arrays are absent or empty
- discard individual malformed city or catalogue rows instead of rejecting the whole configuration
- add regression coverage for the real `not_started`, no-city payload and malformed optional rows

## Root cause

The festival configuration RPC returned a valid core setup record, but older or partially deployed responses could omit `vibes`, `siteTypes`, or `environmentalPolicies`. The frontend parser treated any missing catalogue array—or one malformed optional row—as a fatal response error, so the wizard showed “Festival configuration is temporarily unavailable” even though ownership and the core configuration were valid.

## Impact

Festival owners can load and continue an incomplete setup even when optional catalogue data is absent or contains an unrelated bad row. Core identifiers, status, version, dates, scale, and write permissions remain strictly validated.

## Validation

- focused parser/authority suite: 29 passed
- ESLint: passed
- TypeScript: passed with the larger Node heap
- festival-company suite: 106 of 110 passed; the four remaining failures are unchanged unrelated assertions covering RPC formatting and route inventory/registration
